### PR TITLE
feat: Add Financial Label Classifications and Essential Spending Serv…

### DIFF
--- a/code/FinanceManager.Api/Controllers/EssentialSpendingController.cs
+++ b/code/FinanceManager.Api/Controllers/EssentialSpendingController.cs
@@ -1,0 +1,25 @@
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Domain.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Api.Controllers;
+
+[Authorize]
+[Route("api/[controller]")]
+[ApiController]
+[Tags("Financial Analysis")]
+public class EssentialSpendingController(IEssentialSpendingService essentialSpendingService, ICurrencyRepository currencyRepository) : ControllerBase
+{
+    [HttpGet("GetEssentialSpending/{userId:int}/{currencyId:int}/{start:DateTime}/{end:DateTime}/{step:long?}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<TimeSeriesModel>))]
+    public async Task<IActionResult> GetEssentialSpending(int userId, int currencyId, DateTime start, DateTime end, long? step = null, [FromQuery] List<int>? accountIds = null, CancellationToken cancellationToken = default)
+    {
+        var currency = await currencyRepository.GetCurrencies(cancellationToken).SingleAsync(x => x.Id == currencyId, cancellationToken);
+        return Ok(accountIds is { Count: > 0 }
+            ? await essentialSpendingService.GetEssentialSpending(userId, currency, start, end, accountIds)
+            : await essentialSpendingService.GetEssentialSpending(userId, currency, start, end));
+    }
+}

--- a/code/FinanceManager.Api/Controllers/FinancialLabelController.cs
+++ b/code/FinanceManager.Api/Controllers/FinancialLabelController.cs
@@ -44,6 +44,17 @@ public class FinancialLabelController(IFinancialLabelsRepository financialLabels
     public async Task<IActionResult> UpdateName([FromQuery] int id, string name, CancellationToken cancellationToken = default) =>
     Ok(await financialLabelsRepository.UpdateName(id, name, cancellationToken));
 
+    [HttpPost("add-classification")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(bool))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> AddClassification(AddFinancialLabelClassification classification, CancellationToken cancellationToken = default)
+    {
+        if (!FinancialLabelClassificationCatalog.TryNormalize(classification.Kind, classification.Value, out string normalizedKind, out string normalizedValue))
+            return BadRequest("Invalid financial label classification.");
+
+        return Ok(await financialLabelsRepository.AddClassification(classification.LabelId, normalizedKind, normalizedValue, cancellationToken));
+    }
+
     [HttpDelete("delete")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(bool))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/code/FinanceManager.Api/Migrations/20260310094304_AddFinancialLabelClassifications.Designer.cs
+++ b/code/FinanceManager.Api/Migrations/20260310094304_AddFinancialLabelClassifications.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceManager.Infrastructure.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceManager.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310094304_AddFinancialLabelClassifications")]
+    partial class AddFinancialLabelClassifications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/code/FinanceManager.Api/Migrations/20260310094304_AddFinancialLabelClassifications.cs
+++ b/code/FinanceManager.Api/Migrations/20260310094304_AddFinancialLabelClassifications.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace FinanceManager.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFinancialLabelClassifications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "FinancialLabels",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.CreateTable(
+                name: "FinancialLabelClassifications",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    LabelId = table.Column<int>(type: "integer", nullable: false),
+                    Kind = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Value = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FinancialLabelClassifications", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FinancialLabelClassifications_FinancialLabels_LabelId",
+                        column: x => x.LabelId,
+                        principalTable: "FinancialLabels",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FinancialLabelClassifications_LabelId_Kind",
+                table: "FinancialLabelClassifications",
+                columns: new[] { "LabelId", "Kind" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FinancialLabelClassifications");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "FinancialLabels",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(200)",
+                oldMaxLength: 200);
+        }
+    }
+}

--- a/code/FinanceManager.Application/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Application/ServiceCollectionExtension.cs
@@ -24,6 +24,8 @@ public static class ServiceCollectionExtension
     {
         services.AddScoped<ISettingsService, SettingsService>()
                 .AddScoped<IMoneyFlowService, MoneyFlowService>()
+            .AddScoped<IEssentialSpendingServiceTyped, CurrencyEssentialSpendingService>()
+            .AddScoped<IEssentialSpendingService, EssentialSpendingService>()
                 .AddScoped<IBalanceServiceTyped, CurrencyBalanceService>()
                 .AddScoped<IBalanceServiceTyped, BondBalanceService>()
                 .AddScoped<IBalanceServiceTyped, StockBalanceService>()

--- a/code/FinanceManager.Application/Services/Currencies/CurrencyEssentialSpendingService.cs
+++ b/code/FinanceManager.Application/Services/Currencies/CurrencyEssentialSpendingService.cs
@@ -1,0 +1,80 @@
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using FinanceManager.Domain.Entities.Shared.Accounts;
+using FinanceManager.Domain.Repositories.Account;
+using FinanceManager.Domain.Services;
+
+namespace FinanceManager.Application.Services.Currencies;
+
+public class CurrencyEssentialSpendingService(IFinancialAccountRepository financialAccountRepository) : IEssentialSpendingServiceTyped
+{
+    private static readonly TimeSpan OneDay = TimeSpan.FromDays(1);
+
+    public bool IsOfType<T>() => typeof(T) == typeof(CurrencyAccount);
+
+    public Task<List<TimeSeriesModel>> GetEssentialSpending(int userId, Currency currency, DateTime start, DateTime end) =>
+        GetEssentialSpending(userId, currency, start, end, []);
+
+    public async Task<List<TimeSeriesModel>> GetEssentialSpending(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds)
+    {
+        var result = await AggregateByDay(userId, start, end, accountIds);
+        return BucketToSeries(result);
+    }
+
+    private async Task<Dictionary<DateTime, decimal>> AggregateByDay(int userId, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds)
+    {
+        if (end > DateTime.UtcNow) end = DateTime.UtcNow;
+
+        Dictionary<DateTime, decimal> result = [];
+        var accountIdFilter = accountIds.Count > 0 ? accountIds.ToHashSet() : [];
+
+        await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end))
+        {
+            if (account?.Entries is null) continue;
+            if (accountIdFilter.Count > 0 && !accountIdFilter.Contains(account.AccountId)) continue;
+
+            for (var date = end.Date; date >= start.Date; date = date.Add(-OneDay))
+            {
+                if (!result.ContainsKey(date)) result.Add(date, 0);
+
+                var entries = account.Get(date);
+                foreach (var entry in entries.Select(x => x as FinancialEntryBase).Where(x => x is not null))
+                {
+                    if (entry!.PostingDate.Date != date.Date) continue;
+                    if (entry.ValueChange >= 0) continue;
+                    if (!HasResolvedClassification(entry.Labels, FinancialLabelClassificationCatalog.EssentialValue)) continue;
+
+                    result[date] += entry.ValueChange;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static bool HasResolvedClassification(IEnumerable<FinancialLabel> labels, string expectedValue)
+    {
+        var counts = labels
+            .SelectMany(label => label.Classifications)
+            .Where(classification => classification.Kind == FinancialLabelClassificationCatalog.SpendingNecessityKind)
+            .GroupBy(classification => classification.Value)
+            .Select(group => new { Value = group.Key, Count = group.Count() })
+            .OrderByDescending(group => group.Count)
+            .ThenBy(group => group.Value, StringComparer.Ordinal)
+            .ToList();
+
+        if (counts.Count == 0)
+            return false;
+
+        if (counts.Count > 1 && counts[0].Count == counts[1].Count)
+            return false;
+
+        return counts[0].Value == expectedValue;
+    }
+
+    private static List<TimeSeriesModel> BucketToSeries(Dictionary<DateTime, decimal> data) =>
+        TimeBucketService.Get(data.Select(x => (x.Key, x.Value)))
+            .Select(bucket => new TimeSeriesModel(bucket.Date, bucket.Objects.Sum()))
+            .ToList();
+}

--- a/code/FinanceManager.Application/Services/EssentialSpendingService.cs
+++ b/code/FinanceManager.Application/Services/EssentialSpendingService.cs
@@ -1,0 +1,34 @@
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using FinanceManager.Domain.Services;
+
+namespace FinanceManager.Application.Services;
+
+public class EssentialSpendingService(IEnumerable<IEssentialSpendingServiceTyped> typedServices) : IEssentialSpendingService
+{
+    public Task<List<TimeSeriesModel>> GetEssentialSpending(int userId, Currency currency, DateTime start, DateTime end) =>
+        Aggregate(service => service.GetEssentialSpending(userId, currency, start, end));
+
+    public Task<List<TimeSeriesModel>> GetEssentialSpending(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds) =>
+        Aggregate(service => service.GetEssentialSpending(userId, currency, start, end, accountIds));
+
+    private async Task<List<TimeSeriesModel>> Aggregate(Func<IEssentialSpendingServiceTyped, Task<List<TimeSeriesModel>>> getter)
+    {
+        Dictionary<DateTime, decimal> aggregated = [];
+
+        foreach (var service in typedServices)
+        {
+            foreach (var point in await getter(service))
+            {
+                if (aggregated.ContainsKey(point.DateTime))
+                    aggregated[point.DateTime] += point.Value;
+                else
+                    aggregated[point.DateTime] = point.Value;
+            }
+        }
+
+        return aggregated.OrderBy(x => x.Key)
+            .Select(x => new TimeSeriesModel(x.Key, x.Value))
+            .ToList();
+    }
+}

--- a/code/FinanceManager.Components/HttpClients/EssentialSpendingHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/EssentialSpendingHttpClient.cs
@@ -1,0 +1,26 @@
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Components.HttpClients;
+
+public class EssentialSpendingHttpClient(HttpClient httpClient)
+{
+    public Task<List<TimeSeriesModel>> GetEssentialSpending(int userId, Currency currency, DateTime start, DateTime end) =>
+        GetEssentialSpending(userId, currency, start, end, []);
+
+    public async Task<List<TimeSeriesModel>> GetEssentialSpending(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds)
+    {
+        string endpoint = AppendAccountIdsQuery($"{httpClient.BaseAddress}api/EssentialSpending/GetEssentialSpending/{userId}/{currency.Id}/{start:O}/{end:O}", accountIds);
+        var result = await httpClient.GetFromJsonAsync<List<TimeSeriesModel>>(endpoint);
+        return result ?? [];
+    }
+
+    private static string AppendAccountIdsQuery(string endpoint, IReadOnlyCollection<int> accountIds)
+    {
+        if (accountIds.Count == 0) return endpoint;
+
+        var query = string.Join("&", accountIds.Select(accountId => $"accountIds={accountId}"));
+        return endpoint.Contains('?') ? $"{endpoint}&{query}" : $"{endpoint}?{query}";
+    }
+}

--- a/code/FinanceManager.Components/HttpClients/FinancialLabelHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/FinancialLabelHttpClient.cs
@@ -8,14 +8,17 @@ public class FinancialLabelHttpClient(HttpClient httpClient)
 {
     public Task<int> GetCount(CancellationToken cancellationToken = default) =>
         httpClient.GetFromJsonAsync<int>($"{httpClient.BaseAddress}api/FinancialLabel/get-count", cancellationToken);
+
     public Task<FinancialLabel?> Get(int labelId, CancellationToken cancellationToken = default) =>
         httpClient.GetFromJsonAsync<FinancialLabel>($"{httpClient.BaseAddress}api/FinancialLabel/get-by-id?id={labelId}", cancellationToken);
+
     public async Task<List<FinancialLabel>> Get(int index, int count, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.GetFromJsonAsync<List<FinancialLabel>>($"{httpClient.BaseAddress}api/FinancialLabel/get-by-index-and-count?index={index}&count={count}", cancellationToken);
 
         return result ?? [];
     }
+
     public async Task<bool> Add(AddFinancialLabel addFinancialLabel, CancellationToken cancellationToken = default)
     {
         try
@@ -28,8 +31,10 @@ public class FinancialLabelHttpClient(HttpClient httpClient)
         {
             return false;
         }
+
         return false;
     }
+
     public async Task<bool> UpdateName(int id, string name, CancellationToken cancellationToken = default)
     {
         try
@@ -44,6 +49,23 @@ public class FinancialLabelHttpClient(HttpClient httpClient)
             return false;
         }
     }
+
+    public async Task<bool> AddClassification(AddFinancialLabelClassification classification, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await httpClient.PostAsJsonAsync($"{httpClient.BaseAddress}api/FinancialLabel/add-classification", classification, cancellationToken);
+
+            if (response.IsSuccessStatusCode) return await response.Content.ReadFromJsonAsync<bool>(cancellationToken: cancellationToken);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        return false;
+    }
+
     public async Task<bool> Delete(int id, CancellationToken cancellationToken = default)
     {
         try
@@ -57,6 +79,7 @@ public class FinancialLabelHttpClient(HttpClient httpClient)
             return false;
         }
     }
+
     public async Task<List<FinancialLabel>> GetByAccountId(int accountId, CancellationToken cancellationToken = default)
     {
         var result = await httpClient.GetFromJsonAsync<List<FinancialLabel>>($"{httpClient.BaseAddress}api/FinancialLabel/get-by-account-id?accountId={accountId}", cancellationToken);

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -27,6 +27,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<BondDetailsHttpClient>()
 
                 .AddScoped<MoneyFlowHttpClient>()
+                .AddScoped<EssentialSpendingHttpClient>()
                 .AddScoped<AssetsHttpClient>()
                 .AddScoped<LiabilitiesHttpClient>()
                 .AddScoped<UserHttpClient>()

--- a/code/FinanceManager.Domain/Commands/Account/AddFinancialLabelClassification.cs
+++ b/code/FinanceManager.Domain/Commands/Account/AddFinancialLabelClassification.cs
@@ -1,0 +1,3 @@
+namespace FinanceManager.Application.Commands.Account;
+
+public record AddFinancialLabelClassification(int LabelId, string Kind, string Value);

--- a/code/FinanceManager.Domain/Entities/Shared/Accounts/FinancialLabel.cs
+++ b/code/FinanceManager.Domain/Entities/Shared/Accounts/FinancialLabel.cs
@@ -4,4 +4,5 @@ public class FinancialLabel
 {
     public int Id { get; set; }
     public required string Name { get; set; }
+    public ICollection<FinancialLabelClassification> Classifications { get; set; } = [];
 }

--- a/code/FinanceManager.Domain/Entities/Shared/Accounts/FinancialLabelClassification.cs
+++ b/code/FinanceManager.Domain/Entities/Shared/Accounts/FinancialLabelClassification.cs
@@ -1,0 +1,9 @@
+namespace FinanceManager.Domain.Entities.Shared.Accounts;
+
+public class FinancialLabelClassification
+{
+    public int Id { get; set; }
+    public int LabelId { get; set; }
+    public required string Kind { get; set; }
+    public required string Value { get; set; }
+}

--- a/code/FinanceManager.Domain/Entities/Shared/Accounts/FinancialLabelClassificationCatalog.cs
+++ b/code/FinanceManager.Domain/Entities/Shared/Accounts/FinancialLabelClassificationCatalog.cs
@@ -1,0 +1,50 @@
+namespace FinanceManager.Domain.Entities.Shared.Accounts;
+
+public static class FinancialLabelClassificationCatalog
+{
+    public const string SpendingNecessityKind = "SpendingNecessity";
+    public const string UnknownValue = "Unknown";
+    public const string EssentialValue = "Essential";
+    public const string WantValue = "Want";
+    public const string InvestmentValue = "Investment";
+
+    public static bool TryNormalize(string kind, string value, out string normalizedKind, out string normalizedValue)
+    {
+        normalizedKind = string.Empty;
+        normalizedValue = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(kind) || string.IsNullOrWhiteSpace(value))
+            return false;
+
+        if (kind.Equals(SpendingNecessityKind, StringComparison.OrdinalIgnoreCase))
+        {
+            normalizedKind = SpendingNecessityKind;
+
+            if (value.Equals(UnknownValue, StringComparison.OrdinalIgnoreCase))
+            {
+                normalizedValue = UnknownValue;
+                return true;
+            }
+
+            if (value.Equals(EssentialValue, StringComparison.OrdinalIgnoreCase))
+            {
+                normalizedValue = EssentialValue;
+                return true;
+            }
+
+            if (value.Equals(WantValue, StringComparison.OrdinalIgnoreCase))
+            {
+                normalizedValue = WantValue;
+                return true;
+            }
+
+            if (value.Equals(InvestmentValue, StringComparison.OrdinalIgnoreCase))
+            {
+                normalizedValue = InvestmentValue;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/code/FinanceManager.Domain/Repositories/IFinancialLabelsRepository.cs
+++ b/code/FinanceManager.Domain/Repositories/IFinancialLabelsRepository.cs
@@ -11,4 +11,5 @@ public interface IFinancialLabelsRepository
     Task<bool> Add(string name, CancellationToken cancellationToken = default);
     Task<bool> Delete(int id, CancellationToken cancellationToken = default);
     Task<bool> UpdateName(int id, string name, CancellationToken cancellationToken = default);
+    Task<bool> AddClassification(int labelId, string kind, string value, CancellationToken cancellationToken = default);
 }

--- a/code/FinanceManager.Domain/Repositories/IFinancialLabelsRepository.cs
+++ b/code/FinanceManager.Domain/Repositories/IFinancialLabelsRepository.cs
@@ -11,5 +11,6 @@ public interface IFinancialLabelsRepository
     Task<bool> Add(string name, CancellationToken cancellationToken = default);
     Task<bool> Delete(int id, CancellationToken cancellationToken = default);
     Task<bool> UpdateName(int id, string name, CancellationToken cancellationToken = default);
+    /// <summary>Adds or updates a classification on the specified label. The <paramref name="kind"/> and <paramref name="value"/> must already be normalized (use <see cref="FinanceManager.Domain.Entities.Shared.Accounts.FinancialLabelClassificationCatalog.TryNormalize"/> before calling).</summary>
     Task<bool> AddClassification(int labelId, string kind, string value, CancellationToken cancellationToken = default);
 }

--- a/code/FinanceManager.Domain/Services/IEssentialSpendingService.cs
+++ b/code/FinanceManager.Domain/Services/IEssentialSpendingService.cs
@@ -1,0 +1,10 @@
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+
+namespace FinanceManager.Domain.Services;
+
+public interface IEssentialSpendingService
+{
+    Task<List<TimeSeriesModel>> GetEssentialSpending(int userId, Currency currency, DateTime start, DateTime end);
+    Task<List<TimeSeriesModel>> GetEssentialSpending(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds);
+}

--- a/code/FinanceManager.Domain/Services/IEssentialSpendingServiceTyped.cs
+++ b/code/FinanceManager.Domain/Services/IEssentialSpendingServiceTyped.cs
@@ -1,0 +1,6 @@
+namespace FinanceManager.Domain.Services;
+
+public interface IEssentialSpendingServiceTyped : IEssentialSpendingService
+{
+    bool IsOfType<T>();
+}

--- a/code/FinanceManager.Infrastructure/Contexts/AppDbContext.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/AppDbContext.cs
@@ -23,6 +23,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<StockPriceDto> StockPrices { get; set; } = default!;
     public DbSet<NewVisits> NewVisits { get; set; } = default!;
     public DbSet<FinancialLabel> FinancialLabels { get; set; } = default!;
+    public DbSet<FinancialLabelClassification> FinancialLabelClassifications { get; set; } = default!;
     public DbSet<BondDetails> Bonds { get; set; } = default!;
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -38,6 +39,8 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.ApplyConfiguration(new UserDtoConfiguration());
         modelBuilder.ApplyConfiguration(new BondDetailsConfiguration());
         modelBuilder.ApplyConfiguration(new BondCalculationMethodConfiguration());
+        modelBuilder.ApplyConfiguration(new FinancialLabelConfiguration());
+        modelBuilder.ApplyConfiguration(new FinancialLabelClassificationConfiguration());
 
         base.OnModelCreating(modelBuilder);
     }

--- a/code/FinanceManager.Infrastructure/Contexts/Configurations/FinancialLabelClassificationConfiguration.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/Configurations/FinancialLabelClassificationConfiguration.cs
@@ -1,0 +1,27 @@
+using FinanceManager.Domain.Entities.Shared.Accounts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FinanceManager.Infrastructure.Contexts.Configurations;
+
+internal class FinancialLabelClassificationConfiguration : IEntityTypeConfiguration<FinancialLabelClassification>
+{
+    public void Configure(EntityTypeBuilder<FinancialLabelClassification> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(e => e.Kind)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(e => e.Value)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.HasIndex(e => new { e.LabelId, e.Kind })
+            .IsUnique();
+    }
+}

--- a/code/FinanceManager.Infrastructure/Contexts/Configurations/FinancialLabelConfiguration.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/Configurations/FinancialLabelConfiguration.cs
@@ -8,9 +8,19 @@ internal class FinancialLabelConfiguration : IEntityTypeConfiguration<FinancialL
 {
     public void Configure(EntityTypeBuilder<FinancialLabel> builder)
     {
+        builder.HasKey(e => e.Id);
+
         builder.Property(e => e.Id)
             .ValueGeneratedOnAdd();
 
+        builder.Property(e => e.Name)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.HasMany(e => e.Classifications)
+            .WithOne()
+            .HasForeignKey(e => e.LabelId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 
 }

--- a/code/FinanceManager.Infrastructure/Repositories/FinancialLabelsRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/FinancialLabelsRepository.cs
@@ -22,14 +22,18 @@ internal class FinancialLabelsRepository(AppDbContext context) : IFinancialLabel
     }
 
     public Task<int> GetCount(CancellationToken cancellationToken = default) => context.FinancialLabels.CountAsync(cancellationToken);
-    public IAsyncEnumerable<FinancialLabel> GetLabels(CancellationToken cancellationToken = default) => context.FinancialLabels.ToAsyncEnumerable();
+    public IAsyncEnumerable<FinancialLabel> GetLabels(CancellationToken cancellationToken = default) =>
+        context.FinancialLabels.Include(x => x.Classifications).AsAsyncEnumerable();
 
-    public IAsyncEnumerable<FinancialLabel> GetLabelsByAccountId(int accountId, CancellationToken cancellationToken = default) => context.CurrencyEntries.Where(x => x.AccountId == accountId)
-        .SelectMany(x => x.Labels)
-        .Distinct()
-        .ToAsyncEnumerable();
+    public IAsyncEnumerable<FinancialLabel> GetLabelsByAccountId(int accountId, CancellationToken cancellationToken = default) =>
+        context.CurrencyEntries.Where(x => x.AccountId == accountId)
+            .SelectMany(x => x.Labels)
+            .Include(x => x.Classifications)
+            .Distinct()
+            .AsAsyncEnumerable();
 
-    public Task<FinancialLabel> GetLabelsById(int id, CancellationToken cancellationToken = default) => context.FinancialLabels.SingleAsync(x => x.Id == id, cancellationToken);
+    public Task<FinancialLabel> GetLabelsById(int id, CancellationToken cancellationToken = default) =>
+        context.FinancialLabels.Include(x => x.Classifications).SingleAsync(x => x.Id == id, cancellationToken);
 
     public async Task<bool> UpdateName(int id, string name, CancellationToken cancellationToken = default)
     {
@@ -37,5 +41,34 @@ internal class FinancialLabelsRepository(AppDbContext context) : IFinancialLabel
         elementToRemove.Name = name;
 
         return await context.SaveChangesAsync(cancellationToken) == 1;
+    }
+
+    public async Task<bool> AddClassification(int labelId, string kind, string value, CancellationToken cancellationToken = default)
+    {
+        if (!FinancialLabelClassificationCatalog.TryNormalize(kind, value, out string normalizedKind, out string normalizedValue))
+            throw new ArgumentException("Invalid financial label classification.", nameof(value));
+
+        var label = await context.FinancialLabels
+            .Include(x => x.Classifications)
+            .SingleAsync(x => x.Id == labelId, cancellationToken);
+
+        var existing = label.Classifications.SingleOrDefault(x => x.Kind == normalizedKind);
+        if (existing is null)
+        {
+            label.Classifications.Add(new FinancialLabelClassification
+            {
+                LabelId = labelId,
+                Kind = normalizedKind,
+                Value = normalizedValue
+            });
+
+            return await context.SaveChangesAsync(cancellationToken) > 0;
+        }
+
+        if (existing.Value == normalizedValue)
+            return true;
+
+        existing.Value = normalizedValue;
+        return await context.SaveChangesAsync(cancellationToken) > 0;
     }
 }

--- a/code/FinanceManager.Infrastructure/Repositories/FinancialLabelsRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/FinancialLabelsRepository.cs
@@ -45,30 +45,27 @@ internal class FinancialLabelsRepository(AppDbContext context) : IFinancialLabel
 
     public async Task<bool> AddClassification(int labelId, string kind, string value, CancellationToken cancellationToken = default)
     {
-        if (!FinancialLabelClassificationCatalog.TryNormalize(kind, value, out string normalizedKind, out string normalizedValue))
-            throw new ArgumentException("Invalid financial label classification.", nameof(value));
-
         var label = await context.FinancialLabels
             .Include(x => x.Classifications)
             .SingleAsync(x => x.Id == labelId, cancellationToken);
 
-        var existing = label.Classifications.SingleOrDefault(x => x.Kind == normalizedKind);
+        var existing = label.Classifications.SingleOrDefault(x => x.Kind == kind);
         if (existing is null)
         {
             label.Classifications.Add(new FinancialLabelClassification
             {
                 LabelId = labelId,
-                Kind = normalizedKind,
-                Value = normalizedValue
+                Kind = kind,
+                Value = value
             });
 
             return await context.SaveChangesAsync(cancellationToken) > 0;
         }
 
-        if (existing.Value == normalizedValue)
+        if (existing.Value == value)
             return true;
 
-        existing.Value = normalizedValue;
+        existing.Value = value;
         return await context.SaveChangesAsync(cancellationToken) > 0;
     }
 }

--- a/code/FinanceManager.IntegrationTests/Controllers/EssentialSpendingControllerTests.cs
+++ b/code/FinanceManager.IntegrationTests/Controllers/EssentialSpendingControllerTests.cs
@@ -1,0 +1,123 @@
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.Shared.Accounts;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Infrastructure.Contexts;
+using FinanceManager.Infrastructure.Dtos;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace FinanceManager.IntegrationTests.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public class EssentialSpendingControllerTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider), IDisposable
+{
+    private TestDatabase? _testDatabase;
+    private readonly DateTime _nowUtc = DateTime.UtcNow.Date;
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        _testDatabase = new TestDatabase();
+
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+        if (descriptor != null)
+            services.Remove(descriptor);
+
+        services.AddSingleton(_testDatabase.Context);
+
+#pragma warning disable CS0854
+        var currencyRepoMock = new Mock<ICurrencyRepository>();
+        currencyRepoMock.Setup(x => x.GetCurrencies(It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Range(0, 1).Select(_ => DefaultCurrency.USD));
+#pragma warning restore CS0854
+
+        services.AddSingleton(currencyRepoMock.Object);
+    }
+
+    private async Task SeedEssentialSpendingAccount()
+    {
+        var essentialLabel = new FinancialLabel
+        {
+            Name = "Rent",
+            Classifications =
+            [
+                new FinancialLabelClassification
+                {
+                    Kind = FinancialLabelClassificationCatalog.SpendingNecessityKind,
+                    Value = FinancialLabelClassificationCatalog.EssentialValue
+                }
+            ]
+        };
+
+        var wantLabel = new FinancialLabel
+        {
+            Name = "Entertainment",
+            Classifications =
+            [
+                new FinancialLabelClassification
+                {
+                    Kind = FinancialLabelClassificationCatalog.SpendingNecessityKind,
+                    Value = FinancialLabelClassificationCatalog.WantValue
+                }
+            ]
+        };
+
+        _testDatabase!.Context.FinancialLabels.AddRange(essentialLabel, wantLabel);
+
+        var account = new FinancialAccountBaseDto
+        {
+            UserId = 1,
+            AccountId = 1,
+            Name = "Household",
+            AccountLabel = AccountLabel.Cash,
+            AccountType = AccountType.Currency
+        };
+
+        _testDatabase.Context.Accounts.Add(account);
+        await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _testDatabase.Context.CurrencyEntries.AddRange(
+            new CurrencyAccountEntry(1, 1, _nowUtc.AddDays(-1), 950m, -50m)
+            {
+                Labels = [essentialLabel]
+            },
+            new CurrencyAccountEntry(1, 2, _nowUtc, 930m, -20m)
+            {
+                Labels = [essentialLabel, wantLabel, essentialLabel]
+            },
+            new CurrencyAccountEntry(1, 3, _nowUtc, 920m, -10m)
+            {
+                Labels = [essentialLabel, wantLabel]
+            });
+
+        await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task GetEssentialSpending_ReturnsOnlyResolvedEssentialOutflows()
+    {
+        await SeedEssentialSpendingAccount();
+        Authorize("TestUser", 1, UserRole.User);
+
+        var result = await new EssentialSpendingHttpClient(Client).GetEssentialSpending(1, DefaultCurrency.USD, _nowUtc.AddDays(-1), _nowUtc);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(-50m, result.Single(x => x.DateTime == _nowUtc.AddDays(-1)).Value);
+        Assert.Equal(-20m, result.Single(x => x.DateTime == _nowUtc).Value);
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        if (_testDatabase is null)
+            return;
+
+        _testDatabase.Dispose();
+        _testDatabase = null;
+        GC.SuppressFinalize(this);
+    }
+}

--- a/code/FinanceManager.IntegrationTests/Controllers/FinancialLabelControllerTests.cs
+++ b/code/FinanceManager.IntegrationTests/Controllers/FinancialLabelControllerTests.cs
@@ -108,6 +108,28 @@ public class FinancialLabelControllerTests(OptionsProvider optionsProvider) : Co
     }
 
     [Fact]
+    public async Task AddClassification_StoresNormalizedClassification()
+    {
+        Authorize("TestUser", 1, UserRole.User);
+
+        await new FinancialLabelHttpClient(Client).Add(new AddFinancialLabel("Rent"), TestContext.Current.CancellationToken);
+        var label = (await new FinancialLabelHttpClient(Client).Get(0, 10, TestContext.Current.CancellationToken)).Single();
+
+        var updateResult = await new FinancialLabelHttpClient(Client).AddClassification(
+            new AddFinancialLabelClassification(label.Id, "spendingnecessity", "essential"),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(updateResult);
+
+        var refreshedLabel = await new FinancialLabelHttpClient(Client).Get(label.Id, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(refreshedLabel);
+        var classification = Assert.Single(refreshedLabel.Classifications);
+        Assert.Equal(FinancialLabelClassificationCatalog.SpendingNecessityKind, classification.Kind);
+        Assert.Equal(FinancialLabelClassificationCatalog.EssentialValue, classification.Value);
+    }
+
+    [Fact]
     public async Task Delete_DeletesLabel()
     {
         Authorize("TestUser", 1, UserRole.User);

--- a/code/FinanceManager.UnitTests/Application/Services/CurrencyEssentialSpendingServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/CurrencyEssentialSpendingServiceTests.cs
@@ -1,0 +1,79 @@
+using FinanceManager.Application.Services.Currencies;
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.Shared.Accounts;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories.Account;
+using Moq;
+
+namespace FinanceManager.UnitTests.Application.Services;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class CurrencyEssentialSpendingServiceTests
+{
+    private readonly Mock<IFinancialAccountRepository> _financialAccountRepositoryMock = new();
+    private readonly CurrencyEssentialSpendingService _service;
+    private readonly DateTime _date = new(2026, 3, 10);
+
+    public CurrencyEssentialSpendingServiceTests()
+    {
+        _service = new CurrencyEssentialSpendingService(_financialAccountRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task GetEssentialSpending_IncludesOnlyResolvedEssentialOutflows()
+    {
+        var userId = 1;
+        var essentialLabel = CreateLabel("Rent", FinancialLabelClassificationCatalog.EssentialValue);
+        var wantLabel = CreateLabel("Dining", FinancialLabelClassificationCatalog.WantValue);
+        var account = new CurrencyAccount(userId, 1, "Household", AccountLabel.Cash);
+
+        account.Add(new CurrencyAccountEntry(1, 1, _date, 1000m, -100m) { Labels = [essentialLabel] });
+        account.Add(new CurrencyAccountEntry(1, 2, _date, 950m, -50m) { Labels = [essentialLabel, wantLabel, essentialLabel] });
+        account.Add(new CurrencyAccountEntry(1, 3, _date, 940m, -10m) { Labels = [essentialLabel, wantLabel] });
+        account.Add(new CurrencyAccountEntry(1, 4, _date, 1040m, 100m) { Labels = [essentialLabel] });
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new[] { account }.ToAsyncEnumerable());
+
+        var result = await _service.GetEssentialSpending(userId, DefaultCurrency.PLN, _date, _date);
+
+        Assert.Single(result);
+        Assert.Equal(-150m, result[0].Value);
+    }
+
+    [Fact]
+    public async Task GetEssentialSpending_TieResolution_ExcludesEntry()
+    {
+        var userId = 1;
+        var essentialLabel = CreateLabel("Rent", FinancialLabelClassificationCatalog.EssentialValue);
+        var wantLabel = CreateLabel("Dining", FinancialLabelClassificationCatalog.WantValue);
+        var account = new CurrencyAccount(userId, 1, "Mixed", AccountLabel.Cash);
+
+        account.Add(new CurrencyAccountEntry(1, 1, _date, 990m, -10m) { Labels = [essentialLabel, wantLabel] });
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new[] { account }.ToAsyncEnumerable());
+
+        var result = await _service.GetEssentialSpending(userId, DefaultCurrency.PLN, _date, _date);
+
+        Assert.Single(result);
+        Assert.Equal(0m, result[0].Value);
+    }
+
+    private static FinancialLabel CreateLabel(string name, string value) =>
+        new()
+        {
+            Id = Random.Shared.Next(1, int.MaxValue),
+            Name = name,
+            Classifications =
+            [
+                new FinancialLabelClassification
+                {
+                    Kind = FinancialLabelClassificationCatalog.SpendingNecessityKind,
+                    Value = value
+                }
+            ]
+        };
+}


### PR DESCRIPTION

- Introduced FinancialLabelClassification entity and its corresponding database migration.
- Updated FinancialLabel entity to include a collection of classifications.
- Implemented CurrencyEssentialSpendingService to calculate essential spending based on classifications.
- Created EssentialSpendingService to aggregate spending across different account types.
- Added EssentialSpendingHttpClient for API interactions related to essential spending.
- Developed AddFinancialLabelClassification command for adding classifications to financial labels.
- Enhanced FinancialLabelsRepository to support adding classifications.
- Implemented unit and integration tests for essential spending functionalities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added essential spending analysis with time-series results and optional account filtering.
  * Introduced financial label classifications (SpendingNecessity → Essential/Want/Investment/Unknown) with normalized input handling.
  * New endpoints and client support for retrieving essential spending and adding label classifications.

* **Tests**
  * Added unit and integration tests covering essential spending aggregation, tie-resolution rules, and classification storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->