### PR TITLE
feat: Enhance Bond Management with Unit Value Support

### DIFF
--- a/code/FinanceManager.Api/Controllers/BondDetailsController.cs
+++ b/code/FinanceManager.Api/Controllers/BondDetailsController.cs
@@ -64,6 +64,7 @@ public class BondDetailsController(IBondDetailsRepository bondDetailsRepository,
 
         bond.Name = updateBondDetails.NameToUpdate;
         bond.Issuer = updateBondDetails.IssuerToUpdate;
+        bond.UnitValue = updateBondDetails.UnitValueToUpdate;
 
         if (!await bondDetailsRepository.UpdateAsync(bond, cancellationToken))
             return NotFound();

--- a/code/FinanceManager.Api/Migrations/20260315141303_AddBondUnitValue.Designer.cs
+++ b/code/FinanceManager.Api/Migrations/20260315141303_AddBondUnitValue.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceManager.Infrastructure.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceManager.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260315141303_AddBondUnitValue")]
+    partial class AddBondUnitValue
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/code/FinanceManager.Api/Migrations/20260315141303_AddBondUnitValue.cs
+++ b/code/FinanceManager.Api/Migrations/20260315141303_AddBondUnitValue.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinanceManager.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBondUnitValue : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "UnitValue",
+                table: "Bonds",
+                type: "numeric(18,4)",
+                precision: 18,
+                scale: 4,
+                nullable: false,
+                defaultValue: 100m);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UnitValue",
+                table: "Bonds");
+        }
+    }
+}

--- a/code/FinanceManager.Application/Providers/StockPriceProvider.cs
+++ b/code/FinanceManager.Application/Providers/StockPriceProvider.cs
@@ -11,7 +11,7 @@ public class StockPriceProvider(IStockPriceRepository stockRepository, ICurrency
     {
         if (string.IsNullOrWhiteSpace(ticker)) throw new ArgumentException("{ticker}", nameof(ticker));
 
-        var key = ticker.Trim().ToUpperInvariant();
+        var key = $"STOCK_PRICE_{asOf:yyyyMMdd}_{ticker.Trim().ToUpperInvariant()}";
 
         if (cache.TryGetValue(key, out decimal cached))
             return Task.FromResult(cached);

--- a/code/FinanceManager.Application/Services/AssetsService.cs
+++ b/code/FinanceManager.Application/Services/AssetsService.cs
@@ -46,10 +46,7 @@ public class AssetsService(IEnumerable<IAssetsServiceTyped> typedAssetServices) 
             }
         }
 
-        var timeBucket = TimeBucketService.Get(prices.Select(x => (x.Key, x.Value))).OrderByDescending(x => x.Date);
-        var testResult = timeBucket.Select(x => new TimeSeriesModel() { DateTime = x.Date, Value = x.Objects.Last() }).ToList();
-
-        return timeBucket.Select(x => new TimeSeriesModel() { DateTime = x.Date, Value = x.Objects.Last() }).ToList();
+        return BucketToClosingBalanceSeries(prices);
     }
     public async Task<List<TimeSeriesModel>> GetAssetsTimeSeries(int userId, Currency currency, DateTime start, DateTime end, InvestmentType investmentType)
     {
@@ -66,7 +63,18 @@ public class AssetsService(IEnumerable<IAssetsServiceTyped> typedAssetServices) 
             }
         }
 
-        var timeBucket = TimeBucketService.Get(prices.Select(x => (x.Key, x.Value))).OrderByDescending(x => x.Date);
-        return timeBucket.Select(x => new TimeSeriesModel() { DateTime = x.Date, Value = x.Objects.Last() }).ToList();
+        return BucketToClosingBalanceSeries(prices);
+    }
+
+    private static List<TimeSeriesModel> BucketToClosingBalanceSeries(Dictionary<DateTime, decimal> data)
+    {
+        var dailyTotals = data
+            .GroupBy(x => x.Key.Date)
+            .ToDictionary(group => group.Key, group => group.Sum(x => x.Value));
+
+        return TimeBucketService.Get(dailyTotals.OrderBy(x => x.Key).Select(x => (x.Key, x.Value)))
+            .OrderByDescending(x => x.Date)
+            .Select(bucket => new TimeSeriesModel() { DateTime = bucket.Date, Value = bucket.Objects.Last() })
+            .ToList();
     }
 }

--- a/code/FinanceManager.Application/Services/Bonds/AssetsServiceBond.cs
+++ b/code/FinanceManager.Application/Services/Bonds/AssetsServiceBond.cs
@@ -57,22 +57,38 @@ public class AssetsServiceBond(IFinancialAccountRepository financialAccountRepos
 
     public async IAsyncEnumerable<NameValueResult> GetEndAssetsPerAccount(int userId, Currency currency, DateTime asOfDate)
     {
-        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, asOfDate.AddMinutes(-1), asOfDate).Where(x => x.ContainsAssets))
-            yield return new(account.Name, account.Entries.First().Value);
-    }
+        var bondDetails = await bondDetailsRepository.GetAllAsync().ToDictionaryAsync(x => x.Id);
 
-    public async IAsyncEnumerable<NameValueResult> GetEndAssetsPerType(int userId, Currency currency, DateTime asOfDate)
-    {
         await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, asOfDate.AddMinutes(-1), asOfDate).Where(x => x.ContainsAssets))
         {
             decimal value = 0;
             foreach (var bondDetailsId in account.GetStoredBondsIds())
             {
-                var latestEntry = account.Get(asOfDate)
-                    .FirstOrDefault(x => x.BondDetailsId == bondDetailsId);
+                var latestEntry = account.GetThisOrNextOlder(asOfDate, bondDetailsId);
                 if (latestEntry is null) continue;
+                if (!bondDetails.TryGetValue(bondDetailsId, out var details)) continue;
 
-                value += latestEntry.Value;
+                value += latestEntry.GetPriceAt(DateOnly.FromDateTime(asOfDate), details);
+            }
+
+            yield return new(account.Name, value);
+        }
+    }
+
+    public async IAsyncEnumerable<NameValueResult> GetEndAssetsPerType(int userId, Currency currency, DateTime asOfDate)
+    {
+        var bondDetails = await bondDetailsRepository.GetAllAsync().ToDictionaryAsync(x => x.Id);
+
+        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, asOfDate.AddMinutes(-1), asOfDate).Where(x => x.ContainsAssets))
+        {
+            decimal value = 0;
+            foreach (var bondDetailsId in account.GetStoredBondsIds())
+            {
+                var latestEntry = account.GetThisOrNextOlder(asOfDate, bondDetailsId);
+                if (latestEntry is null) continue;
+                if (!bondDetails.TryGetValue(bondDetailsId, out var details)) continue;
+
+                value += latestEntry.GetPriceAt(DateOnly.FromDateTime(asOfDate), details);
             }
 
             yield return new(account.Name, value);

--- a/code/FinanceManager.Application/Services/Bonds/BondBalanceService.cs
+++ b/code/FinanceManager.Application/Services/Bonds/BondBalanceService.cs
@@ -79,7 +79,7 @@ internal class BondBalanceService(IFinancialAccountRepository financialAccountRe
                 if (!predicate(entry)) continue;
                 if (!bondDetails.TryGetValue(entry.BondDetailsId, out var details)) continue;
 
-                var priceAtDate = entry.GetPrice(DateOnly.FromDateTime(entry.PostingDate), details).Values.LastOrDefault();
+                var priceAtDate = entry.ValueChange * details.UnitValue;
                 if (!result.ContainsKey(entry.PostingDate.Date)) result[entry.PostingDate.Date] = 0;
 
                 result[entry.PostingDate.Date] += entry.ValueChange >= 0 ? priceAtDate : -Math.Abs(priceAtDate);

--- a/code/FinanceManager.Application/Services/InvestmentPaycheckEstimatorService.cs
+++ b/code/FinanceManager.Application/Services/InvestmentPaycheckEstimatorService.cs
@@ -12,7 +12,8 @@ namespace FinanceManager.Application.Services;
 public class InvestmentPaycheckEstimatorService(
     IFinancialAccountRepository financialAccountRepository,
     IFinancialLabelsRepository financialLabelsRepository,
-    IStockPriceProvider stockPriceProvider) : IInvestmentPaycheckEstimatorService
+    IStockPriceProvider stockPriceProvider,
+    IBondDetailsRepository bondDetailsRepository) : IInvestmentPaycheckEstimatorService
 {
     public async Task<InvestmentPaycheckEstimate> GetEstimate(int userId, Currency currency, DateTime asOfDate, decimal annualWithdrawalRate = 0.05m, int salaryMonths = 3)
     {
@@ -49,6 +50,7 @@ public class InvestmentPaycheckEstimatorService(
     private async Task<decimal> GetInvestableAssetsValue(int userId, Currency currency, DateTime asOfDate)
     {
         decimal result = 0;
+        var bondDetails = await bondDetailsRepository.GetAllAsync().ToDictionaryAsync(x => x.Id);
 
         await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, asOfDate.Date, asOfDate))
         {
@@ -57,8 +59,10 @@ public class InvestmentPaycheckEstimatorService(
                 var newestEntry = account.GetThisOrNextOlder(asOfDate, detailsId);
                 if (newestEntry is null)
                     continue;
+                if (!bondDetails.TryGetValue(detailsId, out var details))
+                    continue;
 
-                result += newestEntry.Value;
+                result += newestEntry.GetPriceAt(DateOnly.FromDateTime(asOfDate), details);
             }
         }
 

--- a/code/FinanceManager.Application/Services/MoneyFlowService.cs
+++ b/code/FinanceManager.Application/Services/MoneyFlowService.cs
@@ -11,12 +11,13 @@ using FinanceManager.Domain.Services;
 namespace FinanceManager.Application.Services;
 
 public class MoneyFlowService(IFinancialAccountRepository financialAccountRepository, IFinancialLabelsRepository financialLabelsRepository,
-IStockPriceProvider stockPriceProvider) : IMoneyFlowService
+IStockPriceProvider stockPriceProvider, IBondDetailsRepository bondDetailsRepository) : IMoneyFlowService
 {
     public async Task<decimal?> GetNetWorth(int userId, Currency currency, DateTime date)
     {
         if (date > DateTime.UtcNow) date = DateTime.UtcNow;
         decimal result = 0;
+        var bondDetails = await bondDetailsRepository.GetAllAsync().ToDictionaryAsync(x => x.Id);
 
         await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, date.Date, date))
         {
@@ -32,8 +33,9 @@ IStockPriceProvider stockPriceProvider) : IMoneyFlowService
             {
                 var newestEntry = account.GetThisOrNextOlder(date, detailsId);
                 if (newestEntry is null) continue;
+                if (!bondDetails.TryGetValue(detailsId, out var details)) continue;
 
-                result += newestEntry.Value;
+                result += newestEntry.GetPriceAt(DateOnly.FromDateTime(date), details);
             }
         }
 

--- a/code/FinanceManager.Application/Services/Seeders/BondDetailsSeeder.cs
+++ b/code/FinanceManager.Application/Services/Seeders/BondDetailsSeeder.cs
@@ -24,6 +24,7 @@ public class BondDetailsSeeder(IBondDetailsRepository bondDetailsRepository, ICu
                 EndEmissionDate = new DateOnly(2034, 7, 1),
                 Type = BondType.InflationBond,
                 Currency = plnCurrency,
+                UnitValue = 100m,
                 CalculationMethods =
                 [
                     new ()
@@ -42,6 +43,7 @@ public class BondDetailsSeeder(IBondDetailsRepository bondDetailsRepository, ICu
                 EndEmissionDate = new DateOnly(2034, 4, 1),
                 Type = BondType.InflationBond,
                 Currency = plnCurrency,
+                UnitValue = 100m,
                 CalculationMethods =
                 [
                     new ()
@@ -60,6 +62,7 @@ public class BondDetailsSeeder(IBondDetailsRepository bondDetailsRepository, ICu
                 EndEmissionDate = new DateOnly(2035, 12, 1),
                 Type = BondType.InflationBond,
                 Currency = plnCurrency,
+                UnitValue = 100m,
                 CalculationMethods =
                 [
                     new ()

--- a/code/FinanceManager.Components/Components/Admin/AdminAddBondDetails.razor
+++ b/code/FinanceManager.Components/Components/Admin/AdminAddBondDetails.razor
@@ -48,6 +48,10 @@
             </MudItem>
 
             <MudItem xs="12" sm="6">
+                <MudNumericField T="decimal?" Label="Unit value" @bind-Value="_unitValue" Variant="Variant.Text" />
+            </MudItem>
+
+            <MudItem xs="12" sm="6">
                 <MudSelect T="Capitalization" Label="Capitalization" @bind-Value="_selectedCapitalization" Disabled="true">
                     @foreach (var cap in _capitalizations)
                     {

--- a/code/FinanceManager.Components/Components/Admin/AdminAddBondDetails.razor.cs
+++ b/code/FinanceManager.Components/Components/Admin/AdminAddBondDetails.razor.cs
@@ -22,6 +22,7 @@ public partial class AdminAddBondDetails : ComponentBase
 
     private BondType _selectedType = BondType.InflationBond;
     private Currency _selectedCurrency = DefaultCurrency.PLN;
+    private decimal? _unitValue = 100m;
     private Capitalization _selectedCapitalization = BondDetails.Capitalization;
 
     private DateOperator _methodDateOperator = DateOperator.UntilDate;
@@ -87,6 +88,12 @@ public partial class AdminAddBondDetails : ComponentBase
             return;
         }
 
+        if (!_unitValue.HasValue || _unitValue.Value <= 0)
+        {
+            _errors.Add("Unit value must be greater than 0.");
+            return;
+        }
+
         if (_calculationMethods.Count == 0)
         {
             _errors.Add("At least one calculation method is required.");
@@ -101,6 +108,7 @@ public partial class AdminAddBondDetails : ComponentBase
             EndEmissionDate = DateOnly.FromDateTime(_endDate.Value),
             Type = _selectedType,
             Currency = _selectedCurrency,
+            UnitValue = _unitValue.Value,
             CalculationMethods = _calculationMethods.ToList(),
         };
 

--- a/code/FinanceManager.Components/Components/Admin/AdminBondDetails.razor
+++ b/code/FinanceManager.Components/Components/Admin/AdminBondDetails.razor
@@ -28,12 +28,14 @@
                 <MudTh>Id</MudTh>
                 <MudTh>Name</MudTh>
                 <MudTh>Issuer</MudTh>
+                <MudTh>Unit value</MudTh>
                 <MudTh>Action</MudTh>
             </HeaderContent>
             <RowTemplate>
                 <MudTd DataLabel="Id">@context.Id</MudTd>
                 <MudTd DataLabel="Name">@context.Name</MudTd>
                 <MudTd DataLabel="Issuer">@context.Issuer</MudTd>
+                <MudTd DataLabel="Unit value">@context.UnitValue @context.Currency.ShortName</MudTd>
                 <MudTd DataLabel="Action">
                     <MudStack Row Spacing="1">
                         <MudIconButton Icon="@Icons.Material.Filled.Info" Color="Color.Primary"

--- a/code/FinanceManager.Components/Components/Admin/BondDetailsInfoDialog.razor
+++ b/code/FinanceManager.Components/Components/Admin/BondDetailsInfoDialog.razor
@@ -33,6 +33,10 @@
                     <MudText>@Details.Currency</MudText>
                 </MudItem>
                 <MudItem xs="12" sm="6">
+                    <MudText Typo="Typo.subtitle2">Unit value</MudText>
+                    <MudText>@Details.UnitValue @Details.Currency.ShortName</MudText>
+                </MudItem>
+                <MudItem xs="12" sm="6">
                     <MudText Typo="Typo.subtitle2">Capitalization</MudText>
                     <MudText>@BondDetails.Capitalization</MudText>
                 </MudItem>

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/AddBondEntry.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/AddBondEntry.razor
@@ -12,13 +12,16 @@
                 <MudText Typo="Typo.subtitle1">@BondAccount.Name</MudText>
             </MudItem>
             <MudItem xs="12" sm="6">
-                <MudDatePicker Label="Posting date" @bind-Date="_postingDate" Validation="@(new NotInFutureAttribute())" />
+                <MudDatePicker Label="Posting date" @bind-Date="_postingDate"
+                               Validation="@(new NotInFutureAttribute())" />
             </MudItem>
             <MudItem xs="12" sm="6">
-                <MudTimePicker Label="Time" @bind-Time="_time" Validation="@(new NotInFutureAttributeTime(_postingDate))" />
+                <MudTimePicker Label="Time" @bind-Time="_time"
+                               Validation="@(new NotInFutureAttributeTime(_postingDate))" />
             </MudItem>
             <MudItem xs="12" sm="6">
-                <MudNumericField Required="true" HideSpinButtons="true" @bind-Value="ValueChange" Label="Value change" Variant="Variant.Text" AdornmentText="@_currency.ShortName" Adornment="Adornment.End" />
+                <MudNumericField Required="true" HideSpinButtons="true" @bind-Value="ValueChange" Label="Units change"
+                                 Variant="Variant.Text" />
             </MudItem>
             <MudItem xs="12" sm="6">
                 <MudSelect T="BondDetails" Label="Bond" @bind-Value="_selectedBond" ToStringFunc="@(b => b?.Name)">
@@ -28,32 +31,41 @@
                     }
                 </MudSelect>
             </MudItem>
-            <MudItem xs="12" sm="6">
-                <MudSelect T="string" Label="Label" MultiSelection="true" @bind-Value="_labelValue" @bind-SelectedValues="_selectedLabels">
-                    @foreach (var state in _possibleLabels.Select(x => x.Name))
-                    {
-                        <MudSelectItem T="string" Value="@state">@state</MudSelectItem>
-                    }
-                </MudSelect>
-            </MudItem>
-            <MudItem xs="12">
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick=Add>Add</MudButton>
-                <MudButton Variant="Variant.Outlined" Color="Color.Secondary" DropShadow="false" OnClick=Cancel Class="mx-2">Cancel</MudButton>
-                @if (CustomButton is not null)
-                {
-                    @CustomButton
-                }
-            </MudItem>
-            
-            @if (_errors.Any())
+            @if (_selectedBond is not null)
             {
                 <MudItem xs="12">
-                    @foreach (var error in _errors)
-                    {
-                        <MudAlert Severity="Severity.Error">@error</MudAlert>
-                                            }
+                    <MudText Typo="Typo.caption" Class="mud-text-secondary">Unit value: @_selectedBond.UnitValue
+                        @_selectedBond.Currency.ShortName</MudText>
+                    </MudItem>
+                }
+                <MudItem xs="12" sm="6">
+                    <MudSelect T="string" Label="Label" MultiSelection="true" @bind-Value="_labelValue"
+                               @bind-SelectedValues="_selectedLabels">
+                        @foreach (var state in _possibleLabels.Select(x => x.Name))
+                        {
+                            <MudSelectItem T="string" Value="@state">@state</MudSelectItem>
+                        }
+                    </MudSelect>
                 </MudItem>
-            }
-        </MudGrid>
-    </MudContainer>
-</MudForm>
+                <MudItem xs="12">
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick=Add>Add</MudButton>
+                    <MudButton Variant="Variant.Outlined" Color="Color.Secondary" DropShadow="false" OnClick=Cancel
+                               Class="mx-2">Cancel</MudButton>
+                    @if (CustomButton is not null)
+                    {
+                        @CustomButton
+                    }
+                </MudItem>
+
+                @if (_errors.Any())
+                {
+                    <MudItem xs="12">
+                        @foreach (var error in _errors)
+                        {
+                            <MudAlert Severity="Severity.Error">@error</MudAlert>
+                        }
+                    </MudItem>
+                }
+            </MudGrid>
+        </MudContainer>
+    </MudForm>

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor
@@ -5,8 +5,8 @@
 
 @if (Account is not null && Account.Entries is not null && (IsLoading || Account.Entries.Any()))
 {
-    <AccountDetailsPageContent AccountName="@Account.Name"         ChartData="ChartData"              IsLoading="@IsLoading"
-                               IsLoadingMore="@_isLoadingMore"                  LoadedAllData="@_loadedAllData"                      OnLoadMore="LoadMore">
+    <AccountDetailsPageContent AccountName="@Account.Name" ChartData="ChartData" IsLoading="@IsLoading"
+                               IsLoadingMore="@_isLoadingMore" LoadedAllData="@_loadedAllData" OnLoadMore="LoadMore">
         <ActionButtons>
             <MudButton Variant="Variant.Text" Class="col-12" href="@($"Import/{Account.AccountId}")" Disabled>Import
             </MudButton>
@@ -15,7 +15,7 @@
             </MudButton>
         </ActionButtons>
         <AddEntryOverlay>
-            <MudFab Color="MudBlazor.Color.Primary" StartIcon="@Icons.Material.Filled.Add" Label="Add"       OnClick=ShowOverlay
+            <MudFab Color="MudBlazor.Color.Primary" StartIcon="@Icons.Material.Filled.Add" Label="Add" OnClick=ShowOverlay
                     Style="margin-left: 30px; position: fixed; bottom: 3vh; z-index:2;" />
 
             <MudOverlay Visible="@_addEntryVisibility" DarkBackground="true">
@@ -54,17 +54,17 @@
 
                     @if (_top5 is not null && _top5.Any())
                     {
-                        <AccountTopBottomList Title="Top 5"                         Items="_top5 ?? []"                                             ValueColor="Color.Success"
+                        <AccountTopBottomList Title="Top 5" Items="_top5 ?? []" ValueColor="Color.Success"
                                               ItemTitle="@(item => _bondDetails.FirstOrDefault(x => x.Id == item.Item1.BondDetailsId)?.Name ?? "Bond")"
-                                              ItemValue="@(item => $"{item.Item2} {_currency}")"
+                                              ItemValue="@(item => $"{item.Item2} units")"
                                               ItemDate="@(item => item.Item1.PostingDate.ToString("yyyy-MM-dd"))" />
                     }
 
                     @if (_bottom5 is not null && _bottom5.Any())
                     {
-                        <AccountTopBottomList Title="Bottom 5"                          Items="_bottom5 ?? []"                  ValueColor="Color.Error"
+                        <AccountTopBottomList Title="Bottom 5" Items="_bottom5 ?? []" ValueColor="Color.Error"
                                               ItemTitle="@(item => _bondDetails.FirstOrDefault(x => x.Id == item.Item1.BondDetailsId)?.Name ?? "Bond")"
-                                              ItemValue="@(item => $"{item.Item2} {_currency}")"
+                                              ItemValue="@(item => $"{item.Item2} units")"
                                               ItemDate="@(item => item.Item1.PostingDate.ToString("yyyy-MM-dd"))" />
                     }
                 </MudStack>

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsRow.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsRow.razor
@@ -17,13 +17,13 @@
                 </MudText>
             </MudItem>
             <MudItem xs="3">
-                <MudText Typo="Typo.caption" Color="Color.Default">Balance</MudText>
-                <MudText Typo="Typo.body1">@BondAccountEntry.Value @_currency</MudText>
+                <MudText Typo="Typo.caption" Color="Color.Default">Balance units</MudText>
+                <MudText Typo="Typo.body1">@BondAccountEntry.Value</MudText>
             </MudItem>
             <MudItem xs="3">
-                <MudText Typo="Typo.caption" Color="Color.Default">Change</MudText>
+                <MudText Typo="Typo.caption" Color="Color.Default">Change units</MudText>
                 <MudText Typo="Typo.body1" Color="@(BondAccountEntry.ValueChange > 0 ? Color.Success : Color.Error)">
-                    @BondAccountEntry.ValueChange @_currency
+                    @BondAccountEntry.ValueChange
                 </MudText>
             </MudItem>
             <MudItem xs="3">
@@ -62,6 +62,21 @@
                                 <MudText Typo="Typo.caption" Color="Color.Default">Issuer</MudText>
                                 <MudText Typo="Typo.body1">@BondDetails.Issuer</MudText>
                             </MudItem>
+                            <MudItem xs="6">
+                                <MudText Typo="Typo.caption" Color="Color.Default">Unit value</MudText>
+                                <MudText Typo="Typo.body1">@BondDetails.UnitValue @BondDetails.Currency.ShortName</MudText>
+                            </MudItem>
+                            <MudItem xs="6">
+                                <MudText Typo="Typo.caption" Color="Color.Default">Current value</MudText>
+                                <MudText Typo="Typo.body1">@(CurrentValue?.ToString() ?? "-") @_currency</MudText>
+                            </MudItem>
+                        }
+                        @if (UnitsChangeValue.HasValue)
+                        {
+                            <MudItem xs="12">
+                                <MudText Typo="Typo.caption" Color="Color.Default">Change value</MudText>
+                                <MudText Typo="Typo.body1">@UnitsChangeValue @_currency</MudText>
+                            </MudItem>
                         }
                     </MudGrid>
                     <MudGrid>
@@ -88,6 +103,6 @@
 <MudOverlay @bind-Visible=_removeEntryVisibility DarkBackground="true">
     <MudPaper Class="p-5">
         <RemoveBondEntry BondAccountName=@BondAccount.Name BondAccountEntry="BondAccountEntry" Cancel="HideOverlay"
-            Confirm="Confirm" />
+                         Confirm="Confirm" />
     </MudPaper>
 </MudOverlay>

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsRow.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsRow.razor.cs
@@ -23,6 +23,9 @@ public partial class BondAccountDetailsRow : ComponentBase
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILogger<BondAccountDetailsRow> Logger { get; set; }
 
+    private decimal? CurrentValue => BondDetails is null ? null : BondAccountEntry.Value * BondDetails.UnitValue;
+    private decimal? UnitsChangeValue => BondDetails is null ? null : BondAccountEntry.ValueChange * BondDetails.UnitValue;
+
     protected override void OnInitialized() => _currency = SettingsService.GetCurrency();
 
     public void ShowEditOverlay()

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/RemoveBondEntry.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/RemoveBondEntry.razor
@@ -12,9 +12,10 @@
                 <MudText Typo="Typo.h4">Remove</MudText>
                 <MudText Typo="Typo.subtitle1">@BondAccountName</MudText>
             </MudItem>
-            
+
             <MudItem xs="12" sm="6">
-                <MudNumericField Required="true" HideSpinButtons="true" @bind-Value="ValueChange" Label="Value change" Variant="Variant.Text" AdornmentText="@_currency.ShortName" Adornment="Adornment.End" ReadOnly />
+                <MudNumericField Required="true" HideSpinButtons="true" @bind-Value="ValueChange" Label="Units change"
+                                 Variant="Variant.Text" ReadOnly />
             </MudItem>
 
             <MudItem xs="12" sm="6">
@@ -22,12 +23,14 @@
             </MudItem>
 
             <MudItem xs="12">
-                <MudButton Variant="Variant.Outlined" Color="Color.Primary" DropShadow="false" OnClick=Cancel>Cancel</MudButton>
-                <MudButton Variant="Variant.Filled" Color="Color.Secondary" DropShadow="false" OnClick=Confirm Class="mx-2">Confirm</MudButton>
-            </MudItem>
-        </MudGrid>
-    </MudContainer>
-}
+                <MudButton Variant="Variant.Outlined" Color="Color.Primary" DropShadow="false" OnClick=Cancel>Cancel
+                </MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Secondary" DropShadow="false" OnClick=Confirm Class="mx-2">
+                    Confirm</MudButton>
+                </MudItem>
+            </MudGrid>
+        </MudContainer>
+    }
 
 @code {
     private DateTime? date = new DateTime();
@@ -38,7 +41,7 @@
     [Parameter] public required Func<Task> Cancel { get; set; }
     [Parameter] public required string BondAccountName { get; set; }
     [Parameter] public required BondAccountEntry BondAccountEntry { get; set; }
-    
+
     [Inject] public required ISettingsService SettingsService { get; set; }
 
     protected override void OnParametersSet()

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/UpdateBondEntry.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/UpdateBondEntry.razor
@@ -17,13 +17,15 @@
                     <MudText Typo="Typo.subtitle1">@BondAccount.Name</MudText>
                 </MudItem>
                 <MudItem xs="12" sm="6">
-                    <MudDatePicker Label="Posting date" @bind-Date="_postingDate" Validation="@(new NotInFutureAttribute())" />
+                    <MudDatePicker Label="Posting date" @bind-Date="_postingDate"
+                                   Validation="@(new NotInFutureAttribute())" />
                 </MudItem>
                 <MudItem xs="12" sm="6">
                     <MudTimePicker Label="Time" @bind-Time="_time" />
                 </MudItem>
                 <MudItem xs="12" sm="6">
-                    <MudNumericField Required="true" HideSpinButtons="true" @bind-Value="_valueChange" Label="Value change" Variant="Variant.Text" AdornmentText="@_currency.ShortName" Adornment="Adornment.End" />
+                    <MudNumericField Required="true" HideSpinButtons="true" @bind-Value="_valueChange" Label="Units change"
+                                     Variant="Variant.Text" />
                 </MudItem>
                 <MudItem xs="12" sm="6">
                     <MudSelect T="BondDetails" Label="Bond" @bind-Value="_selectedBond" ToStringFunc="@(b => b?.Name)">
@@ -33,19 +35,29 @@
                         }
                     </MudSelect>
                 </MudItem>
-                <MudItem xs="12" sm="6">
-                    <MudSelect T="string" Label="Label" MultiSelection="true" @bind-Value="_labelValue" @bind-SelectedValues="_selectedLabels">
-                        @foreach (var state in _possibleLabels.Select(x => x.Name))
-                        {
-                            <MudSelectItem T="string" Value="@state">@state</MudSelectItem>
-                        }
-                    </MudSelect>
-                </MudItem>
-                <MudItem xs="12">
-                    <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick=Update>Update</MudButton>
-                    <MudButton Variant="Variant.Outlined" Color="Color.Secondary" DropShadow="false" OnClick=Cancel Class="mx-2">Cancel</MudButton>
-                </MudItem>
-            </MudGrid>
-        </MudContainer>
-    </MudForm>
-}
+                @if (_selectedBond is not null)
+                {
+                    <MudItem xs="12">
+                        <MudText Typo="Typo.caption" Class="mud-text-secondary">Unit value: @_selectedBond.UnitValue
+                            @_selectedBond.Currency.ShortName</MudText>
+                        </MudItem>
+                    }
+                    <MudItem xs="12" sm="6">
+                        <MudSelect T="string" Label="Label" MultiSelection="true" @bind-Value="_labelValue"
+                                   @bind-SelectedValues="_selectedLabels">
+                            @foreach (var state in _possibleLabels.Select(x => x.Name))
+                            {
+                                <MudSelectItem T="string" Value="@state">@state</MudSelectItem>
+                            }
+                        </MudSelect>
+                    </MudItem>
+                    <MudItem xs="12">
+                        <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick=Update>Update
+                        </MudButton>
+                        <MudButton Variant="Variant.Outlined" Color="Color.Secondary" DropShadow="false" OnClick=Cancel
+                                   Class="mx-2">Cancel</MudButton>
+                    </MudItem>
+                </MudGrid>
+            </MudContainer>
+        </MudForm>
+    }

--- a/code/FinanceManager.Domain/Commands/Bonds/UpdateBondDetails.cs
+++ b/code/FinanceManager.Domain/Commands/Bonds/UpdateBondDetails.cs
@@ -1,3 +1,3 @@
 namespace FinanceManager.Application.Commands.Bonds;
 
-public record UpdateBondDetails(int Id, string NameToUpdate, string IssuerToUpdate);
+public record UpdateBondDetails(int Id, string NameToUpdate, string IssuerToUpdate, decimal UnitValueToUpdate);

--- a/code/FinanceManager.Domain/Entities/FinancialAccounts/Bonds/BondAccount.cs
+++ b/code/FinanceManager.Domain/Entities/FinancialAccounts/Bonds/BondAccount.cs
@@ -149,20 +149,27 @@ public class BondAccount : FinancialAccountBase<BondAccountEntry>
         var result = new Dictionary<DateOnly, decimal>();
         if (Entries is null || start > end) return result;
 
-        var detailsIds = Entries.Select(e => e.BondDetailsId).Distinct().ToList();
+        var detailsIds = Entries.Select(e => e.BondDetailsId)
+            .Concat(NextOlderEntries.Keys)
+            .Distinct()
+            .ToList();
         if (!detailsIds.All(id => bondDetails.Any(bd => bd.Id == id)))
             throw new ArgumentException("Not all BondDetails are provided for the entries in this account.");
 
-        List<Dictionary<DateOnly, decimal>> pricesPerDetail = [];
-        foreach (var entry in Entries.Where(x => x.PostingDate <= end.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)))
-            pricesPerDetail.Add(entry.GetPrice(end, bondDetails.Single(bd => bd.Id == entry.BondDetailsId)));
-
-        foreach (var price in pricesPerDetail.SelectMany(dict => dict).OrderBy(x => x.Key))
+        for (var date = start; date <= end; date = date.AddDays(1))
         {
-            if (result.ContainsKey(price.Key))
-                result[price.Key] += price.Value;
-            else
-                result[price.Key] = price.Value;
+            decimal total = 0;
+            foreach (var detailId in detailsIds)
+            {
+                var currentEntry = GetThisOrNextOlder(date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc), detailId);
+                if (currentEntry is null) continue;
+
+                var details = bondDetails.Single(bd => bd.Id == detailId);
+                total += currentEntry.GetPriceAt(date, details);
+            }
+
+            if (total != 0)
+                result[date] = total;
         }
 
         return result;
@@ -181,9 +188,10 @@ public class BondAccount : FinancialAccountBase<BondAccountEntry>
 
     public List<int> GetStoredBondsIds()
     {
-        if (Entries is null) return [];
-
-        return Entries.DistinctBy(x => x.BondDetailsId).Select(x => x.BondDetailsId).ToList();
+        return Entries.Select(x => x.BondDetailsId)
+            .Concat(NextOlderEntries.Keys)
+            .Distinct()
+            .ToList();
     }
 
 }

--- a/code/FinanceManager.Domain/Entities/FinancialAccounts/Bonds/BondAccountEntry.cs
+++ b/code/FinanceManager.Domain/Entities/FinancialAccounts/Bonds/BondAccountEntry.cs
@@ -22,6 +22,15 @@ public class BondAccountEntry(int accountId, int entryId, DateTime postingDate, 
         Labels = this.Labels,
     };
 
+    public decimal GetPriceAt(DateOnly date, BondDetails bondDetails)
+    {
+        if (date < DateOnly.FromDateTime(PostingDate))
+            return 0;
+
+        var priceHistory = GetPrice(date, bondDetails);
+        return priceHistory.TryGetValue(date, out var price) ? price : 0;
+    }
+
     public Dictionary<DateOnly, decimal> GetPrice(DateOnly date, BondDetails bondDetails)
     {
         if (bondDetails.CalculationMethods.Count == 0) throw new InvalidOperationException($"{nameof(BondDetails.CalculationMethods)} can't be empty");
@@ -31,10 +40,10 @@ public class BondAccountEntry(int accountId, int entryId, DateTime postingDate, 
         {
             case Capitalization.Annual:
                 Dictionary<DateOnly, decimal> result = [];
-                decimal capital = ValueChange;
+                decimal capital = Value;
                 decimal current = capital;
                 var postingDate = DateOnly.FromDateTime(PostingDate);
-                result[postingDate] = current;
+                result[postingDate] = current * bondDetails.UnitValue;
                 for (var i = postingDate.AddDays(1); i <= date; i = i.AddDays(1))
                 {
                     var calculation = bondDetails.CalculationMethods.FirstOrDefault(cm => cm.IsActiveAt(i));
@@ -44,7 +53,7 @@ public class BondAccountEntry(int accountId, int entryId, DateTime postingDate, 
 
                     if ((i.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc) - postingDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc)).Days % 365 == 0)
                         capital = current;
-                    result[i] = current;
+                    result[i] = current * bondDetails.UnitValue;
                 }
                 return result;
 

--- a/code/FinanceManager.Domain/Entities/FinancialAccounts/Bonds/BondDetails.cs
+++ b/code/FinanceManager.Domain/Entities/FinancialAccounts/Bonds/BondDetails.cs
@@ -14,6 +14,7 @@ public class BondDetails
     public DateOnly EndEmissionDate { get; set; }
     public required BondType Type { get; set; }
     public required Currency Currency { get; set; }
+    public decimal UnitValue { get; set; } = 100m;
     public List<BondCalculationMethod> CalculationMethods { get; set; } = [];
     public static Capitalization Capitalization => Capitalization.Annual;
 
@@ -24,7 +25,8 @@ public class BondDetails
     [SetsRequiredMembers]
     [JsonConstructor]
     public BondDetails(string name, string issuer, DateOnly startEmissionDate, DateOnly endEmissionDate,
-        List<BondCalculationMethod> calculationMethods, Currency? currency = null, BondType type = BondType.InflationBond)
+        List<BondCalculationMethod> calculationMethods, Currency? currency = null, BondType type = BondType.InflationBond,
+        decimal unitValue = 100m)
     {
         Name = name;
         Issuer = issuer;
@@ -32,6 +34,7 @@ public class BondDetails
         EndEmissionDate = endEmissionDate;
         Type = type;
         Currency = currency ?? DefaultCurrency.PLN;
+        UnitValue = unitValue;
 
         var methodsWithBackRefs = calculationMethods
             .Select(m => m with { BondDetails = this })

--- a/code/FinanceManager.Infrastructure/Contexts/Configurations/BondDetailsConfiguration.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/Configurations/BondDetailsConfiguration.cs
@@ -19,6 +19,10 @@ public class BondDetailsConfiguration : IEntityTypeConfiguration<BondDetails>
             .IsRequired()
             .HasMaxLength(200);
 
+        builder.Property(e => e.UnitValue)
+            .HasPrecision(18, 4)
+            .HasDefaultValue(100m);
+
         // Store enum as int
         builder.Property(e => e.Type).HasConversion<int>();
 

--- a/code/FinanceManager.IntegrationTests/Controllers/BondDetailsControllerTests.cs
+++ b/code/FinanceManager.IntegrationTests/Controllers/BondDetailsControllerTests.cs
@@ -41,6 +41,7 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
             EndEmissionDate = new DateOnly(2028, 1, 1),
             Type = BondType.InflationBond,
             Currency = DefaultCurrency.PLN,
+            UnitValue = 100m,
             CalculationMethods =
             [
                 new()
@@ -59,6 +60,7 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
         Assert.NotNull(result);
         Assert.Equal("Test Bond", result.Name);
         Assert.Equal("Test Issuer", result.Issuer);
+        Assert.Equal(100m, result.UnitValue);
         Assert.True(result.Id > 0);
     }
 
@@ -75,7 +77,8 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
             StartEmissionDate = new DateOnly(2024, 1, 1),
             EndEmissionDate = new DateOnly(2028, 1, 1),
             Type = BondType.InflationBond,
-            Currency = DefaultCurrency.PLN
+            Currency = DefaultCurrency.PLN,
+            UnitValue = 100m
         };
         var added = await client.Add(bond, TestContext.Current.CancellationToken);
 
@@ -102,7 +105,8 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
             StartEmissionDate = new DateOnly(2024, 1, 1),
             EndEmissionDate = new DateOnly(2028, 1, 1),
             Type = BondType.InflationBond,
-            Currency = DefaultCurrency.PLN
+            Currency = DefaultCurrency.PLN,
+            UnitValue = 100m
         }, TestContext.Current.CancellationToken);
         await client.Add(new BondDetails
         {
@@ -111,7 +115,8 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
             StartEmissionDate = new DateOnly(2024, 6, 1),
             EndEmissionDate = new DateOnly(2028, 6, 1),
             Type = BondType.InflationBond,
-            Currency = DefaultCurrency.PLN
+            Currency = DefaultCurrency.PLN,
+            UnitValue = 100m
         }, TestContext.Current.CancellationToken);
 
         // Act
@@ -137,7 +142,8 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
             StartEmissionDate = new DateOnly(2024, 1, 1),
             EndEmissionDate = new DateOnly(2028, 1, 1),
             Type = BondType.InflationBond,
-            Currency = DefaultCurrency.PLN
+            Currency = DefaultCurrency.PLN,
+            UnitValue = 100m
         }, TestContext.Current.CancellationToken);
         await client.Add(new BondDetails
         {
@@ -146,7 +152,8 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
             StartEmissionDate = new DateOnly(2024, 3, 1),
             EndEmissionDate = new DateOnly(2028, 3, 1),
             Type = BondType.InflationBond,
-            Currency = DefaultCurrency.PLN
+            Currency = DefaultCurrency.PLN,
+            UnitValue = 100m
         }, TestContext.Current.CancellationToken);
         await client.Add(new BondDetails
         {
@@ -155,7 +162,8 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
             StartEmissionDate = new DateOnly(2024, 1, 1),
             EndEmissionDate = new DateOnly(2027, 1, 1),
             Type = BondType.InflationBond,
-            Currency = DefaultCurrency.PLN
+            Currency = DefaultCurrency.PLN,
+            UnitValue = 100m
         }, TestContext.Current.CancellationToken);
 
         // Act
@@ -180,12 +188,13 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
             StartEmissionDate = new DateOnly(2024, 1, 1),
             EndEmissionDate = new DateOnly(2028, 1, 1),
             Type = BondType.InflationBond,
-            Currency = DefaultCurrency.PLN
+            Currency = DefaultCurrency.PLN,
+            UnitValue = 100m
         };
         var added = await client.Add(bond, TestContext.Current.CancellationToken);
 
         // Act
-        var updateCommand = new UpdateBondDetails(added!.Id, "Updated Name", "Updated Issuer");
+        var updateCommand = new UpdateBondDetails(added!.Id, "Updated Name", "Updated Issuer", 250m);
         var updateResult = await client.Update(updateCommand, TestContext.Current.CancellationToken);
 
         // Assert
@@ -194,6 +203,7 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
         Assert.NotNull(retrieved);
         Assert.Equal("Updated Name", retrieved.Name);
         Assert.Equal("Updated Issuer", retrieved.Issuer);
+        Assert.Equal(250m, retrieved.UnitValue);
     }
 
     [Fact]
@@ -209,7 +219,8 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
             StartEmissionDate = new DateOnly(2024, 1, 1),
             EndEmissionDate = new DateOnly(2028, 1, 1),
             Type = BondType.InflationBond,
-            Currency = DefaultCurrency.PLN
+            Currency = DefaultCurrency.PLN,
+            UnitValue = 100m
         };
         var added = await client.Add(bond, TestContext.Current.CancellationToken);
 
@@ -236,6 +247,7 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
             EndEmissionDate = new DateOnly(2028, 1, 1),
             Type = BondType.InflationBond,
             Currency = DefaultCurrency.PLN,
+            UnitValue = 100m,
             CalculationMethods =
             [
                 new()
@@ -280,6 +292,7 @@ public class BondDetailsControllerTests(OptionsProvider optionsProvider) : Contr
             EndEmissionDate = new DateOnly(2028, 1, 1),
             Type = BondType.InflationBond,
             Currency = DefaultCurrency.PLN,
+            UnitValue = 100m,
             CalculationMethods =
             [
                 new()

--- a/code/FinanceManager.UnitTests/Application/Services/AssetsServiceBondTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/AssetsServiceBondTests.cs
@@ -1,0 +1,131 @@
+using FinanceManager.Application.Services.Bonds;
+using FinanceManager.Domain.Entities.Bonds;
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Domain.Repositories.Account;
+using Moq;
+
+namespace FinanceManager.UnitTests.Application.Services;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class AssetsServiceBondTests
+{
+    private readonly Mock<IFinancialAccountRepository> _financialAccountRepositoryMock = new();
+    private readonly Mock<IBondDetailsRepository> _bondDetailsRepositoryMock = new();
+    private readonly AssetsServiceBond _service;
+
+    public AssetsServiceBondTests()
+    {
+        _service = new AssetsServiceBond(_financialAccountRepositoryMock.Object, _bondDetailsRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task GetAssetsTimeSeries_ShouldIncludeCarriedForwardBondHoldings()
+    {
+        var startDate = new DateTime(2024, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var endDate = startDate.AddDays(2);
+
+        var account = new BondAccount(
+            1,
+            1,
+            "Bonds",
+            [new BondAccountEntry(1, 2, startDate, 5m, 5m, 2)],
+            AccountLabel.Other,
+            new Dictionary<int, BondAccountEntry>
+            {
+                [1] = new BondAccountEntry(1, 1, startDate.AddDays(-5), 10m, 10m, 1)
+            });
+
+        var bondDetails = new[]
+        {
+            new BondDetails(
+                "Bond A",
+                "Issuer A",
+                DateOnly.FromDateTime(startDate.AddYears(-1)),
+                DateOnly.FromDateTime(endDate.AddYears(1)),
+                [new BondCalculationMethod { Id = 1, DateOperator = DateOperator.UntilDate, DateValue = endDate.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0m }],
+                DefaultCurrency.PLN,
+                BondType.InflationBond,
+                1m)
+            { Id = 1 },
+            new BondDetails(
+                "Bond B",
+                "Issuer B",
+                DateOnly.FromDateTime(startDate),
+                DateOnly.FromDateTime(endDate.AddYears(1)),
+                [new BondCalculationMethod { Id = 2, DateOperator = DateOperator.UntilDate, DateValue = endDate.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0m }],
+                DefaultCurrency.PLN,
+                BondType.InflationBond,
+                1m)
+            { Id = 2 }
+        };
+
+        _financialAccountRepositoryMock
+            .Setup(x => x.GetAccounts<BondAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new[] { account }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .Returns(bondDetails.ToAsyncEnumerable());
+
+        var result = await _service.GetAssetsTimeSeries(1, DefaultCurrency.PLN, startDate, endDate);
+
+        Assert.Equal(3, result.Count);
+        Assert.All(result, point => Assert.Equal(15m, point.Value));
+    }
+
+    [Fact]
+    public async Task GetEndAssetsPerAccount_ShouldIncludeCarriedForwardBondHoldings()
+    {
+        var asOfDate = new DateTime(2024, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+
+        var account = new BondAccount(
+            1,
+            1,
+            "Bonds",
+            [new BondAccountEntry(1, 2, asOfDate.Date.AddHours(8), 5m, 5m, 2)],
+            AccountLabel.Other,
+            new Dictionary<int, BondAccountEntry>
+            {
+                [1] = new BondAccountEntry(1, 1, asOfDate.AddDays(-5), 10m, 10m, 1)
+            });
+
+        var bondDetails = new[]
+        {
+            new BondDetails(
+                "Bond A",
+                "Issuer A",
+                DateOnly.FromDateTime(asOfDate.AddYears(-1)),
+                DateOnly.FromDateTime(asOfDate.AddYears(1)),
+                [new BondCalculationMethod { Id = 1, DateOperator = DateOperator.UntilDate, DateValue = asOfDate.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0m }],
+                DefaultCurrency.PLN,
+                BondType.InflationBond,
+                1m)
+            { Id = 1 },
+            new BondDetails(
+                "Bond B",
+                "Issuer B",
+                DateOnly.FromDateTime(asOfDate),
+                DateOnly.FromDateTime(asOfDate.AddYears(1)),
+                [new BondCalculationMethod { Id = 2, DateOperator = DateOperator.UntilDate, DateValue = asOfDate.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0m }],
+                DefaultCurrency.PLN,
+                BondType.InflationBond,
+                1m)
+            { Id = 2 }
+        };
+
+        _financialAccountRepositoryMock
+            .Setup(x => x.GetAccounts<BondAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new[] { account }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .Returns(bondDetails.ToAsyncEnumerable());
+
+        var result = await _service.GetEndAssetsPerAccount(1, DefaultCurrency.PLN, asOfDate)
+            .ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Single(result);
+        Assert.Equal(15m, result[0].Value);
+    }
+}

--- a/code/FinanceManager.UnitTests/Application/Services/AssetsServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/AssetsServiceTests.cs
@@ -127,4 +127,52 @@ public class AssetsServiceTests
         Assert.Single(aggregated);
         Assert.Equal(10m, aggregated[0].Value);
     }
+
+    [Fact]
+    public async Task GetAssetsTimeSeries_AggregatesSameDayValues_WithDifferentTimestamps()
+    {
+        // Arrange
+        var day = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var morning = day.AddHours(8);
+        var evening = day.AddHours(20);
+
+        _mockService1.Setup(x => x.GetAssetsTimeSeries(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync([new TimeSeriesModel(morning, 10)]);
+        _mockService2.Setup(x => x.GetAssetsTimeSeries(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync([new TimeSeriesModel(evening, 5)]);
+
+        // Act
+        var aggregated = await _assetsService.GetAssetsTimeSeries(1, DefaultCurrency.PLN, day, day.AddDays(1));
+
+        // Assert
+        Assert.Single(aggregated);
+        Assert.Equal(15m, aggregated[0].Value);
+        Assert.Equal(day.Date, aggregated[0].DateTime);
+    }
+
+    [Fact]
+    public async Task GetAssetsTimeSeries_LongRange_UsesClosingBalancePerBucket_AfterSameDayAggregation()
+    {
+        // Arrange
+        var start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var end = start.AddDays(95);
+        var firstDayMorning = start.AddHours(8);
+        var firstDayEvening = start.AddHours(20);
+        var laterInMonth = start.AddDays(30).AddHours(9);
+
+        _mockService1.Setup(x => x.GetAssetsTimeSeries(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync([
+                new TimeSeriesModel(firstDayMorning, 10),
+                new TimeSeriesModel(laterInMonth, 20)
+            ]);
+        _mockService2.Setup(x => x.GetAssetsTimeSeries(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync([new TimeSeriesModel(firstDayEvening, 5)]);
+
+        // Act
+        var aggregated = await _assetsService.GetAssetsTimeSeries(1, DefaultCurrency.PLN, start, end);
+
+        // Assert
+        var januaryBucket = aggregated.Single(x => x.DateTime == start.Date);
+        Assert.Equal(20m, januaryBucket.Value);
+    }
 }

--- a/code/FinanceManager.UnitTests/Application/Services/BondBalanceServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/BondBalanceServiceTests.cs
@@ -39,7 +39,8 @@ public class BondBalanceServiceTests
             DateOnly.FromDateTime(endDate.AddYears(1)),
             [new BondCalculationMethod { DateOperator = DateOperator.UntilDate, DateValue = endDate.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0 }],
             DefaultCurrency.PLN,
-            BondType.InflationBond)
+            BondType.InflationBond,
+            100m)
         {
             Id = 1
         };
@@ -51,7 +52,7 @@ public class BondBalanceServiceTests
         var result = await _service.GetClosingBalance(userId, DefaultCurrency.PLN, startDate, endDate);
 
         Assert.Equal(3, result.Count);
-        Assert.All(result, point => Assert.Equal(100, point.Value));
+        Assert.All(result, point => Assert.Equal(10000, point.Value));
     }
 
     [Fact]
@@ -73,7 +74,8 @@ public class BondBalanceServiceTests
             DateOnly.FromDateTime(endDate.AddYears(1)),
             [new BondCalculationMethod { DateOperator = DateOperator.UntilDate, DateValue = endDate.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0 }],
             DefaultCurrency.PLN,
-            BondType.InflationBond)
+            BondType.InflationBond,
+            100m)
         {
             Id = 1
         };
@@ -85,7 +87,7 @@ public class BondBalanceServiceTests
         var result = await _service.GetNetCashFlow(userId, DefaultCurrency.PLN, startDate, endDate);
 
         Assert.Equal(2, result.Count);
-        Assert.Equal(100, result.Single(x => x.DateTime == startDate).Value);
-        Assert.Equal(-50, result.Single(x => x.DateTime == endDate).Value);
+        Assert.Equal(10000, result.Single(x => x.DateTime == startDate).Value);
+        Assert.Equal(-5000, result.Single(x => x.DateTime == endDate).Value);
     }
 }

--- a/code/FinanceManager.UnitTests/Application/Services/InvestmentPaycheckEstimatorServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/InvestmentPaycheckEstimatorServiceTests.cs
@@ -22,6 +22,7 @@ public class InvestmentPaycheckEstimatorServiceTests
     private readonly Mock<IFinancialLabelsRepository> _financialLabelsRepositoryMock = new();
     private readonly Mock<IStockPriceRepository> _stockRepositoryMock = new();
     private readonly Mock<ICurrencyExchangeService> _currencyExchangeServiceMock = new();
+    private readonly Mock<IBondDetailsRepository> _bondDetailsRepositoryMock = new();
     private readonly InvestmentPaycheckEstimatorService _service;
 
     public InvestmentPaycheckEstimatorServiceTests()
@@ -32,7 +33,7 @@ public class InvestmentPaycheckEstimatorServiceTests
 
         IMemoryCache cache = new MemoryCache(new MemoryCacheOptions());
         var stockPriceProvider = new StockPriceProvider(_stockRepositoryMock.Object, _currencyExchangeServiceMock.Object, cache);
-        _service = new InvestmentPaycheckEstimatorService(_financialAccountRepositoryMock.Object, _financialLabelsRepositoryMock.Object, stockPriceProvider);
+        _service = new InvestmentPaycheckEstimatorService(_financialAccountRepositoryMock.Object, _financialLabelsRepositoryMock.Object, stockPriceProvider, _bondDetailsRepositoryMock.Object);
     }
 
     [Fact]
@@ -65,6 +66,23 @@ public class InvestmentPaycheckEstimatorServiceTests
         _financialAccountRepositoryMock
             .Setup(x => x.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(new[] { bondAccount }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .Returns(new[]
+            {
+                new BondDetails(
+                    "Bond",
+                    "Issuer",
+                    DateOnly.FromDateTime(asOfDate.AddYears(-1)),
+                    DateOnly.FromDateTime(asOfDate.AddYears(1)),
+                    [new BondCalculationMethod { DateOperator = DateOperator.UntilDate, DateValue = asOfDate.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0m }],
+                    DefaultCurrency.PLN,
+                    BondType.InflationBond,
+                    1m)
+                {
+                    Id = 1
+                }
+            }.ToAsyncEnumerable());
 
         _stockRepositoryMock
             .Setup(x => x.GetThisOrNextOlder("MSFT", It.IsAny<DateTime>()))
@@ -103,6 +121,23 @@ public class InvestmentPaycheckEstimatorServiceTests
         _financialAccountRepositoryMock
             .Setup(x => x.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(new[] { bondAccount }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock
+            .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .Returns(new[]
+            {
+                new BondDetails(
+                    "Bond",
+                    "Issuer",
+                    DateOnly.FromDateTime(asOfDate.AddYears(-1)),
+                    DateOnly.FromDateTime(asOfDate.AddYears(1)),
+                    [new BondCalculationMethod { DateOperator = DateOperator.UntilDate, DateValue = asOfDate.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0m }],
+                    DefaultCurrency.PLN,
+                    BondType.InflationBond,
+                    1m)
+                {
+                    Id = 1
+                }
+            }.ToAsyncEnumerable());
 
         var result = await _service.GetEstimate(userId, DefaultCurrency.PLN, asOfDate, 0.04m, 3);
 

--- a/code/FinanceManager.UnitTests/Application/Services/MoneyFlowServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/MoneyFlowServiceTests.cs
@@ -26,6 +26,7 @@ public class MoneyFlowServiceTests
     private readonly Mock<IStockPriceRepository> _stockRepository = new();
     private readonly Mock<ICurrencyExchangeService> _currencyExchangeService = new();
     private readonly Mock<IFinancialLabelsRepository> _financialLabelsRepositoryMock = new();
+    private readonly Mock<IBondDetailsRepository> _bondDetailsRepositoryMock = new();
     private readonly List<CurrencyAccount> _currencyAccounts;
     private readonly List<StockAccount> _investmentAccountAccounts;
 
@@ -63,8 +64,24 @@ public class MoneyFlowServiceTests
         IMemoryCache cache = new MemoryCache(new MemoryCacheOptions());
         var stockPriceProvider = new StockPriceProvider(_stockRepository.Object, _currencyExchangeService.Object, cache);
 
-        _moneyFlowService = new MoneyFlowService(_financialAccountRepositoryMock.Object, _financialLabelsRepositoryMock.Object, stockPriceProvider);
+        _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Empty<BondDetails>());
+
+        _moneyFlowService = new MoneyFlowService(_financialAccountRepositoryMock.Object, _financialLabelsRepositoryMock.Object, stockPriceProvider, _bondDetailsRepositoryMock.Object);
     }
+
+    private static BondDetails CreateBondDetails(int id, DateTime date, decimal unitValue = 1m) =>
+        new(
+            $"Bond {id}",
+            "Issuer",
+            DateOnly.FromDateTime(date.AddYears(-1)),
+            DateOnly.FromDateTime(date.AddYears(1)),
+            [new BondCalculationMethod { DateOperator = DateOperator.UntilDate, DateValue = date.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0m }],
+            DefaultCurrency.PLN,
+            BondType.InflationBond,
+            unitValue)
+        {
+            Id = id
+        };
 
 
 
@@ -198,6 +215,8 @@ public class MoneyFlowServiceTests
             .Returns(new[] { stockAccount }.ToAsyncEnumerable());
         _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(new[] { bondAccount }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .Returns(new[] { CreateBondDetails(1, date) }.ToAsyncEnumerable());
 
         _stockRepository.Setup(x => x.GetThisOrNextOlder("MSFT", It.IsAny<DateTime>()))
             .ReturnsAsync(new StockPrice { Currency = DefaultCurrency.PLN, Ticker = "MSFT", PricePerUnit = 100m });
@@ -314,6 +333,8 @@ public class MoneyFlowServiceTests
             .Returns(new[] { stockAccount }.ToAsyncEnumerable());
         _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(new[] { bondAccount }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .Returns(new[] { CreateBondDetails(1, date) }.ToAsyncEnumerable());
 
         _stockRepository.Setup(x => x.GetThisOrNextOlder("MEGA", It.IsAny<DateTime>()))
             .ReturnsAsync(new StockPrice { Currency = DefaultCurrency.PLN, Ticker = "MEGA", PricePerUnit = 1.11m });
@@ -379,6 +400,13 @@ public class MoneyFlowServiceTests
             .Returns(AsyncEnumerable.Empty<StockAccount>());
         _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(new[] { bondAccount }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
+            .Returns(new[]
+            {
+                CreateBondDetails(1, date),
+                CreateBondDetails(2, date),
+                CreateBondDetails(3, date)
+            }.ToAsyncEnumerable());
 
         // Act
         var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, date);

--- a/code/FinanceManager.UnitTests/Domain/Entities/Bonds/BondAccountEntryTests.cs
+++ b/code/FinanceManager.UnitTests/Domain/Entities/Bonds/BondAccountEntryTests.cs
@@ -62,7 +62,8 @@ public class BondAccountEntryTests
             "Issuer",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(1)),
-            [calculationMethod]
+            [calculationMethod],
+            unitValue: 1m
         );
 
         var targetDate = DateOnly.FromDateTime(postingDate.AddDays(2));
@@ -75,6 +76,34 @@ public class BondAccountEntryTests
         Assert.Equal(3, result.Count);
         Assert.Equal(100m, result[DateOnly.FromDateTime(postingDate)]);
         Assert.Equal(100.01m, result[DateOnly.FromDateTime(postingDate.AddDays(1))]);
+    }
+
+    [Fact]
+    public void GetPrice_ShouldApplyUnitValueMultiplier()
+    {
+        var postingDate = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var entry = new BondAccountEntry(1, 1, postingDate, 10m, 10m, 1);
+
+        var calculationMethod = new BondCalculationMethod
+        {
+            Id = 1,
+            DateOperator = FinanceManager.Domain.Enums.DateOperator.UntilDate,
+            DateValue = "2024-01-01",
+            Rate = 0m
+        };
+
+        var bondDetails = new BondDetails(
+            "Test Bond",
+            "Issuer",
+            DateOnly.FromDateTime(postingDate),
+            DateOnly.FromDateTime(postingDate.AddYears(1)),
+            [calculationMethod],
+            unitValue: 100m
+        );
+
+        var result = entry.GetPrice(DateOnly.FromDateTime(postingDate), bondDetails);
+
+        Assert.Equal(1000m, result[DateOnly.FromDateTime(postingDate)]);
     }
 
     [Fact]
@@ -97,7 +126,8 @@ public class BondAccountEntryTests
             "Issuer",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(3)),
-            [calculationMethod]
+            [calculationMethod],
+            unitValue: 1m
         );
 
         // Target date is after 365 days (should capitalize even though 2024 is leap year)
@@ -145,7 +175,8 @@ public class BondAccountEntryTests
             "Issuer",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(1)),
-            [calculationMethod1, calculationMethod2]
+            [calculationMethod1, calculationMethod2],
+            unitValue: 1m
         );
 
         var beforeRateChange = DateOnly.FromDateTime(new DateTime(2023, 6, 30, 0, 0, 0, DateTimeKind.Utc));
@@ -182,7 +213,8 @@ public class BondAccountEntryTests
             "Issuer",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(5)),
-            [calculationMethod]
+            [calculationMethod],
+            unitValue: 1m
         );
 
         var targetDate = DateOnly.FromDateTime(postingDate.AddYears(5));
@@ -210,7 +242,7 @@ public class BondAccountEntryTests
     {
         // Arrange - Bond redemption (selling/withdrawing)
         var postingDate = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        var entry = new BondAccountEntry(1, 1, postingDate, 0m, -500m, 1); // Negative value change
+        var entry = new BondAccountEntry(1, 1, postingDate, -500m, -500m, 1); // Negative value change
 
         var calculationMethod = new BondCalculationMethod
         {
@@ -225,7 +257,8 @@ public class BondAccountEntryTests
             "Issuer",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(1)),
-            [calculationMethod]
+            [calculationMethod],
+            unitValue: 1m
         );
 
         var targetDate = DateOnly.FromDateTime(postingDate.AddDays(10));
@@ -261,7 +294,8 @@ public class BondAccountEntryTests
             "Issuer",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(1)),
-            [calculationMethod]
+            [calculationMethod],
+            unitValue: 1m
         );
 
         var targetDate = DateOnly.FromDateTime(postingDate);
@@ -294,7 +328,8 @@ public class BondAccountEntryTests
             "Issuer",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(1)),
-            [calculationMethod]
+            [calculationMethod],
+            unitValue: 1m
         );
 
         var targetDate = DateOnly.FromDateTime(postingDate.AddDays(100));
@@ -302,9 +337,9 @@ public class BondAccountEntryTests
         // Act
         var result = entry.GetPrice(targetDate, bondDetails);
 
-        // Assert - Should start from ValueChange (2000) not Value (0)
-        Assert.Equal(2000m, result[DateOnly.FromDateTime(postingDate)]);
-        Assert.True(result[targetDate] > 2000m, "Value should grow from initial ValueChange");
+        // Assert - Should start from Value (0), because Value tracks the active unit balance.
+        Assert.Equal(0m, result[DateOnly.FromDateTime(postingDate)]);
+        Assert.Equal(0m, result[targetDate]);
     }
 
     [Fact]
@@ -327,7 +362,8 @@ public class BondAccountEntryTests
             "Issuer",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(1)),
-            [calculationMethod]
+            [calculationMethod],
+            unitValue: 1m
         );
 
         var targetDate = DateOnly.FromDateTime(postingDate.AddDays(10));

--- a/code/FinanceManager.UnitTests/Domain/Entities/Bonds/BondAccountTests.cs
+++ b/code/FinanceManager.UnitTests/Domain/Entities/Bonds/BondAccountTests.cs
@@ -84,7 +84,8 @@ public class BondAccountTests
             "Issuer",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(1)),
-            [calculationMethod]
+            [calculationMethod],
+            unitValue: 1m
         )
         { Id = 1 };
 
@@ -94,7 +95,7 @@ public class BondAccountTests
         // Assert
         Assert.Equal(5, result.Count);
         Assert.Equal(100.01m, result[DateOnly.FromDateTime(postingDate.AddDays(1))]);
-        Assert.Equal(200.04m, result[DateOnly.FromDateTime(endDate)], 2);
+        Assert.Equal(200m, result[DateOnly.FromDateTime(endDate)], 2);
     }
 
     [Fact]
@@ -134,7 +135,8 @@ public class BondAccountTests
             "Issuer A",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(1)),
-            [calculationMethod1]
+            [calculationMethod1],
+            unitValue: 1m
         )
         { Id = 1 };
 
@@ -143,7 +145,8 @@ public class BondAccountTests
             "Issuer B",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(1)),
-            [calculationMethod2]
+            [calculationMethod2],
+            unitValue: 1m
         )
         { Id = 2 };
 
@@ -197,7 +200,8 @@ public class BondAccountTests
             "Issuer",
             DateOnly.FromDateTime(postingDate),
             DateOnly.FromDateTime(postingDate.AddYears(1)),
-            [calculationMethod]
+            [calculationMethod],
+            unitValue: 1m
         )
         { Id = 1 };
 
@@ -209,9 +213,8 @@ public class BondAccountTests
             targetDate,
             [bondDetails]);
 
-        // Assert - Should be zero or near-zero throughout
-        Assert.Equal(0m, result[DateOnly.FromDateTime(postingDate)]);
-        Assert.Equal(0m, result[targetDate], 2);
+        // Assert - Zero balance is omitted from the result set.
+        Assert.Empty(result);
     }
 
     [Fact]
@@ -242,7 +245,8 @@ public class BondAccountTests
             "Issuer",
             DateOnly.FromDateTime(startDate),
             DateOnly.FromDateTime(startDate.AddYears(1)),
-            [calculationMethod]
+            [calculationMethod],
+            unitValue: 1m
         )
         { Id = 1 };
 
@@ -267,14 +271,14 @@ public class BondAccountTests
         // Day 29: ~1000 with some growth
         Assert.True(day29 > 1000m && day29 < 1010m);
 
-        // Day 30: Should jump to ~1500 + accumulated interest (new entry added)
-        Assert.True(day30 > 1500m && day30 < 1520m);
+        // Day 30: New entry establishes the cumulative units for that day.
+        Assert.Equal(1500m, day30);
 
-        // Day 60: Should jump again (third entry)
-        Assert.True(day60 > 1750m && day60 < 1780m);
+        // Day 60: Third entry establishes the new cumulative units.
+        Assert.Equal(1750m, day60);
 
         // Day 90: All entries accumulating
-        Assert.True(day90 > 1760m, $"Expected final value > 1760, got {day90}");
+        Assert.True(day90 > 1755m, $"Expected final value > 1755, got {day90}");
     }
 
     [Fact]
@@ -316,5 +320,49 @@ public class BondAccountTests
                 [])); // No bond details provided
 
         Assert.Contains("BondDetails", exception.Message);
+    }
+
+    [Fact]
+    public void GetDailyPrice_ShouldIncludeBondsFromNextOlderEntries()
+    {
+        var startDate = new DateTime(2024, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var endDate = startDate.AddDays(2);
+
+        var carriedBondEntry = new BondAccountEntry(1, 1, startDate.AddDays(-5), 10m, 10m, 1);
+        var currentBondEntry = new BondAccountEntry(1, 2, startDate, 5m, 5m, 2);
+
+        var account = new BondAccount(
+            1,
+            1,
+            "Test Account",
+            [currentBondEntry],
+            AccountLabel.Other,
+            new Dictionary<int, BondAccountEntry> { [1] = carriedBondEntry });
+
+        var firstBondDetails = new BondDetails(
+            "Bond A",
+            "Issuer A",
+            DateOnly.FromDateTime(startDate.AddYears(-1)),
+            DateOnly.FromDateTime(endDate.AddYears(1)),
+            [new BondCalculationMethod { Id = 1, DateOperator = DateOperator.UntilDate, DateValue = endDate.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0m }],
+            unitValue: 1m)
+        { Id = 1 };
+
+        var secondBondDetails = new BondDetails(
+            "Bond B",
+            "Issuer B",
+            DateOnly.FromDateTime(startDate),
+            DateOnly.FromDateTime(endDate.AddYears(1)),
+            [new BondCalculationMethod { Id = 2, DateOperator = DateOperator.UntilDate, DateValue = endDate.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0m }],
+            unitValue: 1m)
+        { Id = 2 };
+
+        var result = account.GetDailyPrice(
+            DateOnly.FromDateTime(startDate),
+            DateOnly.FromDateTime(endDate),
+            [firstBondDetails, secondBondDetails]);
+
+        Assert.Equal(3, result.Count);
+        Assert.All(result.Values, value => Assert.Equal(15m, value));
     }
 }


### PR DESCRIPTION
- Added UnitValue property to BondDetails and updated related configurations.
- Modified UpdateBondDetails command to include UnitValueToUpdate.
- Updated BondAccount and BondAccountEntry to utilize UnitValue in price calculations.
- Enhanced tests to validate new UnitValue functionality across services and entities.
- Ensured backward compatibility by adjusting existing tests and logic to accommodate new UnitValue calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Unit Value property to bonds (default: 100). Users can now configure the unit value when creating or updating bond details.
  * Bond account entries now display unit-based values and calculations alongside currency values.
  * Enhanced bond details UI with Unit Value column in tables and detail views.
  * Improved bond entry forms with label multi-select functionality and unit value displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->