### PR TITLE
feat: add LM Studio as AI provider to replace GitHub Copilot

### DIFF
--- a/code/FinanceManager.Api/Program.cs
+++ b/code/FinanceManager.Api/Program.cs
@@ -30,6 +30,7 @@ builder.Services
 
 builder.Services.Configure<JwtAuthOptions>(builder.Configuration.GetSection("JwtConfig"));
 builder.Services.Configure<StockApiOptions>(builder.Configuration.GetSection("StockApi"));
+builder.Services.Configure<LmStudioOptions>(builder.Configuration.GetSection("LmStudio"));
 builder.Services.Configure<OpenRouterOptions>(builder.Configuration.GetSection("OpenRouter"));
 builder.Services.Configure<GitHubModelsOptions>(builder.Configuration.GetSection("GitHubModels"));
 builder.Services.Configure<OllamaOptions>(builder.Configuration.GetSection("Ollama"));

--- a/code/FinanceManager.Api/appsettings.json
+++ b/code/FinanceManager.Api/appsettings.json
@@ -27,21 +27,26 @@
     "TotalRequestTimeoutSeconds": 900,
     "CircuitBreakerSamplingDurationSeconds": 1200
   },
+  "LmStudio": {
+    "BaseUrl": "http://localhost:1234/v1",
+    "ApiKey": "lm-studio",
+    "RequestTimeoutSeconds": 600
+  },
   "OpenRouter": {
     "BaseUrl": "https://openrouter.ai/api/v1",
     "ApiKey": "",
     "RequestTimeoutSeconds": 600
   },
   "AiProvider": {
-    "Provider": "OpenRouter"
+    "Provider": "LmStudio"
   },
   "AIProviderFallbackStrategies": [
     {
       "Name": "default",
       "Providers": [
         {
-          "Provider": "GitHub",
-          "Model": "gpt-5-mini"
+          "Provider": "LmStudio",
+          "Model": "local-model"
         },
         {
           "Provider": "OpenRouter",

--- a/code/FinanceManager.Application/Options/LmStudioOptions.cs
+++ b/code/FinanceManager.Application/Options/LmStudioOptions.cs
@@ -1,0 +1,8 @@
+namespace FinanceManager.Application.Options;
+
+public sealed class LmStudioOptions
+{
+    public string BaseUrl { get; set; } = "http://localhost:1234/v1";
+    public string ApiKey { get; set; } = "lm-studio";
+    public int RequestTimeoutSeconds { get; set; } = 180;
+}

--- a/code/FinanceManager.Infrastructure/Services/Ai/LmStudioChatClient.cs
+++ b/code/FinanceManager.Infrastructure/Services/Ai/LmStudioChatClient.cs
@@ -1,0 +1,66 @@
+using FinanceManager.Application.Options;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenAI;
+using System.ClientModel;
+
+namespace FinanceManager.Infrastructure.Services.Ai;
+
+internal sealed class LmStudioChatClient(
+    IOptions<LmStudioOptions> options,
+    ILogger<LmStudioChatClient> logger) : INamedChatClient
+{
+    public string ProviderName => "LmStudio";
+
+    public async Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? chatOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        var modelId = chatOptions?.ModelId?.Trim();
+        if (string.IsNullOrWhiteSpace(modelId))
+        {
+            logger.LogWarning("LM Studio request skipped because ChatOptions.ModelId is empty.");
+            return new ChatResponse(new ChatMessage(ChatRole.Assistant, string.Empty));
+        }
+
+        var openAiClient = CreateOpenAiClient();
+        var chatClient = openAiClient.GetChatClient(modelId).AsIChatClient();
+        return await chatClient.GetResponseAsync(messages, chatOptions, cancellationToken);
+    }
+
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? chatOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        var modelId = chatOptions?.ModelId?.Trim();
+        if (string.IsNullOrWhiteSpace(modelId))
+        {
+            logger.LogWarning("LM Studio streaming request skipped because ChatOptions.ModelId is empty.");
+            return AsyncEnumerable.Empty<ChatResponseUpdate>();
+        }
+
+        var openAiClient = CreateOpenAiClient();
+        var chatClient = openAiClient.GetChatClient(modelId).AsIChatClient();
+        return chatClient.GetStreamingResponseAsync(messages, chatOptions, cancellationToken);
+    }
+
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    public void Dispose() { }
+
+    private OpenAIClient CreateOpenAiClient()
+    {
+        var config = options.Value;
+        var timeoutSeconds = config.RequestTimeoutSeconds > 0 ? config.RequestTimeoutSeconds : 180;
+        return new OpenAIClient(
+            new ApiKeyCredential(config.ApiKey),
+            new OpenAIClientOptions
+            {
+                Endpoint = new Uri(config.BaseUrl),
+                NetworkTimeout = TimeSpan.FromSeconds(timeoutSeconds)
+            });
+    }
+}

--- a/code/FinanceManager.Infrastructure/Services/Ai/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/Services/Ai/ServiceCollectionExtension.cs
@@ -11,6 +11,7 @@ public static class ServiceCollectionExtension
     {
         services.AddHttpClient<IAlphaVantageClient, AlphaVantageClient>();
 
+        services.AddScoped<INamedChatClient, LmStudioChatClient>();
         services.AddScoped<INamedChatClient, OpenRouterChatClient>();
         services.AddScoped<INamedChatClient, CopilotChatClient>();
         services.AddScoped<INamedChatClient, OllamaChatClient>();


### PR DESCRIPTION
Adds LmStudioChatClient and LmStudioOptions. LM Studio exposes an
OpenAI-compatible REST API so the client follows the same pattern as
OpenRouterChatClient. The fallback strategy is updated to prefer LM
Studio first, with OpenRouter and Ollama as fallbacks. GitHub Copilot
is removed from the fallback chain since the subscription was cancelled.

https://claude.ai/code/session_019yKE1p2DtuRiN2ZqAtd57n