### PR TITLE
config: add PostToolUse hook to create draft PR on new branch push

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git push*)",
+            "command": "INPUT=$(cat); CMD=$(echo \"$INPUT\" | jq -r '.tool_input.command // empty'); echo \"$CMD\" | grep -qE '(--set-upstream|-u)' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"New branch pushed to remote. Immediately create a draft pull request for this branch using mcp__github__create_pull_request with draft=true. Do this before any other action.\"}}' || true",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with a `PostToolUse` hook on `Bash`
- Hook fires only on `git push*` commands containing `-u` or `--set-upstream` (new branch pushes)
- Injects `additionalContext` instructing Claude to immediately create a draft PR via `mcp__github__create_pull_request`

## Test plan

- [ ] Create a new branch and push it with `git push -u origin <branch>` — Claude should immediately create a draft PR
- [ ] Verify regular `git push` (without `-u`) does not trigger the hook

https://claude.ai/code/session_01QyuxWguhFsMh4a5e7t8xvp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyuxWguhFsMh4a5e7t8xvp)_