### PR TITLE
Add date range filter to account transaction lists (issue #19)

### DIFF
--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor
@@ -32,7 +32,10 @@
             </MudOverlay>
         </AddEntryOverlay>
         <EntryFilter>
-            <ValueChangeRangeFilterBar From="_filterFrom" To="_filterTo" OnFilterChanged="OnFilterChanged" />
+            <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                <DateRangeFilterBar From="_filterDateStart" To="_filterDateEnd" OnFilterChanged="OnDateFilterChanged" />
+                <ValueChangeRangeFilterBar From="_filterFrom" To="_filterTo" OnFilterChanged="OnFilterChanged" />
+            </MudStack>
         </EntryFilter>
         <Entries>
             @{

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor.cs
@@ -34,6 +34,8 @@ public partial class BondAccountDetailsPageContent : ComponentBase
 
     private decimal? _filterFrom;
     private decimal? _filterTo;
+    private DateTime? _filterDateStart;
+    private DateTime? _filterDateEnd;
 
     public bool IsLoading = false;
     public BondAccount? Account { get; set; }
@@ -189,7 +191,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase
             if (_user is null) return;
 
             var requestedDateStart = _dateStart;
-            _dateEnd = DateTime.UtcNow;
+            _dateEnd = _filterDateEnd ?? DateTime.UtcNow;
             Account = await FinancialAccountService.GetAccount<BondAccount>(_user.UserId, AccountId, requestedDateStart, _dateEnd, _minimumEntryCount);
             UpdateDateStartFromLoadedEntries(requestedDateStart);
 
@@ -255,7 +257,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase
         }
     }
 
-    private bool HasActiveFilter => _filterFrom.HasValue || _filterTo.HasValue;
+    private bool HasActiveFilter => _filterFrom.HasValue || _filterTo.HasValue || _filterDateStart.HasValue || _filterDateEnd.HasValue;
 
     private List<BondAccountEntry> GetFilteredEntries()
     {
@@ -267,6 +269,10 @@ public partial class BondAccountDetailsPageContent : ComponentBase
             entries = entries.Where(x => x.ValueChange >= _filterFrom.Value);
         if (_filterTo.HasValue)
             entries = entries.Where(x => x.ValueChange <= _filterTo.Value);
+        if (_filterDateStart.HasValue)
+            entries = entries.Where(x => x.PostingDate.Date >= _filterDateStart.Value.Date);
+        if (_filterDateEnd.HasValue)
+            entries = entries.Where(x => x.PostingDate.Date <= _filterDateEnd.Value.Date);
 
         return entries.OrderByDescending(x => x.PostingDate).ToList();
     }
@@ -275,6 +281,20 @@ public partial class BondAccountDetailsPageContent : ComponentBase
     {
         _filterFrom = filter.From;
         _filterTo = filter.To;
+    }
+
+    private async Task OnDateFilterChanged((DateTime? From, DateTime? To) filter)
+    {
+        _filterDateStart = filter.From;
+        _filterDateEnd = filter.To;
+
+        var defaultDateStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+        _dateStart = _filterDateStart ?? (_filterDateEnd.HasValue && _filterDateEnd.Value.Date < defaultDateStart
+            ? new DateTime(_filterDateEnd.Value.Year, _filterDateEnd.Value.Month, 1)
+            : defaultDateStart);
+        _loadedAllData = false;
+        await UpdateEntries();
+        StateHasChanged();
     }
 
     private void UpdateDateStartFromLoadedEntries(DateTime requestedDateStart)

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor.cs
@@ -191,7 +191,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase
             if (_user is null) return;
 
             var requestedDateStart = _dateStart;
-            _dateEnd = _filterDateEnd ?? DateTime.UtcNow;
+            _dateEnd = _filterDateEnd.HasValue ? _filterDateEnd.Value.Date.AddDays(1).AddTicks(-1) : DateTime.UtcNow;
             Account = await FinancialAccountService.GetAccount<BondAccount>(_user.UserId, AccountId, requestedDateStart, _dateEnd, _minimumEntryCount);
             UpdateDateStartFromLoadedEntries(requestedDateStart);
 
@@ -289,9 +289,8 @@ public partial class BondAccountDetailsPageContent : ComponentBase
         _filterDateEnd = filter.To;
 
         var defaultDateStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
-        _dateStart = _filterDateStart ?? (_filterDateEnd.HasValue && _filterDateEnd.Value.Date < defaultDateStart
-            ? new DateTime(_filterDateEnd.Value.Year, _filterDateEnd.Value.Month, 1)
-            : defaultDateStart);
+        var fallbackStart = Account?.Start?.Date ?? defaultDateStart;
+        _dateStart = _filterDateStart ?? (_filterDateEnd.HasValue ? fallbackStart : defaultDateStart);
         _loadedAllData = false;
         await UpdateEntries();
         StateHasChanged();

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
@@ -40,7 +40,10 @@ else if (IsLoading || Account.Entries.Any())
             </MudOverlay>
         </AddEntryOverlay>
         <EntryFilter>
-            <ValueChangeRangeFilterBar From="_filterFrom" To="_filterTo" OnFilterChanged="OnFilterChanged" />
+            <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                <DateRangeFilterBar From="_filterDateStart" To="_filterDateEnd" OnFilterChanged="OnDateFilterChanged" />
+                <ValueChangeRangeFilterBar From="_filterFrom" To="_filterTo" OnFilterChanged="OnFilterChanged" />
+            </MudStack>
         </EntryFilter>
         <Entries>
             @{

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor.cs
@@ -30,6 +30,8 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
 
     private decimal? _filterFrom;
     private decimal? _filterTo;
+    private DateTime? _filterDateStart;
+    private DateTime? _filterDateEnd;
 
     public bool IsLoading = false;
     public CurrencyAccount? Account { get; set; }
@@ -163,7 +165,7 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
             if (_user is null) return;
 
             var requestedDateStart = _dateStart;
-            _dateEnd = DateTime.UtcNow;
+            _dateEnd = _filterDateEnd ?? DateTime.UtcNow;
             Account = await FinancialAccountService.GetAccount<CurrencyAccount>(_user.UserId, AccountId, requestedDateStart, _dateEnd, _minimumEntryCount);
             UpdateDateStartFromLoadedEntries(requestedDateStart);
 
@@ -207,7 +209,7 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
         });
     }
 
-    private bool HasActiveFilter => _filterFrom.HasValue || _filterTo.HasValue;
+    private bool HasActiveFilter => _filterFrom.HasValue || _filterTo.HasValue || _filterDateStart.HasValue || _filterDateEnd.HasValue;
 
     private List<CurrencyAccountEntry> GetFilteredEntries()
     {
@@ -219,6 +221,10 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
             entries = entries.Where(x => x.ValueChange >= _filterFrom.Value);
         if (_filterTo.HasValue)
             entries = entries.Where(x => x.ValueChange <= _filterTo.Value);
+        if (_filterDateStart.HasValue)
+            entries = entries.Where(x => x.PostingDate.Date >= _filterDateStart.Value.Date);
+        if (_filterDateEnd.HasValue)
+            entries = entries.Where(x => x.PostingDate.Date <= _filterDateEnd.Value.Date);
 
         return entries.OrderByDescending(x => x.PostingDate).ToList();
     }
@@ -227,6 +233,20 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
     {
         _filterFrom = filter.From;
         _filterTo = filter.To;
+    }
+
+    private async Task OnDateFilterChanged((DateTime? From, DateTime? To) filter)
+    {
+        _filterDateStart = filter.From;
+        _filterDateEnd = filter.To;
+
+        var defaultDateStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+        _dateStart = _filterDateStart ?? (_filterDateEnd.HasValue && _filterDateEnd.Value.Date < defaultDateStart
+            ? new DateTime(_filterDateEnd.Value.Year, _filterDateEnd.Value.Month, 1)
+            : defaultDateStart);
+        _loadedAllData = false;
+        await UpdateEntries();
+        StateHasChanged();
     }
 
     private void UpdateDateStartFromLoadedEntries(DateTime requestedDateStart)

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor.cs
@@ -165,7 +165,7 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
             if (_user is null) return;
 
             var requestedDateStart = _dateStart;
-            _dateEnd = _filterDateEnd ?? DateTime.UtcNow;
+            _dateEnd = _filterDateEnd.HasValue ? _filterDateEnd.Value.Date.AddDays(1).AddTicks(-1) : DateTime.UtcNow;
             Account = await FinancialAccountService.GetAccount<CurrencyAccount>(_user.UserId, AccountId, requestedDateStart, _dateEnd, _minimumEntryCount);
             UpdateDateStartFromLoadedEntries(requestedDateStart);
 
@@ -241,9 +241,8 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
         _filterDateEnd = filter.To;
 
         var defaultDateStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
-        _dateStart = _filterDateStart ?? (_filterDateEnd.HasValue && _filterDateEnd.Value.Date < defaultDateStart
-            ? new DateTime(_filterDateEnd.Value.Year, _filterDateEnd.Value.Month, 1)
-            : defaultDateStart);
+        var fallbackStart = Account?.Start?.Date ?? defaultDateStart;
+        _dateStart = _filterDateStart ?? (_filterDateEnd.HasValue ? fallbackStart : defaultDateStart);
         _loadedAllData = false;
         await UpdateEntries();
         StateHasChanged();

--- a/code/FinanceManager.Components/Components/FinancialAccounts/Shared/DateRangeFilterBar.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/Shared/DateRangeFilterBar.razor
@@ -1,0 +1,98 @@
+<MudPaper Elevation="0" Style="background-color:transparent;">
+    <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Default">
+            <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                <MudMenu Dense="true" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopLeft" @ref="_menu">
+                    <ActivatorContent>
+                        <MudButton Variant="Variant.Text" Size="Size.Small" Style="text-transform: none; padding: 0;">
+                            <span class="mud-typography-caption">Date range</span>
+                            @if (HasActiveFilter)
+                            {
+                                <span class="mud-typography-caption ms-1">@GetRangeLabel()</span>
+                            }
+                        </MudButton>
+                    </ActivatorContent>
+                    <ChildContent>
+                        <MudPaper Class="pa-3" Elevation="0" Style="min-width: 260px;">
+                            <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                                <MudText Typo="Typo.subtitle2">Filter entries by date range</MudText>
+                            </MudStack>
+                            <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
+                                <MudDatePicker Date="From" DateChanged="OnFromChanged" Label="From"
+                                               Variant="Variant.Outlined" Margin="Margin.Dense" Clearable
+                                               Style="max-width: 140px;" />
+                                <MudDatePicker Date="To" DateChanged="OnToChanged" Label="To"
+                                               Variant="Variant.Outlined" Margin="Margin.Dense" Clearable
+                                               Style="max-width: 140px;" />
+                            </MudStack>
+                            @if (!string.IsNullOrEmpty(_validationError))
+                            {
+                                <MudText Color="Color.Error" Typo="Typo.caption" Class="mt-1">@_validationError</MudText>
+                            }
+                        </MudPaper>
+                    </ChildContent>
+                </MudMenu>
+                @if (HasActiveFilter)
+                {
+                    <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" Color="Color.Default"
+                                   @onclick="ResetFilter" />
+                }
+            </MudStack>
+        </MudChip>
+    </MudStack>
+</MudPaper>
+
+@code {
+    private string? _validationError;
+    private MudMenu? _menu;
+
+    [Parameter] public DateTime? From { get; set; }
+    [Parameter] public DateTime? To { get; set; }
+    [Parameter] public EventCallback<(DateTime? From, DateTime? To)> OnFilterChanged { get; set; }
+
+    private bool HasActiveFilter => From.HasValue || To.HasValue;
+
+    private string GetRangeLabel()
+    {
+        if (From.HasValue && To.HasValue)
+            return $"{From.Value:dd/MM}..{To.Value:dd/MM}";
+        if (From.HasValue)
+            return $">= {From.Value:dd/MM}";
+        if (To.HasValue)
+            return $"<= {To.Value:dd/MM}";
+
+        return string.Empty;
+    }
+
+    private async Task OnFromChanged(DateTime? value)
+    {
+        From = value;
+        await ApplyFilter();
+    }
+
+    private async Task OnToChanged(DateTime? value)
+    {
+        To = value;
+        await ApplyFilter();
+    }
+
+    private async Task ApplyFilter()
+    {
+        if (From.HasValue && To.HasValue && From.Value.Date > To.Value.Date)
+        {
+            _validationError = "'From' must be less than or equal to 'To'";
+            return;
+        }
+
+        _validationError = null;
+        await OnFilterChanged.InvokeAsync((From, To));
+    }
+
+    private async Task ResetFilter(MouseEventArgs args)
+    {
+        From = null;
+        To = null;
+        _validationError = null;
+        await OnFilterChanged.InvokeAsync((null, null));
+    }
+}

--- a/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsPageContent.razor
@@ -40,7 +40,10 @@ else if (Account is not null && Account.Entries is not null && (Account.Entries.
             </MudOverlay>
         </AddEntryOverlay>
         <EntryFilter>
-            <ValueChangeRangeFilterBar From="_filterFrom" To="_filterTo" OnFilterChanged="OnFilterChanged" />
+            <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                <DateRangeFilterBar From="_filterDateStart" To="_filterDateEnd" OnFilterChanged="OnDateFilterChanged" />
+                <ValueChangeRangeFilterBar From="_filterFrom" To="_filterTo" OnFilterChanged="OnFilterChanged" />
+            </MudStack>
         </EntryFilter>
         <Entries>
             @{

--- a/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsPageContent.razor.cs
@@ -225,7 +225,7 @@ public partial class StockAccountDetailsPageContent : ComponentBase
             if (_user is null) return;
 
             var requestedDateStart = _dateStart;
-            _dateEnd = _filterDateEnd ?? DateTime.UtcNow;
+            _dateEnd = _filterDateEnd.HasValue ? _filterDateEnd.Value.Date.AddDays(1).AddTicks(-1) : DateTime.UtcNow;
             Account = await FinancialAccountService.GetAccount<StockAccount>(_user.UserId, AccountId, requestedDateStart, _dateEnd, _minimumEntryCount);
             UpdateDateStartFromLoadedEntries(requestedDateStart);
         }
@@ -378,9 +378,8 @@ public partial class StockAccountDetailsPageContent : ComponentBase
         _filterDateEnd = filter.To;
 
         var defaultDateStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
-        _dateStart = _filterDateStart ?? (_filterDateEnd.HasValue && _filterDateEnd.Value.Date < defaultDateStart
-            ? new DateTime(_filterDateEnd.Value.Year, _filterDateEnd.Value.Month, 1)
-            : defaultDateStart);
+        var fallbackStart = Account?.Start?.Date ?? defaultDateStart;
+        _dateStart = _filterDateStart ?? (_filterDateEnd.HasValue ? fallbackStart : defaultDateStart);
         _loadedAllData = false;
         await UpdateEntries();
         StateHasChanged();

--- a/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsPageContent.razor.cs
@@ -39,6 +39,8 @@ public partial class StockAccountDetailsPageContent : ComponentBase
 
     private decimal? _filterFrom;
     private decimal? _filterTo;
+    private DateTime? _filterDateStart;
+    private DateTime? _filterDateEnd;
 
 
     public StockAccount? Account { get; set; }
@@ -223,7 +225,7 @@ public partial class StockAccountDetailsPageContent : ComponentBase
             if (_user is null) return;
 
             var requestedDateStart = _dateStart;
-            _dateEnd = DateTime.UtcNow;
+            _dateEnd = _filterDateEnd ?? DateTime.UtcNow;
             Account = await FinancialAccountService.GetAccount<StockAccount>(_user.UserId, AccountId, requestedDateStart, _dateEnd, _minimumEntryCount);
             UpdateDateStartFromLoadedEntries(requestedDateStart);
         }
@@ -344,7 +346,7 @@ public partial class StockAccountDetailsPageContent : ComponentBase
         });
     }
 
-    private bool HasActiveFilter => _filterFrom.HasValue || _filterTo.HasValue;
+    private bool HasActiveFilter => _filterFrom.HasValue || _filterTo.HasValue || _filterDateStart.HasValue || _filterDateEnd.HasValue;
 
     private List<StockAccountEntry> GetFilteredEntries()
     {
@@ -356,6 +358,10 @@ public partial class StockAccountDetailsPageContent : ComponentBase
             entries = entries.Where(x => x.ValueChange >= _filterFrom.Value);
         if (_filterTo.HasValue)
             entries = entries.Where(x => x.ValueChange <= _filterTo.Value);
+        if (_filterDateStart.HasValue)
+            entries = entries.Where(x => x.PostingDate.Date >= _filterDateStart.Value.Date);
+        if (_filterDateEnd.HasValue)
+            entries = entries.Where(x => x.PostingDate.Date <= _filterDateEnd.Value.Date);
 
         return entries.OrderByDescending(x => x.PostingDate).ToList();
     }
@@ -364,6 +370,20 @@ public partial class StockAccountDetailsPageContent : ComponentBase
     {
         _filterFrom = filter.From;
         _filterTo = filter.To;
+    }
+
+    private async Task OnDateFilterChanged((DateTime? From, DateTime? To) filter)
+    {
+        _filterDateStart = filter.From;
+        _filterDateEnd = filter.To;
+
+        var defaultDateStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
+        _dateStart = _filterDateStart ?? (_filterDateEnd.HasValue && _filterDateEnd.Value.Date < defaultDateStart
+            ? new DateTime(_filterDateEnd.Value.Year, _filterDateEnd.Value.Month, 1)
+            : defaultDateStart);
+        _loadedAllData = false;
+        await UpdateEntries();
+        StateHasChanged();
     }
 
     private void UpdateDateStartFromLoadedEntries(DateTime requestedDateStart)

--- a/code/FinanceManager.Infrastructure/Services/Ai/LmStudioChatClient.cs
+++ b/code/FinanceManager.Infrastructure/Services/Ai/LmStudioChatClient.cs
@@ -55,7 +55,8 @@ internal sealed class LmStudioChatClient(
 
         var openAiClient = await CreateOpenAiClientAsync(cancellationToken);
         var chatClient = openAiClient.GetChatClient(modelId).AsIChatClient();
-        return chatClient.GetStreamingResponseAsync(messages, SanitizeOptions(chatOptions), cancellationToken);
+        await foreach (var update in chatClient.GetStreamingResponseAsync(messages, SanitizeOptions(chatOptions), cancellationToken))
+            yield return update;
     }
 
     // Default token budget for LM Studio reasoning models (e.g. qwen3 thinking variants), which


### PR DESCRIPTION
Creates DateRangeFilterBar component (chip+dropdown with MudDatePicker
controls) and integrates it alongside the existing value change filter on
all three account detail pages (Currency, Stock, Bond). Selecting a date
range triggers an API re-fetch scoped to that window; clearing the filter
restores the default loading window. Client-side filtering also applies
inclusive .Date comparisons so time-of-day does not affect boundary
entries.

https://claude.ai/code/session_01WeH5MKfJA4QxKYf7Zni6cv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date-range filtering to Bond, Currency, and Stock account details pages. Users can now filter financial entries by posting date in addition to value-range filters. The new filter controls integrate seamlessly with the existing UI, enabling more granular control over displayed account entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->