### PR TITLE
Add NetWorthTimeSeriesCard to Assets page (issue #149)

### DIFF
--- a/code/FinanceManager.Components/Components/AssetsPage.razor
+++ b/code/FinanceManager.Components/Components/AssetsPage.razor
@@ -1,11 +1,16 @@
 ﻿@page "/Assets"
 @using FinanceManager.Components.Components.Dashboard.Cards.Assets
+@using FinanceManager.Components.Components.Dashboard.Cards.TimeSeries
 
 <PageTitle>Assets</PageTitle>
 <MudContainer Class="py-2">
     <MudGrid Spacing="2">
         <MudItem xs="12">
             <AssetsTimeSeriesCard StartDateTime=StartDate EndDateTime="@EndDate" />
+        </MudItem>
+
+        <MudItem xs="12">
+            <NetWorthTimeSeriesCard StartDateTime=StartDate EndDateTime="@EndDate" />
         </MudItem>
 
         <MudItem xs="12" lg="4">

--- a/code/FinanceManager.Components/Components/AssetsPage.razor
+++ b/code/FinanceManager.Components/Components/AssetsPage.razor
@@ -1,16 +1,11 @@
 ﻿@page "/Assets"
 @using FinanceManager.Components.Components.Dashboard.Cards.Assets
-@using FinanceManager.Components.Components.Dashboard.Cards.TimeSeries
 
 <PageTitle>Assets</PageTitle>
 <MudContainer Class="py-2">
     <MudGrid Spacing="2">
         <MudItem xs="12">
             <AssetsTimeSeriesCard StartDateTime=StartDate EndDateTime="@EndDate" />
-        </MudItem>
-
-        <MudItem xs="12">
-            <NetWorthTimeSeriesCard StartDateTime=StartDate EndDateTime="@EndDate" />
         </MudItem>
 
         <MudItem xs="12" lg="4">

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/TimeSeries/NetWorthTimeSeriesCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/TimeSeries/NetWorthTimeSeriesCard.razor
@@ -1,0 +1,26 @@
+@using FinanceManager.Components.Components.SharedComponents.Charts
+
+<MudCard Outlined Class="d-flex flex-nowrap" Style="@($"height:{Height}")">
+    <MudPaper Class="flex-grow-0 p-3" Elevation="0">
+        <MudText Typo=Typo.h5>Net worth over time</MudText>
+    </MudPaper>
+    <MudPaper Class="flex-grow-1 overflow-auto" Elevation="0">
+        @if (_isLoading)
+        {
+            <div style="height:100%">
+                <ChartSpinner MaxHeight=@Height />
+            </div>
+        }
+        else if (ChartData.Any())
+        {
+            <LineChartJs
+                Series="@([ChartData.OrderBy(x => x.Key).Select(x => new ChartJsLineDataPoint(x.Key.ToLocalTime(), x.Value)).ToList()])" />
+        }
+        else
+        {
+            <div class="d-flex flex-grow-1 justify-center align-content-center flex-wrap">
+                <MudText Typo="Typo.button" HtmlTag="h3">No data</MudText>
+            </div>
+        }
+    </MudPaper>
+</MudCard>

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/TimeSeries/NetWorthTimeSeriesCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/TimeSeries/NetWorthTimeSeriesCard.razor.cs
@@ -1,0 +1,40 @@
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Components.Components.Dashboard.Cards.TimeSeries;
+
+public partial class NetWorthTimeSeriesCard
+{
+    private bool _isLoading;
+    public Dictionary<DateTime, decimal> ChartData { get; set; } = [];
+
+    [Parameter] public DateTime StartDateTime { get; set; }
+    [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
+    [Parameter] public string Height { get; set; } = "250px";
+
+    [Inject] public required ILogger<NetWorthTimeSeriesCard> Logger { get; set; }
+    [Inject] public required MoneyFlowHttpClient MoneyFlowHttpClient { get; set; }
+    [Inject] public required ISettingsService SettingsService { get; set; }
+    [Inject] public required ILoginService LoginService { get; set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        var user = await LoginService.GetLoggedUser();
+        if (user is null) return;
+
+        _isLoading = true;
+        StateHasChanged();
+        try
+        {
+            ChartData = await MoneyFlowHttpClient.GetNetWorth(user.UserId, SettingsService.GetCurrency(), StartDateTime, EndDateTime);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error getting net worth time series data");
+        }
+
+        _isLoading = false;
+    }
+}

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/TimeSeries/NetWorthTimeSeriesCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/TimeSeries/NetWorthTimeSeriesCard.razor.cs
@@ -22,7 +22,11 @@ public partial class NetWorthTimeSeriesCard
     protected override async Task OnParametersSetAsync()
     {
         var user = await LoginService.GetLoggedUser();
-        if (user is null) return;
+        if (user is null)
+        {
+            ChartData = [];
+            return;
+        }
 
         _isLoading = true;
         StateHasChanged();
@@ -32,9 +36,12 @@ public partial class NetWorthTimeSeriesCard
         }
         catch (Exception ex)
         {
+            ChartData = [];
             Logger.LogError(ex, "Error getting net worth time series data");
         }
-
-        _isLoading = false;
+        finally
+        {
+            _isLoading = false;
+        }
     }
 }

--- a/code/FinanceManager.Components/Components/Dashboard/Dashboard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Dashboard.razor
@@ -1,12 +1,17 @@
 ﻿@using FinanceManager.Components.Components.Dashboard.Cards
 @using FinanceManager.Components.Components.Dashboard.Cards.Assets
 @using FinanceManager.Components.Components.Dashboard.Cards.Liabilities
+@using FinanceManager.Components.Components.Dashboard.Cards.TimeSeries
 
 <MudContainer Class="py-2">
     <MudGrid Spacing="2">
 
         <MudItem xs="12" md="12">
             <NetWorthOverviewCard Height="@($"{_unitHeight}px")" StartDateTime="@StartDate" EndDateTime="@EndDate" />
+        </MudItem>
+
+        <MudItem xs="12">
+            <NetWorthTimeSeriesCard StartDateTime="@StartDate" EndDateTime="@EndDate" />
         </MudItem>
 
         <MudItem xs="12" md="6">


### PR DESCRIPTION
The Assets page had an "Assets value over time" chart covering only
investment assets. Issue #149 asks for a net worth timeline that combines
all account types (assets + liabilities) in the user's base currency.

Adds NetWorthTimeSeriesCard using the existing MoneyFlow/GetNetWorth
time-range API endpoint and wires it into AssetsPage below the existing
assets chart.

https://claude.ai/code/session_017y2CfcdT2WNwjkBHs2efQK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Net worth over time" card to the dashboard that displays net worth trends using an interactive line chart. Users can view historical net worth data across a configurable date range with adjustable card height. The chart displays a loading indicator while data is being retrieved and shows a message when no data is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->