### PR TITLE
Add diversification proxy gauge widget (#130)

### DIFF
--- a/code/FinanceManager.Api/Controllers/DiversificationController.cs
+++ b/code/FinanceManager.Api/Controllers/DiversificationController.cs
@@ -2,6 +2,7 @@ using FinanceManager.Domain.Entities.MoneyFlowModels;
 using FinanceManager.Domain.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace FinanceManager.Api.Controllers;
 
@@ -13,6 +14,17 @@ public class DiversificationController(IDiversificationService diversificationSe
 {
     [HttpGet("{userId:int}/{asOfDate:DateTime}")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DiversificationScore))]
-    public async Task<IActionResult> GetDiversificationScore(int userId, DateTime asOfDate, CancellationToken cancellationToken = default) =>
-        Ok(await diversificationService.GetDiversificationScore(userId, asOfDate));
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetDiversificationScore(int userId, DateTime asOfDate, CancellationToken cancellationToken = default)
+    {
+        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out var authenticatedUserId))
+            return Forbid();
+
+        if (authenticatedUserId != userId)
+            return Forbid();
+
+        return Ok(await diversificationService.GetDiversificationScore(userId, asOfDate));
+    }
 }

--- a/code/FinanceManager.Api/Controllers/DiversificationController.cs
+++ b/code/FinanceManager.Api/Controllers/DiversificationController.cs
@@ -1,0 +1,18 @@
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using FinanceManager.Domain.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinanceManager.Api.Controllers;
+
+[Route("api/[controller]")]
+[Authorize]
+[ApiController]
+[Tags("Financial Analysis")]
+public class DiversificationController(IDiversificationService diversificationService) : ControllerBase
+{
+    [HttpGet("{userId:int}/{asOfDate:DateTime}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DiversificationScore))]
+    public async Task<IActionResult> GetDiversificationScore(int userId, DateTime asOfDate, CancellationToken cancellationToken = default) =>
+        Ok(await diversificationService.GetDiversificationScore(userId, asOfDate));
+}

--- a/code/FinanceManager.Application/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Application/ServiceCollectionExtension.cs
@@ -83,6 +83,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<ILabelSetterAiService, LabelSetterAiService>()
                 .AddScoped<ILabelSuggestionAiService, LabelSuggestionAiService>()
                 .AddScoped<IRecurringTransactionDetectorService, RecurringTransactionDetectorService>()
+                .AddScoped<IDiversificationService, DiversificationService>()
             ;
 
         return services;

--- a/code/FinanceManager.Application/Services/DiversificationService.cs
+++ b/code/FinanceManager.Application/Services/DiversificationService.cs
@@ -55,8 +55,8 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
             uniqueTickers.Add($"cash_{account.AccountId}");
         }
 
-        var assetClassScore = (int)(distinctClasses.Count / (double)TotalSupportedClasses * 50);
-        var holdingsScore = (int)(Math.Min(uniqueTickers.Count / (double)HoldingsBenchmark, 1.0) * 50);
+        var assetClassScore = CalculateAssetClassScore(distinctClasses.Count);
+        var holdingsScore = CalculateHoldingsScore(uniqueTickers.Count);
         var totalScore = assetClassScore + holdingsScore;
 
         var band = totalScore switch
@@ -68,4 +68,10 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
 
         return new DiversificationScore(totalScore, assetClassScore, holdingsScore, band);
     }
+
+    private static int CalculateAssetClassScore(int distinctClassCount) =>
+        (int)(distinctClassCount / (double)TotalSupportedClasses * 50);
+
+    private static int CalculateHoldingsScore(int uniqueTickerCount) =>
+        (int)(Math.Min(uniqueTickerCount / (double)HoldingsBenchmark, 1.0) * 50);
 }

--- a/code/FinanceManager.Application/Services/DiversificationService.cs
+++ b/code/FinanceManager.Application/Services/DiversificationService.cs
@@ -15,39 +15,11 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
 
     public async Task<DiversificationScore> GetDiversificationScore(int userId, DateTime asOfDate)
     {
-        var distinctClasses = new HashSet<InvestmentType>();
-        var uniqueTickers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var heldAssetClasses = await GetHeldAssetClasses(userId, asOfDate);
+        var uniqueHoldings = await GetUniqueHoldingsPerType(userId, asOfDate);
 
-        await foreach (var account in financialAccountRepository.GetAccounts<StockAccount>(userId, DateTime.MinValue, asOfDate))
-        {
-            var tickers = account.GetStoredTickers();
-            foreach (var ticker in tickers)
-                uniqueTickers.Add(ticker);
-
-            if (tickers.Count > 0)
-                distinctClasses.Add(InvestmentType.Stock);
-        }
-
-        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, DateTime.MinValue, asOfDate))
-        {
-            if (account.Entries.Count == 0) continue;
-
-            distinctClasses.Add(InvestmentType.Bond);
-            foreach (var entry in account.Entries)
-                uniqueTickers.Add($"bond_{entry.BondDetailsId}");
-        }
-
-        var hasCash = await financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate)
-            .AnyAsync(account => account.Entries.Count > 0);
-
-        if (hasCash)
-        {
-            distinctClasses.Add(InvestmentType.Cash);
-            uniqueTickers.Add("cash");
-        }
-
-        var assetClassScore = CalculateAssetClassScore(distinctClasses.Count);
-        var holdingsScore = CalculateHoldingsScore(uniqueTickers.Count);
+        var assetClassScore = CalculateAssetClassScore(heldAssetClasses.Count);
+        var holdingsScore = CalculateHoldingsScore(uniqueHoldings.Count);
         var totalScore = assetClassScore + holdingsScore;
 
         var band = totalScore switch
@@ -58,6 +30,44 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
         };
 
         return new DiversificationScore(totalScore, assetClassScore, holdingsScore, band);
+    }
+
+    private async Task<HashSet<InvestmentType>> GetHeldAssetClasses(int userId, DateTime asOfDate)
+    {
+        var heldClasses = new HashSet<InvestmentType>();
+
+        var hasStocks = await financialAccountRepository.GetAccounts<StockAccount>(userId, DateTime.MinValue, asOfDate)
+            .AnyAsync(account => account.Entries.Count > 0);
+        if (hasStocks) heldClasses.Add(InvestmentType.Stock);
+
+        var hasBonds = await financialAccountRepository.GetAccounts<BondAccount>(userId, DateTime.MinValue, asOfDate)
+            .AnyAsync(account => account.Entries.Count > 0);
+        if (hasBonds) heldClasses.Add(InvestmentType.Bond);
+
+        var hasCash = await financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate)
+            .AnyAsync(account => account.Entries.Count > 0);
+        if (hasCash) heldClasses.Add(InvestmentType.Cash);
+
+        return heldClasses;
+    }
+
+    private async Task<HashSet<string>> GetUniqueHoldingsPerType(int userId, DateTime asOfDate)
+    {
+        var uniqueTickers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        await foreach (var account in financialAccountRepository.GetAccounts<StockAccount>(userId, DateTime.MinValue, asOfDate))
+            foreach (var ticker in account.GetStoredTickers())
+                uniqueTickers.Add(ticker);
+
+        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, DateTime.MinValue, asOfDate))
+            foreach (var entry in account.Entries)
+                uniqueTickers.Add($"bond_{entry.BondDetailsId}");
+
+        var hasCash = await financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate)
+            .AnyAsync(account => account.Entries.Count > 0);
+        if (hasCash) uniqueTickers.Add("cash");
+
+        return uniqueTickers;
     }
 
     private static int CalculateAssetClassScore(int distinctClassCount) =>

--- a/code/FinanceManager.Application/Services/DiversificationService.cs
+++ b/code/FinanceManager.Application/Services/DiversificationService.cs
@@ -37,12 +37,13 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
                 uniqueTickers.Add($"bond_{entry.BondDetailsId}");
         }
 
-        await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate))
-        {
-            if (account.Entries.Count == 0) continue;
+        var hasCash = await financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate)
+            .AnyAsync(account => account.Entries.Count > 0);
 
+        if (hasCash)
+        {
             distinctClasses.Add(InvestmentType.Cash);
-            uniqueTickers.Add($"cash_{account.AccountId}");
+            uniqueTickers.Add("cash");
         }
 
         var assetClassScore = CalculateAssetClassScore(distinctClasses.Count);

--- a/code/FinanceManager.Application/Services/DiversificationService.cs
+++ b/code/FinanceManager.Application/Services/DiversificationService.cs
@@ -1,0 +1,71 @@
+using FinanceManager.Domain.Entities.Bonds;
+using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using FinanceManager.Domain.Entities.Stocks;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories.Account;
+using FinanceManager.Domain.Services;
+
+namespace FinanceManager.Application.Services;
+
+public class DiversificationService(IFinancialAccountRepository financialAccountRepository) : IDiversificationService
+{
+    private static readonly HashSet<InvestmentType> SupportedClasses =
+    [
+        InvestmentType.Cash,
+        InvestmentType.Stock,
+        InvestmentType.Bond,
+        InvestmentType.Property,
+        InvestmentType.Crypto,
+        InvestmentType.Commodities,
+    ];
+
+    private const int TotalSupportedClasses = 6;
+    private const int HoldingsBenchmark = 30;
+
+    public async Task<DiversificationScore> GetDiversificationScore(int userId, DateTime asOfDate)
+    {
+        var distinctClasses = new HashSet<InvestmentType>();
+        var uniqueTickers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        await foreach (var account in financialAccountRepository.GetAccounts<StockAccount>(userId, DateTime.MinValue, asOfDate))
+        {
+            foreach (var ticker in account.GetStoredTickers())
+                uniqueTickers.Add(ticker);
+
+            foreach (var type in account.GetStoredTypes())
+                if (SupportedClasses.Contains(type))
+                    distinctClasses.Add(type);
+        }
+
+        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, DateTime.MinValue, asOfDate))
+        {
+            if (account.Entries.Count == 0) continue;
+
+            distinctClasses.Add(InvestmentType.Bond);
+            foreach (var entry in account.Entries)
+                uniqueTickers.Add($"bond_{entry.BondDetailsId}");
+        }
+
+        await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate))
+        {
+            if (account.Entries.Count == 0) continue;
+
+            distinctClasses.Add(InvestmentType.Cash);
+            uniqueTickers.Add($"cash_{account.AccountId}");
+        }
+
+        var assetClassScore = (int)(distinctClasses.Count / (double)TotalSupportedClasses * 50);
+        var holdingsScore = (int)(Math.Min(uniqueTickers.Count / (double)HoldingsBenchmark, 1.0) * 50);
+        var totalScore = assetClassScore + holdingsScore;
+
+        var band = totalScore switch
+        {
+            <= 33 => "Limited",
+            <= 66 => "Moderate",
+            _ => "Broad"
+        };
+
+        return new DiversificationScore(totalScore, assetClassScore, holdingsScore, band);
+    }
+}

--- a/code/FinanceManager.Application/Services/DiversificationService.cs
+++ b/code/FinanceManager.Application/Services/DiversificationService.cs
@@ -10,16 +10,6 @@ namespace FinanceManager.Application.Services;
 
 public class DiversificationService(IFinancialAccountRepository financialAccountRepository) : IDiversificationService
 {
-    private static readonly HashSet<InvestmentType> SupportedClasses =
-    [
-        InvestmentType.Cash,
-        InvestmentType.Stock,
-        InvestmentType.Bond,
-        InvestmentType.Property,
-        InvestmentType.Crypto,
-        InvestmentType.Commodities,
-    ];
-
     private const int TotalSupportedClasses = 6;
     private const int HoldingsBenchmark = 30;
 
@@ -30,12 +20,12 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
 
         await foreach (var account in financialAccountRepository.GetAccounts<StockAccount>(userId, DateTime.MinValue, asOfDate))
         {
-            foreach (var ticker in account.GetStoredTickers())
+            var tickers = account.GetStoredTickers();
+            foreach (var ticker in tickers)
                 uniqueTickers.Add(ticker);
 
-            foreach (var type in account.GetStoredTypes())
-                if (SupportedClasses.Contains(type))
-                    distinctClasses.Add(type);
+            if (tickers.Count > 0)
+                distinctClasses.Add(InvestmentType.Stock);
         }
 
         await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, DateTime.MinValue, asOfDate))

--- a/code/FinanceManager.Application/Services/DiversificationService.cs
+++ b/code/FinanceManager.Application/Services/DiversificationService.cs
@@ -22,14 +22,7 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
         var holdingsScore = CalculateHoldingsScore(uniqueHoldings.Count);
         var totalScore = assetClassScore + holdingsScore;
 
-        var band = totalScore switch
-        {
-            <= 33 => "Limited",
-            <= 66 => "Moderate",
-            _ => "Broad"
-        };
-
-        return new DiversificationScore(totalScore, assetClassScore, holdingsScore, band);
+        return new DiversificationScore(totalScore, assetClassScore, holdingsScore, GetBand(totalScore));
     }
 
     private async Task<HashSet<InvestmentType>> GetHeldAssetClasses(int userId, DateTime asOfDate)
@@ -69,6 +62,13 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
 
         return uniqueTickers;
     }
+
+    internal static string GetBand(int totalScore) => totalScore switch
+    {
+        <= 33 => "Limited",
+        <= 66 => "Moderate",
+        _ => "Broad"
+    };
 
     private static int CalculateAssetClassScore(int distinctClassCount) =>
         (int)(distinctClassCount / (double)TotalSupportedClasses * 50);

--- a/code/FinanceManager.Application/Services/DiversificationService.cs
+++ b/code/FinanceManager.Application/Services/DiversificationService.cs
@@ -45,7 +45,7 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
         if (hasBonds) heldClasses.Add(InvestmentType.Bond);
 
         var hasCash = await financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate)
-            .AnyAsync(account => account.Entries.Count > 0);
+            .AnyAsync(account => account.ContainsAssets);
         if (hasCash) heldClasses.Add(InvestmentType.Cash);
 
         return heldClasses;
@@ -64,7 +64,7 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
                 uniqueTickers.Add($"bond_{entry.BondDetailsId}");
 
         var hasCash = await financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate)
-            .AnyAsync(account => account.Entries.Count > 0);
+            .AnyAsync(account => account.ContainsAssets);
         if (hasCash) uniqueTickers.Add("cash");
 
         return uniqueTickers;

--- a/code/FinanceManager.Application/Services/DiversificationService.cs
+++ b/code/FinanceManager.Application/Services/DiversificationService.cs
@@ -57,7 +57,7 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
 
         await foreach (var account in financialAccountRepository.GetAccounts<StockAccount>(userId, DateTime.MinValue, asOfDate))
             foreach (var ticker in account.GetStoredTickers())
-                uniqueTickers.Add(ticker);
+                uniqueTickers.Add($"stock_{ticker}");
 
         await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, DateTime.MinValue, asOfDate))
             foreach (var entry in account.Entries)

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor
@@ -1,0 +1,40 @@
+<MudCard Outlined Class="d-flex flex-nowrap" Style="@($"height:{Height};")">
+    <MudPaper Class="flex-grow-0 p-3" Elevation="0">
+        <div class="d-flex align-center gap-1">
+            <MudText Typo="Typo.h5">Diversification proxy</MudText>
+            <MudTooltip Text="Based on number of asset classes and unique holdings; not investment advice.">
+                <MudIconButton Icon="@Icons.Material.Filled.Info" Size="Size.Small" />
+            </MudTooltip>
+        </div>
+        @if (!_isLoading && _score is not null)
+        {
+            <MudText Typo="Typo.h6" Class="mb-2 text-muted">@_score.Band</MudText>
+        }
+    </MudPaper>
+
+    <MudPaper Class="flex-grow-1 overflow-hidden d-flex align-center justify-center" Elevation="0">
+        @if (_isLoading)
+        {
+            <div style="height:100%">
+                <ChartSpinner MaxHeight=@Height />
+            </div>
+        }
+        else if (_score is not null)
+        {
+            <div class="d-flex flex-column align-center justify-center gap-2 pa-4" style="width:100%;">
+                <MudText Typo="Typo.h2" Align="Align.Center">@_score.Score<MudText Typo="Typo.h5" Inline Style="opacity:0.5">/100</MudText></MudText>
+                <MudProgressLinear Value="@_score.Score" Max="100" Color="@_bandColor" Rounded Size="Size.Large" Style="width:80%;" />
+                <div class="d-flex justify-space-between" style="width:80%;">
+                    <MudText Typo="Typo.caption">0 — Limited</MudText>
+                    <MudText Typo="Typo.caption">Broad — 100</MudText>
+                </div>
+            </div>
+        }
+        else
+        {
+            <div class="d-flex flex-grow-1 justify-center align-content-center flex-wrap">
+                <MudText Typo="Typo.button" HtmlTag="h3">No data</MudText>
+            </div>
+        }
+    </MudPaper>
+</MudCard>

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor
@@ -3,7 +3,7 @@
         <div class="d-flex align-center gap-1">
             <MudText Typo="Typo.h5">Diversification proxy</MudText>
             <MudTooltip Text="Based on number of asset classes and unique holdings; not investment advice.">
-                <MudIconButton Icon="@Icons.Material.Filled.Info" Size="Size.Small" />
+                <MudIconButton Icon="@Icons.Material.Filled.Info" Size="Size.Small" AriaLabel="Diversification proxy information" />
             </MudTooltip>
         </div>
         @if (!_isLoading && _score is not null)

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor.cs
@@ -1,0 +1,59 @@
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using FinanceManager.Domain.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+using MudBlazor;
+
+namespace FinanceManager.Components.Components.Dashboard.Cards;
+
+public partial class DiversificationProxyCard
+{
+    private bool _isLoading;
+    private DiversificationScore? _score;
+    private Color _bandColor = Color.Default;
+
+    [Parameter] public string Height { get; set; } = "300px";
+
+    [Inject] public required ILogger<DiversificationProxyCard> Logger { get; set; }
+    [Inject] public required DiversificationHttpClient DiversificationHttpClient { get; set; }
+    [Inject] public required ILoginService LoginService { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadData();
+    }
+
+    private async Task LoadData()
+    {
+        _isLoading = true;
+        StateHasChanged();
+
+        try
+        {
+            var user = await LoginService.GetLoggedUser();
+            if (user is null)
+            {
+                _score = null;
+                return;
+            }
+
+            _score = await DiversificationHttpClient.GetDiversificationScore(user.UserId, DateTime.UtcNow);
+            _bandColor = _score?.Band switch
+            {
+                "Broad" => Color.Success,
+                "Moderate" => Color.Warning,
+                _ => Color.Error
+            };
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading diversification score");
+        }
+        finally
+        {
+            _isLoading = false;
+            StateHasChanged();
+        }
+    }
+}

--- a/code/FinanceManager.Components/Components/Dashboard/Dashboard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Dashboard.razor
@@ -47,6 +47,10 @@
             <RecurringTransactionDetectorCard Height="@($"{_unitHeight * 3}px")" />
         </MudItem>
 
+        <MudItem xs="12" md="6" lg="4">
+            <DiversificationProxyCard Height="@($"{_unitHeight * 3}px")" />
+        </MudItem>
+
     </MudGrid>
 </MudContainer>
 

--- a/code/FinanceManager.Components/HttpClients/DiversificationHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/DiversificationHttpClient.cs
@@ -1,0 +1,20 @@
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Components.HttpClients;
+
+public class DiversificationHttpClient(HttpClient httpClient)
+{
+    public async Task<DiversificationScore?> GetDiversificationScore(int userId, DateTime asOfDate)
+    {
+        try
+        {
+            return await httpClient.GetFromJsonAsync<DiversificationScore>(
+                $"{httpClient.BaseAddress}api/Diversification/{userId}/{asOfDate:O}");
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/code/FinanceManager.Components/HttpClients/DiversificationHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/DiversificationHttpClient.cs
@@ -7,14 +7,8 @@ public class DiversificationHttpClient(HttpClient httpClient)
 {
     public async Task<DiversificationScore?> GetDiversificationScore(int userId, DateTime asOfDate)
     {
-        try
-        {
-            return await httpClient.GetFromJsonAsync<DiversificationScore>(
-                $"{httpClient.BaseAddress}api/Diversification/{userId}/{asOfDate:O}");
-        }
-        catch
-        {
-            return null;
-        }
+        var result = await httpClient.GetFromJsonAsync<DiversificationScore>(
+            $"{httpClient.BaseAddress}api/Diversification/{userId}/{asOfDate:O}");
+        return result;
     }
 }

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -38,6 +38,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<LabelSetterProgressHttpClient>()
                 .AddScoped<FinancialInsightsHttpClient>()
                 .AddScoped<RecurringTransactionDetectorHttpClient>()
+                .AddScoped<DiversificationHttpClient>()
                 .AddScoped<AdministrationUsersHttpClient>()
                 .AddScoped<AdminAiProvidersHttpClient>()
                 .AddScoped<NewVisitorsHttpClient>()

--- a/code/FinanceManager.Domain/Entities/MoneyFlowModels/DiversificationScore.cs
+++ b/code/FinanceManager.Domain/Entities/MoneyFlowModels/DiversificationScore.cs
@@ -1,0 +1,3 @@
+namespace FinanceManager.Domain.Entities.MoneyFlowModels;
+
+public record DiversificationScore(int Score, int AssetClassScore, int HoldingsScore, string Band);

--- a/code/FinanceManager.Domain/Enums/InvestmentType.cs
+++ b/code/FinanceManager.Domain/Enums/InvestmentType.cs
@@ -6,5 +6,7 @@ public enum InvestmentType
     Cash,
     Stock,
     Bond,
-    Property
+    Property,
+    Crypto,
+    Commodities
 }

--- a/code/FinanceManager.Domain/Services/IDiversificationService.cs
+++ b/code/FinanceManager.Domain/Services/IDiversificationService.cs
@@ -1,0 +1,8 @@
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+
+namespace FinanceManager.Domain.Services;
+
+public interface IDiversificationService
+{
+    Task<DiversificationScore> GetDiversificationScore(int userId, DateTime asOfDate);
+}

--- a/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
@@ -152,6 +152,23 @@ public class DiversificationServiceTests
         Assert.Equal(expectedAssetClassScore, result.AssetClassScore);
     }
 
+    [Fact]
+    public async Task GetDiversificationScore_CurrencyAccountWithNegativeBalance_DoesNotCountAsCash()
+    {
+        // Liability-style account: latest balance is negative
+        var debtAccount = new CurrencyAccount(1, 1, "credit", AccountLabel.Other);
+        debtAccount.Add(new CurrencyAccountEntry(1, 1, _asOfDate, -500, -500), false);
+
+        SetupStockAccounts();
+        SetupBondAccounts();
+        SetupCurrencyAccounts(debtAccount);
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        Assert.Equal(0, result.Score);
+        Assert.Equal("Limited", result.Band);
+    }
+
     [Theory]
     [InlineData(0, "Limited")]
     [InlineData(33, "Limited")]

--- a/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
@@ -1,0 +1,152 @@
+using FinanceManager.Application.Services;
+using FinanceManager.Domain.Entities.Bonds;
+using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.Stocks;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories.Account;
+using Moq;
+
+namespace FinanceManager.UnitTests.Application.Services;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class DiversificationServiceTests
+{
+    private readonly Mock<IFinancialAccountRepository> _repositoryMock = new();
+    private readonly DiversificationService _service;
+    private readonly DateTime _asOfDate = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public DiversificationServiceTests() => _service = new(_repositoryMock.Object);
+
+    private void SetupStockAccounts(params StockAccount[] accounts) =>
+        _repositoryMock.Setup(x => x.GetAccounts<StockAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(accounts.ToAsyncEnumerable());
+
+    private void SetupBondAccounts(params BondAccount[] accounts) =>
+        _repositoryMock.Setup(x => x.GetAccounts<BondAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(accounts.ToAsyncEnumerable());
+
+    private void SetupCurrencyAccounts(params CurrencyAccount[] accounts) =>
+        _repositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(accounts.ToAsyncEnumerable());
+
+    [Fact]
+    public async Task GetDiversificationScore_EmptyPortfolio_ReturnsZero()
+    {
+        SetupStockAccounts();
+        SetupBondAccounts();
+        SetupCurrencyAccounts();
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        Assert.Equal(0, result.Score);
+        Assert.Equal(0, result.AssetClassScore);
+        Assert.Equal(0, result.HoldingsScore);
+        Assert.Equal("Limited", result.Band);
+    }
+
+    [Fact]
+    public async Task GetDiversificationScore_OneClassOneTicker_ReturnsLowNonZeroScore()
+    {
+        var account = new StockAccount(1, 1, "stocks");
+        account.Add(new StockAccountEntry(1, 1, _asOfDate, 10, 10, "AAPL", InvestmentType.Stock), false);
+
+        SetupStockAccounts(account);
+        SetupBondAccounts();
+        SetupCurrencyAccounts();
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        // 1 class → (1/6)*50 ≈ 8; 1 ticker → (1/30)*50 ≈ 1; total ≈ 9
+        Assert.True(result.Score > 0);
+        Assert.Equal("Limited", result.Band);
+    }
+
+    [Fact]
+    public async Task GetDiversificationScore_SixClassesThirtyTickers_ReturnsOneHundred()
+    {
+        // 30 stock tickers across multiple investment types
+        var stockAccount = new StockAccount(1, 1, "stocks");
+        for (int i = 1; i <= 20; i++)
+            stockAccount.Add(new StockAccountEntry(1, i, _asOfDate, 10, 10, $"STK{i}", InvestmentType.Stock), false);
+        for (int i = 1; i <= 5; i++)
+            stockAccount.Add(new StockAccountEntry(1, 20 + i, _asOfDate, 10, 10, $"CRY{i}", InvestmentType.Crypto), false);
+        for (int i = 1; i <= 3; i++)
+            stockAccount.Add(new StockAccountEntry(1, 25 + i, _asOfDate, 10, 10, $"COM{i}", InvestmentType.Commodities), false);
+        for (int i = 1; i <= 2; i++)
+            stockAccount.Add(new StockAccountEntry(1, 28 + i, _asOfDate, 10, 10, $"PROP{i}", InvestmentType.Property), false);
+
+        // 2 bond instruments
+        var bondAccount = new BondAccount(1, 2, "bonds",
+            [new BondAccountEntry(2, 1, _asOfDate, 10m, 10m, 1),
+             new BondAccountEntry(2, 2, _asOfDate, 10m, 10m, 2)],
+            AccountLabel.Other);
+
+        // 1 cash account
+        var cashAccount = new CurrencyAccount(1, 3, "cash", AccountLabel.Cash);
+        cashAccount.Add(new CurrencyAccountEntry(3, 1, _asOfDate, 100, 100), false);
+
+        SetupStockAccounts(stockAccount);
+        SetupBondAccounts(bondAccount);
+        SetupCurrencyAccounts(cashAccount);
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        // 6 classes → 50 pts; 30 tickers (20+5+3+2 stocks + 2 bonds + 1 cash) = 33 tickers → 50 pts
+        Assert.Equal(50, result.AssetClassScore);
+        Assert.Equal(50, result.HoldingsScore);
+        Assert.Equal(100, result.Score);
+        Assert.Equal("Broad", result.Band);
+    }
+
+    [Fact]
+    public async Task GetDiversificationScore_DuplicateTickerAcrossAccounts_CountedOnce()
+    {
+        var account1 = new StockAccount(1, 1, "stocks-a");
+        account1.Add(new StockAccountEntry(1, 1, _asOfDate, 10, 10, "AAPL", InvestmentType.Stock), false);
+
+        var account2 = new StockAccount(1, 2, "stocks-b");
+        account2.Add(new StockAccountEntry(2, 1, _asOfDate, 5, 5, "AAPL", InvestmentType.Stock), false);
+
+        SetupStockAccounts(account1, account2);
+        SetupBondAccounts();
+        SetupCurrencyAccounts();
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        // 1 unique ticker despite two accounts
+        var expectedHoldingsScore = (int)(1 / 30.0 * 50);
+        Assert.Equal(expectedHoldingsScore, result.HoldingsScore);
+    }
+
+    [Fact]
+    public async Task GetDiversificationScore_UnknownInvestmentType_IsIgnoredFromAssetClasses()
+    {
+        var account = new StockAccount(1, 1, "mixed");
+        account.Add(new StockAccountEntry(1, 1, _asOfDate, 10, 10, "AAPL", InvestmentType.Stock), false);
+        account.Add(new StockAccountEntry(1, 2, _asOfDate, 5, 5, "???", InvestmentType.Unknown), false);
+
+        SetupStockAccounts(account);
+        SetupBondAccounts();
+        SetupCurrencyAccounts();
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        // Only Stock class counted, Unknown is excluded
+        var expectedAssetClassScore = (int)(1 / 6.0 * 50);
+        Assert.Equal(expectedAssetClassScore, result.AssetClassScore);
+    }
+
+    [Theory]
+    [InlineData(0, "Limited")]
+    [InlineData(33, "Limited")]
+    [InlineData(34, "Moderate")]
+    [InlineData(66, "Moderate")]
+    [InlineData(67, "Broad")]
+    [InlineData(100, "Broad")]
+    public void Band_MatchesScoreRanges(int score, string expectedBand)
+    {
+        var result = new DiversificationScore(score, 0, score, expectedBand);
+        Assert.Equal(expectedBand, result.Band);
+    }
+}

--- a/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
@@ -1,6 +1,7 @@
 using FinanceManager.Application.Services;
 using FinanceManager.Domain.Entities.Bonds;
 using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
 using FinanceManager.Domain.Entities.Stocks;
 using FinanceManager.Domain.Enums;
 using FinanceManager.Domain.Repositories.Account;

--- a/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
@@ -63,26 +63,18 @@ public class DiversificationServiceTests
     }
 
     [Fact]
-    public async Task GetDiversificationScore_SixClassesThirtyTickers_ReturnsOneHundred()
+    public async Task GetDiversificationScore_AllCurrentAccountTypes_ThirtyTickers_ScoresCorrectly()
     {
-        // 30 stock tickers across multiple investment types
+        // 27 stock tickers + 2 bond instruments + 1 cash = 30 unique holdings
         var stockAccount = new StockAccount(1, 1, "stocks");
-        for (int i = 1; i <= 20; i++)
+        for (int i = 1; i <= 27; i++)
             stockAccount.Add(new StockAccountEntry(1, i, _asOfDate, 10, 10, $"STK{i}", InvestmentType.Stock), false);
-        for (int i = 1; i <= 5; i++)
-            stockAccount.Add(new StockAccountEntry(1, 20 + i, _asOfDate, 10, 10, $"CRY{i}", InvestmentType.Crypto), false);
-        for (int i = 1; i <= 3; i++)
-            stockAccount.Add(new StockAccountEntry(1, 25 + i, _asOfDate, 10, 10, $"COM{i}", InvestmentType.Commodities), false);
-        for (int i = 1; i <= 2; i++)
-            stockAccount.Add(new StockAccountEntry(1, 28 + i, _asOfDate, 10, 10, $"PROP{i}", InvestmentType.Property), false);
 
-        // 2 bond instruments
         var bondAccount = new BondAccount(1, 2, "bonds",
             [new BondAccountEntry(2, 1, _asOfDate, 10m, 10m, 1),
              new BondAccountEntry(2, 2, _asOfDate, 10m, 10m, 2)],
             AccountLabel.Other);
 
-        // 1 cash account
         var cashAccount = new CurrencyAccount(1, 3, "cash", AccountLabel.Cash);
         cashAccount.Add(new CurrencyAccountEntry(3, 1, _asOfDate, 100, 100), false);
 
@@ -92,11 +84,11 @@ public class DiversificationServiceTests
 
         var result = await _service.GetDiversificationScore(1, _asOfDate);
 
-        // 6 classes → 50 pts; 30 tickers (20+5+3+2 stocks + 2 bonds + 1 cash) = 33 tickers → 50 pts
-        Assert.Equal(50, result.AssetClassScore);
+        // 3 classes (Stock, Bond, Cash) → (3/6)*50 = 25 pts
+        // 30 tickers → min(30/30, 1)*50 = 50 pts
+        Assert.Equal(25, result.AssetClassScore);
         Assert.Equal(50, result.HoldingsScore);
-        Assert.Equal(100, result.Score);
-        Assert.Equal("Broad", result.Band);
+        Assert.Equal(75, result.Score);
     }
 
     [Fact]
@@ -133,6 +125,28 @@ public class DiversificationServiceTests
         var result = await _service.GetDiversificationScore(1, _asOfDate);
 
         // Only Stock class counted, Unknown is excluded
+        var expectedAssetClassScore = (int)(1 / 6.0 * 50);
+        Assert.Equal(expectedAssetClassScore, result.AssetClassScore);
+    }
+
+    [Fact]
+    public async Task GetDiversificationScore_MultipleCurrencyAccounts_CashCountsAsOneTicker()
+    {
+        var cashAccount1 = new CurrencyAccount(1, 1, "checking", AccountLabel.Cash);
+        cashAccount1.Add(new CurrencyAccountEntry(1, 1, _asOfDate, 500, 500), false);
+
+        var cashAccount2 = new CurrencyAccount(1, 2, "savings", AccountLabel.Cash);
+        cashAccount2.Add(new CurrencyAccountEntry(2, 1, _asOfDate, 1000, 1000), false);
+
+        SetupStockAccounts();
+        SetupBondAccounts();
+        SetupCurrencyAccounts(cashAccount1, cashAccount2);
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        // Two cash accounts → still only 1 cash holding and 1 asset class
+        var expectedHoldingsScore = (int)(1 / 30.0 * 50);
+        Assert.Equal(expectedHoldingsScore, result.HoldingsScore);
         var expectedAssetClassScore = (int)(1 / 6.0 * 50);
         Assert.Equal(expectedAssetClassScore, result.AssetClassScore);
     }

--- a/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
@@ -176,9 +176,8 @@ public class DiversificationServiceTests
     [InlineData(66, "Moderate")]
     [InlineData(67, "Broad")]
     [InlineData(100, "Broad")]
-    public void Band_MatchesScoreRanges(int score, string expectedBand)
+    public void GetBand_MatchesScoreRanges(int score, string expectedBand)
     {
-        var result = new DiversificationScore(score, 0, score, expectedBand);
-        Assert.Equal(expectedBand, result.Band);
+        Assert.Equal(expectedBand, DiversificationService.GetBand(score));
     }
 }


### PR DESCRIPTION
## Summary

Closes #130. Adds a "Diversification proxy" gauge card to the Dashboard that scores a portfolio 0–100 based on asset-class breadth and unique holdings, with a band label (Limited / Moderate / Broad) and an info tooltip clarifying it's not investment advice.

- **Domain**: `DiversificationScore` record, `IDiversificationService`, plus `Crypto` and `Commodities` added to `InvestmentType` to cover all six classes from the spec.
- **Application**: `DiversificationService` follows single-responsibility — `GetHeldAssetClasses` checks per-type whether any account has entries, `GetUniqueHoldingsPerType` aggregates tickers/bond-ids/cash marker, and the orchestrator combines their counts through `CalculateAssetClassScore` and `CalculateHoldingsScore`.
- **API**: `GET api/Diversification/{userId}/{asOfDate}` returns the score; `[Authorize]`, tagged "Financial Analysis".
- **Components**: `DiversificationProxyCard` (gauge via `MudProgressLinear`, color-coded by band) wired into the Dashboard grid; `DiversificationHttpClient` registered in DI.
- **Tests**: Unit tests cover empty portfolio, single holding, all-current-types scoring, duplicate-ticker dedup, unknown investment types, multiple cash accounts counting as one, and band thresholds.

### Scope notes
- Stock accounts currently only contribute the `Stock` class — Crypto / Property / Commodities are reserved for follow-up work when their own account types exist. Asset-class formula keeps the denominator at 6 per spec.
- Multiple cash accounts count as one holding; per-currency cash diversification is deferred.

## Test plan

- [ ] `dotnet build ./code/FinanceManager.slnx` succeeds with warnings-as-errors
- [ ] `dotnet format ./code --verify-no-changes` passes
- [ ] `dotnet test ./code/FinanceManager.UnitTests/FinanceManager.UnitTests.csproj` — new `DiversificationServiceTests` all green
- [ ] Manual: load Dashboard, confirm gauge renders with correct band color for an empty / partial / diverse portfolio
- [ ] Manual: confirm tooltip text and info icon render in the card header

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbEy683LHyZ8G5A3kLuGhx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Introduced a "Diversification proxy" card on the dashboard displaying your portfolio's diversification score (0–100) with color-coded progress indicators and categorization bands: Limited, Moderate, and Broad.

**Tests**
- Added comprehensive unit test coverage for diversification score calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->