### PR TITLE
Refactor filter bar components to use MudChip as menu activator

### DIFF
--- a/code/FinanceManager.Components/Components/FinancialAccounts/Shared/DateRangeFilterBar.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/Shared/DateRangeFilterBar.razor
@@ -1,44 +1,41 @@
 <MudPaper Elevation="0" Style="background-color:transparent;">
     <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
-        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Default">
-            <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
-                <MudMenu Dense="true" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopLeft" @ref="_menu">
-                    <ActivatorContent>
-                        <MudButton Variant="Variant.Text" Size="Size.Small" Style="text-transform: none; padding: 0;">
-                            <span class="mud-typography-caption">Date range</span>
-                            @if (HasActiveFilter)
-                            {
-                                <span class="mud-typography-caption ms-1">@GetRangeLabel()</span>
-                            }
-                        </MudButton>
-                    </ActivatorContent>
-                    <ChildContent>
-                        <MudPaper Class="pa-3" Elevation="0" Style="min-width: 260px;">
-                            <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-                                <MudText Typo="Typo.subtitle2">Filter entries by date range</MudText>
-                            </MudStack>
-                            <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
-                                <MudDatePicker Date="From" DateChanged="OnFromChanged" Label="From"
-                                               Variant="Variant.Outlined" Margin="Margin.Dense" Clearable
-                                               Style="max-width: 140px;" />
-                                <MudDatePicker Date="To" DateChanged="OnToChanged" Label="To"
-                                               Variant="Variant.Outlined" Margin="Margin.Dense" Clearable
-                                               Style="max-width: 140px;" />
-                            </MudStack>
-                            @if (!string.IsNullOrEmpty(_validationError))
-                            {
-                                <MudText Color="Color.Error" Typo="Typo.caption" Class="mt-1">@_validationError</MudText>
-                            }
-                        </MudPaper>
-                    </ChildContent>
-                </MudMenu>
-                @if (HasActiveFilter)
-                {
-                    <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" Color="Color.Default"
-                                   @onclick="ResetFilter" />
-                }
-            </MudStack>
-        </MudChip>
+        <MudMenu Dense="true" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopLeft" @ref="_menu">
+            <ActivatorContent>
+                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Default"
+                         Style="cursor: pointer;">
+                    <span class="mud-typography-caption">Date range</span>
+                    @if (HasActiveFilter)
+                    {
+                        <span class="mud-typography-caption ms-1">@GetRangeLabel()</span>
+                    }
+                </MudChip>
+            </ActivatorContent>
+            <ChildContent>
+                <MudPaper Class="pa-3" Elevation="0" Style="min-width: 260px;">
+                    <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                        <MudText Typo="Typo.subtitle2">Filter entries by date range</MudText>
+                    </MudStack>
+                    <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
+                        <MudDatePicker Date="From" DateChanged="OnFromChanged" Label="From"
+                                       Variant="Variant.Outlined" Margin="Margin.Dense" Clearable
+                                       Style="max-width: 140px;" />
+                        <MudDatePicker Date="To" DateChanged="OnToChanged" Label="To"
+                                       Variant="Variant.Outlined" Margin="Margin.Dense" Clearable
+                                       Style="max-width: 140px;" />
+                    </MudStack>
+                    @if (!string.IsNullOrEmpty(_validationError))
+                    {
+                        <MudText Color="Color.Error" Typo="Typo.caption" Class="mt-1">@_validationError</MudText>
+                    }
+                </MudPaper>
+            </ChildContent>
+        </MudMenu>
+        @if (HasActiveFilter)
+        {
+            <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" Color="Color.Default"
+                           @onclick="ResetFilter" />
+        }
     </MudStack>
 </MudPaper>
 

--- a/code/FinanceManager.Components/Components/FinancialAccounts/Shared/ValueChangeRangeFilterBar.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/Shared/ValueChangeRangeFilterBar.razor
@@ -1,44 +1,41 @@
 <MudPaper Elevation="0" Style="background-color:transparent;">
     <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
-        <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Default">
-            <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
-                <MudMenu Dense="true" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopLeft" @ref="_menu">
-                    <ActivatorContent>
-                        <MudButton Variant="Variant.Text" Size="Size.Small" Style="text-transform: none; padding: 0;">
-                            <span class="mud-typography-caption">Value change</span>
-                            @if (HasActiveFilter)
-                            {
-                                <span class="mud-typography-caption ms-1">@GetRangeLabel()</span>
-                            }
-                        </MudButton>
-                    </ActivatorContent>
-                    <ChildContent>
-                        <MudPaper Class="pa-3" Elevation="0" Style="min-width: 260px;">
-                            <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
-                                <MudText Typo="Typo.subtitle2">Filter entries by value change range</MudText>
-                            </MudStack>
-                            <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
-                                <MudNumericField T="decimal?" Value="From" ValueChanged="OnFromChanged" Label="From"
-                                                 Variant="Variant.Outlined" Margin="Margin.Dense" Clearable
-                                                 Style="max-width: 140px;" />
-                                <MudNumericField T="decimal?" Value="To" ValueChanged="OnToChanged" Label="To"
-                                                 Variant="Variant.Outlined" Margin="Margin.Dense" Clearable
-                                                 Style="max-width: 140px;" />
-                            </MudStack>
-                            @if (!string.IsNullOrEmpty(_validationError))
-                            {
-                                <MudText Color="Color.Error" Typo="Typo.caption" Class="mt-1">@_validationError</MudText>
-                            }
-                        </MudPaper>
-                    </ChildContent>
-                </MudMenu>
-                @if (HasActiveFilter)
-                {
-                    <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" Color="Color.Default"
-                                   @onclick="ResetFilter" />
-                }
-            </MudStack>
-        </MudChip>
+        <MudMenu Dense="true" AnchorOrigin="Origin.BottomLeft" TransformOrigin="Origin.TopLeft" @ref="_menu">
+            <ActivatorContent>
+                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Default"
+                         Style="cursor: pointer;">
+                    <span class="mud-typography-caption">Value change</span>
+                    @if (HasActiveFilter)
+                    {
+                        <span class="mud-typography-caption ms-1">@GetRangeLabel()</span>
+                    }
+                </MudChip>
+            </ActivatorContent>
+            <ChildContent>
+                <MudPaper Class="pa-3" Elevation="0" Style="min-width: 260px;">
+                    <MudStack Row AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+                        <MudText Typo="Typo.subtitle2">Filter entries by value change range</MudText>
+                    </MudStack>
+                    <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
+                        <MudNumericField T="decimal?" Value="From" ValueChanged="OnFromChanged" Label="From"
+                                         Variant="Variant.Outlined" Margin="Margin.Dense" Clearable
+                                         Style="max-width: 140px;" />
+                        <MudNumericField T="decimal?" Value="To" ValueChanged="OnToChanged" Label="To"
+                                         Variant="Variant.Outlined" Margin="Margin.Dense" Clearable
+                                         Style="max-width: 140px;" />
+                    </MudStack>
+                    @if (!string.IsNullOrEmpty(_validationError))
+                    {
+                        <MudText Color="Color.Error" Typo="Typo.caption" Class="mt-1">@_validationError</MudText>
+                    }
+                </MudPaper>
+            </ChildContent>
+        </MudMenu>
+        @if (HasActiveFilter)
+        {
+            <MudIconButton Icon="@Icons.Material.Filled.Close" Size="Size.Small" Color="Color.Default"
+                           @onclick="ResetFilter" />
+        }
     </MudStack>
 </MudPaper>
 


### PR DESCRIPTION
## Summary
Restructured the `DateRangeFilterBar` and `ValueChangeRangeFilterBar` components to use `MudChip` as the direct activator for the filter menu, replacing the previous pattern of nesting a `MudButton` inside a `MudChip` within a `MudStack`.

## Changes
- **Moved `MudChip` into `MudMenu`'s `ActivatorContent`**: The chip now directly triggers the menu, eliminating the intermediate button layer and unnecessary nesting.
- **Simplified component hierarchy**: Removed the inner `MudStack` that wrapped the menu and close button, flattening the structure.
- **Added cursor pointer style**: Applied `cursor: pointer;` to the chip to provide visual feedback that it's clickable.
- **Repositioned clear button**: The close/reset icon button now sits at the same level as the menu in the outer `MudStack`, improving layout clarity.

## Implementation Details
Both filter bar components follow the same refactoring pattern:
- The `MudChip` now serves as the visual trigger and label display
- The menu's `ActivatorContent` contains only the chip
- The conditional close button is rendered outside the menu, adjacent to it in the parent stack
- All filter logic and validation remain unchanged

This change improves the component's semantic structure and reduces DOM nesting while maintaining the same user interaction model.

https://claude.ai/code/session_01MXaN3RkCznz53f213vx7QW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Restructured the date range filter control layout in the Financial Accounts section for improved visual consistency
  * Enhanced the value change range filter control interface for better user experience
  * Refined filter trigger component layouts across financial account filtering features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->