### PR TITLE
Move DiversificationProxyCard from Dashboard to AssetsPage

### DIFF
--- a/code/FinanceManager.Components/Components/AssetsPage.razor
+++ b/code/FinanceManager.Components/Components/AssetsPage.razor
@@ -25,6 +25,10 @@
         <MudItem xs="12" lg="4">
             <InvestmentRateCard StartDateTime=StartDate EndDateTime="@EndDate" Height="@($"{1.5 * _unitHeight}px")" />
         </MudItem>
+
+        <MudItem xs="12" lg="4">
+            <DiversificationProxyCard Height="@($"{2 * _unitHeight}px")" />
+        </MudItem>
     </MudGrid>
 </MudContainer>
 

--- a/code/FinanceManager.Components/Components/Dashboard/Dashboard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Dashboard.razor
@@ -52,10 +52,6 @@
             <RecurringTransactionDetectorCard Height="@($"{_unitHeight * 3}px")" />
         </MudItem>
 
-        <MudItem xs="12" md="6" lg="4">
-            <DiversificationProxyCard Height="@($"{_unitHeight * 3}px")" />
-        </MudItem>
-
     </MudGrid>
 </MudContainer>
 


### PR DESCRIPTION
## Summary
Relocates the `DiversificationProxyCard` component from the Dashboard to the AssetsPage, adjusting its layout and height to fit the new context.

## Changes
- **Dashboard.razor**: Removed the `DiversificationProxyCard` component (previously displayed at 3× unit height on md/lg breakpoints)
- **AssetsPage.razor**: Added `DiversificationProxyCard` component in a new `MudItem` (displayed at 2× unit height on lg breakpoints, full width on xs)

## Implementation Details
- The card is repositioned to provide better organization of asset-related information on the dedicated Assets page
- Height adjusted from `3 * _unitHeight` to `2 * _unitHeight` to match the visual hierarchy of the AssetsPage layout
- Responsive grid configuration updated: `xs="12" lg="4"` ensures the card displays full-width on mobile and one-third width on large screens, consistent with other cards on the page

https://claude.ai/code/session_01HJqMsVrnehxmpqFr5g28d9