### PR TITLE
fix: resolve #164 - Diversification score: use current positions instead of full history

### DIFF
--- a/code/FinanceManager.Application/Services/DiversificationService.cs
+++ b/code/FinanceManager.Application/Services/DiversificationService.cs
@@ -15,8 +15,7 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
 
     public async Task<DiversificationScore> GetDiversificationScore(int userId, DateTime asOfDate)
     {
-        var heldAssetClasses = await GetHeldAssetClasses(userId, asOfDate);
-        var uniqueHoldings = await GetUniqueHoldingsPerType(userId, asOfDate);
+        var (heldAssetClasses, uniqueHoldings) = await GetCurrentHoldings(userId, asOfDate);
 
         var assetClassScore = CalculateAssetClassScore(heldAssetClasses.Count);
         var holdingsScore = CalculateHoldingsScore(uniqueHoldings.Count);
@@ -25,42 +24,65 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
         return new DiversificationScore(totalScore, assetClassScore, holdingsScore, GetBand(totalScore));
     }
 
-    private async Task<HashSet<InvestmentType>> GetHeldAssetClasses(int userId, DateTime asOfDate)
+    private async Task<(HashSet<InvestmentType> AssetClasses, HashSet<string> Holdings)> GetCurrentHoldings(int userId, DateTime asOfDate)
     {
         var heldClasses = new HashSet<InvestmentType>();
-
-        var hasStocks = await financialAccountRepository.GetAccounts<StockAccount>(userId, DateTime.MinValue, asOfDate)
-            .AnyAsync(account => account.Entries.Count > 0);
-        if (hasStocks) heldClasses.Add(InvestmentType.Stock);
-
-        var hasBonds = await financialAccountRepository.GetAccounts<BondAccount>(userId, DateTime.MinValue, asOfDate)
-            .AnyAsync(account => account.Entries.Count > 0);
-        if (hasBonds) heldClasses.Add(InvestmentType.Bond);
-
-        var hasCash = await financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate)
-            .AnyAsync(account => account.ContainsAssets);
-        if (hasCash) heldClasses.Add(InvestmentType.Cash);
-
-        return heldClasses;
-    }
-
-    private async Task<HashSet<string>> GetUniqueHoldingsPerType(int userId, DateTime asOfDate)
-    {
-        var uniqueTickers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var uniqueHoldings = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         await foreach (var account in financialAccountRepository.GetAccounts<StockAccount>(userId, DateTime.MinValue, asOfDate))
-            foreach (var ticker in account.GetStoredTickers())
-                uniqueTickers.Add($"stock_{ticker}");
+        {
+            foreach (var ticker in GetCurrentlyHeldTickers(account, asOfDate))
+            {
+                uniqueHoldings.Add($"stock_{ticker}");
+                heldClasses.Add(InvestmentType.Stock);
+            }
+        }
 
         await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, DateTime.MinValue, asOfDate))
-            foreach (var entry in account.Entries)
-                uniqueTickers.Add($"bond_{entry.BondDetailsId}");
+        {
+            foreach (var bondId in GetCurrentlyHeldBondIds(account, asOfDate))
+            {
+                uniqueHoldings.Add($"bond_{bondId}");
+                heldClasses.Add(InvestmentType.Bond);
+            }
+        }
 
-        var hasCash = await financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate)
-            .AnyAsync(account => account.ContainsAssets);
-        if (hasCash) uniqueTickers.Add("cash");
+        await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate))
+        {
+            if (HasCurrentCash(account, asOfDate))
+            {
+                uniqueHoldings.Add("cash");
+                heldClasses.Add(InvestmentType.Cash);
+            }
+        }
 
-        return uniqueTickers;
+        return (heldClasses, uniqueHoldings);
+    }
+
+    private static IEnumerable<string> GetCurrentlyHeldTickers(StockAccount account, DateTime asOfDate)
+    {
+        foreach (var ticker in account.GetStoredTickers())
+        {
+            var entry = account.GetThisOrNextOlder(asOfDate, ticker);
+            if (entry is not null && entry.Value > 0)
+                yield return ticker;
+        }
+    }
+
+    private static IEnumerable<int> GetCurrentlyHeldBondIds(BondAccount account, DateTime asOfDate)
+    {
+        foreach (var bondId in account.GetStoredBondsIds())
+        {
+            var entry = account.GetThisOrNextOlder(asOfDate, bondId);
+            if (entry is not null && entry.Value > 0)
+                yield return bondId;
+        }
+    }
+
+    private static bool HasCurrentCash(CurrencyAccount account, DateTime asOfDate)
+    {
+        var entry = account.GetThisOrNextOlder(asOfDate);
+        return entry is not null && entry.Value > 0;
     }
 
     internal static string GetBand(int totalScore) => totalScore switch

--- a/code/FinanceManager.Application/Services/DiversificationService.cs
+++ b/code/FinanceManager.Application/Services/DiversificationService.cs
@@ -64,7 +64,7 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
         foreach (var ticker in account.GetStoredTickers())
         {
             var entry = account.GetThisOrNextOlder(asOfDate, ticker);
-            if (entry is not null && entry.Value > 0)
+            if (entry is { InvestmentType: InvestmentType.Stock } && entry.Value > 0)
                 yield return ticker;
         }
     }

--- a/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
@@ -169,6 +169,144 @@ public class DiversificationServiceTests
         Assert.Equal("Limited", result.Band);
     }
 
+    [Fact]
+    public async Task GetDiversificationScore_StockFullySold_NotCounted()
+    {
+        // Buy 10 shares, then sell all 10. Net position = 0 → not held.
+        var buyDate = _asOfDate.AddDays(-30);
+        var sellDate = _asOfDate.AddDays(-10);
+        var account = new StockAccount(1, 1, "stocks");
+        account.Add(new StockAccountEntry(1, 1, buyDate, 10, 10, "AAPL", InvestmentType.Stock), false);
+        account.Add(new StockAccountEntry(1, 2, sellDate, 0, -10, "AAPL", InvestmentType.Stock), false);
+
+        SetupStockAccounts(account);
+        SetupBondAccounts();
+        SetupCurrencyAccounts();
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        Assert.Equal(0, result.HoldingsScore);
+        Assert.Equal(0, result.AssetClassScore);
+        Assert.Equal(0, result.Score);
+    }
+
+    [Fact]
+    public async Task GetDiversificationScore_StockFullySold_OneStillHeld_OnlyHeldCounts()
+    {
+        // AAPL fully sold, MSFT still held → only MSFT counts; Stock class still present.
+        var buyDate = _asOfDate.AddDays(-30);
+        var sellDate = _asOfDate.AddDays(-10);
+        var account = new StockAccount(1, 1, "stocks");
+        account.Add(new StockAccountEntry(1, 1, buyDate, 10, 10, "AAPL", InvestmentType.Stock), false);
+        account.Add(new StockAccountEntry(1, 2, sellDate, 0, -10, "AAPL", InvestmentType.Stock), false);
+        account.Add(new StockAccountEntry(1, 3, buyDate, 5, 5, "MSFT", InvestmentType.Stock), false);
+
+        SetupStockAccounts(account);
+        SetupBondAccounts();
+        SetupCurrencyAccounts();
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        var expectedHoldingsScore = (int)(1 / 30.0 * 50);
+        var expectedAssetClassScore = (int)(1 / 6.0 * 50);
+        Assert.Equal(expectedHoldingsScore, result.HoldingsScore);
+        Assert.Equal(expectedAssetClassScore, result.AssetClassScore);
+    }
+
+    [Fact]
+    public async Task GetDiversificationScore_StockPartiallySold_StillCounted()
+    {
+        // Buy 10, sell 5. Net = 5 > 0 → still held.
+        var buyDate = _asOfDate.AddDays(-30);
+        var sellDate = _asOfDate.AddDays(-10);
+        var account = new StockAccount(1, 1, "stocks");
+        account.Add(new StockAccountEntry(1, 1, buyDate, 10, 10, "AAPL", InvestmentType.Stock), false);
+        account.Add(new StockAccountEntry(1, 2, sellDate, 5, -5, "AAPL", InvestmentType.Stock), false);
+
+        SetupStockAccounts(account);
+        SetupBondAccounts();
+        SetupCurrencyAccounts();
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        var expectedHoldingsScore = (int)(1 / 30.0 * 50);
+        var expectedAssetClassScore = (int)(1 / 6.0 * 50);
+        Assert.Equal(expectedHoldingsScore, result.HoldingsScore);
+        Assert.Equal(expectedAssetClassScore, result.AssetClassScore);
+    }
+
+    [Fact]
+    public async Task GetDiversificationScore_BondFullyLiquidated_NotCounted()
+    {
+        // Bond 1 fully liquidated, bond 2 still held.
+        var buyDate = _asOfDate.AddDays(-30);
+        var sellDate = _asOfDate.AddDays(-10);
+        var bondAccount = new BondAccount(1, 1, "bonds",
+            [
+                new BondAccountEntry(1, 1, buyDate, 10m, 10m, 1),
+                new BondAccountEntry(1, 2, sellDate, 0m, -10m, 1),
+                new BondAccountEntry(1, 3, buyDate, 10m, 10m, 2),
+            ],
+            AccountLabel.Other);
+
+        SetupStockAccounts();
+        SetupBondAccounts(bondAccount);
+        SetupCurrencyAccounts();
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        // Only bond 2 counts → 1 ticker, 1 asset class
+        var expectedHoldingsScore = (int)(1 / 30.0 * 50);
+        var expectedAssetClassScore = (int)(1 / 6.0 * 50);
+        Assert.Equal(expectedHoldingsScore, result.HoldingsScore);
+        Assert.Equal(expectedAssetClassScore, result.AssetClassScore);
+    }
+
+    [Fact]
+    public async Task GetDiversificationScore_AllBondsLiquidated_BondClassExcluded()
+    {
+        var buyDate = _asOfDate.AddDays(-30);
+        var sellDate = _asOfDate.AddDays(-10);
+        var bondAccount = new BondAccount(1, 1, "bonds",
+            [
+                new BondAccountEntry(1, 1, buyDate, 10m, 10m, 1),
+                new BondAccountEntry(1, 2, sellDate, 0m, -10m, 1),
+            ],
+            AccountLabel.Other);
+
+        SetupStockAccounts();
+        SetupBondAccounts(bondAccount);
+        SetupCurrencyAccounts();
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        Assert.Equal(0, result.HoldingsScore);
+        Assert.Equal(0, result.AssetClassScore);
+    }
+
+    [Fact]
+    public async Task GetDiversificationScore_HoldingSoldInOneAccount_HeldInAnother_StillCounts()
+    {
+        // AAPL sold in account 1, but still held in account 2 → ticker is currently held.
+        var buyDate = _asOfDate.AddDays(-30);
+        var sellDate = _asOfDate.AddDays(-10);
+        var account1 = new StockAccount(1, 1, "stocks-a");
+        account1.Add(new StockAccountEntry(1, 1, buyDate, 10, 10, "AAPL", InvestmentType.Stock), false);
+        account1.Add(new StockAccountEntry(1, 2, sellDate, 0, -10, "AAPL", InvestmentType.Stock), false);
+
+        var account2 = new StockAccount(1, 2, "stocks-b");
+        account2.Add(new StockAccountEntry(2, 1, buyDate, 5, 5, "AAPL", InvestmentType.Stock), false);
+
+        SetupStockAccounts(account1, account2);
+        SetupBondAccounts();
+        SetupCurrencyAccounts();
+
+        var result = await _service.GetDiversificationScore(1, _asOfDate);
+
+        var expectedHoldingsScore = (int)(1 / 30.0 * 50);
+        Assert.Equal(expectedHoldingsScore, result.HoldingsScore);
+    }
+
     [Theory]
     [InlineData(0, "Limited")]
     [InlineData(33, "Limited")]


### PR DESCRIPTION
Closes #164

## Summary

The diversification service was counting every instrument that ever appeared in account history when computing `HoldingsScore` and `AssetClassScore`. A stock sold years ago still inflated the holdings count, and a fully liquidated equity position still added `Stock` to the asset classes set.

This change derives both scores from **currently held positions** as of `asOfDate` — the latest non-zero `Value` per instrument.

## Changes

- `DiversificationService` rewritten to do a single pass that collects asset classes as a side effect of finding currently-held instruments:
  - **Stock**: for each unique ticker, `GetThisOrNextOlder(asOfDate, ticker)` → include only if `Value > 0`.
  - **Bond**: same pattern using distinct `BondDetailsId` and `BondAccount.GetThisOrNextOlder(asOfDate, bondDetailsId)`.
  - **Cash**: `CurrencyAccount.GetThisOrNextOlder(asOfDate).Value > 0` instead of `ContainsAssets` — consistent as-of-date semantic.
- Asset-class membership is now derived from finding at least one currently-held instrument, so `HoldingsScore` and `AssetClassScore` can never disagree.

## Tests

Six new unit tests:

- `GetDiversificationScore_StockFullySold_NotCounted`
- `GetDiversificationScore_StockFullySold_OneStillHeld_OnlyHeldCounts`
- `GetDiversificationScore_StockPartiallySold_StillCounted`
- `GetDiversificationScore_BondFullyLiquidated_NotCounted`
- `GetDiversificationScore_AllBondsLiquidated_BondClassExcluded`
- `GetDiversificationScore_HoldingSoldInOneAccount_HeldInAnother_StillCounts`

All 271 unit tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_0177uBycNm9m1fqAH4nfLdDm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diversification scoring now uses only current positive holdings, so fully liquidated positions are excluded and asset classes reflect holdings actually held at the date, while holdings present across multiple accounts are correctly recognized.

* **Tests**
  * Added unit tests covering fully liquidated and partially sold stocks/bonds, multi-account holdings, and related edge cases ensuring scoring accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->