### PR TITLE
Improve bond account details row UI to match stock display pattern #174

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ FinanceManager is an online budgeting tool built with Blazor WebAssembly + ASP.N
 
 The solution file is `code/FinanceManager.slnx`. Target framework is `.NET 10`.
 
+## Commit Messages
+
+Always include the GitHub issue number being resolved in the commit message subject line using `#<number>` (e.g. `Fix bond UI display #174`).
+
 ## Branching Workflow
 
 **Feature branches merge into `develop`, never directly into `main`.** When opening a PR for a feature branch, the base must be `develop`. Only `develop` is promoted to `main` (e.g., for releases). If asked to open a PR against `main` from a feature branch, push back and switch the base to `develop`.

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsRow.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsRow.razor
@@ -16,20 +16,50 @@
                     }
                 </MudText>
             </MudItem>
-            <MudItem xs="3">
-                <MudText Typo="Typo.caption" Color="Color.Default">Balance units</MudText>
-                <MudText Typo="Typo.body1">@BondAccountEntry.Value</MudText>
+
+            <MudItem xs="5">
+                @if (CurrentValue.HasValue)
+                {
+                    <MudText Typo="Typo.caption" Color="Color.Default">Total evaluation</MudText>
+                    <MudStack Row Spacing="1" Class="d-flex align-center justify-start">
+                        <MudText Typo="Typo.body1">@($"{CurrentValue.Value.ToString("0.00")}")</MudText>
+                        <MudText Typo="Typo.body1">@_currency</MudText>
+                        @if (UnitsChangeValue.HasValue)
+                        {
+                            <MudText Typo="Typo.caption" Color="@(UnitsChangeValue.Value >= 0 ? Color.Success : Color.Error)">
+                                (@(UnitsChangeValue.Value >= 0 ? "+" : "-")@Math.Abs(UnitsChangeValue.Value).ToString("0.00"))
+                            </MudText>
+                        }
+                    </MudStack>
+                }
+                else
+                {
+                    <MudText Typo="Typo.caption" Color="Color.Default">Balance units</MudText>
+                    <MudStack Row Spacing="1" Class="d-flex align-center justify-start">
+                        <MudText Typo="Typo.body1">@BondAccountEntry.Value.ToString("G29")</MudText>
+                        <MudText Typo="Typo.caption" Color="@(BondAccountEntry.ValueChange >= 0 ? Color.Success : Color.Error)">
+                            (@(BondAccountEntry.ValueChange >= 0 ? "+" : "")@BondAccountEntry.ValueChange.ToString("G29"))
+                        </MudText>
+                    </MudStack>
+                }
             </MudItem>
-            <MudItem xs="3">
-                <MudText Typo="Typo.caption" Color="Color.Default">Change units</MudText>
-                <MudText Typo="Typo.body1" Color="@(BondAccountEntry.ValueChange > 0 ? Color.Success : Color.Error)">
-                    @BondAccountEntry.ValueChange
-                </MudText>
-            </MudItem>
-            <MudItem xs="3">
-                <MudText Typo="Typo.caption" Color="Color.Default">Posting date</MudText>
-                <MudText Typo="Typo.body1">@BondAccountEntry.PostingDate.ToString("dd-MM-yyyy")</MudText>
-            </MudItem>
+
+            @if (UnrealizedGainLoss is not null)
+            {
+                <MudItem xs="4">
+                    <MudText Typo="Typo.caption" Color="Color.Default">Unrealized gain/loss</MudText>
+                    <MudStack Row Spacing="1" Class="d-flex align-center justify-start">
+                        <MudText Typo="Typo.body1"
+                                 Color="@(UnrealizedGainLoss.UnrealizedGainLoss >= 0 ? Color.Success : Color.Error)">
+                            @UnrealizedGainLoss.UnrealizedGainLoss.ToString("0.00") @_currency
+                        </MudText>
+                        <MudText Typo="Typo.caption"
+                                 Color="@(UnrealizedGainLoss.UnrealizedGainLoss >= 0 ? Color.Success : Color.Error)">
+                            (@UnrealizedGainLoss.UnrealizedGainLossPercent.ToString("0.00")%)
+                        </MudText>
+                    </MudStack>
+                </MudItem>
+            }
         </MudGrid>
     </TitleContent>
 
@@ -56,6 +86,17 @@
                                 </MudStack>
                             </MudItem>
                         }
+                        <MudItem xs="5">
+                            <MudText Typo="Typo.caption" Color="Color.Default">Units</MudText>
+                            <MudStack Row Spacing="1" Class="d-flex align-center justify-start">
+                                <MudText Typo="Typo.body1">@BondAccountEntry.Value.ToString("G29")</MudText>
+                                <MudText Typo="Typo.caption"
+                                         Color="@(BondAccountEntry.ValueChange >= 0 ? Color.Success : Color.Error)">
+                                    (@(BondAccountEntry.ValueChange >= 0 ? "+" : "")@BondAccountEntry.ValueChange.ToString("G29"))
+                                </MudText>
+                            </MudStack>
+                        </MudItem>
+
                         @if (BondDetails is not null)
                         {
                             <MudItem xs="12">
@@ -65,17 +106,6 @@
                             <MudItem xs="6">
                                 <MudText Typo="Typo.caption" Color="Color.Default">Unit value</MudText>
                                 <MudText Typo="Typo.body1">@BondDetails.UnitValue.ToString("0.00") @BondDetails.Currency.ShortName</MudText>
-                            </MudItem>
-                            <MudItem xs="6">
-                                <MudText Typo="Typo.caption" Color="Color.Default">Current value</MudText>
-                                <MudText Typo="Typo.body1">@(CurrentValue.HasValue ? CurrentValue.Value.ToString("0.00") : "-") @_currency</MudText>
-                            </MudItem>
-                        }
-                        @if (UnitsChangeValue.HasValue)
-                        {
-                            <MudItem xs="12">
-                                <MudText Typo="Typo.caption" Color="Color.Default">Change value</MudText>
-                                <MudText Typo="Typo.body1">@UnitsChangeValue.Value.ToString("0.00") @_currency</MudText>
                             </MudItem>
                         }
                         @if (UnrealizedGainLoss is not null)

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsRow.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsRow.razor.cs
@@ -28,7 +28,13 @@ public partial class BondAccountDetailsRow : ComponentBase
     private decimal? CurrentValue => BondDetails is null ? null : BondAccountEntry.Value * BondDetails.UnitValue;
     private decimal? UnitsChangeValue => BondDetails is null ? null : BondAccountEntry.ValueChange * BondDetails.UnitValue;
 
-    protected override void OnInitialized() => _currency = SettingsService.GetCurrency();
+    protected override void OnParametersSet()
+    {
+        _currency = SettingsService.GetCurrency();
+        if (BondDetails is not null)
+            _currency = BondDetails.Currency;
+        base.OnParametersSet();
+    }
 
     public void ShowEditOverlay()
     {


### PR DESCRIPTION
Row title now shows total monetary evaluation (units × unit price) with
the change in brackets, and unrealized gain/loss — matching the stock
account details row. Currency is resolved from BondDetails when available.
Expanded view retains posting date, labels, issuer, unit value and
detailed unrealized data.

https://claude.ai/code/session_013gdfwA3u6ARGyBVgg2bUsF