### PR TITLE
Assert bond CSV export contains Bond column not BondDetailsId #187

### DIFF
--- a/code/FinanceManager.IntegrationTests/Controllers/BondAccountControllerTests.cs
+++ b/code/FinanceManager.IntegrationTests/Controllers/BondAccountControllerTests.cs
@@ -249,7 +249,7 @@ public class BondAccountControllerTests(OptionsProvider optionsProvider) : Contr
 
         var csv = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Contains("PostingDate", csv, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("BondDetailsId", csv, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Bond", csv, StringComparison.OrdinalIgnoreCase);
     }
 
     public override void Dispose()


### PR DESCRIPTION
The export DTO exposes the bond's display name in a column named "Bond";
there is no BondDetailsId column, and per the issue discussion the FK
shouldn't be in the CSV — import/export work on bond name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Bond account CSV export test validation improved to ensure accurate header field naming and better alignment with user-facing data specifications for financial exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->