### PR TITLE
Batch MoneyFlowService.GetNetWorth range to preload once #167

### DIFF
--- a/code/FinanceManager.Application/Services/MoneyFlowService.cs
+++ b/code/FinanceManager.Application/Services/MoneyFlowService.cs
@@ -61,11 +61,72 @@ IStockPriceProvider stockPriceProvider, IBondDetailsRepository bondDetailsReposi
 
         Dictionary<DateTime, decimal> result = [];
 
+        var bondDetails = await bondDetailsRepository.GetAllAsync().ToDictionaryAsync(x => x.Id);
+
+        List<CurrencyAccount> currencyAccounts = [];
+        await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end))
+            currencyAccounts.Add(account);
+
+        List<BondAccount> bondAccounts = [];
+        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, start, end))
+            bondAccounts.Add(account);
+
+        List<StockAccount> stockAccounts = [];
+        await foreach (var account in financialAccountRepository.GetAccounts<StockAccount>(userId, start, end))
+            stockAccounts.Add(account);
+
+        Dictionary<string, IReadOnlyDictionary<DateTime, decimal>> pricesByTicker = new(StringComparer.OrdinalIgnoreCase);
+        var tickers = stockAccounts.SelectMany(x => x.GetStoredTickers()).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        if (tickers.Count > 0)
+        {
+            var preloadTasks = tickers.ToDictionary(
+                ticker => ticker,
+                ticker => stockPriceProvider.GetPricePerUnitSeriesAsync(ticker, currency, start.Date, end.Date),
+                StringComparer.OrdinalIgnoreCase);
+
+            await Task.WhenAll(preloadTasks.Values);
+            foreach (var preloadTask in preloadTasks)
+                pricesByTicker[preloadTask.Key] = await preloadTask.Value;
+        }
+
         for (DateTime date = end; date >= start; date = date.AddDays(-1))
         {
-            var netWorth = await GetNetWorth(userId, currency, date);
-            if (netWorth is null) continue;
-            result.Add(date, netWorth.Value);
+            decimal dailyTotal = 0;
+
+            foreach (var account in currencyAccounts)
+            {
+                var entry = account.GetThisOrNextOlder(date);
+                if (entry is null) continue;
+                dailyTotal += entry.Value;
+            }
+
+            foreach (var account in bondAccounts)
+            {
+                foreach (var detailsId in account.GetStoredBondsIds())
+                {
+                    var entry = account.GetThisOrNextOlder(date, detailsId);
+                    if (entry is null) continue;
+                    if (!bondDetails.TryGetValue(detailsId, out var details))
+                        throw new InvalidOperationException($"Bond valuation requires details for bond id {detailsId}.");
+
+                    dailyTotal += entry.GetPriceAt(DateOnly.FromDateTime(date), details);
+                }
+            }
+
+            foreach (var account in stockAccounts)
+            {
+                foreach (var ticker in account.GetStoredTickers())
+                {
+                    var entry = account.GetThisOrNextOlder(date, ticker);
+                    if (entry is null) continue;
+                    if (!pricesByTicker.TryGetValue(ticker, out var tickerPrices)) continue;
+                    if (!tickerPrices.TryGetValue(date.Date, out var pricePerUnit)) continue;
+
+                    dailyTotal += entry.Value * pricePerUnit;
+                }
+            }
+
+            result.Add(date, Math.Round(dailyTotal, 2));
         }
         return result;
     }

--- a/code/FinanceManager.Application/Services/MoneyFlowService.cs
+++ b/code/FinanceManager.Application/Services/MoneyFlowService.cs
@@ -75,8 +75,12 @@ IStockPriceProvider stockPriceProvider, IBondDetailsRepository bondDetailsReposi
         await foreach (var account in financialAccountRepository.GetAccounts<StockAccount>(userId, start, end))
             stockAccounts.Add(account);
 
+        Dictionary<int, List<string>> tickersByAccount = stockAccounts.ToDictionary(
+            x => x.AccountId,
+            x => x.GetStoredTickers().Concat(x.NextOlderEntries.Keys).Distinct(StringComparer.OrdinalIgnoreCase).ToList());
+
         Dictionary<string, IReadOnlyDictionary<DateTime, decimal>> pricesByTicker = new(StringComparer.OrdinalIgnoreCase);
-        var tickers = stockAccounts.SelectMany(x => x.GetStoredTickers()).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        var tickers = tickersByAccount.Values.SelectMany(x => x).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         if (tickers.Count > 0)
         {
             var preloadTasks = tickers.ToDictionary(
@@ -115,7 +119,7 @@ IStockPriceProvider stockPriceProvider, IBondDetailsRepository bondDetailsReposi
 
             foreach (var account in stockAccounts)
             {
-                foreach (var ticker in account.GetStoredTickers())
+                foreach (var ticker in tickersByAccount[account.AccountId])
                 {
                     var entry = account.GetThisOrNextOlder(date, ticker);
                     if (entry is null) continue;

--- a/code/FinanceManager.IntegrationTests/Controllers/MoneyFlowControllerTests.cs
+++ b/code/FinanceManager.IntegrationTests/Controllers/MoneyFlowControllerTests.cs
@@ -478,6 +478,129 @@ public class MoneyFlowControllerTests(OptionsProvider optionsProvider) : Control
     }
 
     [Fact]
+    public async Task GetNetWorth_RangeVersion_MatchesSingleDateResults()
+    {
+        // Arrange - Currency + Bond + Stock accounts spanning multiple dates
+        await SeedWithTestCurrencyAccount("Range Match Currency");
+
+        var bondAccount = new FinancialAccountBaseDto
+        {
+            UserId = 1,
+            AccountId = 30,
+            Name = "Range Match Bonds",
+            AccountLabel = AccountLabel.Other,
+            AccountType = AccountType.Bond
+        };
+        _testDatabase!.Context.Accounts.Add(bondAccount);
+        _testDatabase.Context.Bonds.Add(CreateBondDetails(30, _nowUtc));
+        await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _testDatabase.Context.BondEntries.Add(new BondAccountEntry(30, 1, _nowUtc.AddDays(-9), 1000m, 1000m, 30));
+        _testDatabase.Context.BondEntries.Add(new BondAccountEntry(30, 2, _nowUtc.AddDays(-4), 1500m, 500m, 30));
+        await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var stockAccount = new FinancialAccountBaseDto
+        {
+            UserId = 1,
+            AccountId = 31,
+            Name = "Range Match Stocks",
+            AccountLabel = AccountLabel.Other,
+            AccountType = AccountType.Stock
+        };
+        _testDatabase.Context.Accounts.Add(stockAccount);
+
+        var usdCurrency = await _testDatabase.Context.Currencies.FindAsync([1], TestContext.Current.CancellationToken)
+            ?? _testDatabase.Context.Currencies.Add(new Currency(1, "USD", "$")).Entity;
+
+        var stockDetails = new StockDetails
+        {
+            Ticker = "RNGM",
+            Name = "Range Match Inc.",
+            Type = "Stock",
+            Region = "US",
+            Currency = usdCurrency
+        };
+        _testDatabase.Context.StockDetails.Add(stockDetails);
+        for (int i = 0; i <= 10; i++)
+            _testDatabase.Context.StockPrices.Add(new StockPriceDto
+            {
+                PricePerUnit = 50m + i,
+                StockDetails = stockDetails,
+                Date = _nowUtc.AddDays(-i)
+            });
+        await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _testDatabase.Context.StockEntries.Add(new StockAccountEntry(31, 1, _nowUtc.AddDays(-8), 5m, 5m, "RNGM", InvestmentType.Stock));
+        _testDatabase.Context.StockEntries.Add(new StockAccountEntry(31, 2, _nowUtc.AddDays(-3), 10m, 5m, "RNGM", InvestmentType.Stock));
+        await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        Authorize("TestUser", 1, UserRole.User);
+
+        var client = new MoneyFlowHttpClient(Client);
+        var rangeStart = _nowUtc.AddDays(-7);
+        var rangeEnd = _nowUtc;
+
+        // Act - call range endpoint once and compare against per-day single-date calls
+        var rangeResult = await client.GetNetWorth(1, DefaultCurrency.USD, rangeStart, rangeEnd);
+
+        var expected = new Dictionary<DateTime, decimal?>();
+        for (DateTime date = rangeEnd; date >= rangeStart; date = date.AddDays(-1))
+            expected[date] = await client.GetNetWorth(1, DefaultCurrency.USD, date);
+
+        // Assert - same days, same values
+        Assert.NotNull(rangeResult);
+        Assert.Equal(expected.Count, rangeResult.Count);
+        foreach (var (date, singleValue) in expected)
+        {
+            Assert.True(rangeResult.ContainsKey(date), $"Range result missing date {date:o}");
+            Assert.True(singleValue.HasValue, $"Single-date result missing value for {date:o}");
+            Assert.Equal(singleValue!.Value, rangeResult[date]);
+        }
+    }
+
+    [Fact]
+    public async Task GetNetWorth_RangeVersion_PerformsEfficiently()
+    {
+        // Arrange - 500 entries over 500 days (mirrors GetNetWorth_LargePortfolio_PerformsEfficiently)
+        var accountName = "Range Perf Portfolio";
+        if (!await _testDatabase!.Context.Accounts.AnyAsync(x => x.Name == accountName, TestContext.Current.CancellationToken))
+        {
+            var account = new FinancialAccountBaseDto
+            {
+                UserId = 1,
+                AccountId = 40,
+                Name = accountName,
+                AccountLabel = AccountLabel.Cash,
+                AccountType = AccountType.Currency
+            };
+            _testDatabase.Context.Accounts.Add(account);
+            await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+            decimal runningValue = 0;
+            for (int i = 0; i < 500; i++)
+            {
+                runningValue += 100m;
+                _testDatabase.Context.CurrencyEntries.Add(
+                    new CurrencyAccountEntry(40, i + 1, _nowUtc.AddDays(-500 + i), runningValue, 100m) { Labels = [] });
+            }
+            await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
+        Authorize("TestUser", 1, UserRole.User);
+
+        // Act - 365-day range
+        var startTime = DateTime.UtcNow;
+        var result = await new MoneyFlowHttpClient(Client).GetNetWorth(1, DefaultCurrency.USD, _nowUtc.AddDays(-365), _nowUtc);
+        var duration = DateTime.UtcNow - startTime;
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotEmpty(result);
+        Assert.True(duration.TotalSeconds < 5,
+            $"GetNetWorth range took {duration.TotalSeconds}s, expected < 5s");
+    }
+
+    [Fact]
     public async Task GetNetWorth_MultipleUsersIsolation_ReturnsOnlyUserData()
     {
         // Arrange - Create accounts for two different users

--- a/code/FinanceManager.UnitTests/Application/Services/MoneyFlowServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/MoneyFlowServiceTests.cs
@@ -59,6 +59,8 @@ public class MoneyFlowServiceTests
                        .ReturnsAsync(new StockPrice() { Currency = DefaultCurrency.PLN, Ticker = "TESTSTOCK1", PricePerUnit = 2 });
         _stockRepository.Setup(x => x.Get("TESTSTOCK2", It.IsAny<DateTime>()))
                         .ReturnsAsync(new StockPrice() { Currency = DefaultCurrency.PLN, Ticker = "TESTSTOCK2", PricePerUnit = 4 });
+        _stockRepository.Setup(x => x.GetRange(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                        .ReturnsAsync((IReadOnlyList<StockPrice>)[]);
 
         _currencyExchangeService.Setup(x => x.GetExchangeRateAsync(It.IsAny<Currency>(), It.IsAny<Currency>(), It.IsAny<DateTime>())).ReturnsAsync(1);
 


### PR DESCRIPTION
closes #167

## Summary
- Refactor `MoneyFlowService.GetNetWorth(start, end)` to replace the per-day query loop with a single-pass preload + in-memory date walk, matching the `StockBalanceService.GetClosingBalance` pattern (bond details + accounts loaded once, stock price series fetched in parallel via `IStockPriceProvider.GetPricePerUnitSeriesAsync`).
- Single-date overload (`GetNetWorth(date)`) is unchanged so existing callers and tests are unaffected.
- Cuts the prior `O(days × accounts × queries)` cost of the dashboard time-series endpoint (`GET /api/MoneyFlow/GetNetWorth/{userId}/{currencyId}/{start}/{end}`) to a small constant number of repository calls.

## Tests
- New integration test `GetNetWorth_RangeVersion_MatchesSingleDateResults`: seeds currency + bond + stock entries, calls the range endpoint once and the single-date endpoint per day, asserts every date/value pair matches — guards against behavioural drift versus the old per-day loop.
- New integration test `GetNetWorth_RangeVersion_PerformsEfficiently`: mirrors the existing 500-entry single-date `< 5s` guard but exercises the 365-day range path.
- Unit test mock for `IStockPriceRepository.GetRange` returns an empty list to match the non-nullable interface contract (the new range path goes through `GetPricesAsync` which uses `GetRange`).

## Test plan
- [x] `dotnet build ./code/FinanceManager.slnx` — 0 warnings, 0 errors
- [x] `dotnet test ./code/FinanceManager.UnitTests/...` — 282 passed
- [x] MoneyFlow integration tests — 17 passed (incl. 2 new)
- [x] `dotnet format` — verified on the three changed files

https://claude.ai/code/session_016A8DhrMf5Lwzt3kHyppM2v

---
_Generated by [Claude Code](https://claude.ai/code/session_016A8DhrMf5Lwzt3kHyppM2v)_