### PR TITLE
Implement CalVer versioning with automatic build-time stamping #183

### DIFF
--- a/code/Directory.Build.props
+++ b/code/Directory.Build.props
@@ -10,4 +10,17 @@
 		<LangVersion>latest</LangVersion>
 		<CopilotCliDownloadTimeout>600000</CopilotCliDownloadTimeout>
 	</PropertyGroup>
+
+	<!-- CalVer (YY.MM.DD) stamped automatically at build time. See issue #183. -->
+	<PropertyGroup>
+		<CalVerYear>$([System.DateTime]::UtcNow.ToString("yy"))</CalVerYear>
+		<CalVerMonth>$([System.DateTime]::UtcNow.ToString("MM"))</CalVerMonth>
+		<CalVerDay>$([System.DateTime]::UtcNow.ToString("dd"))</CalVerDay>
+		<CalVerNumericMonth>$([System.DateTime]::UtcNow.Month)</CalVerNumericMonth>
+		<CalVerNumericDay>$([System.DateTime]::UtcNow.Day)</CalVerNumericDay>
+		<Version>$(CalVerYear).$(CalVerNumericMonth).$(CalVerNumericDay)</Version>
+		<AssemblyVersion>$(CalVerYear).$(CalVerNumericMonth).$(CalVerNumericDay).0</AssemblyVersion>
+		<FileVersion>$(CalVerYear).$(CalVerNumericMonth).$(CalVerNumericDay).0</FileVersion>
+		<InformationalVersion>$(CalVerYear).$(CalVerMonth).$(CalVerDay)</InformationalVersion>
+	</PropertyGroup>
 </Project>

--- a/code/FinanceManager.Components/ApplicationVersion.cs
+++ b/code/FinanceManager.Components/ApplicationVersion.cs
@@ -1,6 +1,21 @@
+using System.Reflection;
+
 namespace FinanceManager.Components;
 
 public static class ApplicationVersion
 {
-    public static string Version => "v0.6.0";
+    public static string Version { get; } = ReadInformationalVersion();
+
+    private static string ReadInformationalVersion()
+    {
+        var attribute = typeof(ApplicationVersion).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+        if (attribute is null) return string.Empty;
+
+        // Strip the build metadata suffix MSBuild appends (e.g. "26.05.25+abc1234").
+        var raw = attribute.InformationalVersion;
+        var plus = raw.IndexOf('+');
+        return plus >= 0 ? raw[..plus] : raw;
+    }
 }

--- a/code/FinanceManager.UnitTests/Components/ApplicationVersionTests.cs
+++ b/code/FinanceManager.UnitTests/Components/ApplicationVersionTests.cs
@@ -1,0 +1,29 @@
+using FinanceManager.Components;
+using System.Reflection;
+
+namespace FinanceManager.UnitTests.Components;
+
+[Trait("Category", "Unit")]
+public class ApplicationVersionTests
+{
+    [Fact]
+    public void Version_MatchesCalVerFormat()
+    {
+        Assert.Matches(@"^\d{2}\.\d{2}\.\d{2}$", ApplicationVersion.Version);
+    }
+
+    [Fact]
+    public void Version_ReflectsInformationalVersionAttribute()
+    {
+        var attribute = typeof(ApplicationVersion).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+        Assert.NotNull(attribute);
+
+        var expected = attribute!.InformationalVersion;
+        var plus = expected.IndexOf('+');
+        if (plus >= 0) expected = expected[..plus];
+
+        Assert.Equal(expected, ApplicationVersion.Version);
+    }
+}


### PR DESCRIPTION
## Summary
Replaces hardcoded semantic versioning with Calendar Versioning (CalVer) that is automatically stamped at build time based on the current UTC date. The version is now derived from MSBuild properties and reflected in assembly metadata, eliminating the need for manual version updates.

## Changes
- **Directory.Build.props**: Added CalVer property group that computes `Version`, `AssemblyVersion`, `FileVersion`, and `InformationalVersion` from `System.DateTime.UtcNow` at build time using the format `YY.MM.DD`
- **ApplicationVersion.cs**: Changed from hardcoded `"v0.6.0"` to dynamically reading the `AssemblyInformationalVersionAttribute` at runtime, with logic to strip MSBuild's build metadata suffix (e.g., `+abc1234`)
- **ApplicationVersionTests.cs** (new): Added unit tests to verify:
  - Version string matches the CalVer regex pattern `^\d{2}\.\d{2}\.\d{2}$`
  - `ApplicationVersion.Version` correctly reflects the assembly's `InformationalVersionAttribute`

## Implementation Details
- CalVer properties are computed using MSBuild's `$([System.DateTime]::UtcNow...)` syntax, ensuring consistent versioning across all builds
- `AssemblyVersion` and `FileVersion` include a `.0` suffix for compatibility with Windows file versioning
- `InformationalVersion` uses zero-padded month/day (`MM`/`dd`) for human readability
- `ApplicationVersion.Version` uses numeric month/day to avoid leading zeros in the semantic version
- The runtime reader strips the `+` metadata suffix that MSBuild appends during deterministic builds

Closes #183

https://claude.ai/code/session_01XEM8bUcgNKUNQNMwZfAB8p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application versioning to use automatic calendar-based versioning format (YY.MM.DD), replacing manual version updates. Version is now derived from assembly metadata at build time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->