### PR TITLE
Add changelog infrastructure and documentation

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: changelog
+description: Use this skill whenever a code change introduces a user-visible difference (new feature, behaviour change, bug fix, removal, security patch). It explains how to add or update entries in the root `CHANGELOG.md` so the project keeps a consistent, human-readable history any agent can extend.
+---
+
+# Maintaining `CHANGELOG.md`
+
+FinanceManager keeps a single `CHANGELOG.md` at the repository root. It follows the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format. This is the source of truth — GitHub renders it, the in-app changelog view (issue #185 / follow-up) will fetch it, and LinkedIn/release posts are written from it. There is no auto-generation: every change that ships goes in by hand.
+
+## Versioning model
+
+The project uses **CalVer in the form `YY.M.D`** (year.month.day, no leading zeros), stamped automatically by `Directory.Build.props` (see issue #183). A new version block is opened **every time a change lands on `develop`** that we'd want users to know about — there is no separate "release" step. Today's date determines the version number; if multiple changes land the same day, group them under the same `YY.M.D` block.
+
+- Top of file always has an `## [Unreleased]` section. Work-in-progress entries accumulate there.
+- When a change is merged to `develop`, rename `[Unreleased]` to `[YY.M.D]` with today's date and add a fresh empty `[Unreleased]` above it. If a `[YY.M.D]` block already exists for today, merge the new entries into it instead of creating a duplicate.
+- Dates are ISO 8601 (`YYYY-MM-DD`).
+
+## File structure
+
+```markdown
+# Changelog
+
+All notable changes to FinanceManager are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
+CalVer (`YY.M.D`).
+
+## [Unreleased]
+
+### Added
+- Short, user-focused description of a new feature. #<issue>
+
+## [26.5.25] - 2026-05-25
+
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+```
+
+Entries are in **reverse chronological order** (newest at the top, just below `[Unreleased]`).
+
+## Allowed sections
+
+Use only these six headings, in this fixed order, omitting any that are empty:
+
+| Section | Use for |
+|---|---|
+| `Added` | New features or capabilities visible to a user. |
+| `Changed` | Behaviour/UX changes to existing functionality. |
+| `Deprecated` | Features still available but slated for removal. |
+| `Removed` | Features that no longer exist. |
+| `Fixed` | Bug fixes. |
+| `Security` | Vulnerability patches and hardening. |
+
+## Writing entries — house rules
+
+1. **One line per entry.** A short sentence in present tense, user-perspective. *Good:* "Add date-range filter to account transaction lists." *Bad:* "Refactored `TransactionFilterController.GetByDate` to accept nullable `DateTime`."
+2. **Reference the issue.** Every entry ends with the GitHub issue number it resolves, prefixed with `#` — e.g. `... #174`. If a change has no issue, omit the reference rather than invent one. This matches the project's commit message rule (`CLAUDE.md` → "Commit Messages").
+3. **Skip non-user-visible changes.** Pure refactors, test-only changes, CI tweaks, dependency bumps without behavioural impact, and internal docs do **not** belong in the changelog. If in doubt: would a user, beta tester, or future-you reading release notes care? If no, skip.
+4. **Group by user value, not by implementation.** A single feature spread across many commits/PRs gets one line. Multiple unrelated fixes get one line each.
+5. **No code identifiers** in entries unless they're user-facing (page names, settings, labels). Don't mention class names, method names, namespaces, file paths.
+6. **Markdown only**, no HTML. Inline links are fine.
+
+## Workflow checklist for an agent making a change
+
+When you finish a code change that has a user-visible effect:
+
+1. Open `CHANGELOG.md`.
+2. Locate or create the `## [Unreleased]` block at the top.
+3. Under the appropriate section heading (`### Added` / `### Changed` / etc., creating the heading if missing), append a one-line entry following the rules above, ending with `#<issue>`.
+4. Stage `CHANGELOG.md` together with the code change in the same commit. The commit message already references the issue per project convention — the changelog line mirrors it.
+5. Do not write to past `[YY.M.D]` blocks; history is immutable once dated.
+
+## Promoting `[Unreleased]` to a release
+
+This is normally done as part of the merge that ships the change:
+
+1. Rename `## [Unreleased]` to `## [YY.M.D] - YYYY-MM-DD` using today's UTC date (matching `Directory.Build.props`).
+2. Insert a new empty `## [Unreleased]` block above it.
+3. If a block for today's date already exists, fold the entries into it (preserve section order, no duplicates) and delete the redundant header.
+
+## What NOT to do
+
+- Don't auto-generate from `git log` — entries are curated, not dumped.
+- Don't add front-matter, tables of contents, or "Contributors" sections.
+- Don't reorder existing dated blocks; only the top `[Unreleased]` block is mutable.
+- Don't edit `CHANGELOG.md` in a commit that has no other code/doc changes unless the user explicitly asks for a changelog-only fix.
+- Don't put credentials, internal URLs, or customer data into entries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,99 @@
+# Changelog
+
+All notable changes to FinanceManager are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
+CalVer (`YY.M.D`) stamped at build time.
+
+See [`.claude/skills/changelog/SKILL.md`](./.claude/skills/changelog/SKILL.md) for the
+rules agents must follow when updating this file.
+
+## [Unreleased]
+
+## [26.5.25] - 2026-05-25
+
+### Added
+- Automated CalVer (`YY.M.D`) versioning stamped at build time. #183
+- Auto-deploy of the `develop` branch to the dev Azure Web App. #189
+- Diversification proxy gauge widget on the assets page. #130
+- Recurring transactions card with drill-down on the dashboard. #179
+- Net-worth time-series card on the dashboard and assets page. #149
+- Date-range filter on bond, currency, and stock account transaction lists. #19
+- AI provider management tab in the admin panel, including provider fallback chain configuration. #169
+- LM Studio support as an AI provider.
+- Outlier sub-score explanations on the diversification card. #173
+
+### Changed
+- Diversification card visualization switched to an ApexCharts radial-bar gauge with chip explanations. #173
+- Diversification meter moved from the dashboard to the assets page. #166
+- Bond account details rows redesigned to match the stock display pattern. #174
+- Full README rewrite. #170
+- Recurring-transaction grouping now uses similarity matching across months.
+- Performance: net-worth range queries now preload once instead of per-day refetch. #167
+
+### Fixed
+- Diversification score now uses current positions rather than full account history. #164
+- Carry-over stock tickers are included in range valuation. #167
+- Guest user data is no longer persisted in the main application database. #171
+- Bond CSV export now contains a `Bond` column (previously `BondDetailsId`). #187
+- Filter chip click on account details filter bars.
+- Net-worth chart clears stale data on null-user and failed-fetch paths.
+- `To`-only date filter respects end-of-day boundary.
+
+## [26.4.29] - 2026-04-29
+
+### Added
+- Currency account import with real-time progress via SignalR.
+- Bond account import.
+- Stock-entry import with conflict resolution.
+- CSV export for bond, currency, and stock accounts, including shares count and price on stock exports.
+- Currency exchange-rate providers with caching.
+- Skeleton loading states for charts and side panels on account details pages.
+- Recent-entries loader for historical account entries on stock account details.
+
+### Changed
+- Stock price retrieval now supports currency conversion and uses optimized price-series indexing.
+- Account export DTOs refactored for consistency across asset types.
+
+### Fixed
+- Null-result handling in bond, currency, and stock import components.
+
+## [26.3.17] - 2026-03-17
+
+### Added
+- Investment Paycheck Estimator with safe-withdrawal-rate inputs. #128
+- Essentials spending calculator and financial label classifications. #127
+- Distribution-of-expense card on the dashboard. #126
+- Dedicated balance services for currency, bond, and stock accounts, enabling per-asset-type cash-flow and closing-balance reporting.
+
+### Changed
+- Investment Paycheck Estimator excludes the current partial month from salary average for more accurate projections.
+- Refined transaction categorization prompt and financial labels.
+
+## [26.2.28] - 2026-02-28
+
+### Added
+- AI-generated financial insights with background generation and prompt provider. #122
+- AI label assignment for currency entries, with batching, deduplication, and a "no match" sentinel for unlabelled entries.
+- Label-setter progress tracking surfaced through API and UI components.
+- Bond management: issuer retrieval, bond details, and admin UI.
+- Confirm-delete dialog for stocks.
+- Value-change range filter on bond, currency, and stock account details.
+- Search, breadcrumb navigation, and refreshed UI on admin pages.
+- `ContractorDetails` field on currency entries, optional during import.
+- CSV header mapping configurable per user, with admin UI and API endpoints.
+- `Investment` and `Undisclosed Income` defaults added to the standard label seeder.
+
+### Changed
+- AI provider stack migrated to `Microsoft.Extensions.AI` with a configurable fallback chain.
+- GitHub Models provider switched to `GitHub.Copilot.SDK` via `CopilotChatClient`.
+- Account command surface unified around `AddAccount` across bond, currency, and stock flows.
+
+### Fixed
+- CORS configuration for cross-origin requests in development.
+- Stock price provider robustness with null checks and improved currency-exchange resource handling.
+
+## [26.1.18] - 2026-01-18
+
+### Changed
+- "Bank account" renamed to "Cash account" across the UI, API, and storage. #116
+- Account and stock-entry naming refactored for clarity across components and services.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,27 @@ Always include the GitHub issue number being resolved in the commit message subj
 
 **Feature branches merge into `develop`, never directly into `main`.** When opening a PR for a feature branch, the base must be `develop`. Only `develop` is promoted to `main` (e.g., for releases). If asked to open a PR against `main` from a feature branch, push back and switch the base to `develop`.
 
-**Branch naming**: name branches with the issue name only — nothing more. Use the issue's title/identifier as the branch name, with no prefixes, suffixes, or extra descriptors.
+### Branch naming
+
+Branch naming is **critical for the changelog to work**. Every changelog entry ends with `#<issue>` (see [`.claude/skills/changelog/SKILL.md`](./.claude/skills/changelog/SKILL.md)), and that number is sourced from the branch → commit → PR chain. If the branch doesn't carry the issue number, the link breaks and the entry can't be written correctly.
+
+**Format**: `<issue-number>-<kebab-issue-title>`
+
+- `<issue-number>` — the GitHub issue number, no `#`, no `issue-` prefix.
+- `<kebab-issue-title>` — the issue's title, lower-case, words joined by hyphens, punctuation stripped. Truncate at a word boundary if it would otherwise exceed ~60 characters total.
+- No prefixes (`feature/`, `fix/`, `claude/`, your username, etc.) and no suffixes (`-v2`, `-wip`, random tokens).
+
+**Examples**:
+
+| Issue | Branch |
+|---|---|
+| #128 "Add investment paycheck estimator" | `128-add-investment-paycheck-estimator` |
+| #174 "Improve bond UI display" | `174-improve-bond-ui-display` |
+| #19 "Date range filter on account transactions" | `19-date-range-filter-on-account-transactions` |
+
+**One issue per branch.** A branch must cover exactly one issue so the resulting commit, PR, and changelog entry all share a single `#<issue>` reference. If the work splits across multiple issues, split the branch.
+
+**No issue? Don't open the branch yet** — create the GitHub issue first so the number exists. Tiny, non-user-visible chores (CI tweaks, dependency bumps, doc typos) that won't get a changelog entry are the only acceptable exception; in that case use a short kebab-case description (`fix-ci-dotnet-test-mtp`) and skip the changelog edit.
 
 ## Pull Requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ Always include the GitHub issue number being resolved in the commit message subj
 
 When opening a pull request that resolves a GitHub issue, the PR body must include a GitHub auto-close keyword referencing the issue (e.g. `closes #123`) so that merging the PR automatically closes the linked issue.
 
+## Changelog
+
+Every code change that has a user-visible effect must add an entry to `CHANGELOG.md` (Keep a Changelog format, CalVer `YY.M.D`). The rules — section headings, wording, issue references, and how to promote `[Unreleased]` — live in [`.claude/skills/changelog/SKILL.md`](./.claude/skills/changelog/SKILL.md). Stage the changelog edit in the same commit as the code change. Pure refactors, test-only changes, CI tweaks, and dependency bumps without behavioural impact do not need a changelog entry.
+
 ## Agent Requirements
 
 - **Install the .NET SDK before coding.** Any task that involves code changes requires the .NET 10 SDK to be installed first so that `dotnet build`, `dotnet format`, and `dotnet test` can run. If `dotnet --list-sdks` does not show a `10.*` SDK, install it before making changes — see "Installing the .NET SDK" below for the path that works in the cloud sandbox.


### PR DESCRIPTION
## Summary

Establishes a formal changelog system for FinanceManager following the Keep a Changelog 1.1.0 format with CalVer (`YY.M.D`) versioning. This includes the root `CHANGELOG.md` file with historical entries, a dedicated skill document for agents, and updated project conventions in `CLAUDE.md`.

## Changes

- **Added `CHANGELOG.md`**: Root changelog file with Keep a Changelog structure, CalVer versioning scheme, and historical entries from v26.1.18 through v26.5.25 (unreleased). Entries are curated by user-visible impact (features, behaviour changes, bug fixes) with GitHub issue references.

- **Added `.claude/skills/changelog/SKILL.md`**: Comprehensive agent skill documenting:
  - CalVer versioning model (`YY.M.D`, stamped at build time)
  - File structure and allowed section headings (Added, Changed, Deprecated, Removed, Fixed, Security)
  - House rules for entry wording (present tense, user-perspective, issue references, no code identifiers)
  - Workflow checklist for agents updating the changelog
  - Promotion rules for moving `[Unreleased]` to dated releases

- **Updated `CLAUDE.md`**:
  - Expanded branch naming rules to require `<issue-number>-<kebab-issue-title>` format (e.g., `128-add-investment-paycheck-estimator`) to ensure changelog entries can be correctly linked
  - Added explicit guidance that one issue per branch is required
  - Added new "Changelog" section documenting the requirement that user-visible changes must update `CHANGELOG.md` in the same commit
  - Clarified that pure refactors, test-only changes, CI tweaks, and dependency bumps without behavioural impact do not require changelog entries

## Implementation Details

- The changelog uses reverse chronological order (newest at top, below `[Unreleased]`).
- Entries are one line per change, user-focused, ending with `#<issue>` reference.
- The versioning scheme is automated via `Directory.Build.props` (issue #183); agents promote `[Unreleased]` to `[YY.M.D] - YYYY-MM-DD` when changes land on `develop`.
- Branch naming now enforces issue numbers in the branch name itself, making the changelog reference chain (branch → commit → PR → changelog) unambiguous.

https://claude.ai/code/session_01JzHfG4x2ixbaeD6d6DWneJ