### PR TITLE
Add admin log viewer #212

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ rules agents must follow when updating this file.
 
 ## [Unreleased]
 
+### Added
+- Admin log viewer: warnings and errors emitted by the API are now persisted to the database and surfaced in the admin panel as a "Recent warnings & errors" dashboard widget and a full `/Admin/Logs` page with warning/error filtering and pagination. A retention background service purges entries older than the configured cutoff (default 30 days) on API start and once a day, and a SignalR hub pushes new entries to the UI live. #212
+
 ### Changed
 - Guest demo data now generates realistic per-account-type entries: currency labels respect income vs expense sign, stock and bond holdings never go negative, and stock prices are prefilled across the seeded range. #206
 - Settings page redesigned as a single-page, TOC-style layout with Profile, Password, Subscription, and Danger zone sections and a sticky save bar. #209

--- a/code/FinanceManager.Api/Controllers/Admin/AdminLogsController.cs
+++ b/code/FinanceManager.Api/Controllers/Admin/AdminLogsController.cs
@@ -21,7 +21,7 @@ public class AdminLogsController(ILogEntryRepository repository) : ControllerBas
     public async Task<IActionResult> GetLatest([FromQuery] int count = 5, CancellationToken cancellationToken = default)
     {
         if (count <= 0) return BadRequest("count must be greater than zero.");
-        if (count > 50) count = 50;
+        if (count > 50) return BadRequest("count must be 50 or less.");
 
         var entries = await repository.GetLatest(count, _warningAndError, cancellationToken);
         return Ok(entries.Select(Map).ToList());
@@ -37,7 +37,7 @@ public class AdminLogsController(ILogEntryRepository repository) : ControllerBas
     {
         if (skip < 0) return BadRequest("skip must be non-negative.");
         if (take <= 0) return BadRequest("take must be greater than zero.");
-        if (take > 200) take = 200;
+        if (take > 200) return BadRequest("take must be 200 or less.");
 
         var levels = ParseLevels(level);
         var (items, total) = await repository.GetPaged(skip, take, levels, cancellationToken);

--- a/code/FinanceManager.Api/Controllers/Admin/AdminLogsController.cs
+++ b/code/FinanceManager.Api/Controllers/Admin/AdminLogsController.cs
@@ -1,5 +1,5 @@
 using FinanceManager.Domain.Dtos;
-using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Entities.Logging;
 using FinanceManager.Domain.Enums;
 using FinanceManager.Domain.Repositories;
 using Microsoft.AspNetCore.Authorization;

--- a/code/FinanceManager.Api/Controllers/Admin/AdminLogsController.cs
+++ b/code/FinanceManager.Api/Controllers/Admin/AdminLogsController.cs
@@ -1,0 +1,56 @@
+using FinanceManager.Domain.Dtos;
+using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinanceManager.Api.Controllers.Admin;
+
+[Route("api/admin/logs")]
+[Authorize(Roles = "Admin")]
+[ApiController]
+[Tags("Administration")]
+public class AdminLogsController(ILogEntryRepository repository) : ControllerBase
+{
+    private static readonly IReadOnlyCollection<LogSeverity> _warningAndError =
+        [LogSeverity.Warning, LogSeverity.Error, LogSeverity.Critical];
+
+    [HttpGet("latest")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<LogEntryDto>))]
+    public async Task<IActionResult> GetLatest([FromQuery] int count = 5, CancellationToken cancellationToken = default)
+    {
+        if (count <= 0) return BadRequest("count must be greater than zero.");
+        if (count > 50) count = 50;
+
+        var entries = await repository.GetLatest(count, _warningAndError, cancellationToken);
+        return Ok(entries.Select(Map).ToList());
+    }
+
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PagedLogEntriesDto))]
+    public async Task<IActionResult> GetPaged(
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = 25,
+        [FromQuery] string? level = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (skip < 0) return BadRequest("skip must be non-negative.");
+        if (take <= 0) return BadRequest("take must be greater than zero.");
+        if (take > 200) take = 200;
+
+        var levels = ParseLevels(level);
+        var (items, total) = await repository.GetPaged(skip, take, levels, cancellationToken);
+        return Ok(new PagedLogEntriesDto(items.Select(Map).ToList(), total));
+    }
+
+    private static IReadOnlyCollection<LogSeverity> ParseLevels(string? level) => level?.ToLowerInvariant() switch
+    {
+        "warning" => [LogSeverity.Warning],
+        "error" => [LogSeverity.Error, LogSeverity.Critical],
+        _ => _warningAndError,
+    };
+
+    private static LogEntryDto Map(LogEntry e) =>
+        new(e.Id, e.TimestampUtc, e.Level, e.Category, e.Message, e.Exception, e.EventId, e.EventName);
+}

--- a/code/FinanceManager.Api/Hubs/AdminLogsHub.cs
+++ b/code/FinanceManager.Api/Hubs/AdminLogsHub.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace FinanceManager.Api.Hubs;
+
+[Authorize(Roles = "Admin")]
+public class AdminLogsHub : Hub
+{
+    public const string GroupName = "admin-logs";
+
+    public Task Subscribe() => Groups.AddToGroupAsync(Context.ConnectionId, GroupName);
+}

--- a/code/FinanceManager.Api/Logging/DatabaseLogger.cs
+++ b/code/FinanceManager.Api/Logging/DatabaseLogger.cs
@@ -1,0 +1,57 @@
+using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Enums;
+
+namespace FinanceManager.Api.Logging;
+
+public sealed class DatabaseLogger(string category, ILogEntryQueue queue) : ILogger
+{
+    // Prevent recursive logging: any log written by the persistence/broadcast pipeline
+    // (EF Core, SignalR, our own services) would otherwise re-enter the queue.
+    private static readonly AsyncLocal<bool> _suppressed = new();
+
+    public static IDisposable BeginSuppression()
+    {
+        _suppressed.Value = true;
+        return new SuppressionScope();
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) =>
+        logLevel >= LogLevel.Warning && logLevel != LogLevel.None && !_suppressed.Value;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel)) return;
+        if (formatter is null) return;
+
+        var message = formatter(state, exception);
+        if (string.IsNullOrEmpty(message) && exception is null) return;
+
+        var entry = new LogEntry
+        {
+            TimestampUtc = DateTime.UtcNow,
+            Level = (LogSeverity)logLevel,
+            Category = Truncate(category, 256),
+            Message = Truncate(message ?? string.Empty, 4096),
+            Exception = exception?.ToString(),
+            EventId = eventId.Id == 0 ? null : eventId.Id,
+            EventName = string.IsNullOrEmpty(eventId.Name) ? null : Truncate(eventId.Name, 256),
+        };
+
+        queue.TryEnqueue(entry);
+    }
+
+    private static string Truncate(string value, int max) =>
+        value.Length <= max ? value : value[..max];
+
+    private sealed class SuppressionScope : IDisposable
+    {
+        public void Dispose() => _suppressed.Value = false;
+    }
+}

--- a/code/FinanceManager.Api/Logging/DatabaseLogger.cs
+++ b/code/FinanceManager.Api/Logging/DatabaseLogger.cs
@@ -1,4 +1,4 @@
-using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Entities.Logging;
 using FinanceManager.Domain.Enums;
 
 namespace FinanceManager.Api.Logging;

--- a/code/FinanceManager.Api/Logging/DatabaseLogger.cs
+++ b/code/FinanceManager.Api/Logging/DatabaseLogger.cs
@@ -44,6 +44,11 @@ public sealed class DatabaseLogger(string category, ILogEntryQueue queue) : ILog
             EventName = string.IsNullOrEmpty(eventId.Name) ? null : Truncate(eventId.Name, 256),
         };
 
+        // The queue is bounded with FullMode = DropOldest, so TryEnqueue only fails
+        // when the channel is closed (process shutdown). We intentionally don't
+        // surface that — a logger that throws or re-logs from inside Log() would
+        // either crash callers or recurse. Dropping the oldest pending entry under
+        // sustained load is the explicit trade-off for back-pressure-free logging.
         queue.TryEnqueue(entry);
     }
 

--- a/code/FinanceManager.Api/Logging/DatabaseLoggerProvider.cs
+++ b/code/FinanceManager.Api/Logging/DatabaseLoggerProvider.cs
@@ -1,0 +1,14 @@
+using System.Collections.Concurrent;
+
+namespace FinanceManager.Api.Logging;
+
+[ProviderAlias("Database")]
+public sealed class DatabaseLoggerProvider(ILogEntryQueue queue) : ILoggerProvider
+{
+    private readonly ConcurrentDictionary<string, DatabaseLogger> _loggers = new();
+
+    public ILogger CreateLogger(string categoryName) =>
+        _loggers.GetOrAdd(categoryName, name => new DatabaseLogger(name, queue));
+
+    public void Dispose() => _loggers.Clear();
+}

--- a/code/FinanceManager.Api/Logging/LogEntryPersistenceBackgroundService.cs
+++ b/code/FinanceManager.Api/Logging/LogEntryPersistenceBackgroundService.cs
@@ -1,6 +1,6 @@
 using FinanceManager.Api.Hubs;
 using FinanceManager.Domain.Dtos;
-using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Entities.Logging;
 using FinanceManager.Domain.Repositories;
 using Microsoft.AspNetCore.SignalR;
 

--- a/code/FinanceManager.Api/Logging/LogEntryPersistenceBackgroundService.cs
+++ b/code/FinanceManager.Api/Logging/LogEntryPersistenceBackgroundService.cs
@@ -1,0 +1,102 @@
+using FinanceManager.Api.Hubs;
+using FinanceManager.Domain.Dtos;
+using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Repositories;
+using Microsoft.AspNetCore.SignalR;
+
+namespace FinanceManager.Api.Logging;
+
+public sealed class LogEntryPersistenceBackgroundService(
+    ILogEntryQueue queue,
+    IServiceScopeFactory scopeFactory,
+    IHubContext<AdminLogsHub> hubContext,
+    ILogger<LogEntryPersistenceBackgroundService> logger) : BackgroundService
+{
+    private const int _maxBatchSize = 50;
+    private static readonly TimeSpan _flushInterval = TimeSpan.FromSeconds(2);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var _ = DatabaseLogger.BeginSuppression();
+        logger.LogInformation("Log persistence background service started.");
+
+        var buffer = new List<LogEntry>(_maxBatchSize);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (!await queue.Reader.WaitToReadAsync(stoppingToken))
+                    break;
+
+                using var batchTimeout = new CancellationTokenSource(_flushInterval);
+                using var linked = CancellationTokenSource.CreateLinkedTokenSource(batchTimeout.Token, stoppingToken);
+
+                buffer.Clear();
+                try
+                {
+                    while (buffer.Count < _maxBatchSize && queue.Reader.TryRead(out var entry))
+                        buffer.Add(entry);
+
+                    while (buffer.Count < _maxBatchSize && await queue.Reader.WaitToReadAsync(linked.Token))
+                    {
+                        while (buffer.Count < _maxBatchSize && queue.Reader.TryRead(out var entry))
+                            buffer.Add(entry);
+                    }
+                }
+                catch (OperationCanceledException) when (batchTimeout.IsCancellationRequested && !stoppingToken.IsCancellationRequested)
+                {
+                    // flush whatever we collected
+                }
+
+                if (buffer.Count == 0) continue;
+
+                await Flush(buffer, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                using var __ = DatabaseLogger.BeginSuppression();
+                logger.LogError(ex, "Failed to persist log batch of {Count} entries.", buffer.Count);
+                // brief backoff to avoid tight failure loop
+                try { await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken); }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+
+        logger.LogInformation("Log persistence background service stopped.");
+    }
+
+    private async Task Flush(List<LogEntry> entries, CancellationToken cancellationToken)
+    {
+        using var _ = DatabaseLogger.BeginSuppression();
+
+        using var scope = scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<ILogEntryRepository>();
+        await repository.AddRange(entries, cancellationToken);
+
+        var payload = entries
+            .Select(e => new LogEntryDto(
+                e.Id,
+                e.TimestampUtc,
+                e.Level,
+                e.Category,
+                e.Message,
+                e.Exception,
+                e.EventId,
+                e.EventName))
+            .ToArray();
+
+        try
+        {
+            await hubContext.Clients.Group(AdminLogsHub.GroupName).SendAsync("LogsAppended", payload, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to broadcast log batch over SignalR.");
+        }
+    }
+}

--- a/code/FinanceManager.Api/Logging/LogEntryQueue.cs
+++ b/code/FinanceManager.Api/Logging/LogEntryQueue.cs
@@ -1,0 +1,24 @@
+using FinanceManager.Domain.Entities.Logs;
+using System.Threading.Channels;
+
+namespace FinanceManager.Api.Logging;
+
+public interface ILogEntryQueue
+{
+    bool TryEnqueue(LogEntry entry);
+    ChannelReader<LogEntry> Reader { get; }
+}
+
+public sealed class LogEntryQueue : ILogEntryQueue
+{
+    private readonly Channel<LogEntry> _channel = Channel.CreateBounded<LogEntry>(new BoundedChannelOptions(2048)
+    {
+        FullMode = BoundedChannelFullMode.DropOldest,
+        SingleReader = true,
+        SingleWriter = false,
+    });
+
+    public ChannelReader<LogEntry> Reader => _channel.Reader;
+
+    public bool TryEnqueue(LogEntry entry) => _channel.Writer.TryWrite(entry);
+}

--- a/code/FinanceManager.Api/Logging/LogEntryQueue.cs
+++ b/code/FinanceManager.Api/Logging/LogEntryQueue.cs
@@ -1,4 +1,4 @@
-using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Entities.Logging;
 using System.Threading.Channels;
 
 namespace FinanceManager.Api.Logging;

--- a/code/FinanceManager.Api/Logging/LogRetentionBackgroundService.cs
+++ b/code/FinanceManager.Api/Logging/LogRetentionBackgroundService.cs
@@ -1,0 +1,54 @@
+using FinanceManager.Domain.Repositories;
+using Microsoft.Extensions.Options;
+
+namespace FinanceManager.Api.Logging;
+
+public sealed class LogRetentionBackgroundService(
+    IServiceScopeFactory scopeFactory,
+    IOptionsMonitor<LogRetentionOptions> options,
+    ILogger<LogRetentionBackgroundService> logger) : BackgroundService
+{
+    private static readonly TimeSpan _interval = TimeSpan.FromHours(24);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Initial cleanup on startup.
+        await Cleanup(stoppingToken);
+
+        using var timer = new PeriodicTimer(_interval);
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (!await timer.WaitForNextTickAsync(stoppingToken)) break;
+                await Cleanup(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    private async Task Cleanup(CancellationToken cancellationToken)
+    {
+        using var _ = DatabaseLogger.BeginSuppression();
+
+        try
+        {
+            var retentionDays = Math.Max(1, options.CurrentValue.RetentionDays);
+            var cutoffUtc = DateTime.UtcNow.AddDays(-retentionDays);
+
+            using var scope = scopeFactory.CreateScope();
+            var repository = scope.ServiceProvider.GetRequiredService<ILogEntryRepository>();
+            var deleted = await repository.DeleteOlderThan(cutoffUtc, cancellationToken);
+
+            if (deleted > 0)
+                logger.LogInformation("Log retention removed {Count} entries older than {Cutoff:o}.", deleted, cutoffUtc);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Log retention cleanup failed.");
+        }
+    }
+}

--- a/code/FinanceManager.Api/Logging/LogRetentionOptions.cs
+++ b/code/FinanceManager.Api/Logging/LogRetentionOptions.cs
@@ -1,0 +1,8 @@
+namespace FinanceManager.Api.Logging;
+
+public class LogRetentionOptions
+{
+    public const string SectionName = "LogRetention";
+
+    public int RetentionDays { get; set; } = 30;
+}

--- a/code/FinanceManager.Api/Migrations/20260526114648_AddLogEntries.Designer.cs
+++ b/code/FinanceManager.Api/Migrations/20260526114648_AddLogEntries.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceManager.Infrastructure.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceManager.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260526114648_AddLogEntries")]
+    partial class AddLogEntries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/code/FinanceManager.Api/Migrations/20260526114648_AddLogEntries.Designer.cs
+++ b/code/FinanceManager.Api/Migrations/20260526114648_AddLogEntries.Designer.cs
@@ -320,7 +320,7 @@ namespace FinanceManager.Api.Migrations
                     b.ToTable("CsvHeaderMappings");
                 });
 
-            modelBuilder.Entity("FinanceManager.Domain.Entities.Logs.LogEntry", b =>
+            modelBuilder.Entity("FinanceManager.Domain.Entities.Logging.LogEntry", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()

--- a/code/FinanceManager.Api/Migrations/20260526114648_AddLogEntries.cs
+++ b/code/FinanceManager.Api/Migrations/20260526114648_AddLogEntries.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using System;
+
+#nullable disable
+
+namespace FinanceManager.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLogEntries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LogEntries",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TimestampUtc = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Level = table.Column<int>(type: "integer", nullable: false),
+                    Category = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    Message = table.Column<string>(type: "character varying(4096)", maxLength: 4096, nullable: false),
+                    Exception = table.Column<string>(type: "text", nullable: true),
+                    EventId = table.Column<int>(type: "integer", nullable: true),
+                    EventName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LogEntries", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LogEntries_Level_TimestampUtc",
+                table: "LogEntries",
+                columns: new[] { "Level", "TimestampUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LogEntries_TimestampUtc",
+                table: "LogEntries",
+                column: "TimestampUtc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LogEntries");
+        }
+    }
+}

--- a/code/FinanceManager.Api/Migrations/AppDbContextModelSnapshot.cs
+++ b/code/FinanceManager.Api/Migrations/AppDbContextModelSnapshot.cs
@@ -317,7 +317,7 @@ namespace FinanceManager.Api.Migrations
                     b.ToTable("CsvHeaderMappings");
                 });
 
-            modelBuilder.Entity("FinanceManager.Domain.Entities.Logs.LogEntry", b =>
+            modelBuilder.Entity("FinanceManager.Domain.Entities.Logging.LogEntry", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()

--- a/code/FinanceManager.Api/Program.cs
+++ b/code/FinanceManager.Api/Program.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Api.Logging;
 using FinanceManager.Api.Services;
 using FinanceManager.Api.Services.Guest;
 using FinanceManager.Application;
@@ -91,7 +92,9 @@ builder.Services.AddCors(options =>
             var accessToken = context.Request.Query["access_token"];
             var path = context.HttpContext.Request.Path;
             if (!string.IsNullOrWhiteSpace(accessToken) &&
-                (path.StartsWithSegments("/hubs/currency-import") || path.StartsWithSegments("/hubs/label-setter-progress")))
+                (path.StartsWithSegments("/hubs/currency-import")
+                 || path.StartsWithSegments("/hubs/label-setter-progress")
+                 || path.StartsWithSegments("/hubs/admin-logs")))
                 context.Token = accessToken;
 
             return Task.CompletedTask;
@@ -137,6 +140,15 @@ builder.Services.AddSingleton<ICurrencyImportJobChannel, CurrencyImportJobChanne
 builder.Services.AddSingleton<ICurrencyImportJobStore, CurrencyImportJobStore>();
 builder.Services.AddHostedService<CurrencyImportBackgroundService>();
 
+builder.Services.Configure<LogRetentionOptions>(builder.Configuration.GetSection(LogRetentionOptions.SectionName));
+builder.Services.AddSingleton<ILogEntryQueue, LogEntryQueue>();
+builder.Services.AddSingleton<ILoggerProvider>(sp => new DatabaseLoggerProvider(sp.GetRequiredService<ILogEntryQueue>()));
+builder.Logging.AddFilter<DatabaseLoggerProvider>("Microsoft.EntityFrameworkCore", LogLevel.None);
+builder.Logging.AddFilter<DatabaseLoggerProvider>("Microsoft.AspNetCore.SignalR", LogLevel.None);
+builder.Logging.AddFilter<DatabaseLoggerProvider>("Microsoft.AspNetCore.Http.Connections", LogLevel.None);
+builder.Services.AddHostedService<LogEntryPersistenceBackgroundService>();
+builder.Services.AddHostedService<LogRetentionBackgroundService>();
+
 var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
@@ -163,5 +175,6 @@ app.UseAuthorization();
 app.MapControllers();
 app.MapHub<FinanceManager.Api.Hubs.CurrencyImportHub>("/hubs/currency-import");
 app.MapHub<FinanceManager.Api.Hubs.LabelSetterProgressHub>("/hubs/label-setter-progress");
+app.MapHub<FinanceManager.Api.Hubs.AdminLogsHub>("/hubs/admin-logs");
 app.MapFallbackToFile("index.html");
 app.Run();

--- a/code/FinanceManager.Api/appsettings.json
+++ b/code/FinanceManager.Api/appsettings.json
@@ -18,6 +18,9 @@
       "FinanceManager": "Trace"
     }
   },
+  "LogRetention": {
+    "RetentionDays": 30
+  },
   "StockApi": {
     "BaseUrl": "https://www.alphavantage.co/query",
     "OutputSize": "full"

--- a/code/FinanceManager.Components/Components/Admin/AdminDashboard.razor
+++ b/code/FinanceManager.Components/Components/Admin/AdminDashboard.razor
@@ -157,4 +157,8 @@
     <MudItem xs="12" md="6">
         <LabelSetterProgressCard />
     </MudItem>
+
+    <MudItem xs="12" md="6">
+        <AdminLogsCard />
+    </MudItem>
 </MudGrid>

--- a/code/FinanceManager.Components/Components/Admin/AdminLogsCard.razor
+++ b/code/FinanceManager.Components/Components/Admin/AdminLogsCard.razor
@@ -1,0 +1,54 @@
+@using FinanceManager.Domain.Dtos
+@using FinanceManager.Domain.Enums
+@implements IAsyncDisposable
+
+<MudCard Outlined>
+    <MudCardContent>
+        <MudPaper Class="d-flex justify-start gap-2 flex-grow-1 flex-column px-3 py-1" Elevation="0">
+            <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
+                <MudIcon Icon="@Icons.Material.Filled.ReportProblem" Color="Color.Warning" />
+                <MudText>Recent warnings & errors</MudText>
+                <MudSpacer />
+                <MudLink Href="Admin/Logs">View all</MudLink>
+            </MudStack>
+
+            @if (_loadError is not null)
+            {
+                <MudAlert Severity="Severity.Error" Dense>@_loadError</MudAlert>
+            }
+            else if (_entries is null)
+            {
+                <StringSpinner CharactersCount="6" />
+            }
+            else if (_entries.Count == 0)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Secondary">
+                    No warnings or errors recorded.
+                </MudText>
+            }
+            else
+            {
+                <MudList T="LogEntryDto" Dense DisablePadding>
+                    @foreach (var entry in _entries)
+                    {
+                        <MudListItem T="LogEntryDto">
+                            <MudStack Row AlignItems="AlignItems.Center" Spacing="2" Class="w-100">
+                                <MudChip T="string" Size="Size.Small" Color="@LevelColor(entry.Level)" Variant="Variant.Filled">
+                                    @entry.Level.ToString()
+                                </MudChip>
+                                <MudStack Spacing="0" Class="flex-grow-1" Style="min-width:0">
+                                    <MudText Typo="Typo.body2" Style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis">
+                                        @entry.Message
+                                    </MudText>
+                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
+                                        @entry.Category · @entry.TimestampUtc.ToLocalTime().ToString("g")
+                                    </MudText>
+                                </MudStack>
+                            </MudStack>
+                        </MudListItem>
+                    }
+                </MudList>
+            }
+        </MudPaper>
+    </MudCardContent>
+</MudCard>

--- a/code/FinanceManager.Components/Components/Admin/AdminLogsCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Admin/AdminLogsCard.razor.cs
@@ -1,0 +1,92 @@
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.Dtos;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.SignalR.Client;
+using MudBlazor;
+
+namespace FinanceManager.Components.Components.Admin;
+
+public partial class AdminLogsCard : ComponentBase, IAsyncDisposable
+{
+    private const int _maxEntries = 5;
+    private List<LogEntryDto>? _entries;
+    private string? _loadError;
+    private HubConnection? _hubConnection;
+
+    [Inject] public required AdminLogsHttpClient AdminLogsHttpClient { get; set; }
+    [Inject] public required NavigationManager NavigationManager { get; set; }
+    [Inject] public required ILoginService LoginService { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _entries = await AdminLogsHttpClient.GetLatest(_maxEntries);
+        }
+        catch (Exception ex)
+        {
+            _loadError = $"Failed to load logs: {ex.Message}";
+        }
+
+        await ConnectHub();
+    }
+
+    private async Task ConnectHub()
+    {
+        try
+        {
+            _hubConnection = new HubConnectionBuilder()
+                .WithUrl(NavigationManager.ToAbsoluteUri("hubs/admin-logs"), options =>
+                {
+                    options.AccessTokenProvider = async () => (await LoginService.GetLoggedUser())?.Token;
+                })
+                .WithAutomaticReconnect()
+                .Build();
+
+            _hubConnection.On<LogEntryDto[]>("LogsAppended", batch =>
+            {
+                if (batch is null || batch.Length == 0) return;
+                _entries ??= [];
+                var merged = batch.Concat(_entries)
+                    .OrderByDescending(e => e.TimestampUtc)
+                    .ThenByDescending(e => e.Id)
+                    .Take(_maxEntries)
+                    .ToList();
+                _entries = merged;
+                _ = InvokeAsync(StateHasChanged);
+            });
+
+            _hubConnection.Reconnected += async _ =>
+            {
+                if (_hubConnection is not null)
+                    await _hubConnection.InvokeAsync("Subscribe");
+            };
+
+            await _hubConnection.StartAsync();
+            await _hubConnection.InvokeAsync("Subscribe");
+        }
+        catch (Exception ex)
+        {
+            _loadError = $"Live updates disabled: {ex.Message}";
+        }
+    }
+
+    private static Color LevelColor(LogSeverity level) => level switch
+    {
+        LogSeverity.Critical => Color.Error,
+        LogSeverity.Error => Color.Error,
+        LogSeverity.Warning => Color.Warning,
+        _ => Color.Default,
+    };
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_hubConnection is not null)
+        {
+            await _hubConnection.DisposeAsync();
+            _hubConnection = null;
+        }
+    }
+}

--- a/code/FinanceManager.Components/Components/Admin/AdminLogsPage.razor
+++ b/code/FinanceManager.Components/Components/Admin/AdminLogsPage.razor
@@ -1,0 +1,80 @@
+@page "/Admin/Logs"
+@attribute [Authorize(Roles = "Admin")]
+@layout AdminLayout
+
+@using FinanceManager.Domain.Dtos
+@using FinanceManager.Domain.Enums
+@using Microsoft.AspNetCore.Authorization
+@implements IAsyncDisposable
+
+<MudStack Spacing="3">
+    <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
+        <MudIcon Icon="@Icons.Material.Filled.ReportProblem" Color="Color.Warning" />
+        <MudText Typo="Typo.h5">Application logs</MudText>
+        <MudSpacer />
+        <MudToggleGroup T="string" SelectionMode="SelectionMode.SingleSelection" Color="Color.Primary"
+                        Outlined="true" Dense="true" Value="@_levelFilter" ValueChanged="OnLevelChanged">
+            <MudToggleItem Value="@("all")">All</MudToggleItem>
+            <MudToggleItem Value="@("warning")">Warning</MudToggleItem>
+            <MudToggleItem Value="@("error")">Error</MudToggleItem>
+        </MudToggleGroup>
+    </MudStack>
+
+    @if (_loadError is not null)
+    {
+        <MudAlert Severity="Severity.Error" Dense>@_loadError</MudAlert>
+    }
+
+    <MudPaper Outlined Class="pa-0">
+        <MudTable T="LogEntryDto" Items="@_page" Loading="@_loading" Hover Dense Bordered="false"
+                  Breakpoint="Breakpoint.Sm">
+            <HeaderContent>
+                <MudTh Style="width:110px">Level</MudTh>
+                <MudTh Style="width:180px">When</MudTh>
+                <MudTh>Message</MudTh>
+                <MudTh Style="width:280px">Category</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>
+                    <MudChip T="string" Size="Size.Small" Color="@LevelColor(context.Level)" Variant="Variant.Filled">
+                        @context.Level.ToString()
+                    </MudChip>
+                </MudTd>
+                <MudTd>
+                    <MudText Typo="Typo.caption">@context.TimestampUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</MudText>
+                </MudTd>
+                <MudTd>
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.body2">@context.Message</MudText>
+                        @if (!string.IsNullOrEmpty(context.Exception))
+                        {
+                            <MudText Typo="Typo.caption" Color="Color.Error" Style="white-space:pre-wrap;max-height:160px;overflow:auto">
+                                @context.Exception
+                            </MudText>
+                        }
+                    </MudStack>
+                </MudTd>
+                <MudTd>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">@context.Category</MudText>
+                </MudTd>
+            </RowTemplate>
+            <NoRecordsContent>
+                <MudText Typo="Typo.body2" Color="Color.Secondary" Class="pa-3">
+                    No log entries match the current filter.
+                </MudText>
+            </NoRecordsContent>
+        </MudTable>
+
+        <MudStack Row AlignItems="AlignItems.Center" Spacing="2" Class="pa-3">
+            <MudText Typo="Typo.caption" Color="Color.Secondary">
+                Showing @FromDisplay()&ndash;@ToDisplay() of @_totalCount
+            </MudText>
+            <MudSpacer />
+            <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" Disabled="@(_skip <= 0 || _loading)"
+                           OnClick="PrevPage" Size="Size.Small" />
+            <MudText Typo="Typo.body2">Page @CurrentPage / @TotalPages</MudText>
+            <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Disabled="@(_skip + _take >= _totalCount || _loading)"
+                           OnClick="NextPage" Size="Size.Small" />
+        </MudStack>
+    </MudPaper>
+</MudStack>

--- a/code/FinanceManager.Components/Components/Admin/AdminLogsPage.razor.cs
+++ b/code/FinanceManager.Components/Components/Admin/AdminLogsPage.razor.cs
@@ -1,0 +1,129 @@
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.Dtos;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.SignalR.Client;
+using MudBlazor;
+
+namespace FinanceManager.Components.Components.Admin;
+
+public partial class AdminLogsPage : ComponentBase, IAsyncDisposable
+{
+    private List<LogEntryDto> _page = [];
+    private int _totalCount;
+    private int _skip;
+    private const int _take = 25;
+    private string _levelFilter = "all";
+    private bool _loading;
+    private string? _loadError;
+    private HubConnection? _hubConnection;
+
+    [Inject] public required AdminLogsHttpClient AdminLogsHttpClient { get; set; }
+    [Inject] public required NavigationManager NavigationManager { get; set; }
+    [Inject] public required ILoginService LoginService { get; set; }
+
+    private int CurrentPage => _totalCount == 0 ? 1 : (_skip / _take) + 1;
+    private int TotalPages => _totalCount == 0 ? 1 : (int)Math.Ceiling(_totalCount / (double)_take);
+    private int FromDisplay() => _totalCount == 0 ? 0 : _skip + 1;
+    private int ToDisplay() => Math.Min(_skip + _take, _totalCount);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadPage();
+        await ConnectHub();
+    }
+
+    private async Task LoadPage()
+    {
+        _loading = true;
+        try
+        {
+            var levelParam = _levelFilter == "all" ? null : _levelFilter;
+            var result = await AdminLogsHttpClient.GetPaged(_skip, _take, levelParam);
+            _page = result.Items.ToList();
+            _totalCount = result.TotalCount;
+            _loadError = null;
+        }
+        catch (Exception ex)
+        {
+            _loadError = $"Failed to load logs: {ex.Message}";
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task OnLevelChanged(string? value)
+    {
+        _levelFilter = string.IsNullOrEmpty(value) ? "all" : value;
+        _skip = 0;
+        await LoadPage();
+    }
+
+    private async Task PrevPage()
+    {
+        _skip = Math.Max(0, _skip - _take);
+        await LoadPage();
+    }
+
+    private async Task NextPage()
+    {
+        if (_skip + _take >= _totalCount) return;
+        _skip += _take;
+        await LoadPage();
+    }
+
+    private async Task ConnectHub()
+    {
+        try
+        {
+            _hubConnection = new HubConnectionBuilder()
+                .WithUrl(NavigationManager.ToAbsoluteUri("hubs/admin-logs"), options =>
+                {
+                    options.AccessTokenProvider = async () => (await LoginService.GetLoggedUser())?.Token;
+                })
+                .WithAutomaticReconnect()
+                .Build();
+
+            _hubConnection.On<LogEntryDto[]>("LogsAppended", batch =>
+            {
+                // Only refresh when viewing the first page so live updates don't
+                // shift the user's scroll position while they're paging history.
+                if (_skip == 0)
+                    _ = InvokeAsync(LoadPage);
+            });
+
+            _hubConnection.Reconnected += async _ =>
+            {
+                if (_hubConnection is not null)
+                    await _hubConnection.InvokeAsync("Subscribe");
+            };
+
+            await _hubConnection.StartAsync();
+            await _hubConnection.InvokeAsync("Subscribe");
+        }
+        catch
+        {
+            // Live updates are optional — page still works without them.
+        }
+    }
+
+    private static Color LevelColor(LogSeverity level) => level switch
+    {
+        LogSeverity.Critical => Color.Error,
+        LogSeverity.Error => Color.Error,
+        LogSeverity.Warning => Color.Warning,
+        _ => Color.Default,
+    };
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_hubConnection is not null)
+        {
+            await _hubConnection.DisposeAsync();
+            _hubConnection = null;
+        }
+    }
+}

--- a/code/FinanceManager.Components/Components/Layout/AdminLayout.razor
+++ b/code/FinanceManager.Components/Components/Layout/AdminLayout.razor
@@ -27,6 +27,7 @@
             <MudNavLink Icon="@Icons.Material.Filled.AccountBalance" Href="Admin/Bonds">Bonds</MudNavLink>
             <MudNavLink Icon="@Icons.Material.Filled.ShowChart" Href="Admin/Stocks">Stocks</MudNavLink>
             <MudNavLink Icon="@Icons.Material.Filled.SmartToy" Href="Admin/AiProviders">AI Providers</MudNavLink>
+            <MudNavLink Icon="@Icons.Material.Filled.ReportProblem" Href="Admin/Logs">Logs</MudNavLink>
         </MudNavMenu>
 
     </MudDrawer>
@@ -90,6 +91,7 @@
                 "AddLabel" => "Add label",
                 "AddUser" => "Add user",
                 "AiProviders" => "AI Providers",
+                "Logs" => "Logs",
                 _ => section
             };
 

--- a/code/FinanceManager.Components/HttpClients/AdminLogsHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/AdminLogsHttpClient.cs
@@ -3,36 +3,27 @@ using System.Net.Http.Json;
 
 namespace FinanceManager.Components.HttpClients;
 
+// Other typed clients in this project swallow exceptions and return empty
+// collections, but the log viewer specifically needs to surface API/network
+// failures: rendering "no warnings or errors" when the API is down would hide
+// the very kind of incident this feature exists to expose. The card and page
+// both wrap these calls in try/catch and set _loadError.
 public class AdminLogsHttpClient(HttpClient httpClient)
 {
     public async Task<List<LogEntryDto>> GetLatest(int count = 5)
     {
-        try
-        {
-            var result = await httpClient.GetFromJsonAsync<List<LogEntryDto>>(
-                $"{httpClient.BaseAddress}api/admin/logs/latest?count={count}");
-            return result ?? [];
-        }
-        catch
-        {
-            return [];
-        }
+        var result = await httpClient.GetFromJsonAsync<List<LogEntryDto>>(
+            $"{httpClient.BaseAddress}api/admin/logs/latest?count={count}");
+        return result ?? [];
     }
 
     public async Task<PagedLogEntriesDto> GetPaged(int skip, int take, string? level = null)
     {
-        try
-        {
-            var url = $"{httpClient.BaseAddress}api/admin/logs?skip={skip}&take={take}";
-            if (!string.IsNullOrWhiteSpace(level))
-                url += $"&level={Uri.EscapeDataString(level)}";
+        var url = $"{httpClient.BaseAddress}api/admin/logs?skip={skip}&take={take}";
+        if (!string.IsNullOrWhiteSpace(level))
+            url += $"&level={Uri.EscapeDataString(level)}";
 
-            var result = await httpClient.GetFromJsonAsync<PagedLogEntriesDto>(url);
-            return result ?? new PagedLogEntriesDto([], 0);
-        }
-        catch
-        {
-            return new PagedLogEntriesDto([], 0);
-        }
+        var result = await httpClient.GetFromJsonAsync<PagedLogEntriesDto>(url);
+        return result ?? new PagedLogEntriesDto([], 0);
     }
 }

--- a/code/FinanceManager.Components/HttpClients/AdminLogsHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/AdminLogsHttpClient.cs
@@ -1,0 +1,38 @@
+using FinanceManager.Domain.Dtos;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Components.HttpClients;
+
+public class AdminLogsHttpClient(HttpClient httpClient)
+{
+    public async Task<List<LogEntryDto>> GetLatest(int count = 5)
+    {
+        try
+        {
+            var result = await httpClient.GetFromJsonAsync<List<LogEntryDto>>(
+                $"{httpClient.BaseAddress}api/admin/logs/latest?count={count}");
+            return result ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    public async Task<PagedLogEntriesDto> GetPaged(int skip, int take, string? level = null)
+    {
+        try
+        {
+            var url = $"{httpClient.BaseAddress}api/admin/logs?skip={skip}&take={take}";
+            if (!string.IsNullOrWhiteSpace(level))
+                url += $"&level={Uri.EscapeDataString(level)}";
+
+            var result = await httpClient.GetFromJsonAsync<PagedLogEntriesDto>(url);
+            return result ?? new PagedLogEntriesDto([], 0);
+        }
+        catch
+        {
+            return new PagedLogEntriesDto([], 0);
+        }
+    }
+}

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -41,6 +41,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<DiversificationHttpClient>()
                 .AddScoped<AdministrationUsersHttpClient>()
                 .AddScoped<AdminAiProvidersHttpClient>()
+                .AddScoped<AdminLogsHttpClient>()
                 .AddScoped<NewVisitorsHttpClient>()
                 .AddScoped<CsvHeaderMappingHttpClient>()
                 .AddScoped<AccountDataSynchronizationService>()

--- a/code/FinanceManager.Domain/Dtos/LogEntryDto.cs
+++ b/code/FinanceManager.Domain/Dtos/LogEntryDto.cs
@@ -1,0 +1,15 @@
+using FinanceManager.Domain.Enums;
+
+namespace FinanceManager.Domain.Dtos;
+
+public record LogEntryDto(
+    int Id,
+    DateTime TimestampUtc,
+    LogSeverity Level,
+    string Category,
+    string Message,
+    string? Exception,
+    int? EventId,
+    string? EventName);
+
+public record PagedLogEntriesDto(IReadOnlyList<LogEntryDto> Items, int TotalCount);

--- a/code/FinanceManager.Domain/Entities/Logging/LogEntry.cs
+++ b/code/FinanceManager.Domain/Entities/Logging/LogEntry.cs
@@ -1,0 +1,15 @@
+using FinanceManager.Domain.Enums;
+
+namespace FinanceManager.Domain.Entities.Logging;
+
+public class LogEntry
+{
+    public int Id { get; set; }
+    public DateTime TimestampUtc { get; set; }
+    public LogSeverity Level { get; set; }
+    public string Category { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string? Exception { get; set; }
+    public int? EventId { get; set; }
+    public string? EventName { get; set; }
+}

--- a/code/FinanceManager.Domain/Enums/LogSeverity.cs
+++ b/code/FinanceManager.Domain/Enums/LogSeverity.cs
@@ -1,0 +1,14 @@
+namespace FinanceManager.Domain.Enums;
+
+// Numeric values mirror Microsoft.Extensions.Logging.LogLevel so callers in the
+// API/Components layers can cast directly without a lookup table.
+public enum LogSeverity
+{
+    Trace = 0,
+    Debug = 1,
+    Information = 2,
+    Warning = 3,
+    Error = 4,
+    Critical = 5,
+    None = 6,
+}

--- a/code/FinanceManager.Domain/Repositories/ILogEntryRepository.cs
+++ b/code/FinanceManager.Domain/Repositories/ILogEntryRepository.cs
@@ -1,4 +1,4 @@
-using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Entities.Logging;
 using FinanceManager.Domain.Enums;
 
 namespace FinanceManager.Domain.Repositories;

--- a/code/FinanceManager.Domain/Repositories/ILogEntryRepository.cs
+++ b/code/FinanceManager.Domain/Repositories/ILogEntryRepository.cs
@@ -1,0 +1,19 @@
+using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Enums;
+
+namespace FinanceManager.Domain.Repositories;
+
+public interface ILogEntryRepository
+{
+    Task AddRange(IEnumerable<LogEntry> entries, CancellationToken cancellationToken = default);
+
+    Task<List<LogEntry>> GetLatest(int count, IReadOnlyCollection<LogSeverity>? levels = null, CancellationToken cancellationToken = default);
+
+    Task<(List<LogEntry> Items, int TotalCount)> GetPaged(
+        int skip,
+        int take,
+        IReadOnlyCollection<LogSeverity>? levels = null,
+        CancellationToken cancellationToken = default);
+
+    Task<int> DeleteOlderThan(DateTime cutoffUtc, CancellationToken cancellationToken = default);
+}

--- a/code/FinanceManager.Infrastructure/Contexts/AppDbContext.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/AppDbContext.cs
@@ -3,6 +3,7 @@ using FinanceManager.Domain.Entities.Bonds;
 using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
 using FinanceManager.Domain.Entities.Imports;
+using FinanceManager.Domain.Entities.Logs;
 using FinanceManager.Domain.Entities.Shared.Accounts;
 using FinanceManager.Domain.Entities.Stocks;
 using FinanceManager.Domain.Entities.Users;
@@ -32,6 +33,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<AiProviderConfiguration> AiProviderConfigurations { get; set; } = default!;
     public DbSet<AiFallbackEntry> AiFallbackEntries { get; set; } = default!;
     public DbSet<AiProviderModel> AiProviderModels { get; set; } = default!;
+    public DbSet<LogEntry> LogEntries { get; set; } = default!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -54,6 +56,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.ApplyConfiguration(new AiProviderConfigurationConfiguration());
         modelBuilder.ApplyConfiguration(new AiFallbackEntryConfiguration());
         modelBuilder.ApplyConfiguration(new AiProviderModelConfiguration());
+        modelBuilder.ApplyConfiguration(new LogEntryConfiguration());
 
         base.OnModelCreating(modelBuilder);
     }

--- a/code/FinanceManager.Infrastructure/Contexts/AppDbContext.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/AppDbContext.cs
@@ -3,7 +3,7 @@ using FinanceManager.Domain.Entities.Bonds;
 using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
 using FinanceManager.Domain.Entities.Imports;
-using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Entities.Logging;
 using FinanceManager.Domain.Entities.Shared.Accounts;
 using FinanceManager.Domain.Entities.Stocks;
 using FinanceManager.Domain.Entities.Users;

--- a/code/FinanceManager.Infrastructure/Contexts/Configurations/LogEntryConfiguration.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/Configurations/LogEntryConfiguration.cs
@@ -1,0 +1,28 @@
+using FinanceManager.Domain.Entities.Logs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FinanceManager.Infrastructure.Contexts.Configurations;
+
+public class LogEntryConfiguration : IEntityTypeConfiguration<LogEntry>
+{
+    public void Configure(EntityTypeBuilder<LogEntry> builder)
+    {
+        builder.Property(e => e.Id)
+            .ValueGeneratedOnAdd();
+
+        builder.Property(e => e.Category)
+            .HasMaxLength(256)
+            .IsRequired();
+
+        builder.Property(e => e.Message)
+            .HasMaxLength(4096)
+            .IsRequired();
+
+        builder.Property(e => e.EventName)
+            .HasMaxLength(256);
+
+        builder.HasIndex(e => e.TimestampUtc);
+        builder.HasIndex(e => new { e.Level, e.TimestampUtc });
+    }
+}

--- a/code/FinanceManager.Infrastructure/Contexts/Configurations/LogEntryConfiguration.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/Configurations/LogEntryConfiguration.cs
@@ -1,4 +1,4 @@
-using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Entities.Logging;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 

--- a/code/FinanceManager.Infrastructure/Repositories/LogEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/LogEntryRepository.cs
@@ -1,4 +1,4 @@
-using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Entities.Logging;
 using FinanceManager.Domain.Enums;
 using FinanceManager.Domain.Repositories;
 using FinanceManager.Infrastructure.Contexts;

--- a/code/FinanceManager.Infrastructure/Repositories/LogEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/LogEntryRepository.cs
@@ -1,0 +1,55 @@
+using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Infrastructure.Contexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Infrastructure.Repositories;
+
+public class LogEntryRepository(AppDbContext context) : ILogEntryRepository
+{
+    public async Task AddRange(IEnumerable<LogEntry> entries, CancellationToken cancellationToken = default)
+    {
+        context.LogEntries.AddRange(entries);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public Task<List<LogEntry>> GetLatest(int count, IReadOnlyCollection<LogSeverity>? levels = null, CancellationToken cancellationToken = default)
+    {
+        var query = context.LogEntries.AsNoTracking();
+        if (levels is { Count: > 0 })
+            query = query.Where(e => levels.Contains(e.Level));
+
+        return query
+            .OrderByDescending(e => e.TimestampUtc)
+            .ThenByDescending(e => e.Id)
+            .Take(count)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<(List<LogEntry> Items, int TotalCount)> GetPaged(
+        int skip,
+        int take,
+        IReadOnlyCollection<LogSeverity>? levels = null,
+        CancellationToken cancellationToken = default)
+    {
+        var query = context.LogEntries.AsNoTracking();
+        if (levels is { Count: > 0 })
+            query = query.Where(e => levels.Contains(e.Level));
+
+        var total = await query.CountAsync(cancellationToken);
+        var items = await query
+            .OrderByDescending(e => e.TimestampUtc)
+            .ThenByDescending(e => e.Id)
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync(cancellationToken);
+
+        return (items, total);
+    }
+
+    public Task<int> DeleteOlderThan(DateTime cutoffUtc, CancellationToken cancellationToken = default) =>
+        context.LogEntries
+            .Where(e => e.TimestampUtc < cutoffUtc)
+            .ExecuteDeleteAsync(cancellationToken);
+}

--- a/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
@@ -61,6 +61,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<ICsvHeaderMappingRepository, CsvHeaderMappingRepository>()
                 .AddScoped<IInflationDataProvider, InMemoryInflationDataProvider>()
                 .AddScoped<IAiProviderConfigRepository, AiProviderConfigRepository>()
+                .AddScoped<ILogEntryRepository, LogEntryRepository>()
 
                 .AddSingleton<IInsightsPromptProvider, InsightsPromptProvider>()
                 .AddSingleton<ILabelSetterPromptProvider, LabelSetterPromptProvider>()

--- a/code/FinanceManager.IntegrationTests/FinanceManagerApiTestApp.cs
+++ b/code/FinanceManager.IntegrationTests/FinanceManagerApiTestApp.cs
@@ -1,4 +1,5 @@
 ﻿using FinanceManager.Api;
+using FinanceManager.Api.Logging;
 using FinanceManager.Api.Services;
 using FinanceManager.Infrastructure.Services;
 using Microsoft.AspNetCore.Hosting;
@@ -28,6 +29,14 @@ internal sealed class FinanceManagerApiTestApp : WebApplicationFactory<ApiEntryP
                 var labelSetterDescriptor = s.FirstOrDefault(d => d.ImplementationType == typeof(LabelSetterStartupService));
                 if (labelSetterDescriptor != null)
                     s.Remove(labelSetterDescriptor);
+
+                var logPersistenceDescriptor = s.FirstOrDefault(d => d.ImplementationType == typeof(LogEntryPersistenceBackgroundService));
+                if (logPersistenceDescriptor != null)
+                    s.Remove(logPersistenceDescriptor);
+
+                var logRetentionDescriptor = s.FirstOrDefault(d => d.ImplementationType == typeof(LogRetentionBackgroundService));
+                if (logRetentionDescriptor != null)
+                    s.Remove(logRetentionDescriptor);
 
                 services?.Invoke(s);
             });

--- a/code/FinanceManager.UnitTests/Api/Controllers/AdminLogsControllerTests.cs
+++ b/code/FinanceManager.UnitTests/Api/Controllers/AdminLogsControllerTests.cs
@@ -39,16 +39,23 @@ public class AdminLogsControllerTests
     }
 
     [Fact]
-    public async Task GetLatest_CapsCountAt50()
+    public async Task GetLatest_CountAbove50IsBadRequest()
     {
-        _repository
-            .Setup(r => r.GetLatest(50, It.IsAny<IReadOnlyCollection<LogSeverity>?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([])
-            .Verifiable();
+        var result = await _controller.GetLatest(9999, TestContext.Current.CancellationToken);
+        Assert.IsType<BadRequestObjectResult>(result);
+        _repository.Verify(
+            r => r.GetLatest(It.IsAny<int>(), It.IsAny<IReadOnlyCollection<LogSeverity>?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 
-        await _controller.GetLatest(9999, TestContext.Current.CancellationToken);
-
-        _repository.Verify();
+    [Fact]
+    public async Task GetPaged_TakeAbove200IsBadRequest()
+    {
+        var result = await _controller.GetPaged(0, 500, null, TestContext.Current.CancellationToken);
+        Assert.IsType<BadRequestObjectResult>(result);
+        _repository.Verify(
+            r => r.GetPaged(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<IReadOnlyCollection<LogSeverity>?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/code/FinanceManager.UnitTests/Api/Controllers/AdminLogsControllerTests.cs
+++ b/code/FinanceManager.UnitTests/Api/Controllers/AdminLogsControllerTests.cs
@@ -1,6 +1,6 @@
 using FinanceManager.Api.Controllers.Admin;
 using FinanceManager.Domain.Dtos;
-using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Entities.Logging;
 using FinanceManager.Domain.Enums;
 using FinanceManager.Domain.Repositories;
 using Microsoft.AspNetCore.Mvc;

--- a/code/FinanceManager.UnitTests/Api/Controllers/AdminLogsControllerTests.cs
+++ b/code/FinanceManager.UnitTests/Api/Controllers/AdminLogsControllerTests.cs
@@ -1,0 +1,105 @@
+using FinanceManager.Api.Controllers.Admin;
+using FinanceManager.Domain.Dtos;
+using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace FinanceManager.UnitTests.Api.Controllers;
+
+[Trait("Category", "Unit")]
+public class AdminLogsControllerTests
+{
+    private readonly Mock<ILogEntryRepository> _repository = new();
+    private readonly AdminLogsController _controller;
+
+    public AdminLogsControllerTests()
+    {
+        _controller = new AdminLogsController(_repository.Object);
+    }
+
+    [Fact]
+    public async Task GetLatest_RestrictsToWarningAndError()
+    {
+        IReadOnlyCollection<LogSeverity>? capturedLevels = null;
+        _repository
+            .Setup(r => r.GetLatest(5, It.IsAny<IReadOnlyCollection<LogSeverity>?>(), It.IsAny<CancellationToken>()))
+            .Callback<int, IReadOnlyCollection<LogSeverity>?, CancellationToken>((_, levels, _) => capturedLevels = levels)
+            .ReturnsAsync([]);
+
+        var result = await _controller.GetLatest(5, TestContext.Current.CancellationToken);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(capturedLevels);
+        Assert.Contains(LogSeverity.Warning, capturedLevels!);
+        Assert.Contains(LogSeverity.Error, capturedLevels);
+        Assert.Contains(LogSeverity.Critical, capturedLevels);
+        Assert.DoesNotContain(LogSeverity.Information, capturedLevels);
+    }
+
+    [Fact]
+    public async Task GetLatest_CapsCountAt50()
+    {
+        _repository
+            .Setup(r => r.GetLatest(50, It.IsAny<IReadOnlyCollection<LogSeverity>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([])
+            .Verifiable();
+
+        await _controller.GetLatest(9999, TestContext.Current.CancellationToken);
+
+        _repository.Verify();
+    }
+
+    [Fact]
+    public async Task GetLatest_NonPositiveCountIsBadRequest()
+    {
+        var result = await _controller.GetLatest(0, TestContext.Current.CancellationToken);
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetPaged_ParsesErrorFilter()
+    {
+        IReadOnlyCollection<LogSeverity>? capturedLevels = null;
+        _repository
+            .Setup(r => r.GetPaged(0, 25, It.IsAny<IReadOnlyCollection<LogSeverity>?>(), It.IsAny<CancellationToken>()))
+            .Callback<int, int, IReadOnlyCollection<LogSeverity>?, CancellationToken>((_, _, levels, _) => capturedLevels = levels)
+            .ReturnsAsync(([], 0));
+
+        await _controller.GetPaged(0, 25, "error", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(capturedLevels);
+        Assert.Contains(LogSeverity.Error, capturedLevels!);
+        Assert.Contains(LogSeverity.Critical, capturedLevels);
+        Assert.DoesNotContain(LogSeverity.Warning, capturedLevels);
+    }
+
+    [Fact]
+    public async Task GetPaged_MapsEntriesAndTotal()
+    {
+        var entries = new List<LogEntry>
+        {
+            new() { Id = 1, TimestampUtc = DateTime.UtcNow, Level = LogSeverity.Error, Category = "Cat", Message = "boom" }
+        };
+
+        _repository
+            .Setup(r => r.GetPaged(0, 25, It.IsAny<IReadOnlyCollection<LogSeverity>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((entries, 7));
+
+        var result = await _controller.GetPaged(0, 25, null, TestContext.Current.CancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var paged = Assert.IsType<PagedLogEntriesDto>(ok.Value);
+        Assert.Equal(7, paged.TotalCount);
+        Assert.Single(paged.Items);
+        Assert.Equal("boom", paged.Items[0].Message);
+    }
+
+    [Fact]
+    public async Task GetPaged_NegativeSkipIsBadRequest()
+    {
+        var result = await _controller.GetPaged(-1, 25, null, TestContext.Current.CancellationToken);
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+}

--- a/code/FinanceManager.UnitTests/Api/Logging/DatabaseLoggerTests.cs
+++ b/code/FinanceManager.UnitTests/Api/Logging/DatabaseLoggerTests.cs
@@ -1,5 +1,5 @@
 using FinanceManager.Api.Logging;
-using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Entities.Logging;
 using FinanceManager.Domain.Enums;
 using Microsoft.Extensions.Logging;
 using System.Threading.Channels;

--- a/code/FinanceManager.UnitTests/Api/Logging/DatabaseLoggerTests.cs
+++ b/code/FinanceManager.UnitTests/Api/Logging/DatabaseLoggerTests.cs
@@ -1,0 +1,109 @@
+using FinanceManager.Api.Logging;
+using FinanceManager.Domain.Entities.Logs;
+using FinanceManager.Domain.Enums;
+using Microsoft.Extensions.Logging;
+using System.Threading.Channels;
+
+namespace FinanceManager.UnitTests.Api.Logging;
+
+[Trait("Category", "Unit")]
+public class DatabaseLoggerTests
+{
+    [Theory]
+    [InlineData(LogLevel.Trace, false)]
+    [InlineData(LogLevel.Debug, false)]
+    [InlineData(LogLevel.Information, false)]
+    [InlineData(LogLevel.Warning, true)]
+    [InlineData(LogLevel.Error, true)]
+    [InlineData(LogLevel.Critical, true)]
+    public void IsEnabled_OnlyWarningAndAbove(LogLevel level, bool expected)
+    {
+        var logger = new DatabaseLogger("test", new RecordingQueue());
+        Assert.Equal(expected, logger.IsEnabled(level));
+    }
+
+    [Fact]
+    public void Log_BelowWarning_DoesNotEnqueue()
+    {
+        var queue = new RecordingQueue();
+        var logger = new DatabaseLogger("test", queue);
+
+        logger.LogInformation("hello");
+
+        Assert.Empty(queue.Captured);
+    }
+
+    [Fact]
+    public void Log_Warning_EnqueuesEntryWithMappedSeverity()
+    {
+        var queue = new RecordingQueue();
+        var logger = new DatabaseLogger("MyCat", queue);
+
+        logger.LogWarning(new EventId(42, "myEvent"), "something happened {x}", "y");
+
+        Assert.Single(queue.Captured);
+        var entry = queue.Captured[0];
+        Assert.Equal(LogSeverity.Warning, entry.Level);
+        Assert.Equal("MyCat", entry.Category);
+        Assert.Equal("something happened y", entry.Message);
+        Assert.Equal(42, entry.EventId);
+        Assert.Equal("myEvent", entry.EventName);
+    }
+
+    [Fact]
+    public void Log_WithException_CapturesExceptionString()
+    {
+        var queue = new RecordingQueue();
+        var logger = new DatabaseLogger("MyCat", queue);
+
+        logger.LogError(new InvalidOperationException("boom"), "bad");
+
+        var entry = Assert.Single(queue.Captured);
+        Assert.Equal(LogSeverity.Error, entry.Level);
+        Assert.NotNull(entry.Exception);
+        Assert.Contains("InvalidOperationException", entry.Exception);
+    }
+
+    [Fact]
+    public void Suppression_PreventsEnqueueWithinScope()
+    {
+        var queue = new RecordingQueue();
+        var logger = new DatabaseLogger("MyCat", queue);
+
+        using (DatabaseLogger.BeginSuppression())
+        {
+            logger.LogError("inside");
+        }
+
+        logger.LogError("outside");
+
+        Assert.Single(queue.Captured);
+        Assert.Equal("outside", queue.Captured[0].Message);
+    }
+
+    [Fact]
+    public void Log_TruncatesOverlongMessage()
+    {
+        var queue = new RecordingQueue();
+        var logger = new DatabaseLogger("MyCat", queue);
+
+        var longMessage = new string('x', 5000);
+        logger.LogWarning(longMessage);
+
+        var entry = Assert.Single(queue.Captured);
+        Assert.Equal(4096, entry.Message.Length);
+    }
+
+    private sealed class RecordingQueue : ILogEntryQueue
+    {
+        public List<LogEntry> Captured { get; } = new();
+
+        public ChannelReader<LogEntry> Reader => Channel.CreateUnbounded<LogEntry>().Reader;
+
+        public bool TryEnqueue(LogEntry entry)
+        {
+            Captured.Add(entry);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the admin log viewer described in #212.

- New `LogEntries` table and EF Core migration; warnings, errors, and criticals emitted by the API are persisted via a database `ILoggerProvider` that drains a bounded `Channel<LogEntry>` from a background service.
- The same background service broadcasts new entries over a SignalR hub at `/hubs/admin-logs`, so both the admin dashboard widget and the full `/Admin/Logs` page update live.
- Admin dashboard now shows a "Recent warnings & errors" card with the latest 5 entries and a link to the full page.
- `/Admin/Logs` page provides warning/error filtering and pagination over the persisted entries.
- A retention background service purges entries older than the configured cutoff on API startup and once per day. The cutoff is loaded from `LogRetention:RetentionDays` in `appsettings.json` (default 30 days).
- Recursive logging from the persistence pipeline itself is guarded with an `AsyncLocal<bool>` suppression flag and EF Core / SignalR categories are filtered out of the database provider so DB writes don't generate more logs that need to be written.

## Test plan

- [x] `dotnet build ./code/FinanceManager.slnx` passes with no warnings (warnings-as-errors enabled).
- [x] `dotnet test --project ./FinanceManager.UnitTests/FinanceManager.UnitTests.csproj` passes (309/309), including new tests for the controller filter, count cap, validation, and the `DatabaseLogger` severity gating, suppression, truncation, and exception capture.
- [ ] Manual smoke: log in as admin → dashboard widget renders → trigger a warning → entry appears in widget without refresh → open `/Admin/Logs` → filter Warning vs Error → paginate.

closes #212

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kv415Y3CgosjRNNbtCiXVV)_