### PR TITLE
Hide mobile nav drawer behind app-bar hamburger #216

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ rules agents must follow when updating this file.
 - Guest demo data now generates realistic per-account-type entries: currency labels respect income vs expense sign, stock and bond holdings never go negative, and stock prices are prefilled across the seeded range. #206
 - Settings page redesigned as a single-page, TOC-style layout with Profile, Password, Subscription, and Danger zone sections and a sticky save bar. #209
 - Recurring transactions details UI improved: year now shows as small muted annotation at top, table dates simplified to MM-dd format, and long descriptions are trimmed with tooltips to maximize space utilization. #213
+- Mobile navigation drawer is now hidden by default and slides in as a temporary overlay when the app-bar hamburger is tapped, freeing horizontal space for page content; desktop keeps the existing mini-rail behavior. #216
 
 ### Fixed
 - Guest dashboard's net cash flow card no longer times out — stock price lookups now preload in bulk per ticker instead of one external resolve per entry. #208

--- a/code/FinanceManager.Components/Components/Layout/MainLayout.razor
+++ b/code/FinanceManager.Components/Components/Layout/MainLayout.razor
@@ -1,8 +1,7 @@
 ﻿@using FinanceManager.Domain.Services
 
 @inherits LayoutComponentBase
-@inject NavigationManager Navigation
-@inject ILoginService LoginService
+@implements IAsyncDisposable
 
 <AuthorizeView>
     <NotAuthorized>
@@ -11,10 +10,10 @@
     <Authorized>
         <MudLayout>
             <MudAppBar Dense Elevation="0">
-                <MudIconButton Icon="@Icons.Material.Filled.Menu" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
+                <MudIconButton Icon="@Icons.Material.Filled.Menu" Edge="Edge.Start" OnClick="@DrawerToggle" />
             </MudAppBar>
 
-            <MudDrawer @bind-Open="_drawerOpen" Variant="@DrawerVariant.Mini" Elevation="0">
+            <MudDrawer @bind-Open="_drawerOpen" Variant="@_drawerVariant" Elevation="0">
                 <NavMenu DrawerIsOpen=_drawerOpen />
                 <MudSpacer />
                 <MudNavMenu>
@@ -31,16 +30,46 @@
 </AuthorizeView>
 
 @code {
+    [Inject] public NavigationManager Navigation { get; set; } = default!;
+    [Inject] public ILoginService LoginService { get; set; } = default!;
+    [Inject] public IBrowserViewportService BrowserViewportService { get; set; } = default!;
 
-    bool _drawerOpen = true;
+    private readonly Guid _viewportSubscriptionId = Guid.NewGuid();
+    private bool _drawerOpen = true;
+    private bool _isMobile;
+    private DrawerVariant _drawerVariant = DrawerVariant.Mini;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+
+        await BrowserViewportService.SubscribeAsync(_viewportSubscriptionId, async args =>
+        {
+            ApplyBreakpoint(args.Breakpoint);
+            await InvokeAsync(StateHasChanged);
+        }, fireImmediately: true);
+    }
+
+    private void ApplyBreakpoint(Breakpoint breakpoint)
+    {
+        var isMobile = breakpoint is Breakpoint.Xs or Breakpoint.Sm;
+        if (isMobile == _isMobile) return;
+
+        _isMobile = isMobile;
+        _drawerVariant = isMobile ? DrawerVariant.Temporary : DrawerVariant.Mini;
+        _drawerOpen = !isMobile;
+    }
+
+    private void DrawerToggle() => _drawerOpen = !_drawerOpen;
 
     private async Task LogOut()
     {
         await LoginService.Logout();
         Navigation.NavigateTo("login");
     }
-    void DrawerToggle()
+
+    public async ValueTask DisposeAsync()
     {
-        _drawerOpen = !_drawerOpen;
+        await BrowserViewportService.UnsubscribeAsync(_viewportSubscriptionId);
     }
 }


### PR DESCRIPTION
## Summary
- Hide the nav drawer by default on mobile (Xs/Sm) and reveal it as a temporary slide-in overlay when the app-bar hamburger is tapped.
- Keep desktop (>= Md) behavior unchanged: `DrawerVariant.Mini` with hamburger collapsing/expanding the icon rail.
- React to viewport changes via `IBrowserViewportService` so resizing across the breakpoint resets the drawer to the appropriate default state.

Closes #216

## Test plan
- [ ] At ≤ Sm width: drawer is hidden on load; tapping the hamburger slides it in over content with a scrim; tapping the scrim or a nav link closes it.
- [ ] At ≥ Md width: drawer renders as the mini rail and hamburger collapses/expands it (existing behavior).
- [ ] Resize from desktop → mobile: drawer collapses to hidden.
- [ ] Resize from mobile → desktop: drawer reappears as mini rail.
- [ ] Settings and Log out items still work from both variants.
- [ ] `dotnet build` clean, `dotnet test` passes (310/310 locally), `dotnet format` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DzsRDZ9DUMRBKbPaivGcjn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation drawer now adapts responsively to different screen sizes, switching between temporary and compact variants on mobile and desktop respectively.

* **Improvements**
  * Enhanced layout resource management for better cleanup on component disposal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->