### PR TITLE
Reflow settings page rows on mobile #218

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "Bash(dotnet build *)",
       "mcp__Claude_Preview__preview_start",
       "PowerShell(\"done\")",
-      "PowerShell($ProgressPreference='SilentlyContinue'; $until=\\(Get-Date\\).AddSeconds\\(120\\); while\\(\\(Get-Date\\) -lt $until\\){ try { $r = Invoke-WebRequest -SkipCertificateCheck -UseBasicParsing -Uri https://localhost:5001/ -TimeoutSec 4; \"$\\($r.StatusCode\\)\"; break } catch { Start-Sleep 4 } })"
+      "PowerShell($ProgressPreference='SilentlyContinue'; $until=\\(Get-Date\\).AddSeconds\\(120\\); while\\(\\(Get-Date\\) -lt $until\\){ try { $r = Invoke-WebRequest -SkipCertificateCheck -UseBasicParsing -Uri https://localhost:5001/ -TimeoutSec 4; \"$\\($r.StatusCode\\)\"; break } catch { Start-Sleep 4 } })",
+      "mcp__b1838a51-7e97-4ec4-944c-571647e8c754__microsoft_docs_search"
     ]
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ rules agents must follow when updating this file.
 ### Fixed
 - Guest dashboard's net cash flow card no longer times out — stock price lookups now preload in bulk per ticker instead of one external resolve per entry. #208
 - Dashboard and asset pages no longer make an external OpenFIGI request for every stock price lookup — ticker→ISIN resolution is now cached in memory and served from local `StockDetails` first, with OpenFIGI as last-resort fallback.
+- Settings page no longer overflows on mobile — profile row, danger zone, and the unsaved-changes bar reflow vertically on narrow viewports while the desktop layout stays unchanged. #218
 
 ## [26.5.25] - 2026-05-25
 

--- a/code/FinanceManager.Components/Components/User/UserSettingsPage.razor
+++ b/code/FinanceManager.Components/Components/User/UserSettingsPage.razor
@@ -34,16 +34,19 @@
                         Your public identity within Finance Manager.
                     </MudText>
 
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3" Class="mb-4">
-                        <MudAvatar Color="Color.Primary" Size="Size.Large">@_userData.Login.ToUpper()[0]</MudAvatar>
-                        <MudStack Spacing="0">
-                            <MudText Typo="Typo.subtitle1">@_userData.Login</MudText>
-                            <MudText Typo="Typo.body2" Color="Color.Secondary">@_userData.Login</MudText>
+                    <div class="d-flex flex-column flex-md-row align-md-center gap-3 mb-4">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3" Class="mud-width-full" Style="min-width:0;">
+                            <MudAvatar Color="Color.Primary" Size="Size.Large">@_userData.Login.ToUpper()[0]</MudAvatar>
+                            <MudStack Spacing="0" Style="min-width:0;">
+                                <MudText Typo="Typo.subtitle1" Style="word-break:break-word;">@_userData.Login</MudText>
+                                <MudText Typo="Typo.body2" Color="Color.Secondary" Style="word-break:break-word;">@_userData.Login</MudText>
+                            </MudStack>
                         </MudStack>
-                        <MudSpacer />
-                        <MudButton Variant="Variant.Outlined" Disabled="true">Upload photo</MudButton>
-                        <MudButton Variant="Variant.Text" Disabled="true">Remove</MudButton>
-                    </MudStack>
+                        <MudStack Row="true" Spacing="2" Class="flex-wrap">
+                            <MudButton Variant="Variant.Outlined" Disabled="true">Upload photo</MudButton>
+                            <MudButton Variant="Variant.Text" Disabled="true">Remove</MudButton>
+                        </MudStack>
+                    </div>
 
                     <MudGrid>
                         <MudItem xs="12" md="6">
@@ -162,7 +165,7 @@
                         Permanently delete this account and all associated financial data. This cannot be undone.
                     </MudText>
 
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+                    <div class="d-flex flex-column flex-sm-row align-sm-center gap-3">
                         <MudTextField T="string"
                                       @bind-Value="_deleteConfirmation"
                                       Immediate="true"
@@ -178,7 +181,7 @@
                                    OnClick="DeleteMyAccount">
                             Delete account
                         </MudButton>
-                    </MudStack>
+                    </div>
                 </section>
 
                 @if (_errors.Count > 0 || _warnings.Count > 0 || _info.Count > 0)
@@ -204,12 +207,11 @@
         @if (_isDirty)
         {
             <MudPaper Elevation="8" Square="true"
-                      Style="position:sticky; bottom:0; left:0; right:0;
-                             display:flex; align-items:center; gap:12px;
-                             padding:12px 24px; z-index:5;
+                      Class="d-flex flex-wrap align-center gap-2 py-2 px-3 px-sm-6"
+                      Style="position:sticky; bottom:0; left:0; right:0; z-index:5;
                              background:var(--mud-palette-surface);
                              border-top:1px solid var(--mud-palette-divider);">
-                <MudIcon Icon="@Icons.Material.Filled.Circle" Color="Color.Primary" Size="Size.Small" />
+                <MudIcon Icon="@Icons.Material.Filled.Circle" Color="Color.Primary" Size="Size.Small" Class="d-none d-sm-flex" />
                 <MudText Typo="Typo.body2">You have unsaved changes.</MudText>
                 <MudSpacer />
                 <MudButton OnClick="DiscardChanges">Discard</MudButton>

--- a/code/FinanceManager.Components/Components/User/UserSettingsPage.razor
+++ b/code/FinanceManager.Components/Components/User/UserSettingsPage.razor
@@ -6,7 +6,7 @@
     @if (_userData is not null)
     {
         <MudGrid>
-            <MudItem xs="12" md="3">
+            <MudItem xs="12" md="3" Class="d-none d-md-block">
                 <div style="position:sticky; top:16px;">
                     <MudList T="string"
                              SelectionMode="SelectionMode.SingleSelection"


### PR DESCRIPTION
## Summary

Fixes mobile layout overflow on `/UserSettings`. Desktop layout is unchanged.

- **Profile row** — avatar+identity block and the action buttons now sit in a `d-flex flex-column flex-md-row` container, so buttons drop below the identity on `xs/sm`.
- **Danger zone row** — same `flex-column flex-sm-row` pattern so the *Delete account* button drops below the confirmation field on narrow screens.
- **Sticky unsaved-changes bar** — converted inline `padding:12px 24px` to `py-2 px-3 px-sm-6` and added `flex-wrap` so *Discard* / *Save changes* wrap to a new line when the row is too narrow. The leading indicator icon is hidden on `xs`.
- **Section TOC list** — the Profile / Password / Subscription / Danger zone navigator on the left is hidden on `xs/sm` (each section is reachable by scrolling).

No new CSS files; only MudBlazor utility classes / inline `Class` attributes.

closes #218

## Test plan

- [ ] At ≤ 600px width, profile, danger zone, and save bar reflow vertically with no horizontal overflow.
- [ ] At ≤ 600px width, the section TOC list is hidden; first content visible is the "Account settings" heading.
- [ ] At ≥ 960px (md), the page renders exactly as before — TOC on the left, horizontal action rows, sticky save bar single-line.
- [ ] `dotnet build` clean; all 310 unit tests pass.

https://claude.ai/code/session_012xT5rDMTPvdj5udYfbSnmh

---
_Generated by [Claude Code](https://claude.ai/code/session_012xT5rDMTPvdj5udYfbSnmh)_