### PR TITLE
Skip redundant tests on develop push to speed up dev deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
   code-quality:
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     steps:
       - name: Checkout code
@@ -81,6 +82,7 @@ jobs:
   security-scan:
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     steps:
       - name: Checkout code
@@ -118,6 +120,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     env:
       FINANCE_MANAGER_DB_KEY: ${{ secrets.FINANCE_MANAGER_DB_KEY }}
 
@@ -155,7 +158,7 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     needs: [build, unit-tests]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     env:
       FINANCE_MANAGER_DB_KEY: ${{ secrets.FINANCE_MANAGER_DB_KEY }}
       UseInMemoryDatabase: true
@@ -191,8 +194,16 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [integration-tests, code-quality, security-scan]
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    needs: [build, unit-tests, integration-tests, code-quality, security-scan]
+    if: |
+      always()
+      && github.event_name == 'push'
+      && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+      && needs.build.result == 'success'
+      && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'skipped')
+      && (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped')
+      && (needs.code-quality.result == 'success' || needs.code-quality.result == 'skipped')
+      && (needs.security-scan.result == 'success' || needs.security-scan.result == 'skipped')
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Skip `code-quality`, `security-scan`, `unit-tests`, and `integration-tests` on push to `develop` — they already ran on the PR.
- Move `integration-tests` into the PR trigger so coverage isn't lost (previously they only ran on push to `main`/`develop`).
- Rewrite `publish.if` with `always()` plus per-need `success || skipped` checks so it still proceeds when test jobs are skipped on develop push, but continues to block on real failures when they do run.

Push to `main` still runs the full pipeline before production deploy.

## Test plan
- [ ] Push to `develop` runs only `build` → `publish` → `deploy-dev`.
- [ ] Opening a PR runs `build`, `code-quality`, `security-scan`, `unit-tests`, `integration-tests`.
- [ ] Push to `main` runs the full pipeline and deploys to production.
- [ ] A real failure in `unit-tests` on a PR still blocks the eventual `publish` job after merge to `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016kCc2jv88DrL9zyhEsDokF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with improved job gating: code quality, security, and test jobs now execute selectively for pull requests and main branch pushes.
  * Strengthened publishing safeguards by requiring all quality, security, and test checks to pass or be skipped before release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->