### PR TITLE
Fix guest stock pricing: seed real ISIN + StockDetails #222

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ rules agents must follow when updating this file.
 - Mobile navigation drawer is now hidden by default and slides in as a temporary overlay when the app-bar hamburger is tapped, freeing horizontal space for page content; desktop keeps the existing mini-rail behavior. #216
 
 ### Fixed
+- Guest stock account no longer shows "Stock price unavailable" on every entry — the demo seeder now stores a real ISIN and a matching `StockDetails` row so the ticker resolves from the local sandbox instead of falling through to OpenFIGI. #222
 - Guest dashboard's net cash flow card no longer times out — stock price lookups now preload in bulk per ticker instead of one external resolve per entry. #208
 - Dashboard and asset pages no longer make an external OpenFIGI request for every stock price lookup — ticker→ISIN resolution is now cached in memory and served from local `StockDetails` first, with OpenFIGI as last-resort fallback.
 - Settings page no longer overflows on mobile — profile row, danger zone, and the unsaved-changes bar reflow vertically on narrow viewports while the desktop layout stays unchanged. #218

--- a/code/FinanceManager.Application/Services/Seeders/StockAccountSeeder.cs
+++ b/code/FinanceManager.Application/Services/Seeders/StockAccountSeeder.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Entities.Stocks;
 using FinanceManager.Domain.Enums;
 using FinanceManager.Domain.Repositories;
@@ -10,20 +11,44 @@ public class StockAccountSeeder(
     IFinancialAccountRepository accountRepository,
     IAccountRepository<StockAccount> stockAccountRepository,
     IStockPriceRepository stockPriceRepository,
+    IStockDetailsRepository stockDetailsRepository,
     ICurrencyRepository currencyRepository,
     ILogger<StockAccountSeeder> logger)
 {
-    private const string DemoIsin = "CSPX.LON";
+    // CSPX.LON is iShares Core S&P 500 UCITS ETF; its real ISIN is IE00B5BMR087.
+    // Seeding a matching StockDetails row lets CachingIsinResolver resolve the ticker
+    // from the local DB instead of falling through to OpenFIGI on every price lookup.
+    private const string DemoTicker = "CSPX.LON";
+    private const string DemoIsin = "IE00B5BMR087";
 
     public async Task Seed(int userId, DateTime start, DateTime end, CancellationToken cancellationToken = default)
     {
         if (await stockAccountRepository.GetAvailableAccounts(userId).AnyAsync(cancellationToken)) return;
 
         logger.LogTrace("Seeding stock account.");
+        var currency = await currencyRepository.GetByCode("USD", cancellationToken)
+            ?? await currencyRepository.GetOrAdd("USD", "$", cancellationToken);
+
+        await SeedStockDetails(currency, cancellationToken);
         await SeedStockAccount(userId, start, end, cancellationToken);
 
         logger.LogTrace("Prefilling stock prices for {Isin}.", DemoIsin);
-        await SeedStockPrices(DemoIsin, start, end, cancellationToken);
+        await SeedStockPrices(DemoIsin, currency, start, end, cancellationToken);
+    }
+
+    private async Task SeedStockDetails(Currency currency, CancellationToken cancellationToken)
+    {
+        if (await stockDetailsRepository.Get(DemoIsin, cancellationToken) is not null) return;
+
+        await stockDetailsRepository.Add(new StockDetails
+        {
+            Isin = DemoIsin,
+            Ticker = DemoTicker,
+            Name = "iShares Core S&P 500 UCITS ETF",
+            Type = "ETF",
+            Region = "LSE",
+            Currency = currency
+        }, cancellationToken);
     }
 
     private async Task SeedStockAccount(int userId, DateTime start, DateTime end, CancellationToken cancellationToken)
@@ -63,11 +88,8 @@ public class StockAccountSeeder(
         await accountRepository.AddAccount(account);
     }
 
-    private async Task SeedStockPrices(string isin, DateTime start, DateTime end, CancellationToken cancellationToken)
+    private async Task SeedStockPrices(string isin, Currency currency, DateTime start, DateTime end, CancellationToken cancellationToken)
     {
-        var currency = await currencyRepository.GetByCode("USD", cancellationToken)
-            ?? await currencyRepository.GetOrAdd("USD", "$", cancellationToken);
-
         // Random-walk price seed: start near a plausible CSPX.LON value and jitter daily so the guest UI shows life-like valuations.
         decimal price = 400m;
         for (var date = start.Date; date <= end.Date; date = date.AddDays(1))

--- a/code/FinanceManager.Infrastructure/Services/Stocks/CachingIsinResolver.cs
+++ b/code/FinanceManager.Infrastructure/Services/Stocks/CachingIsinResolver.cs
@@ -36,6 +36,11 @@ internal sealed class CachingIsinResolver(
             return cached;
 
         var fromDb = await stockDetailsRepository.GetByTicker(normalized, ct);
+        // GetStoredTickers() on StockAccount actually returns ISINs post-#195; the upstream
+        // call site forwards the entry's Isin in the "ticker" slot, so fall back to an ISIN
+        // lookup before paying the OpenFIGI round-trip.
+        if (fromDb is null)
+            fromDb = await stockDetailsRepository.Get(normalized, ct);
         if (fromDb is not null && !string.IsNullOrWhiteSpace(fromDb.Isin))
         {
             cache.Set(cacheKey, fromDb.Isin, _positiveTtl);

--- a/code/FinanceManager.IntegrationTests/FinanceManagerApiTestApp.cs
+++ b/code/FinanceManager.IntegrationTests/FinanceManagerApiTestApp.cs
@@ -12,6 +12,16 @@ namespace FinanceManager.IntegrationTests;
 
 internal sealed class FinanceManagerApiTestApp : WebApplicationFactory<ApiEntryPoint>
 {
+    static FinanceManagerApiTestApp()
+    {
+        // Each host built by WebApplicationFactory loads appsettings*.json with reloadOnChange=true,
+        // which registers FileSystemWatchers (one inotify instance each). On Linux sandboxes the
+        // 128-instance limit is exhausted part-way through a full integration run, and later
+        // WebApplicationFactory constructions throw at host build time. The hosting builder honours
+        // this env var to skip the watcher entirely.
+        Environment.SetEnvironmentVariable("DOTNET_hostBuilder__reloadConfigOnChange", "false");
+    }
+
     public HttpClient Client { get; }
 
     public FinanceManagerApiTestApp(Action<IServiceCollection>? services = null)


### PR DESCRIPTION
## Summary
- Seed a real ISIN (`IE00B5BMR087`) and matching `StockDetails(Ticker=CSPX.LON, …)` row in `StockAccountSeeder` so guest stock entries resolve via the local DB instead of falling through to OpenFIGI — fixes "Stock price unavailable" on every guest stock row.
- Disable `reloadConfigOnChange` in the integration test host (`DOTNET_hostBuilder__reloadConfigOnChange=false`) so a full run no longer exhausts the 128-instance Linux inotify limit. 140/140 integration tests now pass on the cloud sandbox (was 127/140).

closes #222

## Test plan
- [x] `dotnet build ./code/FinanceManager.slnx` — clean, no warnings.
- [x] `dotnet test --project ./code/FinanceManager.UnitTests/FinanceManager.UnitTests.csproj` — 310/310 pass.
- [x] `UseInMemoryDatabase=true dotnet test --project ./code/FinanceManager.IntegrationTests/FinanceManager.IntegrationTests.csproj` — 140/140 pass.
- [ ] Manual: log in as guest, open the seeded stock account, confirm rows show a price + "Total evaluation" instead of "Stock price unavailable".

---
_Generated by [Claude Code](https://claude.ai/code/session_014hy33tFRnJ7kdeGmfE5Sm9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal service architecture and dependency management
  * Enhanced test environment stability for improved reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->