### PR TITLE
Show ticker in stock row title, move ISIN to expansion #224

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ rules agents must follow when updating this file.
 - Admin log viewer: warnings and errors emitted by the API are now persisted to the database and surfaced in the admin panel as a "Recent warnings & errors" dashboard widget and a full `/Admin/Logs` page with warning/error filtering and pagination. A retention background service purges entries older than the configured cutoff (default 30 days) on API start and once a day, and a SignalR hub pushes new entries to the UI live. #212
 
 ### Changed
+- Stock account entry rows now show the ticker symbol in the row title and move the ISIN into the expanded section so the visible identifier is the one users recognize. #224
 - Guest demo data now generates realistic per-account-type entries: currency labels respect income vs expense sign, stock and bond holdings never go negative, and stock prices are prefilled across the seeded range. #206
 - Settings page redesigned as a single-page, TOC-style layout with Profile, Password, Subscription, and Danger zone sections and a sticky save bar. #209
 - Recurring transactions details UI improved: year now shows as small muted annotation at top, table dates simplified to MM-dd format, and long descriptions are trimmed with tooltips to maximize space utilization. #213

--- a/code/FinanceManager.Application/Services/Seeders/StockAccountSeeder.cs
+++ b/code/FinanceManager.Application/Services/Seeders/StockAccountSeeder.cs
@@ -80,7 +80,11 @@ public class StockAccountSeeder(
                 continue;
             }
 
-            account.Add(new StockAccountEntry(account.AccountId, 0, date, 0, change, DemoIsin, InvestmentType.Stock), false);
+            var entry = new StockAccountEntry(account.AccountId, 0, date, 0, change, DemoIsin, InvestmentType.Stock)
+            {
+                Ticker = DemoTicker
+            };
+            account.Add(entry, false);
             heldUnits += change;
         }
 

--- a/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsRow.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsRow.razor
@@ -8,8 +8,8 @@
     <TitleContent>
         <MudGrid>
             <MudItem xs="3">
-                <MudText Typo="Typo.caption" Color="Color.Default">ISIN</MudText>
-                <MudText Typo="Typo.body1">@InvestmentEntry.Isin</MudText>
+                <MudText Typo="Typo.caption" Color="Color.Default">Ticker</MudText>
+                <MudText Typo="Typo.body1">@(string.IsNullOrWhiteSpace(InvestmentEntry.Ticker) ? InvestmentEntry.Isin : InvestmentEntry.Ticker)</MudText>
             </MudItem>
            
             <MudItem xs="5">
@@ -83,6 +83,11 @@
                         <MudItem xs="4">
                             <MudText Typo="Typo.caption" Color="Color.Default">Investment type</MudText>
                             <MudText Typo="Typo.body1">@InvestmentEntry.InvestmentType</MudText>
+                        </MudItem>
+
+                        <MudItem xs="12">
+                            <MudText Typo="Typo.caption" Color="Color.Default">ISIN</MudText>
+                            <MudText Typo="Typo.body1">@InvestmentEntry.Isin</MudText>
                         </MudItem>
 
                         @if (UnrealizedGainLoss is not null && UnrealizedGainLoss.IsExcludedFromTotals &&


### PR DESCRIPTION
## Summary

- Stock account row title now shows the **ticker** (e.g. `CSPX.LON`) instead of the ISIN — the identifier most users actually recognize. Falls back to `Isin` when `Ticker` is empty so legacy / user-entered rows still render something.
- ISIN moved into the expanded body of the row alongside Transaction date / Units / Investment type.
- Guest seeder now also sets `Ticker = "CSPX.LON"` on each seeded entry so the new title has data to show in the guest sandbox.

closes #224

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test --project ./FinanceManager.UnitTests/FinanceManager.UnitTests.csproj` — 310/310 passing
- [ ] Log in as guest in dev, open the seeded stock account, confirm row title shows `Ticker CSPX.LON` and expanding the row reveals `ISIN IE00B5BMR087`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MJhEBPswJdMtLjB4z7pGY3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stock account details now display ticker information with automatic fallback to ISIN when ticker is unavailable
  * Added ISIN field display in the expanded stock account details view

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->