### PR TITLE
Account details page redesign — currency accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ rules agents must follow when updating this file.
 - Admin log viewer: warnings and errors emitted by the API are now persisted to the database and surfaced in the admin panel as a "Recent warnings & errors" dashboard widget and a full `/Admin/Logs` page with warning/error filtering and pagination. A retention background service purges entries older than the configured cutoff (default 30 days) on API start and once a day, and a SignalR hub pushes new entries to the UI live. #212
 
 ### Changed
+- Currency account details page redesigned around a hero (avatar, name, balance, range toggle, chart), a search/filter toolbar with income/expense chips and category picker, day-grouped transaction cards with running balance, and an insight rail (balance change, top 5 income, bottom 5 expenses). #175
 - Stock account entry rows now show the ticker symbol in the row title and move the ISIN into the expanded section so the visible identifier is the one users recognize. #224
 - Guest demo data now generates realistic per-account-type entries: currency labels respect income vs expense sign, stock and bond holdings never go negative, and stock prices are prefilled across the seeded range. #206
 - Settings page redesigned as a single-page, TOC-style layout with Profile, Password, Subscription, and Danger zone sections and a sticky save bar. #209

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountDetailsHero.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountDetailsHero.razor
@@ -1,7 +1,7 @@
 @using FinanceManager.Components.Components.SharedComponents.Charts
 @using FinanceManager.Domain.Entities.MoneyFlowModels
 
-<MudPaper Elevation="0" Class="pa-6 mb-4" Style="background-color: transparent;">
+<MudPaper Elevation="0" Class="pa-6 pb-0 mb-0" Style="background-color: transparent;">
     <MudStack Spacing="4">
         <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="3">
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
@@ -26,10 +26,14 @@
                 </MudToggleGroup>
                 @if (SelectedRange == "Range")
                 {
-                    <MudDateRangePicker DateRange="CustomDateRange" DateRangeChanged="OnCustomDateRangeChanged"
-                                        Variant="Variant.Outlined" Margin="Margin.Dense"
-                                        Style="max-width: 260px;" Clearable="true"
-                                        PlaceholderStart="From" PlaceholderEnd="To" />
+                    <div style="width: 260px;">
+                        <MudDateRangePicker DateRange="CustomDateRange" DateRangeChanged="OnCustomDateRangeChanged"
+                                            Variant="Variant.Outlined" Margin="Margin.Dense"
+                                            PickerVariant="PickerVariant.Dialog"
+                                            DisplayMonths="2" Orientation="Orientation.Landscape"
+                                            Clearable="true"
+                                            PlaceholderStart="From" PlaceholderEnd="To" />
+                    </div>
                 }
             </MudStack>
         </MudStack>
@@ -62,14 +66,14 @@
         </MudStack>
 
     </MudStack>
-    <div class="mx-n6 mb-n6 mt-4" style="min-height: 200px; position: relative;">
+    <div class="mx-n6 mt-2" style="min-height: 200px; position: relative;">
         @if (IsChartLoading)
         {
             <MudSkeleton SkeletonType="SkeletonType.Rectangle" Animation="Animation.Wave" Height="200px" Width="100%" />
         }
         else
         {
-            <LineChartJs Series="@([ChartData.Select(x => new ChartJsLineDataPoint(x.DateTime.ToLocalTime(), x.Value)).ToList()])" />
+            <LineChartJs Series="@_chartSeries" />
         }
     </div>
 </MudPaper>
@@ -87,6 +91,25 @@
     [Parameter] public EventCallback<DateRange?> CustomDateRangeChanged { get; set; }
     [Parameter] public bool IsChartLoading { get; set; }
     [Parameter] public List<TimeSeriesModel> ChartData { get; set; } = [];
+
+    private List<List<ChartJsLineDataPoint>> _chartSeries = [];
+    private List<TimeSeriesModel>? _lastChartData;
+    private int _lastChartDataCount = -1;
+
+    protected override void OnParametersSet()
+    {
+        // Rebuild the chart series only when the underlying ChartData actually changes — the
+        // parent re-renders for unrelated state (e.g. the mobile insights drawer toggle), and
+        // recreating the series list every time would force LineChartJs to re-run its draw
+        // animation for no reason. Reference equality + count covers the in-place mutation
+        // the page does (Clear + AddRange).
+        if (!ReferenceEquals(ChartData, _lastChartData) || ChartData.Count != _lastChartDataCount)
+        {
+            _lastChartData = ChartData;
+            _lastChartDataCount = ChartData.Count;
+            _chartSeries = [ChartData.Select(x => new ChartJsLineDataPoint(x.DateTime.ToLocalTime(), x.Value)).ToList()];
+        }
+    }
 
     private string GetInitial() => string.IsNullOrWhiteSpace(AccountName) ? "?" : AccountName.Trim()[..1].ToUpperInvariant();
 

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountDetailsHero.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountDetailsHero.razor
@@ -1,7 +1,7 @@
 @using FinanceManager.Components.Components.SharedComponents.Charts
 @using FinanceManager.Domain.Entities.MoneyFlowModels
 
-<MudPaper Elevation="0" Class="pa-6 mb-4" Style="overflow: hidden; background-color: transparent;">
+<MudPaper Elevation="0" Class="pa-6 mb-4" Style="background-color: transparent;">
     <MudStack Spacing="4">
         <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="3">
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountDetailsHero.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountDetailsHero.razor
@@ -1,0 +1,104 @@
+@using FinanceManager.Components.Components.SharedComponents.Charts
+@using FinanceManager.Domain.Entities.MoneyFlowModels
+
+<MudPaper Elevation="0" Class="pa-6 mb-4" Style="overflow: hidden; background-color: transparent;">
+    <MudStack Spacing="4">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="3">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
+                <MudAvatar Color="Color.Primary" Variant="Variant.Filled" Size="Size.Large">
+                    @GetInitial()
+                </MudAvatar>
+                <MudStack Spacing="0">
+                    <MudText Typo="Typo.overline" Color="Color.Default">@AccountTypeLabel · @Currency</MudText>
+                    <MudText Typo="Typo.h5">@AccountName</MudText>
+                </MudStack>
+            </MudStack>
+
+            <MudStack AlignItems="AlignItems.End" Spacing="2">
+                <MudToggleGroup T="string" Value="SelectedRange" ValueChanged="OnRangeChanged"
+                                SelectionMode="SelectionMode.SingleSelection" Color="Color.Primary"
+                                Outlined="true" Dense="true">
+                    <MudToggleItem Value="@("1M")" />
+                    <MudToggleItem Value="@("3M")" />
+                    <MudToggleItem Value="@("6M")" />
+                    <MudToggleItem Value="@("1Y")" />
+                    <MudToggleItem Value="@("Range")" />
+                </MudToggleGroup>
+                @if (SelectedRange == "Range")
+                {
+                    <MudDateRangePicker DateRange="CustomDateRange" DateRangeChanged="OnCustomDateRangeChanged"
+                                        Variant="Variant.Outlined" Margin="Margin.Dense"
+                                        Style="max-width: 260px;" Clearable="true"
+                                        PlaceholderStart="From" PlaceholderEnd="To" />
+                }
+            </MudStack>
+        </MudStack>
+
+        <MudStack Row="true" AlignItems="AlignItems.End" Justify="Justify.SpaceBetween" Spacing="4">
+            <MudStack Spacing="1">
+                <MudText Typo="Typo.overline" Color="Color.Default">Balance</MudText>
+                <MudStack Row="true" AlignItems="AlignItems.Baseline" Spacing="1">
+                    <MudText Typo="Typo.h3" Class="fm-tabular">@Balance.ToString("N2")</MudText>
+                    <MudText Typo="Typo.h5" Color="Color.Default">@Currency</MudText>
+                </MudStack>
+            </MudStack>
+
+            <MudStack Spacing="1" AlignItems="AlignItems.End">
+                <MudText Typo="Typo.overline" Color="Color.Default">Change · @SelectedRange</MudText>
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudIcon Icon="@(BalanceChange >= 0 ? Icons.Material.Filled.TrendingUp : Icons.Material.Filled.TrendingDown)"
+                             Color="@(BalanceChange >= 0 ? Color.Success : Color.Error)" Size="Size.Small" />
+                    <MudText Typo="Typo.h6" Color="@(BalanceChange >= 0 ? Color.Success : Color.Error)" Class="fm-tabular">
+                        @(BalanceChange >= 0 ? "+" : "")@BalanceChange.ToString("N2") @Currency
+                    </MudText>
+                    @if (BalanceChangePercent.HasValue)
+                    {
+                        <MudText Typo="Typo.body2" Color="Color.Default" Class="fm-tabular">
+                            · @(BalanceChange >= 0 ? "+" : "")@BalanceChangePercent.Value.ToString("0.0")%
+                        </MudText>
+                    }
+                </MudStack>
+            </MudStack>
+        </MudStack>
+
+    </MudStack>
+    <div class="mx-n6 mb-n6 mt-4" style="min-height: 200px; position: relative;">
+        @if (IsChartLoading)
+        {
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Animation="Animation.Wave" Height="200px" Width="100%" />
+        }
+        else
+        {
+            <LineChartJs Series="@([ChartData.Select(x => new ChartJsLineDataPoint(x.DateTime.ToLocalTime(), x.Value)).ToList()])" />
+        }
+    </div>
+</MudPaper>
+
+@code {
+    [Parameter] public required string AccountName { get; set; }
+    [Parameter] public string AccountTypeLabel { get; set; } = "Cash account";
+    [Parameter] public required string Currency { get; set; }
+    [Parameter] public decimal Balance { get; set; }
+    [Parameter] public decimal BalanceChange { get; set; }
+    [Parameter] public decimal? BalanceChangePercent { get; set; }
+    [Parameter] public string SelectedRange { get; set; } = "3M";
+    [Parameter] public EventCallback<string> SelectedRangeChanged { get; set; }
+    [Parameter] public DateRange? CustomDateRange { get; set; }
+    [Parameter] public EventCallback<DateRange?> CustomDateRangeChanged { get; set; }
+    [Parameter] public bool IsChartLoading { get; set; }
+    [Parameter] public List<TimeSeriesModel> ChartData { get; set; } = [];
+
+    private string GetInitial() => string.IsNullOrWhiteSpace(AccountName) ? "?" : AccountName.Trim()[..1].ToUpperInvariant();
+
+    private async Task OnRangeChanged(string value)
+    {
+        SelectedRange = value;
+        await SelectedRangeChanged.InvokeAsync(value);
+    }
+
+    private async Task OnCustomDateRangeChanged(DateRange? range)
+    {
+        CustomDateRange = range;
+        await CustomDateRangeChanged.InvokeAsync(range);
+    }
+}

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountHistoryToolbar.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountHistoryToolbar.razor
@@ -1,26 +1,28 @@
 @using FinanceManager.Domain.Entities.Shared.Accounts
 
-<div class="pa-3 mb-4">
-    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-        <MudTextField T="string" Value="SearchText" ValueChanged="OnSearchChanged"
-                      Placeholder="Search transactions, notes, categories…"
-                      Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
-                      Variant="Variant.Outlined" Margin="Margin.Dense" Immediate="true"
-                      DebounceInterval="150" Clearable="true" Class="flex-grow-1" />
+<div class="px-0 mb-2">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap">
+        <div style="@(IsMobile ? "flex: 1 1 100%; min-width: 0;" : "flex: 1 1 280px; min-width: 0;")">
+            <MudTextField T="string" Value="SearchText" ValueChanged="OnSearchChanged"
+                          Placeholder="Search transactions, notes, categories…" Adornment="Adornment.Start"
+                          AdornmentIcon="@Icons.Material.Filled.Search" Variant="Variant.Outlined" Margin="Margin.Dense"
+                          Immediate="true" DebounceInterval="150" Clearable="true" />
+        </div>
 
         <MudChipSet T="TxFilter?" SelectedValue="ActiveFilter" SelectedValueChanged="OnFilterChanged"
                     SelectionMode="SelectionMode.ToggleSelection">
-            <MudChip T="TxFilter?" Value="@((TxFilter?)TxFilter.Income)" Color="Color.Success" Variant="Variant.Text"
-                     Icon="@Icons.Material.Filled.ArrowDownward">Income</MudChip>
-            <MudChip T="TxFilter?" Value="@((TxFilter?)TxFilter.Expense)" Color="Color.Error" Variant="Variant.Text"
-                     Icon="@Icons.Material.Filled.ArrowUpward">Expense</MudChip>
+            <MudChip T="TxFilter?" Value="@((TxFilter?)TxFilter.Income)" Color="Color.Default"
+                     Variant="Variant.Outlined" Size="Size.Small" Icon="@Icons.Material.Filled.ArrowUpward"
+                     SelectedColor="Color.Success">Income</MudChip>
+            <MudChip T="TxFilter?" Value="@((TxFilter?)TxFilter.Expense)" Color="Color.Default"
+                     Variant="Variant.Outlined" Size="Size.Small" Icon="@Icons.Material.Filled.ArrowDownward"
+                     SelectedColor="Color.Error">Expense</MudChip>
         </MudChipSet>
 
         @if (AvailableCategories is not null && AvailableCategories.Any())
         {
-            <MudMenu Label="@(SelectedCategory ?? "Category")"
-                     StartIcon="@Icons.Material.Filled.FilterList"
-                     Variant="Variant.Outlined" Size="Size.Small" Dense="true">
+            <MudMenu Label="@(SelectedCategory ?? "Category")" StartIcon="@Icons.Material.Filled.FilterList"
+                     Variant="Variant.Text" Color="Color.Default" Size="Size.Small" Dense="true">
                 @if (SelectedCategory is not null)
                 {
                     <MudMenuItem Icon="@Icons.Material.Filled.Close" OnClick="OnClearCategory">Clear filter</MudMenuItem>
@@ -34,7 +36,14 @@
         }
 
         <div class="ml-auto">
-            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Wrap="Wrap.Wrap">
+                @if (ShowInsightsButton)
+                {
+                    <MudButton Variant="Variant.Outlined" Color="Color.Default" StartIcon="@Icons.Material.Filled.Insights"
+                               Size="Size.Small" OnClick="OnInsightsClick">
+                        Insights
+                    </MudButton>
+                }
                 <MudTooltip Text="Import">
                     <MudIconButton Icon="@Icons.Material.Filled.FileUpload" Size="Size.Small" Color="Color.Default"
                                    Href="@($"/Import/{AccountId}")" />
@@ -72,6 +81,9 @@
     [Parameter] public string? SelectedCategory { get; set; }
     [Parameter] public EventCallback<string?> SelectedCategoryChanged { get; set; }
     [Parameter] public EventCallback OnAddEntry { get; set; }
+    [Parameter] public bool ShowInsightsButton { get; set; }
+    [Parameter] public EventCallback OnInsightsClick { get; set; }
+    [Parameter] public bool IsMobile { get; set; }
 
     private async Task OnSearchChanged(string? value)
     {

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountHistoryToolbar.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountHistoryToolbar.razor
@@ -1,0 +1,99 @@
+@using FinanceManager.Domain.Entities.Shared.Accounts
+
+<div class="pa-3 mb-4">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+        <MudTextField T="string" Value="SearchText" ValueChanged="OnSearchChanged"
+                      Placeholder="Search transactions, notes, categories…"
+                      Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search"
+                      Variant="Variant.Outlined" Margin="Margin.Dense" Immediate="true"
+                      DebounceInterval="150" Clearable="true" Class="flex-grow-1" />
+
+        <MudChipSet T="TxFilter?" SelectedValue="ActiveFilter" SelectedValueChanged="OnFilterChanged"
+                    SelectionMode="SelectionMode.ToggleSelection">
+            <MudChip T="TxFilter?" Value="@((TxFilter?)TxFilter.Income)" Color="Color.Success" Variant="Variant.Text"
+                     Icon="@Icons.Material.Filled.ArrowDownward">Income</MudChip>
+            <MudChip T="TxFilter?" Value="@((TxFilter?)TxFilter.Expense)" Color="Color.Error" Variant="Variant.Text"
+                     Icon="@Icons.Material.Filled.ArrowUpward">Expense</MudChip>
+        </MudChipSet>
+
+        @if (AvailableCategories is not null && AvailableCategories.Any())
+        {
+            <MudMenu Label="@(SelectedCategory ?? "Category")"
+                     StartIcon="@Icons.Material.Filled.FilterList"
+                     Variant="Variant.Outlined" Size="Size.Small" Dense="true">
+                @if (SelectedCategory is not null)
+                {
+                    <MudMenuItem Icon="@Icons.Material.Filled.Close" OnClick="OnClearCategory">Clear filter</MudMenuItem>
+                    <MudDivider />
+                }
+                @foreach (var category in AvailableCategories)
+                {
+                    <MudMenuItem OnClick="@(() => OnCategoryChanged(category))">@category</MudMenuItem>
+                }
+            </MudMenu>
+        }
+
+        <div class="ml-auto">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                <MudTooltip Text="Import">
+                    <MudIconButton Icon="@Icons.Material.Filled.FileUpload" Size="Size.Small" Color="Color.Default"
+                                   Href="@($"/Import/{AccountId}")" />
+                </MudTooltip>
+                <MudTooltip Text="Export">
+                    <MudIconButton Icon="@Icons.Material.Filled.FileDownload" Size="Size.Small" Color="Color.Default"
+                                   Href="@($"/Export/{AccountId}")" />
+                </MudTooltip>
+                <MudTooltip Text="Manage">
+                    <MudIconButton Icon="@Icons.Material.Filled.Settings" Size="Size.Small" Color="Color.Default"
+                                   Href="@($"/ManageAccount/{AccountId}")" />
+                </MudTooltip>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Add"
+                           Size="Size.Small" OnClick="OnAddEntry">
+                    Add entry
+                </MudButton>
+            </MudStack>
+        </div>
+    </MudStack>
+</div>
+
+@code {
+    public enum TxFilter
+    {
+        Income,
+        Expense
+    }
+
+    [Parameter] public required int AccountId { get; set; }
+    [Parameter] public string? SearchText { get; set; }
+    [Parameter] public EventCallback<string?> SearchTextChanged { get; set; }
+    [Parameter] public TxFilter? ActiveFilter { get; set; }
+    [Parameter] public EventCallback<TxFilter?> ActiveFilterChanged { get; set; }
+    [Parameter] public IEnumerable<string>? AvailableCategories { get; set; }
+    [Parameter] public string? SelectedCategory { get; set; }
+    [Parameter] public EventCallback<string?> SelectedCategoryChanged { get; set; }
+    [Parameter] public EventCallback OnAddEntry { get; set; }
+
+    private async Task OnSearchChanged(string? value)
+    {
+        SearchText = value;
+        await SearchTextChanged.InvokeAsync(value);
+    }
+
+    private async Task OnFilterChanged(TxFilter? value)
+    {
+        ActiveFilter = value;
+        await ActiveFilterChanged.InvokeAsync(value);
+    }
+
+    private async Task OnCategoryChanged(string category)
+    {
+        SelectedCategory = category;
+        await SelectedCategoryChanged.InvokeAsync(category);
+    }
+
+    private async Task OnClearCategory()
+    {
+        SelectedCategory = null;
+        await SelectedCategoryChanged.InvokeAsync(null);
+    }
+}

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountMoversCard.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountMoversCard.razor
@@ -1,0 +1,99 @@
+@using FinanceManager.Domain.Entities.FinancialAccounts.Currencies
+
+<MudCard Outlined="true" Style="background-color: transparent;">
+    <MudCardHeader Class="py-2 px-4">
+        <CardHeaderContent>
+            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="w-100">
+                <MudText Typo="Typo.subtitle2">Top movers</MudText>
+                <MudToggleGroup T="MoverMode" Value="_mode" ValueChanged="OnModeChanged"
+                                SelectionMode="SelectionMode.SingleSelection" Color="Color.Primary"
+                                Outlined="true" Dense="true">
+                    <MudToggleItem Value="@MoverMode.Combined" Text="Combined" />
+                    <MudToggleItem Value="@MoverMode.Top" Text="Top" />
+                    <MudToggleItem Value="@MoverMode.Bottom" Text="Bottom" />
+                </MudToggleGroup>
+            </MudStack>
+        </CardHeaderContent>
+    </MudCardHeader>
+    <MudCardContent>
+        @if (_mode is MoverMode.Combined or MoverMode.Top)
+        {
+            @if (_mode == MoverMode.Combined)
+            {
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2">
+                    <MudIcon Size="Size.Small" Icon="@Icons.Material.Filled.ArrowUpward" Color="Color.Success" />
+                    <MudText Typo="Typo.caption" Color="Color.Default">Top 5 income</MudText>
+                </MudStack>
+            }
+            @RenderList(TopEntries, Color.Success)
+        }
+
+        @if (_mode is MoverMode.Combined or MoverMode.Bottom)
+        {
+            @if (_mode == MoverMode.Combined)
+            {
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="mb-2 mt-4">
+                    <MudIcon Size="Size.Small" Icon="@Icons.Material.Filled.ArrowDownward" Color="Color.Error" />
+                    <MudText Typo="Typo.caption" Color="Color.Default">Bottom 5 expenses</MudText>
+                </MudStack>
+            }
+            @RenderList(BottomEntries, Color.Error)
+        }
+    </MudCardContent>
+</MudCard>
+
+@code {
+    public enum MoverMode { Combined, Top, Bottom }
+
+    private MoverMode _mode = MoverMode.Combined;
+
+    [Parameter] public required IEnumerable<CurrencyAccountEntry> TopEntries { get; set; }
+    [Parameter] public required IEnumerable<CurrencyAccountEntry> BottomEntries { get; set; }
+    [Parameter] public required string Currency { get; set; }
+
+    private void OnModeChanged(MoverMode mode) => _mode = mode;
+
+    private RenderFragment RenderList(IEnumerable<CurrencyAccountEntry> entries, Color accent) => __builder =>
+    {
+        if (entries is null || !entries.Any())
+        {
+            <MudText Typo="Typo.caption" Color="Color.Default">No entries in range.</MudText>
+            return;
+        }
+
+        <MudStack Spacing="2">
+            @{
+                var rank = 0;
+            }
+            @foreach (var entry in entries)
+            {
+                rank++;
+                var entryRank = rank;
+                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center">
+                    <MudText Typo="Typo.caption" Color="Color.Default" Class="fm-tabular">@entryRank.ToString("00")</MudText>
+                    <MudStack Spacing="0" Class="flex-grow-1" Style="min-width: 0;">
+                        <MudText Typo="Typo.body2">@GetTitle(entry)</MudText>
+                        <MudText Typo="Typo.caption" Color="Color.Default">
+                            @entry.PostingDate.ToString("dd MMM") · @GetCategory(entry)
+                        </MudText>
+                    </MudStack>
+                    <MudText Typo="Typo.body2" Class="fm-tabular ml-auto" Color="@accent">
+                        @(entry.ValueChange >= 0 ? "+" : "")@entry.ValueChange.ToString("N2") @Currency
+                    </MudText>
+                </MudStack>
+            }
+        </MudStack>
+    };
+
+    private static string GetTitle(CurrencyAccountEntry entry)
+    {
+        if (!string.IsNullOrWhiteSpace(entry.Description))
+            return entry.Description.Length > 40 ? entry.Description[..40] + "…" : entry.Description;
+        if (entry.Labels is not null && entry.Labels.Any())
+            return entry.Labels.First().Name;
+        return "Transaction";
+    }
+
+    private static string GetCategory(CurrencyAccountEntry entry) =>
+        entry.Labels is not null && entry.Labels.Any() ? entry.Labels.First().Name : "Uncategorised";
+}

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/BalanceChangeCard.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/BalanceChangeCard.razor
@@ -1,0 +1,25 @@
+<MudCard Outlined="true" Style="background-color: transparent;">
+    <MudCardContent>
+        <MudText Typo="Typo.overline" Color="Color.Default">Balance change · @RangeLabel</MudText>
+        <MudText Typo="Typo.h3" Class="fm-tabular"
+                 Color="@(BalanceChange >= 0 ? Color.Success : Color.Error)">
+            @(BalanceChange >= 0 ? "+" : "")@BalanceChange.ToString("N2") @Currency
+        </MudText>
+        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center" Class="mt-2">
+            <MudIcon Size="Size.Small"
+                     Icon="@(BalanceChange >= 0 ? Icons.Material.Filled.ArrowUpward : Icons.Material.Filled.ArrowDownward)"
+                     Color="@(BalanceChange >= 0 ? Color.Success : Color.Error)" />
+            <MudText Typo="Typo.caption" Color="Color.Default">
+                From @FromDate.ToString("dd MMM yyyy") to @ToDate.ToString("dd MMM yyyy")
+            </MudText>
+        </MudStack>
+    </MudCardContent>
+</MudCard>
+
+@code {
+    [Parameter] public decimal BalanceChange { get; set; }
+    [Parameter] public required string Currency { get; set; }
+    [Parameter] public string RangeLabel { get; set; } = string.Empty;
+    [Parameter] public DateTime FromDate { get; set; }
+    [Parameter] public DateTime ToDate { get; set; }
+}

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
@@ -1,6 +1,5 @@
 @using FinanceManager.Components.Components.FinancialAccounts.Shared
-@using FinanceManager.Components.Components.SharedComponents.Charts
-@using FinanceManager.Domain.Entities.MoneyFlowModels;
+@using FinanceManager.Domain.Entities.FinancialAccounts.Currencies
 
 @if (Account is null)
 {
@@ -11,84 +10,80 @@
 }
 else if (IsLoading || Account.Entries.Any())
 {
-    <AccountDetailsPageContent AccountName="@Account.Name" ChartData="ChartData" IsLoading="@IsLoading"
-                               IsLoadingMore="@_isLoadingMore" LoadedAllData="@_loadedAllData" OnLoadMore="LoadMore">
+    <AccountDetailsHero AccountName="@Account.Name"
+                        AccountTypeLabel="@_accountTypeLabel"
+                        Currency="@_currency.ShortName"
+                        Balance="@_currentBalance"
+                        BalanceChange="@_balanceChange"
+                        BalanceChangePercent="@_balanceChangePercent"
+                        SelectedRange="@_selectedRange"
+                        SelectedRangeChanged="OnRangeChanged"
+                        CustomDateRange="@_customDateRange"
+                        CustomDateRangeChanged="OnCustomDateRangeChanged"
+                        IsChartLoading="@IsLoading"
+                        ChartData="@ChartData" />
 
-        <ActionButtons>
-            <MudTooltip Text="Import">
-                <MudIconButton Icon="@Icons.Material.Filled.FileUpload" AriaLabel="Import" Color="Color.Primary"
-                               Href="@($"/Import/{Account.AccountId}")" />
-            </MudTooltip>
-            <MudTooltip Text="Export">
-                <MudIconButton Icon="@Icons.Material.Filled.FileDownload" AriaLabel="Export" Color="Color.Primary"
-                               Href="@($"/Export/{Account.AccountId}")" />
-            </MudTooltip>
-            <MudTooltip Text="Manage">
-                <MudIconButton Icon="@Icons.Material.Filled.Settings" AriaLabel="Manage" Color="Color.Primary"
-                               Href="@($"/ManageAccount/{Account.AccountId}")" />
-            </MudTooltip>
-        </ActionButtons>
+    <MudContainer MaxWidth="MaxWidth.Large" Class="px-0">
+        <MudGrid Spacing="6">
+            <MudItem xs="12" lg="8">
+                <AccountHistoryToolbar AccountId="@Account.AccountId"
+                                       SearchText="@_searchText"
+                                       SearchTextChanged="OnSearchChanged"
+                                       ActiveFilter="@_activeFilter"
+                                       ActiveFilterChanged="OnTxFilterChanged"
+                                       AvailableCategories="@_availableCategories"
+                                       SelectedCategory="@_selectedCategory"
+                                       SelectedCategoryChanged="OnCategoryChanged"
+                                       OnAddEntry="ShowAddOverlay" />
 
-        <AddEntryOverlay>
-            <MudFab Color="MudBlazor.Color.Primary" StartIcon="@Icons.Material.Filled.Add" Label="Add" OnClick="ShowOverlay"
-                    Style="margin-left: 30px; position: fixed; bottom: 3vh; z-index:2;" />
-
-            <MudOverlay Visible="@_addEntryVisibility" DarkBackground="true">
-                <MudPaper Class="p-5">
-                    <AddCurrencyEntry CurrencyAccount=Account ActionCompleted="HideOverlay" />
-                </MudPaper>
-            </MudOverlay>
-        </AddEntryOverlay>
-        <EntryFilter>
-            <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
-                <DateRangeFilterBar From="_filterDateStart" To="_filterDateEnd" OnFilterChanged="OnDateFilterChanged" />
-                <ValueChangeRangeFilterBar From="_filterFrom" To="_filterTo" OnFilterChanged="OnFilterChanged" />
-            </MudStack>
-        </EntryFilter>
-        <Entries>
-            @{
-                var filteredEntries = GetFilteredEntries();
-            }
-            @if (HasActiveFilter && !filteredEntries.Any())
-            {
-                <MudAlert Severity="Severity.Info" Class="my-3">No entries match the current filter.</MudAlert>
-            }
-            else
-            {
-                @foreach (var entry in filteredEntries)
-                {
-                    <CurrencyAccountDetailsRow CurrencyAccountEntry="@entry" CurrencyAccount=Account />
-                }
-            }
-        </Entries>
-        <SidePanel>
-            <MudStack>
-                <AccountBalanceChangePanel BalanceChange="@_balanceChange" Currency="@_currency" />
-
-                @if (_top5 is not null && _top5.Any())
-                {
-                    <AccountTopBottomList Title="Top 5" Items="_top5" ValueColor="Color.Success"
-                                          ItemTitle="@(entry => entry.Labels.Any() ? entry.Labels.First().Name : "Transaction")"
-                                          ItemDescription="@(entry => entry.Description)"
-                                          ItemValue="@(entry => $"{entry.ValueChange} {_currency}")"
-                                          ItemDate="@(entry => entry.PostingDate.ToString("dd-MM-yyyy"))" />
+                @{
+                    var filteredEntries = GetFilteredEntries();
+                    var dayGroups = filteredEntries
+                        .GroupBy(e => e.PostingDate.Date)
+                        .OrderByDescending(g => g.Key)
+                        .ToList();
                 }
 
-                @if (_bottom5 is not null && _bottom5.Any())
+                @if (HasActiveFilter && !filteredEntries.Any())
                 {
-                    <AccountTopBottomList Title="Bottom 5" Items="_bottom5" ValueColor="Color.Error"
-                                          ItemTitle="@(entry => entry.Labels.Any() ? entry.Labels.First().Name : "Transaction")"
-                                          ItemDescription="@(entry => entry.Description)"
-                                          ItemValue="@(entry => $"{entry.ValueChange} {_currency}")"
-                                          ItemDate="@(entry => entry.PostingDate.ToString("dd-MM-yyyy"))" />
+                    <MudAlert Severity="Severity.Info" Class="my-3">No entries match the current filter.</MudAlert>
                 }
-            </MudStack>
-        </SidePanel>
-    </AccountDetailsPageContent>
+                else if (!filteredEntries.Any())
+                {
+                    <MudAlert Severity="Severity.Info" Class="my-3">No entries in the selected range.</MudAlert>
+                }
+                else
+                {
+                    @foreach (var group in dayGroups)
+                    {
+                        <DayGroupCard Day="@group.Key" Account="Account" Entries="@group"
+                                      Currency="@_currency.ShortName" />
+                    }
+                }
+            </MudItem>
+
+            <MudItem xs="12" lg="4">
+                <MudStack Spacing="4">
+                    <BalanceChangeCard BalanceChange="@_balanceChange" Currency="@_currency.ShortName"
+                                       RangeLabel="@_selectedRange"
+                                       FromDate="@_dateStart" ToDate="@_dateEnd" />
+
+                    <AccountMoversCard TopEntries="@(_top5 ?? [])" BottomEntries="@(_bottom5 ?? [])"
+                                       Currency="@_currency.ShortName" />
+                </MudStack>
+            </MudItem>
+        </MudGrid>
+    </MudContainer>
+
+    <MudOverlay Visible="@_addEntryVisibility" DarkBackground="true">
+        <MudPaper Class="p-5">
+            <AddCurrencyEntry CurrencyAccount=Account ActionCompleted="HideAddOverlay" />
+        </MudPaper>
+    </MudOverlay>
 }
 else if (!Account.Entries.Any())
 {
-    <AddCurrencyEntry CurrencyAccount=Account ActionCompleted="HideOverlay">
+    <AddCurrencyEntry CurrencyAccount=Account ActionCompleted="HideAddOverlay">
         <CustomButton>
             <MudButton Variant="Variant.Text" Color="MudBlazor.Color.Primary" href="@($"/Import/{Account.AccountId}")">
                 Import
@@ -101,3 +96,8 @@ else if (!Account.Entries.Any())
 {
     <MudAlert Severity="Severity.Error">@ErrorMessage</MudAlert>
 }
+
+<MudScrollToTop TopOffset="400" Selector=".mud-main-content"
+                Style="position: fixed; bottom: 32px; right: 32px; z-index: 5;">
+    <MudFab Color="Color.Primary" Size="Size.Medium" StartIcon="@Icons.Material.Filled.KeyboardArrowUp" />
+</MudScrollToTop>

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
@@ -24,7 +24,7 @@ else if (IsLoading || Account.Entries.Any())
                         ChartData="@ChartData" />
 
     <MudContainer MaxWidth="MaxWidth.Large" Class="px-0">
-        <MudGrid Spacing="6">
+        <MudGrid Spacing="3">
             <MudItem xs="12" lg="8">
                 <AccountHistoryToolbar AccountId="@Account.AccountId"
                                        SearchText="@_searchText"
@@ -34,7 +34,10 @@ else if (IsLoading || Account.Entries.Any())
                                        AvailableCategories="@_availableCategories"
                                        SelectedCategory="@_selectedCategory"
                                        SelectedCategoryChanged="OnCategoryChanged"
-                                       OnAddEntry="ShowAddOverlay" />
+                                       OnAddEntry="ShowAddOverlay"
+                                       ShowInsightsButton="@_isMobile"
+                                       OnInsightsClick="ToggleInsightsDrawer"
+                                       IsMobile="@_isMobile" />
 
                 @{
                     var filteredEntries = GetFilteredEntries();
@@ -62,18 +65,42 @@ else if (IsLoading || Account.Entries.Any())
                 }
             </MudItem>
 
-            <MudItem xs="12" lg="4">
-                <MudStack Spacing="4">
-                    <BalanceChangeCard BalanceChange="@_balanceChange" Currency="@_currency.ShortName"
-                                       RangeLabel="@_selectedRange"
-                                       FromDate="@_dateStart" ToDate="@_dateEnd" />
+            @if (!_isMobile)
+            {
+                <MudItem lg="4">
+                    <MudStack Spacing="4">
+                        <BalanceChangeCard BalanceChange="@_balanceChange" Currency="@_currency.ShortName"
+                                           RangeLabel="@_selectedRange"
+                                           FromDate="@_dateStart" ToDate="@_dateEnd" />
 
-                    <AccountMoversCard TopEntries="@(_top5 ?? [])" BottomEntries="@(_bottom5 ?? [])"
-                                       Currency="@_currency.ShortName" />
-                </MudStack>
-            </MudItem>
+                        <AccountMoversCard TopEntries="@(_top5 ?? [])" BottomEntries="@(_bottom5 ?? [])"
+                                           Currency="@_currency.ShortName" />
+                    </MudStack>
+                </MudItem>
+            }
         </MudGrid>
     </MudContainer>
+
+    @if (_isMobile)
+    {
+        <MudOverlay Visible="@_insightsDrawerOpen" OnClick="CloseInsightsDrawer" DarkBackground="true"
+                    ZIndex="1300" />
+        <div style="@($"position: fixed; top: 0; right: 0; bottom: 0; width: min(360px, 90vw); background: var(--mud-palette-surface); box-shadow: -4px 0 16px rgba(0,0,0,0.4); overflow-y: auto; z-index: 1301; transform: translateX({( _insightsDrawerOpen ? "0" : "100%")}); transition: transform 225ms cubic-bezier(0,0,0.2,1);")">
+            <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Class="pa-3">
+                <MudText Typo="Typo.h6">Insights</MudText>
+                <MudIconButton Icon="@Icons.Material.Filled.Close" OnClick="CloseInsightsDrawer" />
+            </MudStack>
+            <MudDivider />
+            <MudStack Spacing="4" Class="pa-4">
+                <BalanceChangeCard BalanceChange="@_balanceChange" Currency="@_currency.ShortName"
+                                   RangeLabel="@_selectedRange"
+                                   FromDate="@_dateStart" ToDate="@_dateEnd" />
+
+                <AccountMoversCard TopEntries="@(_top5 ?? [])" BottomEntries="@(_bottom5 ?? [])"
+                                   Currency="@_currency.ShortName" />
+            </MudStack>
+        </div>
+    }
 
     <MudOverlay Visible="@_addEntryVisibility" DarkBackground="true">
         <MudPaper Class="p-5">

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
@@ -97,7 +97,8 @@ else if (!Account.Entries.Any())
     <MudAlert Severity="Severity.Error">@ErrorMessage</MudAlert>
 }
 
-<MudScrollToTop TopOffset="400" Selector=".mud-main-content"
-                Style="position: fixed; bottom: 32px; right: 32px; z-index: 5;">
-    <MudFab Color="Color.Primary" Size="Size.Medium" StartIcon="@Icons.Material.Filled.KeyboardArrowUp" />
+<MudScrollToTop TopOffset="400" ScrollBehavior="ScrollBehavior.Smooth">
+    <MudFab Color="Color.Primary" Size="Size.Medium"
+            StartIcon="@Icons.Material.Filled.KeyboardArrowUp"
+            aria-label="Scroll to top" />
 </MudScrollToTop>

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor.cs
@@ -1,10 +1,10 @@
-using FinanceManager.Components.Helpers;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
 using FinanceManager.Domain.Entities.MoneyFlowModels;
 using FinanceManager.Domain.Entities.Users;
+using FinanceManager.Domain.Enums;
 using FinanceManager.Domain.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
@@ -14,24 +14,26 @@ namespace FinanceManager.Components.Components.FinancialAccounts.CurrencyAccount
 
 public partial class CurrencyAccountDetailsPageContent : ComponentBase
 {
-    private const int _minimumEntryCount = 50;
-
-    private bool _isLoadingMore = false;
-    private decimal _balanceChange = 100;
-    private bool _loadedAllData = false;
+    private string _selectedRange = "3M";
     private DateTime _dateStart;
     private DateTime _dateEnd = DateTime.UtcNow;
+    private DateRange? _customDateRange;
 
     private bool _addEntryVisibility;
+
+    private string? _searchText;
+    private AccountHistoryToolbar.TxFilter? _activeFilter;
+    private string? _selectedCategory;
+    private IEnumerable<string> _availableCategories = [];
+
+    private decimal _currentBalance;
+    private decimal _balanceChange;
+    private decimal? _balanceChangePercent;
     private List<CurrencyAccountEntry>? _top5;
     private List<CurrencyAccountEntry>? _bottom5;
     private Currency _currency = DefaultCurrency.PLN;
+    private string _accountTypeLabel = "Cash account";
     private UserSession? _user;
-
-    private decimal? _filterFrom;
-    private decimal? _filterTo;
-    private DateTime? _filterDateStart;
-    private DateTime? _filterDateEnd;
 
     public bool IsLoading = false;
     public CurrencyAccount? Account { get; set; }
@@ -47,79 +49,83 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
     [Inject] public required MoneyFlowHttpClient MoneyFlowHttpClient { get; set; }
     [Inject] public required ILogger<CurrencyAccountDetailsPageContent> Logger { get; set; }
 
-    public async Task ShowOverlay()
+    public Task ShowAddOverlay()
     {
         _addEntryVisibility = true;
         StateHasChanged();
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 
-    public async Task HideOverlay()
+    public Task HideAddOverlay()
     {
         _addEntryVisibility = false;
         StateHasChanged();
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 
     public async Task UpdateInfo()
     {
         if (Account is null || Account.Entries is null) return;
 
-        UpdateLoadStateFromAccount();
+        if (Account.Entries.Count == 0)
+        {
+            _currentBalance = 0;
+            _balanceChange = 0;
+            _balanceChangePercent = null;
+            _top5 = [];
+            _bottom5 = [];
+            return;
+        }
 
-        if (Account.Entries.Count == 0) return;
+        var filteredEntries = GetFilteredEntries();
 
-        var entriesOrdered = Account.Entries.OrderByDescending(x => x.ValueChange);
+        var entriesOrdered = filteredEntries.OrderByDescending(x => x.ValueChange).ToList();
         _top5 = entriesOrdered.Where(x => x.ValueChange > 0).Take(5).ToList();
-        _bottom5 = entriesOrdered.Skip(Math.Max(Account.Entries.Count - 5, 0))
-                                .Where(x => x.ValueChange < 0)
-                                .Take(5)
-                                .OrderBy(x => x.ValueChange)
-                                .ToList();
+        _bottom5 = entriesOrdered.Where(x => x.ValueChange < 0)
+                                 .OrderBy(x => x.ValueChange)
+                                 .Take(5)
+                                 .ToList();
 
-        _balanceChange = Account.Entries.First().Value - Account.Entries.Last().Value;
+        _currentBalance = Account.Entries.First().Value;
+        _balanceChange = filteredEntries.Sum(e => e.ValueChange);
+
+        var startBalance = _currentBalance - _balanceChange;
+        _balanceChangePercent = startBalance == 0 ? null : _balanceChange / startBalance * 100m;
+
+        _availableCategories = Account.Entries
+            .SelectMany(e => e.Labels ?? [])
+            .Where(l => l is not null)
+            .Select(l => l.Name)
+            .Distinct()
+            .OrderBy(n => n)
+            .ToList();
+
+        _accountTypeLabel = Account.AccountType switch
+        {
+            AccountLabel.Cash => "Cash account",
+            AccountLabel.Stock => "Stock account",
+            AccountLabel.Bond => "Bond account",
+            AccountLabel.Crypto => "Crypto account",
+            AccountLabel.Loan => "Loan account",
+            AccountLabel.RealEstate => "Real estate account",
+            _ => "Account"
+        };
 
         await UpdateChartData();
-    }
-
-    public async Task LoadMore()
-    {
-        if (Account is null || Account.Start is null) return;
-        if (_user is null) return;
-
-        _isLoadingMore = true;
-
-        try
-        {
-            var loadResult = await RecentEntriesLoader.LoadMoreAsync(
-                Account,
-                _dateStart,
-                _dateEnd,
-                CreateLoaderOptions());
-
-            Account = loadResult.Account;
-            _dateStart = loadResult.DateStart;
-
-            await UpdateChartData();
-            await UpdateInfo();
-        }
-        finally
-        {
-            _isLoadingMore = false;
-        }
     }
 
     protected override async Task OnInitializedAsync()
     {
         try
         {
-            _dateStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
             _user = await LoginService.GetLoggedUser();
             if (_user is null)
             {
                 IsLoading = false;
                 return;
             }
+
+            SetDateRangeForSelection();
 
             var loadTask = UpdateEntries();
             var delayTask = Task.Delay(2000);
@@ -145,7 +151,7 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
         {
             if (Account is not null && Account.AccountId == AccountId) return;
             IsLoading = true;
-            _loadedAllData = false;
+            SetDateRangeForSelection();
             await UpdateEntries();
         }
         catch (Exception ex)
@@ -164,10 +170,8 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
         {
             if (_user is null) return;
 
-            var requestedDateStart = _dateStart;
-            _dateEnd = _filterDateEnd.HasValue ? _filterDateEnd.Value.Date.AddDays(1).AddTicks(-1) : DateTime.UtcNow;
-            Account = await FinancialAccountService.GetAccount<CurrencyAccount>(_user.UserId, AccountId, requestedDateStart, _dateEnd, _minimumEntryCount);
-            UpdateDateStartFromLoadedEntries(requestedDateStart);
+            _dateEnd = DateTime.UtcNow;
+            Account = await FinancialAccountService.GetAccount<CurrencyAccount>(_user.UserId, AccountId, _dateStart, _dateEnd);
 
             if (Account?.Entries is not null)
                 await UpdateInfo();
@@ -189,17 +193,6 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
         ChartData.AddRange(chartData.SkipWhile(x => x.Value == 0));
     }
 
-    private void UpdateLoadStateFromAccount()
-    {
-        if (Account is null)
-        {
-            _loadedAllData = false;
-            return;
-        }
-
-        _loadedAllData = Account.NextOlderEntry is null;
-    }
-
     private void AccountDataSynchronizationService_AccountsChanged()
     {
         Task.Run(async () =>
@@ -209,7 +202,64 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
         });
     }
 
-    private bool HasActiveFilter => _filterFrom.HasValue || _filterTo.HasValue || _filterDateStart.HasValue || _filterDateEnd.HasValue;
+    private async Task OnRangeChanged(string value)
+    {
+        _selectedRange = value;
+        SetDateRangeForSelection();
+        IsLoading = true;
+        StateHasChanged();
+        try
+        {
+            await UpdateEntries();
+        }
+        finally
+        {
+            IsLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnCustomDateRangeChanged(DateRange? range)
+    {
+        _customDateRange = range;
+        if (_selectedRange != "Range") return;
+        SetDateRangeForSelection();
+        IsLoading = true;
+        StateHasChanged();
+        try
+        {
+            await UpdateEntries();
+        }
+        finally
+        {
+            IsLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnSearchChanged(string? value)
+    {
+        _searchText = value;
+        await UpdateInfo();
+        StateHasChanged();
+    }
+
+    private async Task OnTxFilterChanged(AccountHistoryToolbar.TxFilter? value)
+    {
+        _activeFilter = value;
+        await UpdateInfo();
+        StateHasChanged();
+    }
+
+    private async Task OnCategoryChanged(string? value)
+    {
+        _selectedCategory = value;
+        await UpdateInfo();
+        StateHasChanged();
+    }
+
+    private bool HasActiveFilter =>
+        !string.IsNullOrWhiteSpace(_searchText) || _activeFilter.HasValue || _selectedCategory is not null;
 
     private List<CurrencyAccountEntry> GetFilteredEntries()
     {
@@ -217,53 +267,45 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
 
         IEnumerable<CurrencyAccountEntry> entries = Account.Entries;
 
-        if (_filterFrom.HasValue)
-            entries = entries.Where(x => x.ValueChange >= _filterFrom.Value);
-        if (_filterTo.HasValue)
-            entries = entries.Where(x => x.ValueChange <= _filterTo.Value);
-        if (_filterDateStart.HasValue)
-            entries = entries.Where(x => x.PostingDate.Date >= _filterDateStart.Value.Date);
-        if (_filterDateEnd.HasValue)
-            entries = entries.Where(x => x.PostingDate.Date <= _filterDateEnd.Value.Date);
+        if (_activeFilter == AccountHistoryToolbar.TxFilter.Income)
+            entries = entries.Where(x => x.ValueChange > 0);
+        else if (_activeFilter == AccountHistoryToolbar.TxFilter.Expense)
+            entries = entries.Where(x => x.ValueChange < 0);
+
+        if (!string.IsNullOrWhiteSpace(_selectedCategory))
+            entries = entries.Where(x => x.Labels is not null
+                && x.Labels.Any(l => string.Equals(l.Name, _selectedCategory, StringComparison.OrdinalIgnoreCase)));
+
+        if (!string.IsNullOrWhiteSpace(_searchText))
+        {
+            var needle = _searchText.Trim();
+            entries = entries.Where(x =>
+                (!string.IsNullOrEmpty(x.Description) && x.Description.Contains(needle, StringComparison.OrdinalIgnoreCase))
+                || (!string.IsNullOrEmpty(x.ContractorDetails) && x.ContractorDetails.Contains(needle, StringComparison.OrdinalIgnoreCase))
+                || (x.Labels is not null && x.Labels.Any(l => l.Name.Contains(needle, StringComparison.OrdinalIgnoreCase))));
+        }
 
         return entries.OrderByDescending(x => x.PostingDate).ToList();
     }
 
-    private void OnFilterChanged((decimal? From, decimal? To) filter)
+    private void SetDateRangeForSelection()
     {
-        _filterFrom = filter.From;
-        _filterTo = filter.To;
-    }
-
-    private async Task OnDateFilterChanged((DateTime? From, DateTime? To) filter)
-    {
-        _filterDateStart = filter.From;
-        _filterDateEnd = filter.To;
-
-        var defaultDateStart = new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, 1);
-        var fallbackStart = Account?.Start?.Date ?? defaultDateStart;
-        _dateStart = _filterDateStart ?? (_filterDateEnd.HasValue ? fallbackStart : defaultDateStart);
-        _loadedAllData = false;
-        await UpdateEntries();
-        StateHasChanged();
-    }
-
-    private void UpdateDateStartFromLoadedEntries(DateTime requestedDateStart)
-    {
-        var oldestLoadedEntryDate = Account?.Entries.LastOrDefault()?.PostingDate;
-        _dateStart = oldestLoadedEntryDate is not null && oldestLoadedEntryDate.Value < requestedDateStart
-            ? oldestLoadedEntryDate.Value
-            : requestedDateStart;
-    }
-
-    private RecentEntriesLoaderOptions<CurrencyAccount> CreateLoaderOptions() =>
-        new()
+        var today = DateTime.UtcNow;
+        if (_selectedRange == "Range")
         {
-            LoadByDateRangeAsync = (dateStart, dateEnd) => _user is null
-                ? Task.FromResult<CurrencyAccount?>(null)
-                : FinancialAccountService.GetAccount<CurrencyAccount>(_user.UserId, AccountId, dateStart, dateEnd),
-            GetEntryCount = account => account.Entries.Count,
-            GetNextOlderReferenceDate = account => account.NextOlderEntry?.PostingDate,
-            HasOlderEntries = account => account.NextOlderEntry is not null,
+            _dateStart = _customDateRange?.Start ?? Account?.Start ?? today.AddMonths(-3);
+            _dateEnd = _customDateRange?.End ?? today;
+            return;
+        }
+
+        _dateStart = _selectedRange switch
+        {
+            "1M" => today.AddMonths(-1),
+            "3M" => today.AddMonths(-3),
+            "6M" => today.AddMonths(-6),
+            "1Y" => today.AddYears(-1),
+            _ => today.AddMonths(-3)
         };
+        _dateEnd = today;
+    }
 }

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor.cs
@@ -12,8 +12,12 @@ using MudBlazor;
 
 namespace FinanceManager.Components.Components.FinancialAccounts.CurrencyAccountComponents;
 
-public partial class CurrencyAccountDetailsPageContent : ComponentBase
+public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDisposable
 {
+    private readonly Guid _viewportSubscriptionId = Guid.NewGuid();
+    private bool _isMobile;
+    private bool _insightsDrawerOpen;
+
     private string _selectedRange = "3M";
     private DateTime _dateStart;
     private DateTime _dateEnd = DateTime.UtcNow;
@@ -48,12 +52,45 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase
     [Inject] public required ILoginService LoginService { get; set; }
     [Inject] public required MoneyFlowHttpClient MoneyFlowHttpClient { get; set; }
     [Inject] public required ILogger<CurrencyAccountDetailsPageContent> Logger { get; set; }
+    [Inject] public required IBrowserViewportService BrowserViewportService { get; set; }
 
     public Task ShowAddOverlay()
     {
         _addEntryVisibility = true;
         StateHasChanged();
         return Task.CompletedTask;
+    }
+
+    private void ToggleInsightsDrawer() => _insightsDrawerOpen = !_insightsDrawerOpen;
+
+    private void CloseInsightsDrawer() => _insightsDrawerOpen = false;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+
+        await BrowserViewportService.SubscribeAsync(_viewportSubscriptionId, async args =>
+        {
+            var isMobile = args.Breakpoint is Breakpoint.Xs or Breakpoint.Sm or Breakpoint.Md;
+            if (isMobile == _isMobile) return;
+            _isMobile = isMobile;
+            if (!_isMobile) _insightsDrawerOpen = false;
+            await InvokeAsync(StateHasChanged);
+        }, fireImmediately: true);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await BrowserViewportService.UnsubscribeAsync(_viewportSubscriptionId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Failed to unsubscribe from BrowserViewportService");
+        }
+        AccountDataSynchronizationService.AccountsChanged -= AccountDataSynchronizationService_AccountsChanged;
+        GC.SuppressFinalize(this);
     }
 
     public Task HideAddOverlay()

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/DayGroupCard.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/DayGroupCard.razor
@@ -1,0 +1,39 @@
+@using FinanceManager.Domain.Entities.FinancialAccounts.Currencies
+
+<MudCard Outlined="true" Class="mb-3" Style="background-color: transparent;">
+    <MudCardHeader Class="py-1 px-4">
+        <CardHeaderContent>
+            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center" Class="w-100">
+                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Baseline">
+                    <MudText Typo="Typo.subtitle2">@Day.ToString("dd MMM")</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Default">@Day.ToString("dddd")</MudText>
+                </MudStack>
+                <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Baseline">
+                    <MudText Typo="Typo.caption" Color="Color.Default">@Entries.Count() @(Entries.Count() == 1 ? "entry" : "entries")</MudText>
+                    <MudText Typo="Typo.caption" Class="fm-tabular"
+                             Color="@(DailyNet >= 0 ? Color.Success : Color.Error)">
+                        @(DailyNet >= 0 ? "+" : "")@DailyNet.ToString("N2") @Currency
+                    </MudText>
+                </MudStack>
+            </MudStack>
+        </CardHeaderContent>
+    </MudCardHeader>
+    <MudCardContent Class="pa-0">
+        <MudStack Spacing="0">
+            @foreach (var entry in Entries)
+            {
+                <TransactionRow Account="Account" Entry="entry" Currency="@Currency" />
+                <MudDivider />
+            }
+        </MudStack>
+    </MudCardContent>
+</MudCard>
+
+@code {
+    [Parameter] public DateTime Day { get; set; }
+    [Parameter] public required FinanceManager.Domain.Entities.FinancialAccounts.Currencies.CurrencyAccount Account { get; set; }
+    [Parameter] public required IEnumerable<CurrencyAccountEntry> Entries { get; set; }
+    [Parameter] public required string Currency { get; set; }
+
+    private decimal DailyNet => Entries.Sum(e => e.ValueChange);
+}

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/TransactionRow.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/TransactionRow.razor
@@ -1,0 +1,166 @@
+@using FinanceManager.Domain.Entities.Currencies
+@using FinanceManager.Domain.Entities.FinancialAccounts.Currencies
+@using FinanceManager.Domain.Entities.Shared.Accounts
+
+<div class="d-flex align-start pa-2 mud-list-item-clickable" style="cursor: pointer;" @onclick="ToggleExpanded">
+    <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Start" Class="w-100">
+        <MudAvatar Size="Size.Medium" Variant="Variant.Filled" Color="Color.Default">
+            @GetAvatarLabel()
+        </MudAvatar>
+
+        <MudStack Spacing="0" Class="flex-grow-1" Style="min-width: 0;">
+            <MudText Typo="Typo.body1">@GetTitle()</MudText>
+            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                @if (Entry.Labels is not null && Entry.Labels.Any())
+                {
+                    <MudChip T="string" Size="Size.Small" Variant="Variant.Text"
+                             Style="height: 20px; font-size: 11px;">@Entry.Labels.First().Name</MudChip>
+                }
+                <MudText Typo="Typo.caption" Color="Color.Default">· @Entry.PostingDate.ToLocalTime().ToString("HH:mm")</MudText>
+            </MudStack>
+        </MudStack>
+
+        <MudText Typo="Typo.body1" Class="fm-tabular"
+                 Color="@(Entry.ValueChange >= 0 ? Color.Success : Color.Error)">
+            @(Entry.ValueChange >= 0 ? "+" : "")@Entry.ValueChange.ToString("N2") @Currency
+        </MudText>
+
+        <MudStack Spacing="0" AlignItems="AlignItems.End" Style="min-width: 110px;">
+            <MudText Typo="Typo.overline" Color="Color.Default">Balance</MudText>
+            <MudText Typo="Typo.caption" Class="fm-tabular">@Entry.Value.ToString("N2") @Currency</MudText>
+        </MudStack>
+    </MudStack>
+</div>
+
+<MudCollapse Expanded="_expanded">
+    <div class="px-4 pb-3" style="padding-left: 60px;">
+        <MudGrid Spacing="2">
+            <MudItem xs="6">
+                <MudText Typo="Typo.caption" Color="Color.Default">Posting date</MudText>
+                <MudText Typo="Typo.body2">@Entry.PostingDate.ToString("dd-MM-yyyy HH:mm")</MudText>
+            </MudItem>
+            @if (Entry.Labels is not null && Entry.Labels.Any())
+            {
+                <MudItem xs="6">
+                    <MudText Typo="Typo.caption" Color="Color.Default">Labels</MudText>
+                    <MudStack Row Spacing="1">
+                        @foreach (var label in Entry.Labels)
+                        {
+                            <MudChip T="string" Size="Size.Small">@label.Name</MudChip>
+                        }
+                    </MudStack>
+                </MudItem>
+            }
+            @if (!string.IsNullOrWhiteSpace(Entry.Description))
+            {
+                <MudItem xs="12">
+                    <MudText Typo="Typo.caption" Color="Color.Default">Description</MudText>
+                    <MudText Typo="Typo.body2">@Entry.Description</MudText>
+                </MudItem>
+            }
+            @if (!string.IsNullOrWhiteSpace(Entry.ContractorDetails))
+            {
+                <MudItem xs="12">
+                    <MudText Typo="Typo.caption" Color="Color.Default">Contractor details</MudText>
+                    <MudText Typo="Typo.body2">@Entry.ContractorDetails</MudText>
+                </MudItem>
+            }
+            <MudItem xs="12">
+                <MudButton Variant="Variant.Text" OnClick="ShowEditOverlay">Edit</MudButton>
+                <MudButton Variant="Variant.Text" Color="Color.Error" OnClick="ShowRemoveOverlay">Remove</MudButton>
+            </MudItem>
+        </MudGrid>
+    </div>
+</MudCollapse>
+
+<MudOverlay @bind-Visible="_updateEntryVisibility" DarkBackground="true">
+    <MudPaper Class="p-5">
+        <UpdateCurrencyEntry CurrencyAccount="Account" CurrencyAccountEntry="Entry"
+                             ActionCompleted="HideOverlay" />
+    </MudPaper>
+</MudOverlay>
+
+<MudOverlay @bind-Visible="_removeEntryVisibility" DarkBackground="true">
+    <MudPaper Class="p-5">
+        <RemoveCurrencyEntry CurrencyAccountName="@Account.Name" CurrencyAccountEntry="Entry"
+                             Cancel="HideOverlay" Confirm="ConfirmRemove" />
+    </MudPaper>
+</MudOverlay>
+
+@code {
+    private bool _expanded;
+    private bool _updateEntryVisibility;
+    private bool _removeEntryVisibility;
+
+    [Parameter] public required CurrencyAccount Account { get; set; }
+    [Parameter] public required CurrencyAccountEntry Entry { get; set; }
+    [Parameter] public required string Currency { get; set; }
+    [Parameter] public EventCallback OnEntryChanged { get; set; }
+
+    [Inject] public required FinanceManager.Components.Services.IFinancialAccountService FinancialAccountService { get; set; }
+    [Inject] public required FinanceManager.Components.Services.AccountDataSynchronizationService AccountDataSynchronizationService { get; set; }
+    [Inject] public required Microsoft.Extensions.Logging.ILogger<TransactionRow> Logger { get; set; }
+
+    private void ToggleExpanded() => _expanded = !_expanded;
+
+    private string GetTitle()
+    {
+        if (!string.IsNullOrWhiteSpace(Entry.Description))
+            return Truncate(Entry.Description, 80);
+        if (!string.IsNullOrWhiteSpace(Entry.ContractorDetails))
+            return Truncate(Entry.ContractorDetails, 80);
+        if (Entry.Labels is not null && Entry.Labels.Any())
+            return Entry.Labels.First().Name;
+        return "Transaction";
+    }
+
+    private string GetAvatarLabel()
+    {
+        var firstLabel = Entry.Labels?.FirstOrDefault()?.Name;
+        if (!string.IsNullOrWhiteSpace(firstLabel))
+            return firstLabel.Trim()[..1].ToUpperInvariant();
+        return "?";
+    }
+
+    private static string Truncate(string value, int max) =>
+        value.Length <= max ? value : value[..max] + "…";
+
+    private Task ShowEditOverlay()
+    {
+        _updateEntryVisibility = true;
+        return Task.CompletedTask;
+    }
+
+    private Task ShowRemoveOverlay()
+    {
+        _removeEntryVisibility = true;
+        return Task.CompletedTask;
+    }
+
+    private Task HideOverlay()
+    {
+        _updateEntryVisibility = false;
+        _removeEntryVisibility = false;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    private async Task ConfirmRemove()
+    {
+        _removeEntryVisibility = false;
+        _expanded = false;
+
+        try
+        {
+            await FinancialAccountService.RemoveEntry(Entry.EntryId, Account.AccountId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error while removing entry");
+        }
+
+        await AccountDataSynchronizationService.AccountChanged();
+        await OnEntryChanged.InvokeAsync();
+        await InvokeAsync(StateHasChanged);
+    }
+}

--- a/code/FinanceManager.Components/Components/SharedComponents/Charts/LineChartJs.razor.cs
+++ b/code/FinanceManager.Components/Components/SharedComponents/Charts/LineChartJs.razor.cs
@@ -9,6 +9,7 @@ public partial class LineChartJs : ComponentBase, IAsyncDisposable
 {
     private IJSObjectReference? _chartInstance;
     private CancellationTokenSource _cancellationTokenSource = new();
+    private List<List<ChartJsLineDataPoint>>? _lastRenderedSeries;
 
     [Inject] public required IJSRuntime JSRunTime { get; set; }
     [Inject] public required ILogger<LineChartJs> Logger { get; set; }
@@ -96,6 +97,7 @@ public partial class LineChartJs : ComponentBase, IAsyncDisposable
             }
 
             _chartInstance = await JSRunTime.InvokeAsync<IJSObjectReference>("setupChart", _cancellationTokenSource.Token, Id, config, datasets);
+            _lastRenderedSeries = Series;
 
 
             List<List<ChartJsLineDataPoint>> newSeries = [];
@@ -121,6 +123,13 @@ public partial class LineChartJs : ComponentBase, IAsyncDisposable
     protected override async Task OnParametersSetAsync()
     {
         if (_chartInstance is null) return;
+
+        // Skip the redraw when the parent passed the exact same Series instance we already
+        // rendered. Without this, every parent re-render (even unrelated state changes)
+        // restarts the chart animation. Callers that build the Series inline get a new
+        // reference each render, so they're unaffected.
+        if (ReferenceEquals(_lastRenderedSeries, Series)) return;
+        _lastRenderedSeries = Series;
 
         _cancellationTokenSource.Cancel();
         _cancellationTokenSource = new CancellationTokenSource();

--- a/code/FinanceManager/wwwroot/css/app.css
+++ b/code/FinanceManager/wwwroot/css/app.css
@@ -41,6 +41,11 @@ a:hover {
     color: inherit; /* takes color from parent element */
 }
 
+.fm-tabular {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum" 1;
+}
+
 #blazor-error-ui {
     background: lightyellow;
     bottom: 0;


### PR DESCRIPTION
## Summary

Redesigns the `/AccountDetails/{id}` page for **currency accounts** per the spec in #175. The previous page (collapsible panel list + side-panel filters) is replaced by:

- **Hero** (`AccountDetailsHero`) — avatar + name + balance + change pill + range selector (1M/3M/6M/1Y/RANGE with date picker) + edge-to-edge LineChart.
- **Toolbar** (`AccountHistoryToolbar`) — search field, outlined Income/Expense chips (accent only when selected), Category menu, Import/Export/Manage icons, and the single filled "Add entry" primary CTA. Wraps to multiple lines on narrow viewports; search goes full-width on mobile.
- **Day-grouped transaction cards** (`DayGroupCard` + `TransactionRow`) — dense header with date / weekday / entry count / daily net; rows click to expand inline with edit / remove buttons that open the existing Update/Remove overlays.
- **Insight rail** — `BalanceChangeCard` and `AccountMoversCard` (single card with Combined/Top/Bottom toggle, defaulting to Combined). On desktop the rail sits in the right column; on mobile it's hidden and an **Insights** button in the toolbar opens it as a slide-in drawer.
- **Scroll-to-top FAB** anchored bottom-right, visible after scrolling past 400px.

Stock and Bond accounts keep their existing layout (out of scope for this PR — flagged for follow-up issues).

Other changes worth flagging:
- One CSS rule added (`.fm-tabular`) per the spec's "only acceptable styling exceptions".
- `LineChartJs.OnParametersSetAsync` now skips redrawing when `Series` is the same reference as the last render. The hero caches its converted series so unrelated parent re-renders (e.g. toggling the mobile insights drawer) don't restart the chart's draw animation. Other callers that build `Series` inline get a fresh reference each render and are unaffected.

closes #175

## Test plan

- [ ] `/AccountDetails/{id}` for a currency account renders the new layout at ≥1280 wide.
- [ ] Range pills 1M/3M/6M/1Y refetch and re-derive chart / change / day list / Top 5 / Bottom 5.
- [ ] RANGE pill reveals a date range picker (Dialog variant, two-month landscape); picking from/to dates refetches.
- [ ] Search + Income/Expense + Category compose; Top/Bottom reflect the filtered window.
- [ ] Clicking an Income chip a second time clears the filter (ToggleSelection).
- [ ] Tapping a transaction row expands it inline; Edit / Remove open the existing overlays and behave as before.
- [ ] On mobile (≤Md breakpoint): right rail is hidden, **Insights** button appears in the toolbar and opens a slide-in drawer with the same cards; backdrop tap and close button dismiss it.
- [ ] Mobile search field takes full width with other controls wrapping to a second line.
- [ ] Toggling the Insights drawer does **not** restart the chart's draw animation.
- [ ] Scroll-to-top FAB appears past 400px and smooth-scrolls to the top.
- [ ] `dotnet test` from `code/` passes (310 unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added account details hero displaying balance with trend indicators and date range selection
  * Added transaction history toolbar with search, income/expense filters, and category filtering
  * Added expandable transaction rows with edit and delete capabilities
  * Added balance change and top movers summary cards
  * Added day-grouped transaction organization for improved readability

* **Improvements**
  * Enhanced mobile experience with insights drawer and scroll-to-top functionality
  * Optimized chart rendering performance to eliminate unnecessary animations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->