### PR TITLE
Surface 12-month rate history and EOY projection on investment rate card #229

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ rules agents must follow when updating this file.
 - Admin log viewer: warnings and errors emitted by the API are now persisted to the database and surfaced in the admin panel as a "Recent warnings & errors" dashboard widget and a full `/Admin/Logs` page with warning/error filtering and pagination. A retention background service purges entries older than the configured cutoff (default 30 days) on API start and once a day, and a SignalR hub pushes new entries to the UI live. #212
 
 ### Changed
+- Investment rate card on the Assets page now surfaces a 12-month rate history bar chart (with the current month highlighted) and an end-of-year projection in PLN derived from the YTD pace, alongside the existing rate, salary, and investments-change figures. #229
 - Currency account details page redesigned around a hero (avatar, name, balance, range toggle, chart), a search/filter toolbar with income/expense chips and category picker, day-grouped transaction cards with running balance, and an insight rail (balance change, top 5 income, bottom 5 expenses). #175
 - Stock account entry rows now show the ticker symbol in the row title and move the ISIN into the expanded section so the visible identifier is the one users recognize. #224
 - Guest demo data now generates realistic per-account-type entries: currency labels respect income vs expense sign, stock and bond holdings never go negative, and stock prices are prefilled across the seeded range. #206

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor
@@ -1,39 +1,51 @@
-﻿<MudCard Outlined Class="d-flex flex-column" Style="@($"height:{Height};")">
-    <MudPaper Class="p-3 pb-0" Elevation="0">
-        <div>
-            <MudText Typo="Typo.h5">Investment rate</MudText>
-            <MudText Typo="Typo.body2" Class="text-muted">Investment growth relative to salary.</MudText>
+<MudCard Outlined Class="rounded-lg d-flex flex-column" Style="@($"height:{Height};")">
+    <MudCardContent Class="d-flex flex-column flex-grow-1 pa-4">
+        <div class="mb-3">
+            <MudText Typo="Typo.h6">Investment rate</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary">Investment growth relative to salary.</MudText>
         </div>
-    </MudPaper>
 
-    <MudPaper Class="flex-grow-1 p-3 pt-2 overflow-auto" Elevation="0">
         @if (_isLoading)
         {
             <MudText Typo="Typo.h3" Class="mb-1 text-muted">
                 <StringSpinner CharactersCount="6" />
             </MudText>
         }
-        else if (LatestInvestmentRate is null)
-        {
-            <MudText Typo="Typo.h3" Color="Color.Primary">No data</MudText>
-        }
         else
         {
-            <MudText Typo="Typo.h3" Color="Color.Primary" Class="mb-3">
-                @FormatPercentage(LatestInvestmentRate.GetPercentage())
-            </MudText>
-
-            <div class="d-flex flex-wrap gap-1">
-                <div class="mr-2">
-                    <MudText Typo="Typo.caption" Class="text-muted">Salary</MudText>
-                    <MudText Typo="Typo.body1">@FormatAmount(LatestInvestmentRate.Salary)</MudText>
-                </div>
-                <div class="mr-2">
-                    <MudText Typo="Typo.caption" Class="text-muted">Investments change</MudText>
-                    <MudText Typo="Typo.body1">@FormatAmount(LatestInvestmentRate.InvestmentsChange)
-                    </MudText>
+            <div class="d-flex justify-space-between align-end mb-3">
+                <MudText Typo="Typo.h3" Color="Color.Primary">@FormatPercentage(_currentMonthPercentage)</MudText>
+                <div class="d-flex flex-column align-end">
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">ON TRACK FOR</MudText>
+                    <MudText Typo="Typo.h6">@FormatProjection()</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">by year end</MudText>
                 </div>
             </div>
+
+            <div class="d-flex justify-space-between mb-1">
+                <MudText Typo="Typo.caption" Color="Color.Secondary">Rate by month</MudText>
+                <MudText Typo="Typo.caption" Color="Color.Secondary">avg @FormatAveragePercentage(_ytdAveragePercentage)</MudText>
+            </div>
+            <div class="flex-grow-1" style="min-height: 0;">
+                <MudChart T="double" ChartType="ChartType.Bar" ChartSeries="@_chartSeries"
+                          XAxisLabels="@_chartLabels" ChartOptions="@_chartOptions"
+                          Width="100%" Height="100%" />
+            </div>
+
+            <MudDivider Class="my-2" />
+            <MudGrid Spacing="2">
+                <MudItem xs="6">
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">Salary</MudText>
+                    <MudText Typo="Typo.body1">@FormatAmount(LatestInvestmentRate?.Salary ?? 0)</MudText>
+                </MudItem>
+                <MudItem xs="6">
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">Investments change</MudText>
+                    <MudText Typo="Typo.body1"
+                             Color="@(LatestInvestmentRate?.InvestmentsChange > 0 ? Color.Success : Color.Default)">
+                        @FormatAmount(LatestInvestmentRate?.InvestmentsChange ?? 0)
+                    </MudText>
+                </MudItem>
+            </MudGrid>
         }
-    </MudPaper>
+    </MudCardContent>
 </MudCard>

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
@@ -5,20 +5,34 @@ using FinanceManager.Domain.Entities.MoneyFlowModels;
 using FinanceManager.Domain.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
+using MudBlazor;
 
 namespace FinanceManager.Components.Components.Dashboard.Cards.Assets;
 
 public partial class InvestmentRateCard
 {
+    private const string _mutedBarColor = "#33FFFFFF";
+    private const string _highlightBarColor = "#FF8F00";
+
     private bool _isLoading;
     private Currency _currency = DefaultCurrency.PLN;
+
     public List<InvestmentRate> InvestmentRates { get; set; } = [];
+    public List<InvestmentRate> MonthlyInvestmentRates { get; set; } = [];
+
     private InvestmentRate? LatestInvestmentRate => InvestmentRates.FirstOrDefault(x => x.Salary != 0);
+    private InvestmentRate? CurrentMonthRate => MonthlyInvestmentRates.LastOrDefault();
+
+    private decimal _currentMonthPercentage;
+    private decimal _ytdAveragePercentage;
+    private decimal? _endOfYearProjection;
+    private List<ChartSeries<double>> _chartSeries = [];
+    private ChartOptions _chartOptions = new();
+    private string[] _chartLabels = [];
 
     [Parameter] public string Height { get; set; } = "300px";
     [Parameter] public DateTime StartDateTime { get; set; }
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
-
 
     [Inject] public required ILogger<InvestmentRateCard> Logger { get; set; }
     [Inject] public required AssetsPageCardsCacheService AssetsPageCardsCacheService { get; set; }
@@ -36,6 +50,7 @@ public partial class InvestmentRateCard
         try
         {
             InvestmentRates.Clear();
+            MonthlyInvestmentRates.Clear();
 
             var user = await LoginService.GetLoggedUser();
             if (user is null) return;
@@ -52,21 +67,82 @@ public partial class InvestmentRateCard
 
                 var snapshot = await AssetsPageCardsCacheService.GetSnapshotAsync(context);
                 InvestmentRates = [.. snapshot.InvestmentRates];
+                MonthlyInvestmentRates = [.. snapshot.MonthlyInvestmentRates];
+
+                BuildDerivedState();
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "Error while getting net worth");
+                Logger.LogError(ex, "Error while getting investment rate");
             }
         }
-        catch (Exception)
+        finally
         {
-
-            throw;
+            _isLoading = false;
         }
-        _isLoading = false;
     }
 
-    private static string FormatPercentage(decimal value) => $"{value * 100m:0.00}%";
+    private void BuildDerivedState()
+    {
+        _currentMonthPercentage = CurrentMonthRate?.GetPercentage() ?? 0m;
 
+        var currentYear = EndDateTime.Year;
+        var ytdEntries = MonthlyInvestmentRates
+            .Where(r => r.Start.Year == currentYear && r.Salary != 0)
+            .ToList();
+
+        _ytdAveragePercentage = ytdEntries.Count == 0
+            ? 0m
+            : ytdEntries.Average(r => r.GetPercentage());
+
+        var monthsElapsed = EndDateTime.Month;
+        var investedYtd = MonthlyInvestmentRates
+            .Where(r => r.Start.Year == currentYear)
+            .Sum(r => r.InvestmentsChange);
+
+        _endOfYearProjection = monthsElapsed == 0 || investedYtd == 0
+            ? null
+            : investedYtd / monthsElapsed * 12m;
+
+        BuildChart();
+    }
+
+    private void BuildChart()
+    {
+        var data = MonthlyInvestmentRates
+            .Select(r => (double)(r.GetPercentage() * 100m))
+            .ToArray();
+
+        if (data.Length == 0)
+            data = new double[12];
+
+        _chartLabels = [.. MonthlyInvestmentRates.Select(r => r.Start.ToString("MMM"))];
+        if (_chartLabels.Length == 0)
+            _chartLabels = new string[12];
+
+        _chartSeries =
+        [
+            new ChartSeries<double> { Name = "Rate", Data = data },
+        ];
+
+        var palette = new string[data.Length];
+        for (int i = 0; i < data.Length; i++)
+            palette[i] = _mutedBarColor;
+        if (data.Length > 0 && CurrentMonthRate is { Salary: not 0 })
+            palette[^1] = _highlightBarColor;
+
+        _chartOptions = new ChartOptions
+        {
+            ChartPalette = palette,
+            ShowLegend = false,
+            ShowToolTips = false,
+        };
+    }
+
+    private string FormatPercentage(decimal value) => $"{value * 100m:0.00}%";
+    private string FormatAveragePercentage(decimal value) => $"{value * 100m:0.0}%";
     private string FormatAmount(decimal value) => $"{value:0.00} {_currency.ShortName}";
+    private string FormatProjection() => _endOfYearProjection is null
+        ? "—"
+        : $"{_endOfYearProjection.Value:N0} {_currency.ShortName}";
 }

--- a/code/FinanceManager.Components/Models/AssetsPageCardsCacheSnapshot.cs
+++ b/code/FinanceManager.Components/Models/AssetsPageCardsCacheSnapshot.cs
@@ -4,7 +4,7 @@ namespace FinanceManager.Components.Models;
 
 public sealed class AssetsPageCardsCacheSnapshot
 {
-    public const int CurrentSchemaVersion = 1;
+    public const int CurrentSchemaVersion = 2;
 
     public int SchemaVersion { get; set; } = CurrentSchemaVersion;
     public int UserId { get; set; }
@@ -17,6 +17,7 @@ public sealed class AssetsPageCardsCacheSnapshot
     public List<NameValueResult> EndAssetsPerType { get; set; } = [];
     public List<NameValueResult> EndAssetsPerAccount { get; set; } = [];
     public List<InvestmentRate> InvestmentRates { get; set; } = [];
+    public List<InvestmentRate> MonthlyInvestmentRates { get; set; } = [];
 }
 
 public sealed class AssetsPageCardsRefreshContext

--- a/code/FinanceManager.Components/Services/AssetsPageCardsCacheService.cs
+++ b/code/FinanceManager.Components/Services/AssetsPageCardsCacheService.cs
@@ -2,6 +2,7 @@ using Blazored.LocalStorage;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Components.Models;
 using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
@@ -37,8 +38,9 @@ public class AssetsPageCardsCacheService(
         var assetsPerTypeTask = assetsHttpClient.GetEndAssetsPerType(refreshContext.UserId, DefaultCurrency.PLN, endDate);
         var assetsPerAccountTask = assetsHttpClient.GetEndAssetsPerAccount(refreshContext.UserId, DefaultCurrency.PLN, endDate);
         var investmentRateTask = moneyFlowHttpClient.GetInvestmentRate(refreshContext.UserId, startDate, endDate).ToListAsync().AsTask();
+        var monthlyInvestmentRatesTask = GetMonthlyInvestmentRatesAsync(refreshContext.UserId, endDate);
 
-        await Task.WhenAll(assetsTimeSeriesTask, assetsPerTypeTask, assetsPerAccountTask, investmentRateTask);
+        await Task.WhenAll(assetsTimeSeriesTask, assetsPerTypeTask, assetsPerAccountTask, investmentRateTask, monthlyInvestmentRatesTask);
 
         return new AssetsPageCardsCacheSnapshot
         {
@@ -52,7 +54,32 @@ public class AssetsPageCardsCacheService(
             EndAssetsPerType = [.. (await assetsPerTypeTask)],
             EndAssetsPerAccount = [.. (await assetsPerAccountTask)],
             InvestmentRates = [.. (await investmentRateTask)],
+            MonthlyInvestmentRates = await monthlyInvestmentRatesTask,
         };
+    }
+
+    private async Task<List<InvestmentRate>> GetMonthlyInvestmentRatesAsync(int userId, DateTime endDate)
+    {
+        const int monthsBack = 12;
+        var anchor = new DateTime(endDate.Year, endDate.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var tasks = new Task<(DateTime start, DateTime end, List<InvestmentRate> rates)>[monthsBack];
+        for (int i = 0; i < monthsBack; i++)
+        {
+            var monthStart = anchor.AddMonths(-(monthsBack - 1 - i));
+            var monthEnd = monthStart.AddMonths(1).AddTicks(-1);
+            if (monthEnd > endDate) monthEnd = endDate;
+            tasks[i] = FetchMonthAsync(userId, monthStart, monthEnd);
+        }
+
+        var results = await Task.WhenAll(tasks);
+        return [.. results.Select(r => r.rates.FirstOrDefault() ?? new InvestmentRate { Start = r.start, End = r.end })];
+    }
+
+    private async Task<(DateTime start, DateTime end, List<InvestmentRate> rates)> FetchMonthAsync(int userId, DateTime start, DateTime end)
+    {
+        var rates = await moneyFlowHttpClient.GetInvestmentRate(userId, start, end).ToListAsync();
+        return (start, end, rates);
     }
 
     protected override bool IsUsable(AssetsPageCardsCacheSnapshot? state, string cacheKey, DateTime utcNow)

--- a/code/FinanceManager.Domain/Entities/MoneyFlowModels/InvestmentRate.cs
+++ b/code/FinanceManager.Domain/Entities/MoneyFlowModels/InvestmentRate.cs
@@ -8,5 +8,5 @@ public class InvestmentRate
     public decimal Salary { get; set; }
     public decimal InvestmentsChange { get; set; }
 
-    public decimal GetPercentage() => InvestmentsChange / Salary;
+    public decimal GetPercentage() => Salary == 0 ? 0 : InvestmentsChange / Salary;
 }


### PR DESCRIPTION
Replace the empty body on the Assets-page Investment rate card with a
12-bar monthly history (current month highlighted in amber) and an
end-of-year projection in PLN derived from the year-to-date pace.
Salary and investments-change move into a bordered footer row.

The cache snapshot now also stores 12 monthly InvestmentRate buckets
fetched in parallel; schema version bumped so older cached payloads
are discarded. InvestmentRate.GetPercentage guards against
division by zero so empty months render as muted 0% bars instead of
throwing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Investment rate card redesigned to display "ON TRACK FOR" projections with bar chart visualizing monthly investment rate trends, year-to-date average percentage, and end-of-year forecast.

* **Bug Fixes**
  * Fixed division by zero error occurring when calculating investment rate percentages with zero salary values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->