### PR TITLE
Surface 12-month rate history and EOY projection on investment rate card

### DIFF
--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor
@@ -1,4 +1,4 @@
-<MudCard Outlined Class="rounded-lg d-flex flex-column" Style="@($"height:{Height};")">
+<MudCard Outlined Class="rounded-lg d-flex flex-column investment-rate-card" Style="@($"height:{Height};")">
     <MudCardContent Class="d-flex flex-column flex-grow-1 pa-4">
         <div class="mb-3">
             <MudText Typo="Typo.h6">Investment rate</MudText>
@@ -13,8 +13,10 @@
         }
         else
         {
-            <div class="d-flex justify-space-between align-end mb-3">
-                <MudText Typo="Typo.h3" Color="Color.Primary">@FormatPercentage(_currentMonthPercentage)</MudText>
+            <div class="d-flex flex-wrap align-end gap-3 mb-3" style="row-gap:4px;">
+                <MudText Typo="Typo.h3" Color="Color.Primary" Class="mr-auto">
+                    @FormatPercentage(_currentMonthPercentage)
+                </MudText>
                 <div class="d-flex flex-column align-end">
                     <MudText Typo="Typo.caption" Color="Color.Secondary">ON TRACK FOR</MudText>
                     <MudText Typo="Typo.h6">@FormatProjection()</MudText>
@@ -26,9 +28,9 @@
                 <MudText Typo="Typo.caption" Color="Color.Secondary">Rate by month</MudText>
                 <MudText Typo="Typo.caption" Color="Color.Secondary">avg @FormatAveragePercentage(_ytdAveragePercentage)</MudText>
             </div>
-            <div class="flex-grow-1" style="min-height: 0;">
+            <div class="investment-rate-card__chart flex-grow-1" style="min-height: 0;">
                 <MudChart T="double" ChartType="ChartType.Bar" ChartSeries="@_chartSeries"
-                          XAxisLabels="@_chartLabels" ChartOptions="@_chartOptions"
+                          ChartLabels="@_chartLabels" ChartOptions="@_chartOptions"
                           Width="100%" Height="100%" />
             </div>
 

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
@@ -11,8 +11,7 @@ namespace FinanceManager.Components.Components.Dashboard.Cards.Assets;
 
 public partial class InvestmentRateCard
 {
-    private const string _mutedBarColor = "#33FFFFFF";
-    private const string _highlightBarColor = "#FF8F00";
+    private const string _barColor = "#FFAB00";
 
     private bool _isLoading;
     private Currency _currency = DefaultCurrency.PLN;
@@ -27,7 +26,7 @@ public partial class InvestmentRateCard
     private decimal _ytdAveragePercentage;
     private decimal? _endOfYearProjection;
     private List<ChartSeries<double>> _chartSeries = [];
-    private ChartOptions _chartOptions = new();
+    private BarChartOptions _chartOptions = new();
     private string[] _chartLabels = [];
 
     [Parameter] public string Height { get; set; } = "300px";
@@ -125,17 +124,16 @@ public partial class InvestmentRateCard
             new ChartSeries<double> { Name = "Rate", Data = data },
         ];
 
-        var palette = new string[data.Length];
-        for (int i = 0; i < data.Length; i++)
-            palette[i] = _mutedBarColor;
-        if (data.Length > 0 && CurrentMonthRate is { Salary: not 0 })
-            palette[^1] = _highlightBarColor;
-
-        _chartOptions = new ChartOptions
+        _chartOptions = new BarChartOptions
         {
-            ChartPalette = palette,
+            ChartPalette = [_barColor],
             ShowLegend = false,
             ShowToolTips = false,
+            XAxisLines = false,
+            YAxisLines = false,
+            YAxisTicks = 0,
+            BarWidthRatio = 0.65,
+            XAxisLabelRotation = 0,
         };
     }
 


### PR DESCRIPTION
## Summary

- Replaces the empty body on the Assets-page Investment rate card with a 12-bar monthly history chart and an end-of-year projection in PLN derived from the YTD pace.
- Salary and Investments change move into a bordered footer row at the bottom of the card.
- Cache snapshot now also stores 12 monthly `InvestmentRate` buckets fetched in parallel; `AssetsPageCardsCacheSnapshot` schema version bumped to invalidate old payloads.
- `InvestmentRate.GetPercentage()` now guards against division by zero so empty months render as muted 0% bars instead of throwing.
- Chart polished with `BarChartOptions`: wider amber bars (`BarWidthRatio = 0.65`), gridlines and Y-axis ticks removed, month labels under the bars (`ChartLabels`).
- Headline row uses `flex-wrap` so the rate and EOY projection stack cleanly on narrow viewports.

closes #229

## Test plan

- [x] `dotnet build ./code/FinanceManager.slnx` clean
- [x] `dotnet test ./FinanceManager.UnitTests/FinanceManager.UnitTests.csproj` — 310/310 passing
- [ ] Manual visual check of the Investment rate card on the Assets page in dark and light mode at lg, md, and xs widths
- [ ] Empty/zero-data state still renders without errors (no salary entries in range)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHpyavSoDSUgGpF5owebN3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed the Investment Rate Card with improved visual styling, including rounded corners, enhanced spacing, and better layout alignment
  * Simplified chart display by removing legend and tooltips for a cleaner user interface
  * Updated chart coloring with a uniform single-color palette

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->