### PR TITLE
Fit investment rate chart inside the card and widen bars

### DIFF
--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor
@@ -1,6 +1,6 @@
-<MudCard Outlined Class="rounded-lg d-flex flex-column investment-rate-card" Style="@($"height:{Height};")">
+<MudCard Outlined Class="rounded-lg d-flex flex-column investment-rate-card" Style="@($"height:{Height};overflow:hidden;")">
     <MudCardContent Class="d-flex flex-column flex-grow-1 pa-4">
-        <div class="mb-3">
+        <div class="mb-2">
             <MudText Typo="Typo.h6">Investment rate</MudText>
             <MudText Typo="Typo.body2" Color="Color.Secondary">Investment growth relative to salary.</MudText>
         </div>
@@ -13,13 +13,13 @@
         }
         else
         {
-            <div class="d-flex flex-wrap align-end gap-3 mb-3" style="row-gap:4px;">
-                <MudText Typo="Typo.h3" Color="Color.Primary" Class="mr-auto">
+            <div class="d-flex flex-wrap align-end gap-3 mb-2" style="row-gap:4px;">
+                <MudText Typo="Typo.h4" Color="Color.Primary" Class="mr-auto">
                     @FormatPercentage(_currentMonthPercentage)
                 </MudText>
                 <div class="d-flex flex-column align-end">
                     <MudText Typo="Typo.caption" Color="Color.Secondary">ON TRACK FOR</MudText>
-                    <MudText Typo="Typo.h6">@FormatProjection()</MudText>
+                    <MudText Typo="Typo.subtitle1">@FormatProjection()</MudText>
                     <MudText Typo="Typo.caption" Color="Color.Secondary">by year end</MudText>
                 </div>
             </div>
@@ -28,21 +28,21 @@
                 <MudText Typo="Typo.caption" Color="Color.Secondary">Rate by month</MudText>
                 <MudText Typo="Typo.caption" Color="Color.Secondary">avg @FormatAveragePercentage(_ytdAveragePercentage)</MudText>
             </div>
-            <div class="investment-rate-card__chart flex-grow-1" style="min-height: 0;">
+            <div class="investment-rate-card__chart">
                 <MudChart T="double" ChartType="ChartType.Bar" ChartSeries="@_chartSeries"
                           ChartLabels="@_chartLabels" ChartOptions="@_chartOptions"
-                          Width="100%" Height="100%" />
+                          Width="100%" Height="@ChartHeight" />
             </div>
 
-            <MudDivider Class="my-2" />
-            <MudGrid Spacing="2">
+            <MudDivider Class="my-1" />
+            <MudGrid Spacing="1">
                 <MudItem xs="6">
                     <MudText Typo="Typo.caption" Color="Color.Secondary">Salary</MudText>
-                    <MudText Typo="Typo.body1">@FormatAmount(LatestInvestmentRate?.Salary ?? 0)</MudText>
+                    <MudText Typo="Typo.body2">@FormatAmount(LatestInvestmentRate?.Salary ?? 0)</MudText>
                 </MudItem>
                 <MudItem xs="6">
                     <MudText Typo="Typo.caption" Color="Color.Secondary">Investments change</MudText>
-                    <MudText Typo="Typo.body1"
+                    <MudText Typo="Typo.body2"
                              Color="@(LatestInvestmentRate?.InvestmentsChange > 0 ? Color.Success : Color.Default)">
                         @FormatAmount(LatestInvestmentRate?.InvestmentsChange ?? 0)
                     </MudText>

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
@@ -12,6 +12,8 @@ namespace FinanceManager.Components.Components.Dashboard.Cards.Assets;
 public partial class InvestmentRateCard
 {
     private const string _barColor = "#FFAB00";
+    private const int _chromeHeightPx = 260;
+    private const int _minChartHeightPx = 110;
 
     private bool _isLoading;
     private Currency _currency = DefaultCurrency.PLN;
@@ -30,6 +32,17 @@ public partial class InvestmentRateCard
     private string[] _chartLabels = [];
 
     [Parameter] public string Height { get; set; } = "300px";
+
+    private string ChartHeight => $"{Math.Max(_minChartHeightPx, ParseHeightPx(Height) - _chromeHeightPx)}px";
+
+    private static int ParseHeightPx(string height)
+    {
+        if (height.EndsWith("px", StringComparison.Ordinal)
+            && int.TryParse(height.AsSpan(0, height.Length - 2), out var px))
+            return px;
+        return 380;
+    }
+
     [Parameter] public DateTime StartDateTime { get; set; }
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
 
@@ -131,8 +144,9 @@ public partial class InvestmentRateCard
             ShowToolTips = false,
             XAxisLines = false,
             YAxisLines = false,
-            YAxisTicks = 0,
-            BarWidthRatio = 0.65,
+            MaxNumYAxisTicks = 2,
+            YAxisToStringFunc = _ => string.Empty,
+            BarWidthRatio = 0.85,
             XAxisLabelRotation = 0,
         };
     }

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor.css
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor.css
@@ -1,0 +1,23 @@
+.investment-rate-card__chart {
+    width: 100%;
+    overflow: hidden;
+    flex: 0 0 auto;
+}
+
+.investment-rate-card__chart ::deep svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    max-height: 100%;
+}
+
+.investment-rate-card__chart ::deep .mud-charts-yaxis,
+.investment-rate-card__chart ::deep .mud-charts-grid,
+.investment-rate-card__chart ::deep .mud-charts-gridlines {
+    display: none;
+}
+
+.investment-rate-card__chart ::deep .mud-charts-xaxis text {
+    font-size: 10px;
+    fill: var(--mud-palette-text-secondary);
+}


### PR DESCRIPTION
## Summary

Follow-up to #229. On mobile the chart bars were overflowing below the card border (the chart SVG was rendering taller than the available flex slot), the Y-axis tick labels were noisy, and the bars were too thin.

- Compute the chart pixel `Height` from the card `Height` minus a fixed chrome budget, with a floor — so MudChart no longer needs `100%` height inside a flex item.
- Add `overflow:hidden` on the card as a safety net.
- Bump `BarWidthRatio` from 0.65 to 0.85 so bars fill more of their slot.
- Hide the Y-axis tick text via `YAxisToStringFunc` + `MaxNumYAxisTicks` (the previous `YAxisTicks=0` was a no-op in 9.4).
- Drop the headline from `h3/h6` to `h4/subtitle1` and tighten outer spacing so the percent + EOY block fits the mobile vertical budget.
- Add a scoped `.razor.css` to hide the Y-axis SVG group and clamp the chart SVG to its container so month labels render beneath the bars.

## Test plan

- [x] `dotnet build ./code/FinanceManager.slnx` clean
- [x] `dotnet test FinanceManager.UnitTests` — 310/310 passing
- [ ] Manual check on mobile width: bars fit inside the card, no Y-axis numbers, month labels visible

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHpyavSoDSUgGpF5owebN3)_