### PR TITLE
Tighten mobile currency account details view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ rules agents must follow when updating this file.
 - Settings page redesigned as a single-page, TOC-style layout with Profile, Password, Subscription, and Danger zone sections and a sticky save bar. #209
 - Recurring transactions details UI improved: year now shows as small muted annotation at top, table dates simplified to MM-dd format, and long descriptions are trimmed with tooltips to maximize space utilization. #213
 - Mobile navigation drawer is now hidden by default and slides in as a temporary overlay when the app-bar hamburger is tapped, freeing horizontal space for page content; desktop keeps the existing mini-rail behavior. #216
+- Currency account details page tightened on mobile: the hero hides the avatar, balance, and balance-change blocks (range toggle, account name, and chart stay), and transaction rows drop the avatar and inline `HH:mm` timestamp; desktop layout unchanged. #238
 
 ### Fixed
 - Guest stock account no longer shows "Stock price unavailable" on every entry — the demo seeder now stores a real ISIN and a matching `StockDetails` row so the ticker resolves from the local sandbox instead of falling through to OpenFIGI. #222

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountDetailsHero.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountDetailsHero.razor
@@ -5,9 +5,12 @@
     <MudStack Spacing="4">
         <MudStack Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween" Spacing="3">
             <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="3">
-                <MudAvatar Color="Color.Primary" Variant="Variant.Filled" Size="Size.Large">
-                    @GetInitial()
-                </MudAvatar>
+                @if (!IsMobile)
+                {
+                    <MudAvatar Color="Color.Primary" Variant="Variant.Filled" Size="Size.Large">
+                        @GetInitial()
+                    </MudAvatar>
+                }
                 <MudStack Spacing="0">
                     <MudText Typo="Typo.overline" Color="Color.Default">@AccountTypeLabel · @Currency</MudText>
                     <MudText Typo="Typo.h5">@AccountName</MudText>
@@ -38,32 +41,35 @@
             </MudStack>
         </MudStack>
 
-        <MudStack Row="true" AlignItems="AlignItems.End" Justify="Justify.SpaceBetween" Spacing="4">
-            <MudStack Spacing="1">
-                <MudText Typo="Typo.overline" Color="Color.Default">Balance</MudText>
-                <MudStack Row="true" AlignItems="AlignItems.Baseline" Spacing="1">
-                    <MudText Typo="Typo.h3" Class="fm-tabular">@Balance.ToString("N2")</MudText>
-                    <MudText Typo="Typo.h5" Color="Color.Default">@Currency</MudText>
+        @if (!IsMobile)
+        {
+            <MudStack Row="true" AlignItems="AlignItems.End" Justify="Justify.SpaceBetween" Spacing="4">
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.overline" Color="Color.Default">Balance</MudText>
+                    <MudStack Row="true" AlignItems="AlignItems.Baseline" Spacing="1">
+                        <MudText Typo="Typo.h3" Class="fm-tabular">@Balance.ToString("N2")</MudText>
+                        <MudText Typo="Typo.h5" Color="Color.Default">@Currency</MudText>
+                    </MudStack>
                 </MudStack>
-            </MudStack>
 
-            <MudStack Spacing="1" AlignItems="AlignItems.End">
-                <MudText Typo="Typo.overline" Color="Color.Default">Change · @SelectedRange</MudText>
-                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                    <MudIcon Icon="@(BalanceChange >= 0 ? Icons.Material.Filled.TrendingUp : Icons.Material.Filled.TrendingDown)"
-                             Color="@(BalanceChange >= 0 ? Color.Success : Color.Error)" Size="Size.Small" />
-                    <MudText Typo="Typo.h6" Color="@(BalanceChange >= 0 ? Color.Success : Color.Error)" Class="fm-tabular">
-                        @(BalanceChange >= 0 ? "+" : "")@BalanceChange.ToString("N2") @Currency
-                    </MudText>
-                    @if (BalanceChangePercent.HasValue)
-                    {
-                        <MudText Typo="Typo.body2" Color="Color.Default" Class="fm-tabular">
-                            · @(BalanceChange >= 0 ? "+" : "")@BalanceChangePercent.Value.ToString("0.0")%
+                <MudStack Spacing="1" AlignItems="AlignItems.End">
+                    <MudText Typo="Typo.overline" Color="Color.Default">Change · @SelectedRange</MudText>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                        <MudIcon Icon="@(BalanceChange >= 0 ? Icons.Material.Filled.TrendingUp : Icons.Material.Filled.TrendingDown)"
+                                 Color="@(BalanceChange >= 0 ? Color.Success : Color.Error)" Size="Size.Small" />
+                        <MudText Typo="Typo.h6" Color="@(BalanceChange >= 0 ? Color.Success : Color.Error)" Class="fm-tabular">
+                            @(BalanceChange >= 0 ? "+" : "")@BalanceChange.ToString("N2") @Currency
                         </MudText>
-                    }
+                        @if (BalanceChangePercent.HasValue)
+                        {
+                            <MudText Typo="Typo.body2" Color="Color.Default" Class="fm-tabular">
+                                · @(BalanceChange >= 0 ? "+" : "")@BalanceChangePercent.Value.ToString("0.0")%
+                            </MudText>
+                        }
+                    </MudStack>
                 </MudStack>
             </MudStack>
-        </MudStack>
+        }
 
     </MudStack>
     <div class="mx-n6 mt-2" style="min-height: 200px; position: relative;">
@@ -91,6 +97,7 @@
     [Parameter] public EventCallback<DateRange?> CustomDateRangeChanged { get; set; }
     [Parameter] public bool IsChartLoading { get; set; }
     [Parameter] public List<TimeSeriesModel> ChartData { get; set; } = [];
+    [Parameter] public bool IsMobile { get; set; }
 
     private List<List<ChartJsLineDataPoint>> _chartSeries = [];
     private List<TimeSeriesModel>? _lastChartData;

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
@@ -21,7 +21,8 @@ else if (IsLoading || Account.Entries.Any())
                         CustomDateRange="@_customDateRange"
                         CustomDateRangeChanged="OnCustomDateRangeChanged"
                         IsChartLoading="@IsLoading"
-                        ChartData="@ChartData" />
+                        ChartData="@ChartData"
+                        IsMobile="@_isMobile" />
 
     <MudContainer MaxWidth="MaxWidth.Large" Class="px-0">
         <MudGrid Spacing="3">
@@ -60,7 +61,7 @@ else if (IsLoading || Account.Entries.Any())
                     @foreach (var group in dayGroups)
                     {
                         <DayGroupCard Day="@group.Key" Account="Account" Entries="@group"
-                                      Currency="@_currency.ShortName" />
+                                      Currency="@_currency.ShortName" IsMobile="@_isMobile" />
                     }
                 }
             </MudItem>

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/DayGroupCard.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/DayGroupCard.razor
@@ -22,7 +22,7 @@
         <MudStack Spacing="0">
             @foreach (var entry in Entries)
             {
-                <TransactionRow Account="Account" Entry="entry" Currency="@Currency" />
+                <TransactionRow Account="Account" Entry="entry" Currency="@Currency" IsMobile="@IsMobile" />
                 <MudDivider />
             }
         </MudStack>
@@ -34,6 +34,7 @@
     [Parameter] public required FinanceManager.Domain.Entities.FinancialAccounts.Currencies.CurrencyAccount Account { get; set; }
     [Parameter] public required IEnumerable<CurrencyAccountEntry> Entries { get; set; }
     [Parameter] public required string Currency { get; set; }
+    [Parameter] public bool IsMobile { get; set; }
 
     private decimal DailyNet => Entries.Sum(e => e.ValueChange);
 }

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/TransactionRow.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/TransactionRow.razor
@@ -4,9 +4,12 @@
 
 <div class="d-flex align-start pa-2 mud-list-item-clickable" style="cursor: pointer;" @onclick="ToggleExpanded">
     <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Start" Class="w-100">
-        <MudAvatar Size="Size.Medium" Variant="Variant.Filled" Color="Color.Default">
-            @GetAvatarLabel()
-        </MudAvatar>
+        @if (!IsMobile)
+        {
+            <MudAvatar Size="Size.Medium" Variant="Variant.Filled" Color="Color.Default">
+                @GetAvatarLabel()
+            </MudAvatar>
+        }
 
         <MudStack Spacing="0" Class="flex-grow-1" Style="min-width: 0;">
             <MudText Typo="Typo.body1">@GetTitle()</MudText>
@@ -16,7 +19,10 @@
                     <MudChip T="string" Size="Size.Small" Variant="Variant.Text"
                              Style="height: 20px; font-size: 11px;">@Entry.Labels.First().Name</MudChip>
                 }
-                <MudText Typo="Typo.caption" Color="Color.Default">· @Entry.PostingDate.ToLocalTime().ToString("HH:mm")</MudText>
+                @if (!IsMobile)
+                {
+                    <MudText Typo="Typo.caption" Color="Color.Default">· @Entry.PostingDate.ToLocalTime().ToString("HH:mm")</MudText>
+                }
             </MudStack>
         </MudStack>
 
@@ -96,6 +102,7 @@
     [Parameter] public required CurrencyAccountEntry Entry { get; set; }
     [Parameter] public required string Currency { get; set; }
     [Parameter] public EventCallback OnEntryChanged { get; set; }
+    [Parameter] public bool IsMobile { get; set; }
 
     [Inject] public required FinanceManager.Components.Services.IFinancialAccountService FinancialAccountService { get; set; }
     [Inject] public required FinanceManager.Components.Services.AccountDataSynchronizationService AccountDataSynchronizationService { get; set; }


### PR DESCRIPTION
## Summary

- Hero on mobile (≤Md) hides the account avatar, "Balance" block, and "Change · {range}" block. Account name, eyebrow, range toggle, and chart stay.
- Transaction rows on mobile hide the avatar and the inline `HH:mm` timestamp. The inline-expand "Posting date" detail (full date) is unchanged.
- Desktop layout is byte-identical.

Plumbed via a new `IsMobile` parameter on `AccountDetailsHero`, `DayGroupCard`, and `TransactionRow`, wired from the existing `_isMobile` viewport flag in `CurrencyAccountDetailsPageContent`.

closes #238

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test --project ./FinanceManager.UnitTests/FinanceManager.UnitTests.csproj` — 310 passed
- [ ] Verify hero + day rows on a narrow viewport (manual, not run in sandbox)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTL52831uhefdPwjYAJWYs)_