### PR TITLE
Hide investment rate EOY projection on phone widths

### DIFF
--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor
@@ -20,7 +20,7 @@
                     <MudText Typo="Typo.h3" Color="MudBlazor.Color.Primary">@FormatRateNumber(_currentMonthPercentage)</MudText>
                     <MudText Typo="Typo.h6" Color="MudBlazor.Color.Primary" Class="ml-1">%</MudText>
                 </div>
-                <div class="d-flex flex-column align-end">
+                <div class="d-none d-sm-flex flex-column align-end">
                     <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">ON TRACK FOR</MudText>
                     <MudText Typo="Typo.subtitle1">@FormatProjection()</MudText>
                     <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">by year end</MudText>


### PR DESCRIPTION
## Summary

The `ON TRACK FOR / {eoy} PLN / by year end` block was forcing the headline row to wrap on phone widths, pushing the chart down and clipping the bars. Hide it on `xs` with `d-none d-sm-flex`; the EOY readout reappears at `sm` and above.

closes #229 follow-up

## Test plan

- [x] `dotnet build ./code/FinanceManager.slnx` clean
- [x] `dotnet test FinanceManager.UnitTests` — 310/310 passing
- [ ] Mobile: card shows only the rate headline; bars fit
- [ ] Desktop (≥sm): EOY block visible to the right of the rate

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHpyavSoDSUgGpF5owebN3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Dashboard responsiveness by adjusting the visibility of the projection block on different screen sizes for optimal viewing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->