### PR TITLE
Make currency guest seeder mimic a real monthly budget #240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ rules agents must follow when updating this file.
 - Recurring transactions details UI improved: year now shows as small muted annotation at top, table dates simplified to MM-dd format, and long descriptions are trimmed with tooltips to maximize space utilization. #213
 - Mobile navigation drawer is now hidden by default and slides in as a temporary overlay when the app-bar hamburger is tapped, freeing horizontal space for page content; desktop keeps the existing mini-rail behavior. #216
 - Currency account details page tightened on mobile: the hero hides the avatar, balance, and balance-change blocks (range toggle, account name, and chart stay), and transaction rows drop the avatar and inline `HH:mm` timestamp; desktop layout unchanged. #238
+- Guest cash currency seeder now mirrors a realistic monthly budget: a single 5,000 PLN salary on the 1st, recurring 500 PLN investment on the 3rd, 1,000 PLN rent and 100 PLN utilities on the 4th, and 0–10 randomized everyday purchases per remaining day drawn from a list of plausible merchants, capped so monthly outflows never reach the salary. #240
 
 ### Fixed
 - Guest stock account no longer shows "Stock price unavailable" on every entry — the demo seeder now stores a real ISIN and a matching `StockDetails` row so the ticker resolves from the local sandbox instead of falling through to OpenFIGI. #222

--- a/code/FinanceManager.Application/Services/Seeders/CurrencyAccountSeeder.cs
+++ b/code/FinanceManager.Application/Services/Seeders/CurrencyAccountSeeder.cs
@@ -13,11 +13,17 @@ public class CurrencyAccountSeeder(
     IFinancialLabelsRepository financialLabelsRepository,
     ILogger<CurrencyAccountSeeder> logger)
 {
+    private const decimal MonthlySalary = 5_000m;
+    private const decimal MonthlyInvestment = 500m;
+    private const decimal MonthlyRent = 1_000m;
+    private const decimal MonthlyUtilities = 100m;
+    private const int MaxRandomTransactionsPerDay = 10;
+    private const int MaxRandomTransactionAmount = 150;
+
     // Income labels can only appear on entries whose value change is positive (money coming in).
     private static readonly HashSet<string> _incomeLabels = new(StringComparer.OrdinalIgnoreCase)
     {
         "Salary",
-        "Investment",
         "Undisclosed Income",
     };
 
@@ -34,50 +40,136 @@ public class CurrencyAccountSeeder(
         "Education",
         "Dining Out",
         "Travel",
+        "Investment",
         "Undisclosed Expense",
     };
+
+    private record FakeMerchant(string Description, string LabelName);
+
+    private static readonly FakeMerchant[] _fakeMerchants =
+    [
+        new("Biedronka", "Groceries"),
+        new("Lidl", "Groceries"),
+        new("Carrefour", "Groceries"),
+        new("Auchan", "Groceries"),
+        new("Żabka", "Groceries"),
+        new("Kaufland", "Groceries"),
+        new("Pizza Hut", "Dining Out"),
+        new("McDonald's", "Dining Out"),
+        new("KFC", "Dining Out"),
+        new("Sphinx", "Dining Out"),
+        new("Starbucks", "Dining Out"),
+        new("Uber", "Transportation"),
+        new("Bolt", "Transportation"),
+        new("PKP train ticket", "Transportation"),
+        new("Tram pass", "Transportation"),
+        new("Orlen fuel", "Transportation"),
+        new("Netflix", "Subscription"),
+        new("Spotify", "Subscription"),
+        new("YouTube Premium", "Subscription"),
+        new("Disney+", "Subscription"),
+        new("Cinema City", "Entertainment"),
+        new("Bowling night", "Entertainment"),
+        new("Concert ticket", "Entertainment"),
+        new("Steam game", "Entertainment"),
+        new("Apteka pharmacy", "Healthcare"),
+        new("Doctor visit", "Healthcare"),
+        new("Dentist", "Healthcare"),
+        new("Empik bookstore", "Education"),
+        new("Online course", "Education"),
+        new("Hotel booking", "Travel"),
+        new("Flight ticket", "Travel"),
+        new("Airbnb stay", "Travel"),
+    ];
 
     public async Task Seed(int userId, DateTime start, DateTime end, CancellationToken cancellationToken = default)
     {
         if (await currencyAccountRepository.GetAvailableAccounts(userId).AnyAsync(cancellationToken)) return;
 
         var labels = await GetSeedableLabels(cancellationToken);
+        var labelByName = labels.ToDictionary(l => l.Name, StringComparer.OrdinalIgnoreCase);
 
         logger.LogTrace("Seeding cash currency account.");
-        await SeedCashAccount(userId, labels, start, end, cancellationToken);
+        await SeedCashAccount(userId, labelByName, start, end, cancellationToken);
 
         logger.LogTrace("Seeding loan currency account.");
         await SeedLoanAccount(userId, labels, start, end, cancellationToken);
     }
 
-    private async Task SeedCashAccount(int userId, IReadOnlyList<FinancialLabel> labels, DateTime start, DateTime end, CancellationToken cancellationToken)
+    private async Task SeedCashAccount(int userId, Dictionary<string, FinancialLabel> labelByName, DateTime start, DateTime end, CancellationToken cancellationToken)
     {
         var account = new CurrencyAccount(userId, 0, $"{AccountLabel.Cash} 1", AccountLabel.Cash);
 
-        // Opening balance keeps the account in the black throughout the seeded window even with daily expenses.
-        account.AddEntry(new AddCurrencyEntryDto(start, 2_000, "Opening balance", null, []), false);
+        // Opening balance equals one month's salary so the partial first month can absorb random expenses
+        // before the first day-1 paycheck lands.
+        account.AddEntry(new AddCurrencyEntryDto(start, MonthlySalary, "Opening balance", null, []), false);
+
+        var salaryLabels = LabelsFor(labelByName, "Salary");
+        var investmentLabels = LabelsFor(labelByName, "Investment");
+        var rentLabels = LabelsFor(labelByName, "Rent");
+        var utilitiesLabels = LabelsFor(labelByName, "Utilities");
+
+        var currentMonth = new DateTime(start.Year, start.Month, 1);
+        decimal negativesThisMonth = 0m;
 
         for (var date = start.AddDays(1); date <= end; date = date.AddDays(1))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            // Monthly salary on the 1st.
-            if (date.Day == 1)
+
+            var monthStart = new DateTime(date.Year, date.Month, 1);
+            if (monthStart != currentMonth)
             {
-                var salary = Random.Shared.Next(3_000, 5_000);
-                account.AddEntry(new AddCurrencyEntryDto(date, salary, "Monthly salary", null, PickLabels(labels, salary)), false);
+                currentMonth = monthStart;
+                negativesThisMonth = 0m;
             }
 
-            // Most days have a small expense; a minority have a small positive bump (refund / freelance).
-            var change = Random.Shared.Next(0, 100) < 80
-                ? -Random.Shared.Next(5, 120)
-                : Random.Shared.Next(20, 300);
-
-            account.AddEntry(new AddCurrencyEntryDto(date, change, "", null, PickLabels(labels, change)), false);
+            switch (date.Day)
+            {
+                case 1:
+                    account.AddEntry(new AddCurrencyEntryDto(date, MonthlySalary, "Monthly salary", null, salaryLabels), false);
+                    break;
+                case 3:
+                    account.AddEntry(new AddCurrencyEntryDto(date, -MonthlyInvestment, "Monthly investment", null, investmentLabels), false);
+                    negativesThisMonth += MonthlyInvestment;
+                    break;
+                case 4:
+                    account.AddEntry(new AddCurrencyEntryDto(date, -MonthlyRent, "Rent payment", null, rentLabels), false);
+                    account.AddEntry(new AddCurrencyEntryDto(date, -MonthlyUtilities, "Utilities bill", null, utilitiesLabels), false);
+                    negativesThisMonth += MonthlyRent + MonthlyUtilities;
+                    break;
+                default:
+                    negativesThisMonth = AddRandomNegatives(account, date, labelByName, negativesThisMonth);
+                    break;
+            }
         }
 
         account.RecalculateEntryValues(account.Entries.Count - 1);
         await accountRepository.AddAccount(account);
     }
+
+    private static decimal AddRandomNegatives(CurrencyAccount account, DateTime date, Dictionary<string, FinancialLabel> labelByName, decimal negativesThisMonth)
+    {
+        var transactions = Random.Shared.Next(0, MaxRandomTransactionsPerDay + 1);
+        for (var i = 0; i < transactions; i++)
+        {
+            // Rule from #240: total negatives within a month must stay strictly below the salary.
+            var remaining = MonthlySalary - 1m - negativesThisMonth;
+            if (remaining < 1m) break;
+
+            var max = (int)Math.Floor(Math.Min(MaxRandomTransactionAmount, remaining));
+            if (max < 1) break;
+            var amount = Random.Shared.Next(1, max + 1);
+
+            var merchant = _fakeMerchants[Random.Shared.Next(_fakeMerchants.Length)];
+            var labels = LabelsFor(labelByName, merchant.LabelName);
+            account.AddEntry(new AddCurrencyEntryDto(date, -amount, merchant.Description, null, labels), false);
+            negativesThisMonth += amount;
+        }
+        return negativesThisMonth;
+    }
+
+    private static List<FinancialLabel> LabelsFor(Dictionary<string, FinancialLabel> labelByName, string name) =>
+        labelByName.TryGetValue(name, out var label) ? [label] : [];
 
     private async Task SeedLoanAccount(int userId, IReadOnlyList<FinancialLabel> labels, DateTime start, DateTime end, CancellationToken cancellationToken)
     {

--- a/code/FinanceManager.UnitTests/Application/Services/Seeders/CurrencyAccountSeederTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/Seeders/CurrencyAccountSeederTests.cs
@@ -66,24 +66,32 @@ public class CurrencyAccountSeederTests
     }
 
     [Fact]
-    public async Task Seed_PaysSalaryOnFirstOfEachMonth()
+    public async Task Seed_PaysSalaryExactlyOncePerMonth_At5000_WithSalaryLabel()
     {
         var start = new DateTime(2026, 1, 15);
-        var end = new DateTime(2026, 4, 20);
+        var end = new DateTime(2026, 7, 20);
 
         await _seeder.Seed(userId: 1, start, end, TestContext.Current.CancellationToken);
 
         var cashEntries = GetCashEntries();
         var salaryEntries = cashEntries
-            .Where(e => e.PostingDate.Day == 1 && e.ValueChange > 0)
+            .Where(e => e.Description == "Monthly salary")
             .ToList();
 
-        Assert.Equal(3, salaryEntries.Count); // Feb 1, Mar 1, Apr 1.
+        // Feb–Jul: one salary per complete month in the window.
+        Assert.Equal(6, salaryEntries.Count);
         Assert.All(salaryEntries, e =>
         {
+            Assert.Equal(1, e.PostingDate.Day);
             Assert.Equal(MonthlySalary, e.ValueChange);
-            Assert.Contains(e.Labels, l => l.Name == "Salary");
+            Assert.Equal("Salary", Assert.Single(e.Labels).Name);
         });
+
+        // Each month appears exactly once — no month carries a second salary.
+        var months = salaryEntries
+            .Select(e => new DateTime(e.PostingDate.Year, e.PostingDate.Month, 1))
+            .ToList();
+        Assert.Equal(months.Count, months.Distinct().Count());
     }
 
     [Fact]

--- a/code/FinanceManager.UnitTests/Application/Services/Seeders/CurrencyAccountSeederTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/Seeders/CurrencyAccountSeederTests.cs
@@ -1,0 +1,197 @@
+using FinanceManager.Application.Services.Seeders;
+using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.Shared.Accounts;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Domain.Repositories.Account;
+using FinanceManager.Domain.ValueObjects;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace FinanceManager.UnitTests.Application.Services.Seeders;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class CurrencyAccountSeederTests
+{
+    private const decimal MonthlySalary = 5_000m;
+    private const decimal MonthlyInvestment = 500m;
+    private const decimal MonthlyRent = 1_000m;
+    private const decimal MonthlyUtilities = 100m;
+
+    private static readonly FinancialLabel[] _seededLabels =
+    [
+        new() { Id = 1, Name = "Salary" },
+        new() { Id = 2, Name = "Investment" },
+        new() { Id = 3, Name = "Rent" },
+        new() { Id = 4, Name = "Utilities" },
+        new() { Id = 5, Name = "Groceries" },
+        new() { Id = 6, Name = "Dining Out" },
+        new() { Id = 7, Name = "Transportation" },
+        new() { Id = 8, Name = "Subscription" },
+        new() { Id = 9, Name = "Entertainment" },
+        new() { Id = 10, Name = "Healthcare" },
+        new() { Id = 11, Name = "Education" },
+        new() { Id = 12, Name = "Travel" },
+        new() { Id = 13, Name = "Undisclosed Expense" },
+        new() { Id = 14, Name = "Undisclosed Income" },
+    ];
+
+    private readonly Mock<IFinancialAccountRepository> _accountRepository = new();
+    private readonly Mock<ICurrencyAccountRepository<CurrencyAccount>> _currencyAccountRepository = new();
+    private readonly Mock<IFinancialLabelsRepository> _labelsRepository = new();
+    private readonly List<CurrencyAccount> _savedAccounts = [];
+    private readonly CurrencyAccountSeeder _seeder;
+
+    public CurrencyAccountSeederTests()
+    {
+        _currencyAccountRepository
+            .Setup(r => r.GetAvailableAccounts(It.IsAny<int>()))
+            .Returns(AsyncEnumerable.Empty<AvailableAccount>());
+
+        _labelsRepository
+            .Setup(r => r.GetLabels(It.IsAny<CancellationToken>()))
+            .Returns(_seededLabels.ToAsyncEnumerable());
+
+        _accountRepository
+            .Setup(r => r.AddAccount(It.IsAny<CurrencyAccount>()))
+            .Callback<CurrencyAccount>(a => _savedAccounts.Add(a))
+            .ReturnsAsync(0);
+
+        _seeder = new CurrencyAccountSeeder(
+            _accountRepository.Object,
+            _currencyAccountRepository.Object,
+            _labelsRepository.Object,
+            NullLogger<CurrencyAccountSeeder>.Instance);
+    }
+
+    [Fact]
+    public async Task Seed_PaysSalaryOnFirstOfEachMonth()
+    {
+        var start = new DateTime(2026, 1, 15);
+        var end = new DateTime(2026, 4, 20);
+
+        await _seeder.Seed(userId: 1, start, end, TestContext.Current.CancellationToken);
+
+        var cashEntries = GetCashEntries();
+        var salaryEntries = cashEntries
+            .Where(e => e.PostingDate.Day == 1 && e.ValueChange > 0)
+            .ToList();
+
+        Assert.Equal(3, salaryEntries.Count); // Feb 1, Mar 1, Apr 1.
+        Assert.All(salaryEntries, e =>
+        {
+            Assert.Equal(MonthlySalary, e.ValueChange);
+            Assert.Contains(e.Labels, l => l.Name == "Salary");
+        });
+    }
+
+    [Fact]
+    public async Task Seed_HasNoIncomeOtherThanSalaryAndOpeningBalance()
+    {
+        var start = new DateTime(2026, 1, 15);
+        var end = new DateTime(2026, 5, 1);
+
+        await _seeder.Seed(userId: 1, start, end, TestContext.Current.CancellationToken);
+
+        var cashEntries = GetCashEntries();
+        var positives = cashEntries.Where(e => e.ValueChange > 0).ToList();
+
+        // Allowed positives: one opening balance plus one salary per 1st-of-month within the window.
+        Assert.Contains(positives, e => e.PostingDate == start && e.Description == "Opening balance");
+        Assert.All(positives.Where(e => e.PostingDate != start),
+            e => Assert.Equal(1, e.PostingDate.Day));
+    }
+
+    [Fact]
+    public async Task Seed_RecordsFixedExpensesOnDay3AndDay4()
+    {
+        var start = new DateTime(2026, 1, 31);
+        var end = new DateTime(2026, 3, 10);
+
+        await _seeder.Seed(userId: 1, start, end, TestContext.Current.CancellationToken);
+
+        var cashEntries = GetCashEntries();
+
+        foreach (var month in new[] { new DateTime(2026, 2, 1), new DateTime(2026, 3, 1) })
+        {
+            var day3 = cashEntries.SingleOrDefault(e => e.PostingDate == month.AddDays(2));
+            Assert.NotNull(day3);
+            Assert.Equal(-MonthlyInvestment, day3!.ValueChange);
+            Assert.Contains(day3.Labels, l => l.Name == "Investment");
+
+            var day4Entries = cashEntries.Where(e => e.PostingDate == month.AddDays(3)).ToList();
+            Assert.Equal(2, day4Entries.Count);
+            Assert.Single(day4Entries, e => e.ValueChange == -MonthlyRent && e.Labels.Any(l => l.Name == "Rent"));
+            Assert.Single(day4Entries, e => e.ValueChange == -MonthlyUtilities && e.Labels.Any(l => l.Name == "Utilities"));
+        }
+    }
+
+    [Fact]
+    public async Task Seed_MonthlyNegativesNeverReachSalary()
+    {
+        var start = new DateTime(2026, 1, 15);
+        var end = new DateTime(2026, 6, 30);
+
+        await _seeder.Seed(userId: 1, start, end, TestContext.Current.CancellationToken);
+
+        var cashEntries = GetCashEntries();
+        var monthlyNegatives = cashEntries
+            .Where(e => e.ValueChange < 0)
+            .GroupBy(e => new DateTime(e.PostingDate.Year, e.PostingDate.Month, 1))
+            .Select(g => new { Month = g.Key, Total = -g.Sum(e => e.ValueChange) });
+
+        Assert.All(monthlyNegatives, m => Assert.True(m.Total < MonthlySalary,
+            $"Month {m.Month:yyyy-MM} negatives {m.Total} must be strictly below salary {MonthlySalary}."));
+    }
+
+    [Fact]
+    public async Task Seed_RandomNegativesUseMerchantDescriptions()
+    {
+        var start = new DateTime(2026, 1, 15);
+        var end = new DateTime(2026, 4, 30);
+
+        await _seeder.Seed(userId: 1, start, end, TestContext.Current.CancellationToken);
+
+        var cashEntries = GetCashEntries();
+        var randomNegatives = cashEntries
+            .Where(e => e.ValueChange < 0
+                && e.PostingDate.Day != 3
+                && e.PostingDate.Day != 4)
+            .ToList();
+
+        if (randomNegatives.Count == 0) return; // 0-10 per day means a (very unlikely) all-zero run is possible.
+        Assert.All(randomNegatives, e => Assert.False(string.IsNullOrWhiteSpace(e.Description)));
+        Assert.All(randomNegatives, e => Assert.NotEqual("Rent payment", e.Description));
+        Assert.All(randomNegatives, e => Assert.NotEqual("Utilities bill", e.Description));
+        Assert.All(randomNegatives, e => Assert.NotEqual("Monthly investment", e.Description));
+    }
+
+    [Fact]
+    public async Task Seed_SeedsCashAndLoanAccounts()
+    {
+        var start = new DateTime(2026, 1, 15);
+        var end = new DateTime(2026, 3, 15);
+
+        await _seeder.Seed(userId: 1, start, end, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, _savedAccounts.Count);
+        Assert.Contains(_savedAccounts, a => a.AccountType == AccountLabel.Cash);
+        Assert.Contains(_savedAccounts, a => a.AccountType == AccountLabel.Loan);
+    }
+
+    [Fact]
+    public async Task Seed_SkipsWhenAccountsAlreadyExist()
+    {
+        _currencyAccountRepository
+            .Setup(r => r.GetAvailableAccounts(It.IsAny<int>()))
+            .Returns(new[] { new AvailableAccount(1, "Existing") }.ToAsyncEnumerable());
+
+        await _seeder.Seed(userId: 1, new DateTime(2026, 1, 15), new DateTime(2026, 2, 15), TestContext.Current.CancellationToken);
+
+        Assert.Empty(_savedAccounts);
+    }
+
+    private List<CurrencyAccountEntry> GetCashEntries() =>
+        _savedAccounts.Single(a => a.AccountType == AccountLabel.Cash).Entries.ToList();
+}


### PR DESCRIPTION
Cash account now follows a fixed monthly pattern (5,000 PLN salary on the
1st, 500 PLN investment on the 3rd, 1,000 PLN rent + 100 PLN utilities on
the 4th) with 0-10 random everyday purchases on remaining days drawn from
a list of plausible merchants, capped so monthly outflows never reach the
salary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced demo data seeding with more realistic financial scenarios, including fixed monthly transactions (salary, investments, rent, utilities) and randomized merchant-based expenses.
  * Improved account initialization for demo accounts with better merchant descriptions.

* **Tests**
  * Added comprehensive unit test coverage for demo account seeding logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->