### PR TITLE
Harden account details sync callbacks and keyboard-accessible rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ rules agents must follow when updating this file.
 - Guest loan and bond accounts now move in step with cash: the loan is taken out on the guest's first day with its proceeds credited to cash and repaid in equal monthly instalments shown on both accounts, and the bond account buys a fixed amount each month funded by a matching cash outflow. Investment- and loan-related cash transactions carry a descriptive label (Investment/Loan) and description so it's clear what each one paid for. #240
 
 ### Fixed
+- Expandable transaction rows on the currency, stock, and bond account details pages are now keyboard-accessible — each row exposes a button role and toggles open/closed on Enter or Space. #247
 - Guest stock account no longer shows "Stock price unavailable" on every entry — the demo seeder now stores a real ISIN and a matching `StockDetails` row so the ticker resolves from the local sandbox instead of falling through to OpenFIGI. #222
 - Guest dashboard's net cash flow card no longer times out — stock price lookups now preload in bulk per ticker instead of one external resolve per entry. #208
 - Dashboard and asset pages no longer make an external OpenFIGI request for every stock price lookup — ticker→ISIN resolution is now cached in memory and served from local `StockDetails` first, with OpenFIGI as last-resort fallback.

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor
@@ -9,7 +9,7 @@
         <AccountDetailsPageContentSkeleton />
     }
 }
-else if (IsLoading || Account.Entries.Any())
+else if (IsLoading || Account.Entries?.Any() == true)
 {
     <AccountDetailsHero AccountName="@Account.Name"
                         AccountTypeLabel="@_accountTypeLabel"
@@ -110,7 +110,7 @@ else if (IsLoading || Account.Entries.Any())
         </MudPaper>
     </MudOverlay>
 }
-else if (!Account.Entries.Any())
+else if (Account.Entries?.Any() != true)
 {
     <AddBondEntry BondAccount=Account ActionCompleted="HideAddOverlay">
         <CustomButton>

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondAccountDetailsPageContent.razor.cs
@@ -242,10 +242,17 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
 
     private void AccountDataSynchronizationService_AccountsChanged()
     {
-        Task.Run(async () =>
+        _ = InvokeAsync(async () =>
         {
-            await UpdateEntries();
-            await InvokeAsync(StateHasChanged);
+            try
+            {
+                await UpdateEntries();
+                StateHasChanged();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error while refreshing bond account details after data sync for account ID {AccountId}", AccountId);
+            }
         });
     }
 

--- a/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondTransactionRow.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/BondAccountComponents/BondTransactionRow.razor
@@ -1,6 +1,7 @@
 @using FinanceManager.Domain.Entities.Bonds
 
-<div class="d-flex align-start pa-2 mud-list-item-clickable" style="cursor: pointer;" @onclick="ToggleExpanded">
+<div class="d-flex align-start pa-2 mud-list-item-clickable" style="cursor: pointer;"
+     role="button" tabindex="0" @onclick="ToggleExpanded" @onkeydown="OnKeyDown">
     <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Start" Class="w-100">
         @if (!IsMobile)
         {
@@ -99,7 +100,6 @@
     [Parameter] public required BondAccount Account { get; set; }
     [Parameter] public required BondAccountEntry Entry { get; set; }
     [Parameter] public BondDetails? BondDetails { get; set; }
-    [Parameter] public EventCallback OnEntryChanged { get; set; }
     [Parameter] public bool IsMobile { get; set; }
 
     [Inject] public required FinanceManager.Components.Services.IFinancialAccountService FinancialAccountService { get; set; }
@@ -107,6 +107,12 @@
     [Inject] public required Microsoft.Extensions.Logging.ILogger<BondTransactionRow> Logger { get; set; }
 
     private void ToggleExpanded() => _expanded = !_expanded;
+
+    private void OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or " " or "Spacebar")
+            ToggleExpanded();
+    }
 
     private string GetTitle() =>
         BondDetails is not null && !string.IsNullOrWhiteSpace(BondDetails.Name) ? BondDetails.Name : "Bond";
@@ -155,7 +161,6 @@
         }
 
         await AccountDataSynchronizationService.AccountChanged();
-        await OnEntryChanged.InvokeAsync();
         await InvokeAsync(StateHasChanged);
     }
 }

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor
@@ -8,7 +8,7 @@
         <AccountDetailsPageContentSkeleton />
     }
 }
-else if (IsLoading || Account.Entries.Any())
+else if (IsLoading || Account.Entries?.Any() == true)
 {
     <AccountDetailsHero AccountName="@Account.Name"
                         AccountTypeLabel="@_accountTypeLabel"
@@ -109,7 +109,7 @@ else if (IsLoading || Account.Entries.Any())
         </MudPaper>
     </MudOverlay>
 }
-else if (!Account.Entries.Any())
+else if (Account.Entries?.Any() != true)
 {
     <AddCurrencyEntry CurrencyAccount=Account ActionCompleted="HideAddOverlay">
         <CustomButton>

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/CurrencyAccountDetailsPageContent.razor.cs
@@ -232,10 +232,17 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
 
     private void AccountDataSynchronizationService_AccountsChanged()
     {
-        Task.Run(async () =>
+        _ = InvokeAsync(async () =>
         {
-            await UpdateEntries();
-            await InvokeAsync(StateHasChanged);
+            try
+            {
+                await UpdateEntries();
+                StateHasChanged();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error while refreshing currency account details after data sync for account ID {AccountId}", AccountId);
+            }
         });
     }
 

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/TransactionRow.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/TransactionRow.razor
@@ -2,7 +2,8 @@
 @using FinanceManager.Domain.Entities.FinancialAccounts.Currencies
 @using FinanceManager.Domain.Entities.Shared.Accounts
 
-<div class="d-flex align-start pa-2 mud-list-item-clickable" style="cursor: pointer;" @onclick="ToggleExpanded">
+<div class="d-flex align-start pa-2 mud-list-item-clickable" style="cursor: pointer;"
+     role="button" tabindex="0" @onclick="ToggleExpanded" @onkeydown="OnKeyDown">
     <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Start" Class="w-100">
         @if (!IsMobile)
         {
@@ -101,7 +102,6 @@
     [Parameter] public required CurrencyAccount Account { get; set; }
     [Parameter] public required CurrencyAccountEntry Entry { get; set; }
     [Parameter] public required string Currency { get; set; }
-    [Parameter] public EventCallback OnEntryChanged { get; set; }
     [Parameter] public bool IsMobile { get; set; }
 
     [Inject] public required FinanceManager.Components.Services.IFinancialAccountService FinancialAccountService { get; set; }
@@ -109,6 +109,12 @@
     [Inject] public required Microsoft.Extensions.Logging.ILogger<TransactionRow> Logger { get; set; }
 
     private void ToggleExpanded() => _expanded = !_expanded;
+
+    private void OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or " " or "Spacebar")
+            ToggleExpanded();
+    }
 
     private string GetTitle()
     {
@@ -167,7 +173,6 @@
         }
 
         await AccountDataSynchronizationService.AccountChanged();
-        await OnEntryChanged.InvokeAsync();
         await InvokeAsync(StateHasChanged);
     }
 }

--- a/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsPageContent.razor
@@ -9,7 +9,7 @@
         <AccountDetailsPageContentSkeleton />
     }
 }
-else if (IsLoading || Account.Entries.Any())
+else if (IsLoading || Account.Entries?.Any() == true)
 {
     <AccountDetailsHero AccountName="@Account.Name"
                         AccountTypeLabel="@_accountTypeLabel"
@@ -107,7 +107,7 @@ else if (IsLoading || Account.Entries.Any())
         </MudPaper>
     </MudOverlay>
 }
-else if (!Account.Entries.Any())
+else if (Account.Entries?.Any() != true)
 {
     <AddStockEntry InvestmentAccount=Account ActionCompleted="HideAddOverlay" Tickers=@_availableStocks>
         <CustomButton>

--- a/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockAccountDetailsPageContent.razor.cs
@@ -236,10 +236,17 @@ public partial class StockAccountDetailsPageContent : ComponentBase, IAsyncDispo
 
     private void AccountDataSynchronizationService_AccountsChanged()
     {
-        Task.Run(async () =>
+        _ = InvokeAsync(async () =>
         {
-            await UpdateEntries();
-            await InvokeAsync(StateHasChanged);
+            try
+            {
+                await UpdateEntries();
+                StateHasChanged();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Error while refreshing stock account details after data sync for account ID {AccountId}", AccountId);
+            }
         });
     }
 

--- a/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockTransactionRow.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/StockAccountComponents/StockTransactionRow.razor
@@ -1,6 +1,7 @@
 @using FinanceManager.Domain.Entities.Stocks
 
-<div class="d-flex align-start pa-2 mud-list-item-clickable" style="cursor: pointer;" @onclick="ToggleExpanded">
+<div class="d-flex align-start pa-2 mud-list-item-clickable" style="cursor: pointer;"
+     role="button" tabindex="0" @onclick="ToggleExpanded" @onkeydown="OnKeyDown">
     <MudStack Row="true" Spacing="3" AlignItems="AlignItems.Start" Class="w-100">
         @if (!IsMobile)
         {
@@ -92,7 +93,6 @@
 
     [Parameter] public required StockAccount Account { get; set; }
     [Parameter] public required StockAccountEntry Entry { get; set; }
-    [Parameter] public EventCallback OnEntryChanged { get; set; }
     [Parameter] public bool IsMobile { get; set; }
 
     [Inject] public required FinanceManager.Components.Services.IFinancialAccountService FinancialAccountService { get; set; }
@@ -100,6 +100,12 @@
     [Inject] public required Microsoft.Extensions.Logging.ILogger<StockTransactionRow> Logger { get; set; }
 
     private void ToggleExpanded() => _expanded = !_expanded;
+
+    private void OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or " " or "Spacebar")
+            ToggleExpanded();
+    }
 
     private string GetTitle() =>
         !string.IsNullOrWhiteSpace(Entry.Ticker) ? Entry.Ticker
@@ -148,7 +154,6 @@
         }
 
         await AccountDataSynchronizationService.AccountChanged();
-        await OnEntryChanged.InvokeAsync();
         await InvokeAsync(StateHasChanged);
     }
 }


### PR DESCRIPTION
## Summary

Hardens the three `*AccountDetailsPageContent` pages and their transaction-row components (currency, stock, bond) so they stay aligned, per the CodeRabbit findings tracked in #247.

- **Sync callback no longer fire-and-forget.** `AccountDataSynchronizationService_AccountsChanged` now schedules on the renderer via `InvokeAsync` wrapped in `try/catch` that logs failures, instead of `Task.Run(...)` which could swallow exceptions and race with disposal.
- **Keyboard-accessible rows.** Expandable transaction rows now expose `role="button"`, `tabindex="0"`, and an `@onkeydown` handler that toggles open/closed on Enter/Space.
- **Null-safe markup guards.** Page branch conditions use `Account.Entries?.Any()` so a null `Entries` collection can't throw.
- **Removed dead `OnEntryChanged`.** The unused row parameter and its callback invocation are gone — the post-remove refresh already flows through `AccountDataSynchronizationService.AccountChanged()`.

Applied consistently across all three account types (currency, stock, bond).

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors; warnings-as-errors)
- [x] Unit tests pass (331/331)
- [x] Edited files pass `dotnet format --verify-no-changes`
- [ ] Manual: expand/collapse a transaction row via mouse and via keyboard (Enter/Space, Tab focus)
- [ ] Manual: confirm details pages refresh after adding/removing an entry

closes #247

https://claude.ai/code/session_013KC9d3tRRp9aRQJ83UeCHZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013KC9d3tRRp9aRQJ83UeCHZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard accessibility to transaction rows—users can now expand/collapse entries using Enter or Space keys.

* **Bug Fixes**
  * Improved null-safety handling in account details pages to prevent potential crashes when entries data is unavailable.
  * Enhanced event handler scheduling for account data refreshes to ensure reliable state updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->