### PR TITLE
Fix investment rate card separator rendering as tall rectangle #255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ rules agents must follow when updating this file.
 - Guest loan and bond accounts now move in step with cash: the loan is taken out on the guest's first day with its proceeds credited to cash and repaid in equal monthly instalments shown on both accounts, and the bond account buys a fixed amount each month funded by a matching cash outflow. Investment- and loan-related cash transactions carry a descriptive label (Investment/Loan) and description so it's clear what each one paid for. #240
 
 ### Fixed
+- Investment rate card separator no longer renders as a tall grey rectangle — the divider between the chart and the Salary/Investments footer is now pinned to a thin line instead of stretching to fill the card's leftover vertical space. #255
 - Expandable transaction rows on the currency, stock, and bond account details pages are now keyboard-accessible — each row exposes a button role and toggles open/closed on Enter or Space. #247
 - Guest stock account no longer shows "Stock price unavailable" on every entry — the demo seeder now stores a real ISIN and a matching `StockDetails` row so the ticker resolves from the local sandbox instead of falling through to OpenFIGI. #222
 - Guest dashboard's net cash flow card no longer times out — stock price lookups now preload in bulk per ticker instead of one external resolve per entry. #208

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentRateCard.razor
@@ -48,7 +48,8 @@
                 }
             </div>
 
-            <MudDivider Class="my-1" />
+            @* flex-grow:0 keeps the divider a thin line; MudDivider's default flex-grow:1 would stretch it vertically in this flex-column card. *@
+            <MudDivider Class="my-1" Style="flex-grow:0;" />
             <MudGrid Spacing="1">
                 <MudItem xs="6">
                     <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">Salary</MudText>


### PR DESCRIPTION
The card content is a flex column. MudBlazor's .mud-divider defaults to
flex-grow:1 (to fill width in a flex row), which made the divider stretch
vertically to absorb the card's leftover space and render as a tall grey
rectangle. Pin the divider with flex-grow:0 so it stays a thin line.