### PR TITLE
Fix investment paycheck card info button click handling #227

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ rules agents must follow when updating this file.
 - Guest loan and bond accounts now move in step with cash: the loan is taken out on the guest's first day with its proceeds credited to cash and repaid in equal monthly instalments shown on both accounts, and the bond account buys a fixed amount each month funded by a matching cash outflow. Investment- and loan-related cash transactions carry a descriptive label (Investment/Loan) and description so it's clear what each one paid for. #240
 
 ### Fixed
+- Investment paycheck card's top-right "i" info badge now opens its definitions popover when clicked — the activator icon button was swallowing the click so the tooltip never appeared. #227
 - Expandable transaction rows on the currency, stock, and bond account details pages are now keyboard-accessible — each row exposes a button role and toggles open/closed on Enter or Space. #247
 - Guest stock account no longer shows "Stock price unavailable" on every entry — the demo seeder now stores a real ISIN and a matching `StockDetails` row so the ticker resolves from the local sandbox instead of falling through to OpenFIGI. #222
 - Guest dashboard's net cash flow card no longer times out — stock price lookups now preload in bulk per ticker instead of one external resolve per entry. #208

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentPaycheckEstimatorCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/InvestmentPaycheckEstimatorCard.razor
@@ -7,9 +7,10 @@
                 <MudText Typo="Typo.h6" Class="pc-title">Investment paycheck</MudText>
                 <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight"
                          PopoverClass="pc-info-popover" Dense="true">
-                    <ActivatorContent>
+                    <ActivatorContent Context="menuContext">
                         <MudIconButton Icon="@Icons.Material.Outlined.Info" Size="Size.Small" Color="Color.Default"
-                                       aria-label="What do these numbers mean?" Class="pc-info-btn" />
+                                       aria-label="What do these numbers mean?" Class="pc-info-btn"
+                                       OnClick="@menuContext.ToggleAsync" />
                     </ActivatorContent>
                     <ChildContent>
                         <div class="pc-info-pop">


### PR DESCRIPTION
## Summary
The investment paycheck card's info badge (top-right "i" icon) was not opening its definitions popover when clicked. The issue was that the `MudIconButton` activator was consuming the click event without triggering the menu toggle.

## Changes
- Added `Context="menuContext"` to the `<ActivatorContent>` tag to expose the menu context
- Added `OnClick="@menuContext.ToggleAsync"` to the `MudIconButton` to explicitly toggle the popover when the icon is clicked
- Updated `CHANGELOG.md` with a fixed entry describing the issue and resolution

## Implementation Details
The `MudMenu` component in MUD (Material UI for Blazor) requires the activator content to explicitly call `ToggleAsync()` on the menu context to open/close the popover. Without this, the button click was being handled but the menu state was not being toggled, leaving the popover hidden.

Closes #227

https://claude.ai/code/session_01Y4vinarvad1LAwfoyumf8f