### PR TITLE
Populate guest demo account with sample financial insights #259

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ rules agents must follow when updating this file.
 
 ### Added
 - Admin log viewer: warnings and errors emitted by the API are now persisted to the database and surfaced in the admin panel as a "Recent warnings & errors" dashboard widget and a full `/Admin/Logs` page with warning/error filtering and pagination. A retention background service purges entries older than the configured cutoff (default 30 days) on API start and once a day, and a SignalR hub pushes new entries to the UI live. #212
+- Guest demo account now seeds three sample financial insights so the dashboard Insights card is populated instead of empty when trying out the app. #259
 
 ### Changed
 - Recurring transactions card tightened: reduced dead space between the header and the transaction list, denser list rows, and the details view now shows the transaction title inline with the back-arrow button instead of stacked below it. #253

--- a/code/FinanceManager.Application/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Application/ServiceCollectionExtension.cs
@@ -50,6 +50,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<CurrencyAccountSeeder>()
                 .AddScoped<StockAccountSeeder>()
                 .AddScoped<BondAccountSeeder>()
+                .AddScoped<FinancialInsightsSeeder>()
                 .AddScoped<FinancialLabelSeeder>()
                 .AddScoped<BondDetailsSeeder>()
                 .AddScoped<ISeeder, AdminAccountSeeder>()

--- a/code/FinanceManager.Application/Services/Seeders/FinancialInsightsSeeder.cs
+++ b/code/FinanceManager.Application/Services/Seeders/FinancialInsightsSeeder.cs
@@ -8,7 +8,20 @@ namespace FinanceManager.Application.Services.Seeders;
 public class FinancialInsightsSeeder(IFinancialInsightsRepository financialInsightsRepository, IUserRepository userRepository,
     IConfiguration configuration, ILogger<FinancialInsightsSeeder> logger) : ISeeder
 {
-    private static readonly string[] _tagPool = ["summary", "portfolio", "cashflow", "allocation", "risk", "trend"];
+    // Hand-written demo insights so the dashboard "Financial insights" card looks populated for the guest/demo
+    // account, where the AI generator is not run. Tags must match the lowercase chips the carousel renders.
+    private static readonly (string Title, string Message, string Tags)[] _demoInsights =
+    [
+        ("Spending stayed within budget",
+            "Your cash outflows over the last month were about 8% lower than your six-month average, leaving more room to save.",
+            "cashflow,summary"),
+        ("Portfolio leans towards equities",
+            "Stocks make up the largest share of your invested assets. Review whether this allocation still matches your risk tolerance.",
+            "portfolio,allocation,risk"),
+        ("Your bond ladder is building steadily",
+            "Regular monthly bond purchases are creating a steady stream of future maturities, smoothing out reinvestment risk over time.",
+            "portfolio,trend"),
+    ];
 
     public async Task Seed(CancellationToken cancellationToken = default)
     {
@@ -26,32 +39,33 @@ public class FinancialInsightsSeeder(IFinancialInsightsRepository financialInsig
             return;
         }
 
-        if (await financialInsightsRepository.GetCountByUser(guestUser.UserId, cancellationToken) > 0)
+        await SeedForGuest(guestUser.UserId, cancellationToken);
+    }
+
+    // Seeds the demo insights for a specific (per-session) guest user. Called from GuestAccountSeeder so the
+    // insights card is populated for the throwaway in-memory guest DB created at login.
+    public async Task SeedForGuest(int guestUserId, CancellationToken cancellationToken = default)
+    {
+        if (await financialInsightsRepository.GetCountByUser(guestUserId, cancellationToken) > 0)
             return;
 
         var now = DateTime.UtcNow.Date;
         var insights = new List<FinancialInsight>();
 
-        for (var i = 0; i < 3; i++)
+        for (var i = 0; i < _demoInsights.Length; i++)
         {
+            var (title, message, tags) = _demoInsights[i];
             insights.Add(new FinancialInsight
             {
-                UserId = guestUser.UserId,
+                UserId = guestUserId,
                 AccountId = null,
-                Title = "Lorem ipsum",
-                Message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                Tags = GenerateTags(),
-                CreatedAt = now.AddDays(-2 + i)
+                Title = title,
+                Message = message,
+                Tags = tags,
+                CreatedAt = now.AddDays(-(_demoInsights.Length - 1) + i)
             });
         }
 
         await financialInsightsRepository.AddRange(insights, cancellationToken);
-    }
-
-    private static string GenerateTags()
-    {
-        var first = _tagPool[Random.Shared.Next(_tagPool.Length)];
-        var second = _tagPool[Random.Shared.Next(_tagPool.Length)];
-        return first == second ? first : $"{first},{second}";
     }
 }

--- a/code/FinanceManager.Application/Services/Seeders/GuestAccountSeeder.cs
+++ b/code/FinanceManager.Application/Services/Seeders/GuestAccountSeeder.cs
@@ -11,6 +11,7 @@ public class GuestAccountSeeder(
     CurrencyAccountSeeder currencyAccountSeeder,
     StockAccountSeeder stockAccountSeeder,
     BondAccountSeeder bondAccountSeeder,
+    FinancialInsightsSeeder financialInsightsSeeder,
     ILogger<GuestAccountSeeder> logger)
 {
     public async Task SeedForGuest(int guestUserId, CancellationToken cancellationToken = default)
@@ -28,6 +29,7 @@ public class GuestAccountSeeder(
         await currencyAccountSeeder.Seed(guestUserId, start, end, cancellationToken);
         await stockAccountSeeder.Seed(guestUserId, start, end, cancellationToken);
         await bondAccountSeeder.Seed(guestUserId, start, end, cancellationToken);
+        await financialInsightsSeeder.SeedForGuest(guestUserId, cancellationToken);
         logger.LogTrace("Seeding finished.");
     }
 


### PR DESCRIPTION
## Summary
The guest demo account now seeds three hand-written sample financial insights so the dashboard Insights card displays populated content instead of appearing empty when users try out the app.

## Changes
- **FinancialInsightsSeeder**: Replaced placeholder Lorem Ipsum insights with three realistic demo insights covering spending, portfolio allocation, and bond laddering. Removed the random tag generator and replaced it with a static `_demoInsights` array containing pre-written titles, messages, and tags.
- **FinancialInsightsSeeder.SeedForGuest()**: Extracted the guest seeding logic into a public method so it can be called from `GuestAccountSeeder` during the per-session guest DB initialization.
- **GuestAccountSeeder**: Added `FinancialInsightsSeeder` dependency and now calls `SeedForGuest()` as part of the guest account setup pipeline, ensuring insights are populated alongside accounts and transactions.
- **ServiceCollectionExtension**: Registered `FinancialInsightsSeeder` as a scoped service so it can be injected into `GuestAccountSeeder`.
- **CHANGELOG.md**: Added entry documenting the new demo insights feature.

## Implementation Details
- Tags in the demo insights are lowercase and match the chips rendered by the carousel component.
- Insights are backdated by 0–2 days to simulate a realistic timeline.
- The seeding is idempotent: if insights already exist for the guest user, the method returns early.

Closes #259

https://claude.ai/code/session_01CSbCG7QXahwxaDFAC4DMaM