### PR TITLE
Show held asset classes and holdings on diversification card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Asset diversification card now has a "Show holdings" view that lists your current holdings grouped by asset class — stock tickers, bond names, and cash — loaded on demand when you expand the card. #264
 - Admin log viewer: warnings and errors emitted by the API are now persisted to the database and surfaced in the admin panel as a "Recent warnings & errors" dashboard widget and a full `/Admin/Logs` page with warning/error filtering and pagination. A retention background service purges entries older than the configured cutoff (default 30 days) on API start and once a day, and a SignalR hub pushes new entries to the UI live. #212
 - Guest demo account now seeds three sample financial insights so the dashboard Insights card is populated instead of empty when trying out the app. #259
 

--- a/code/FinanceManager.Api/Controllers/DiversificationController.cs
+++ b/code/FinanceManager.Api/Controllers/DiversificationController.cs
@@ -27,4 +27,20 @@ public class DiversificationController(IDiversificationService diversificationSe
 
         return Ok(await diversificationService.GetDiversificationScore(userId, asOfDate));
     }
+
+    [HttpGet("{userId:int}/{asOfDate:DateTime}/breakdown")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DiversificationBreakdown))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetDiversificationBreakdown(int userId, DateTime asOfDate, CancellationToken cancellationToken = default)
+    {
+        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(userIdClaim) || !int.TryParse(userIdClaim, out var authenticatedUserId))
+            return Forbid();
+
+        if (authenticatedUserId != userId)
+            return Forbid();
+
+        return Ok(await diversificationService.GetDiversificationBreakdown(userId, asOfDate, cancellationToken));
+    }
 }

--- a/code/FinanceManager.Application/Services/DiversificationService.cs
+++ b/code/FinanceManager.Application/Services/DiversificationService.cs
@@ -3,12 +3,16 @@ using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
 using FinanceManager.Domain.Entities.MoneyFlowModels;
 using FinanceManager.Domain.Entities.Stocks;
 using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
 using FinanceManager.Domain.Repositories.Account;
 using FinanceManager.Domain.Services;
 
 namespace FinanceManager.Application.Services;
 
-public class DiversificationService(IFinancialAccountRepository financialAccountRepository) : IDiversificationService
+public class DiversificationService(
+    IFinancialAccountRepository financialAccountRepository,
+    IStockDetailsRepository stockDetailsRepository,
+    IBondDetailsRepository bondDetailsRepository) : IDiversificationService
 {
     private const int _totalSupportedClasses = 6;
     private const int _holdingsBenchmark = 30;
@@ -22,6 +26,78 @@ public class DiversificationService(IFinancialAccountRepository financialAccount
         var totalScore = assetClassScore + holdingsScore;
 
         return new DiversificationScore(totalScore, assetClassScore, holdingsScore, GetBand(totalScore));
+    }
+
+    public async Task<DiversificationBreakdown> GetDiversificationBreakdown(int userId, DateTime asOfDate, CancellationToken cancellationToken = default)
+    {
+        var groups = new List<AssetClassHoldings>();
+
+        var stockHoldings = await GetStockHoldingNames(userId, asOfDate, cancellationToken);
+        if (stockHoldings.Count > 0)
+            groups.Add(new AssetClassHoldings("Stocks", stockHoldings));
+
+        var bondHoldings = await GetBondHoldingNames(userId, asOfDate, cancellationToken);
+        if (bondHoldings.Count > 0)
+            groups.Add(new AssetClassHoldings("Bonds", bondHoldings));
+
+        if (await HasAnyCash(userId, asOfDate))
+            groups.Add(new AssetClassHoldings("Cash", ["Cash"]));
+
+        return new DiversificationBreakdown(groups);
+    }
+
+    private async Task<List<string>> GetStockHoldingNames(int userId, DateTime asOfDate, CancellationToken cancellationToken)
+    {
+        var isins = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        await foreach (var account in financialAccountRepository.GetAccounts<StockAccount>(userId, DateTime.MinValue, asOfDate))
+            foreach (var isin in GetCurrentlyHeldTickers(account, asOfDate))
+                if (seen.Add(isin))
+                    isins.Add(isin);
+
+        if (isins.Count == 0) return [];
+
+        var tickerByIsin = (await stockDetailsRepository.GetAll(cancellationToken))
+            .Where(details => !string.IsNullOrWhiteSpace(details.Isin))
+            .GroupBy(details => details.Isin, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First().Ticker, StringComparer.OrdinalIgnoreCase);
+
+        return [.. isins
+            .Select(isin => tickerByIsin.TryGetValue(isin, out var ticker) && !string.IsNullOrWhiteSpace(ticker) ? ticker : isin)
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    private async Task<List<string>> GetBondHoldingNames(int userId, DateTime asOfDate, CancellationToken cancellationToken)
+    {
+        var bondIds = new List<int>();
+        var seen = new HashSet<int>();
+
+        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, DateTime.MinValue, asOfDate))
+            foreach (var bondId in GetCurrentlyHeldBondIds(account, asOfDate))
+                if (seen.Add(bondId))
+                    bondIds.Add(bondId);
+
+        if (bondIds.Count == 0) return [];
+
+        var names = new List<string>();
+        foreach (var bondId in bondIds)
+        {
+            var details = await bondDetailsRepository.GetByIdAsync(bondId, cancellationToken);
+            names.Add(details is not null && !string.IsNullOrWhiteSpace(details.Name) ? details.Name : $"Bond #{bondId}");
+        }
+
+        names.Sort(StringComparer.OrdinalIgnoreCase);
+        return names;
+    }
+
+    private async Task<bool> HasAnyCash(int userId, DateTime asOfDate)
+    {
+        await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, DateTime.MinValue, asOfDate))
+            if (HasCurrentCash(account, asOfDate))
+                return true;
+
+        return false;
     }
 
     private async Task<(HashSet<InvestmentType> AssetClasses, HashSet<string> Holdings)> GetCurrentHoldings(int userId, DateTime asOfDate)

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor
@@ -15,71 +15,125 @@
                 <ChartSpinner MaxHeight=@Height />
             </div>
         }
-        else if (_score is not null)
+        else if (_score is not null && !_showDetails)
         {
-            <div class="diversification-card__body" style="@_bandStyle">
-                <div class="diversification-card__gauge">
-                    <div class="diversification-card__gaugewrap">
-                        <svg viewBox="0 0 200 108" width="100%" preserveAspectRatio="xMidYMid meet" role="img"
-                             aria-label="@($"Diversification score {_score.Score} out of 100, {_score.Band}")">
-                            <path d="@_trackPath" fill="none" stroke="var(--track)" stroke-width="13" stroke-linecap="round" />
-                            <path d="@_valuePath" fill="none" stroke="var(--c)" stroke-width="13" stroke-linecap="round" />
-                            @foreach (var tick in _ticks)
-                            {
-                                <circle cx="@tick.X" cy="@tick.Y" r="2.1"
-                                        fill="var(--mud-palette-surface)" stroke="var(--track-strong)" stroke-width="1.5" />
-                            }
-                        </svg>
-                        <div class="diversification-card__gaugecenter">
-                            <div class="diversification-card__score">@_score.Score</div>
-                            <div class="diversification-card__of">out of 100</div>
+            <div class="diversification-card__main">
+                <div class="diversification-card__body" style="@_bandStyle">
+                    <div class="diversification-card__gauge">
+                        <div class="diversification-card__gaugewrap">
+                            <svg viewBox="0 0 200 108" width="100%" preserveAspectRatio="xMidYMid meet" role="img"
+                                 aria-label="@($"Diversification score {_score.Score} out of 100, {_score.Band}")">
+                                <path d="@_trackPath" fill="none" stroke="var(--track)" stroke-width="13" stroke-linecap="round" />
+                                <path d="@_valuePath" fill="none" stroke="var(--c)" stroke-width="13" stroke-linecap="round" />
+                                @foreach (var tick in _ticks)
+                                {
+                                    <circle cx="@tick.X" cy="@tick.Y" r="2.1"
+                                            fill="var(--mud-palette-surface)" stroke="var(--track-strong)" stroke-width="1.5" />
+                                }
+                            </svg>
+                            <div class="diversification-card__gaugecenter">
+                                <div class="diversification-card__score">@_score.Score</div>
+                                <div class="diversification-card__of">out of 100</div>
+                            </div>
+                        </div>
+                        <div class="diversification-card__band">@_score.Band</div>
+                    </div>
+
+                    <div class="diversification-card__break">
+                        <div class="diversification-card__overline">Built from</div>
+                        <div class="diversification-card__compbar">
+                            <div class="diversification-card__seg diversification-card__seg--primary"
+                                 style="@($"width:{_score.AssetClassScore}%")"></div>
+                            <div class="diversification-card__seg diversification-card__seg--secondary"
+                                 style="@($"width:{_score.HoldingsScore}%")"></div>
+                        </div>
+                        <div class="diversification-card__keys">
+                            <span><span class="diversification-card__dot diversification-card__dot--primary"></span>Asset classes <b>@_score.AssetClassScore</b></span>
+                            <span><span class="diversification-card__dot diversification-card__dot--secondary"></span>Holdings <b>@_score.HoldingsScore</b></span>
                         </div>
                     </div>
-                    <div class="diversification-card__band">@_score.Band</div>
                 </div>
 
-                <div class="diversification-card__break">
-                    <div class="diversification-card__overline">Built from</div>
-                    <div class="diversification-card__compbar">
-                        <div class="diversification-card__seg diversification-card__seg--primary"
-                             style="@($"width:{_score.AssetClassScore}%")"></div>
-                        <div class="diversification-card__seg diversification-card__seg--secondary"
-                             style="@($"width:{_score.HoldingsScore}%")"></div>
-                    </div>
-                    <div class="diversification-card__keys">
-                        <span><span class="diversification-card__dot diversification-card__dot--primary"></span>Asset classes <b>@_score.AssetClassScore</b></span>
-                        <span><span class="diversification-card__dot diversification-card__dot--secondary"></span>Holdings <b>@_score.HoldingsScore</b></span>
-                    </div>
+                <div class="diversification-card__legend" role="list" aria-label="Diversification bands">
+                    @foreach (var band in _bands)
+                    {
+                        <div role="listitem"
+                             class="@($"diversification-card__pill{(band.Key == _bandKey ? " diversification-card__pill--current" : "")}")"
+                             style="@BandVars(band.Key)">
+                            <span class="diversification-card__pilldot"></span>
+                            <span>@band.Label</span>
+                        </div>
+                    }
                 </div>
-            </div>
 
-            <div class="diversification-card__legend" role="list" aria-label="Diversification bands">
-                @foreach (var band in _bands)
+                @if (_explanations.Count > 0)
                 {
-                    <div role="listitem"
-                         class="@($"diversification-card__pill{(band.Key == _bandKey ? " diversification-card__pill--current" : "")}")"
-                         style="@BandVars(band.Key)">
-                        <span class="diversification-card__pilldot"></span>
-                        <span>@band.Label</span>
+                    <div class="diversification-card__insight" style="@_bandStyle">
+                        <svg class="diversification-card__insighticon" width="16" height="16" viewBox="0 0 24 24"
+                             fill="var(--c)" aria-hidden="true">
+                            <path d="@_insightGlyphPath" />
+                        </svg>
+                        <div class="diversification-card__insightlines">
+                            @foreach (var explanation in _explanations)
+                            {
+                                <p>@explanation</p>
+                            }
+                        </div>
                     </div>
                 }
             </div>
 
-            @if (_explanations.Count > 0)
+            @if (_score.Score > 0)
             {
-                <div class="diversification-card__insight" style="@_bandStyle">
-                    <svg class="diversification-card__insighticon" width="16" height="16" viewBox="0 0 24 24"
-                         fill="var(--c)" aria-hidden="true">
-                        <path d="@_insightGlyphPath" />
-                    </svg>
-                    <div class="diversification-card__insightlines">
-                        @foreach (var explanation in _explanations)
-                        {
-                            <p>@explanation</p>
-                        }
-                    </div>
+                <div class="diversification-card__footer">
+                    <MudButton Variant="Variant.Text" Size="MudBlazor.Size.Small"
+                               EndIcon="@Icons.Material.Filled.ChevronRight" OnClick="ShowDetails">Show holdings</MudButton>
                 </div>
             }
+        }
+        else if (_score is not null && _showDetails)
+        {
+            <div class="diversification-card__details">
+                <button type="button" class="diversification-card__back" @onclick="HideDetails" aria-label="Back to diversification score">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                        <path d="M15.41 7.41 14 6l-6 6 6 6 1.41-1.41L10.83 12z" />
+                    </svg>
+                    <span>Holdings</span>
+                </button>
+
+                @if (_breakdownLoading)
+                {
+                    <div class="diversification-card__center">
+                        <ChartSpinner MaxHeight="180px" />
+                    </div>
+                }
+                else if (_breakdown is not null && _breakdown.AssetClasses.Count > 0)
+                {
+                    <div class="diversification-card__detaillist">
+                        @foreach (var group in _breakdown.AssetClasses)
+                        {
+                            <div class="diversification-card__group">
+                                <div class="diversification-card__grouphead">
+                                    <span>@group.AssetClass</span>
+                                    <span class="diversification-card__groupcount">@group.Holdings.Count</span>
+                                </div>
+                                <div class="diversification-card__chips">
+                                    @foreach (var holding in group.Holdings)
+                                    {
+                                        <span class="diversification-card__chip">@holding</span>
+                                    }
+                                </div>
+                            </div>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <div class="diversification-card__center">
+                        <span class="diversification-card__emptydetails">No holdings to show.</span>
+                    </div>
+                }
+            </div>
         }
         else
         {

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor.cs
@@ -36,6 +36,12 @@ public partial class DiversificationProxyCard
     private string _valuePath = "";
     private List<(string X, string Y)> _ticks = [];
 
+    private int? _userId;
+    private DateTime _asOfDate = DateTime.UtcNow;
+    private bool _showDetails;
+    private bool _breakdownLoading;
+    private DiversificationBreakdown? _breakdown;
+
     [Parameter] public string Height { get; set; } = "300px";
 
     [Inject] public required ILogger<DiversificationProxyCard> Logger { get; set; }
@@ -61,7 +67,9 @@ public partial class DiversificationProxyCard
                 return;
             }
 
-            _score = await DiversificationHttpClient.GetDiversificationScore(user.UserId, DateTime.UtcNow);
+            _userId = user.UserId;
+            _asOfDate = DateTime.UtcNow;
+            _score = await DiversificationHttpClient.GetDiversificationScore(_userId.Value, _asOfDate);
             if (_score is null) return;
 
             _bandKey = _score.Band.ToLowerInvariant();
@@ -83,6 +91,29 @@ public partial class DiversificationProxyCard
 
     // Inline-style custom properties so a single band drives every band-coloured element.
     private static string BandVars(string key) => $"--c:var(--band-{key});--cs:var(--band-{key}-soft);";
+
+    private async Task ShowDetails()
+    {
+        _showDetails = true;
+
+        if (_breakdown is not null || _userId is null) return;
+
+        _breakdownLoading = true;
+        try
+        {
+            _breakdown = await DiversificationHttpClient.GetDiversificationBreakdown(_userId.Value, _asOfDate);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading diversification breakdown");
+        }
+        finally
+        {
+            _breakdownLoading = false;
+        }
+    }
+
+    private void HideDetails() => _showDetails = false;
 
     private void BuildGauge(int score)
     {

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor.css
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor.css
@@ -16,7 +16,7 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 12px;
     padding: 18px 18px 16px;
     container-type: inline-size;
 }
@@ -63,7 +63,7 @@
 .diversification-card__gaugewrap {
     position: relative;
     width: 100%;
-    max-width: 188px;
+    max-width: 158px;
     margin: 0 auto;
 }
 
@@ -252,6 +252,114 @@
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+/* ---- Default face: scrollable middle + pinned footer ---- */
+.diversification-card__main {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+/* ---- Footer "Show holdings" affordance ---- */
+.diversification-card__footer {
+    display: flex;
+    justify-content: center;
+}
+
+/* ---- Holdings details view ---- */
+.diversification-card__details {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.diversification-card__back {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin: 0;
+    padding: 2px 6px 2px 0;
+    border: 0;
+    background: none;
+    cursor: pointer;
+    border-radius: 6px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--mud-palette-text-secondary);
+    transition: color 0.15s;
+}
+
+.diversification-card__back:hover {
+    color: var(--mud-palette-text-primary);
+}
+
+.diversification-card__detaillist {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding-right: 4px;
+}
+
+.diversification-card__group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.diversification-card__grouphead {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--mud-palette-text-secondary);
+}
+
+.diversification-card__groupcount {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 9px;
+    background: var(--track);
+    font-size: 10.5px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+}
+
+.diversification-card__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.diversification-card__chip {
+    padding: 3px 9px;
+    border-radius: 6px;
+    background: var(--track);
+    color: var(--mud-palette-text-primary);
+    font-size: 12px;
+    line-height: 1.5;
+}
+
+.diversification-card__emptydetails {
+    font-size: 13px;
+    color: var(--mud-palette-text-secondary);
 }
 
 /* ---- Responsive: row layout once the card itself is wide enough ---- */

--- a/code/FinanceManager.Components/HttpClients/DiversificationHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/DiversificationHttpClient.cs
@@ -11,4 +11,11 @@ public class DiversificationHttpClient(HttpClient httpClient)
             $"{httpClient.BaseAddress}api/Diversification/{userId}/{asOfDate:O}");
         return result;
     }
+
+    public async Task<DiversificationBreakdown?> GetDiversificationBreakdown(int userId, DateTime asOfDate)
+    {
+        var result = await httpClient.GetFromJsonAsync<DiversificationBreakdown>(
+            $"{httpClient.BaseAddress}api/Diversification/{userId}/{asOfDate:O}/breakdown");
+        return result;
+    }
 }

--- a/code/FinanceManager.Domain/Entities/MoneyFlowModels/DiversificationBreakdown.cs
+++ b/code/FinanceManager.Domain/Entities/MoneyFlowModels/DiversificationBreakdown.cs
@@ -1,0 +1,5 @@
+namespace FinanceManager.Domain.Entities.MoneyFlowModels;
+
+public record AssetClassHoldings(string AssetClass, IReadOnlyList<string> Holdings);
+
+public record DiversificationBreakdown(IReadOnlyList<AssetClassHoldings> AssetClasses);

--- a/code/FinanceManager.Domain/Services/IDiversificationService.cs
+++ b/code/FinanceManager.Domain/Services/IDiversificationService.cs
@@ -5,4 +5,6 @@ namespace FinanceManager.Domain.Services;
 public interface IDiversificationService
 {
     Task<DiversificationScore> GetDiversificationScore(int userId, DateTime asOfDate);
+
+    Task<DiversificationBreakdown> GetDiversificationBreakdown(int userId, DateTime asOfDate, CancellationToken cancellationToken = default);
 }

--- a/code/FinanceManager.IntegrationTests/Controllers/DiversificationControllerTests.cs
+++ b/code/FinanceManager.IntegrationTests/Controllers/DiversificationControllerTests.cs
@@ -1,0 +1,126 @@
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.Entities.Bonds;
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.Shared.Accounts;
+using FinanceManager.Domain.Entities.Stocks;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Infrastructure.Contexts;
+using FinanceManager.Infrastructure.Dtos;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace FinanceManager.IntegrationTests.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public class DiversificationControllerTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider), IDisposable
+{
+    private TestDatabase? _testDatabase;
+    private DateTime _nowUtc;
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        _nowUtc = DateTime.UtcNow.Date;
+        _testDatabase = new TestDatabase();
+
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+        if (descriptor != null)
+            services.Remove(descriptor);
+
+        services.AddSingleton(_testDatabase!.Context);
+    }
+
+    private async Task SeedPortfolio()
+    {
+        var stockAccount = new FinancialAccountBaseDto
+        {
+            UserId = 1,
+            AccountId = 1,
+            Name = "Stocks",
+            AccountLabel = AccountLabel.Other,
+            AccountType = AccountType.Stock
+        };
+        var bondAccount = new FinancialAccountBaseDto
+        {
+            UserId = 1,
+            AccountId = 2,
+            Name = "Bonds",
+            AccountLabel = AccountLabel.Other,
+            AccountType = AccountType.Bond
+        };
+        var cashAccount = new FinancialAccountBaseDto
+        {
+            UserId = 1,
+            AccountId = 3,
+            Name = "Cash",
+            AccountLabel = AccountLabel.Cash,
+            AccountType = AccountType.Currency
+        };
+        _testDatabase!.Context.Accounts.AddRange(stockAccount, bondAccount, cashAccount);
+
+        var usd = new Currency(1, "USD", "$");
+        _testDatabase.Context.Currencies.Add(usd);
+        _testDatabase.Context.StockDetails.Add(new StockDetails
+        {
+            Isin = "US0378331005",
+            Ticker = "AAPL",
+            Name = "Apple Inc.",
+            Type = "Stock",
+            Region = "US",
+            Currency = usd
+        });
+
+        var bond = new BondDetails("Treasury 2030", "Test Issuer",
+            DateOnly.FromDateTime(_nowUtc.AddYears(-1)), DateOnly.FromDateTime(_nowUtc.AddYears(5)), [])
+        { Id = 5 };
+        _testDatabase.Context.Bonds.Add(bond);
+        await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        _testDatabase.Context.StockEntries.Add(
+            new StockAccountEntry(1, 1, _nowUtc.AddDays(-3), 100m, 100m, "US0378331005", InvestmentType.Stock));
+        _testDatabase.Context.BondEntries.Add(
+            new BondAccountEntry(2, 1, _nowUtc.AddDays(-3), 1000m, 1000m, 5));
+        _testDatabase.Context.CurrencyEntries.Add(
+            new CurrencyAccountEntry(3, 1, _nowUtc.AddDays(-3), 500m, 500m) { Labels = [] });
+        await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task GetDiversificationBreakdown_ReturnsHoldingsGroupedByClass()
+    {
+        await SeedPortfolio();
+        Authorize("TestUser", 1, UserRole.User);
+
+        var result = await new DiversificationHttpClient(Client).GetDiversificationBreakdown(1, _nowUtc);
+
+        Assert.NotNull(result);
+        Assert.Equal(["Stocks", "Bonds", "Cash"], result.AssetClasses.Select(g => g.AssetClass));
+        Assert.Equal(["AAPL"], result.AssetClasses[0].Holdings);
+        Assert.Equal(["Treasury 2030"], result.AssetClasses[1].Holdings);
+        Assert.Equal(["Cash"], result.AssetClasses[2].Holdings);
+    }
+
+    [Fact]
+    public async Task GetDiversificationBreakdown_EmptyPortfolio_ReturnsNoGroups()
+    {
+        Authorize("EmptyUser", 99, UserRole.User);
+
+        var result = await new DiversificationHttpClient(Client).GetDiversificationBreakdown(99, _nowUtc);
+
+        Assert.NotNull(result);
+        Assert.Empty(result.AssetClasses);
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        if (_testDatabase is null)
+            return;
+
+        _testDatabase.Dispose();
+        _testDatabase = null;
+        GC.SuppressFinalize(this);
+    }
+}

--- a/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/DiversificationServiceTests.cs
@@ -1,9 +1,11 @@
 using FinanceManager.Application.Services;
 using FinanceManager.Domain.Entities.Bonds;
+using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
 using FinanceManager.Domain.Entities.MoneyFlowModels;
 using FinanceManager.Domain.Entities.Stocks;
 using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
 using FinanceManager.Domain.Repositories.Account;
 using Moq;
 
@@ -14,10 +16,17 @@ namespace FinanceManager.UnitTests.Application.Services;
 public class DiversificationServiceTests
 {
     private readonly Mock<IFinancialAccountRepository> _repositoryMock = new();
+    private readonly Mock<IStockDetailsRepository> _stockDetailsMock = new();
+    private readonly Mock<IBondDetailsRepository> _bondDetailsMock = new();
     private readonly DiversificationService _service;
     private readonly DateTime _asOfDate = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-    public DiversificationServiceTests() => _service = new(_repositoryMock.Object);
+    public DiversificationServiceTests()
+    {
+        _stockDetailsMock.Setup(x => x.GetAll(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _service = new(_repositoryMock.Object, _stockDetailsMock.Object, _bondDetailsMock.Object);
+    }
 
     private void SetupStockAccounts(params StockAccount[] accounts) =>
         _repositoryMock.Setup(x => x.GetAccounts<StockAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
@@ -30,6 +39,23 @@ public class DiversificationServiceTests
     private void SetupCurrencyAccounts(params CurrencyAccount[] accounts) =>
         _repositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(accounts.ToAsyncEnumerable());
+
+    private void SetupStockDetails(params StockDetails[] details) =>
+        _stockDetailsMock.Setup(x => x.GetAll(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+    private void SetupBondDetails(params BondDetails[] details)
+    {
+        foreach (var detail in details)
+            _bondDetailsMock.Setup(x => x.GetByIdAsync(detail.Id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(detail);
+    }
+
+    private static StockDetails Stock(string isin, string ticker) =>
+        new() { Isin = isin, Ticker = ticker, Currency = new Currency(1, "USD", "$") };
+
+    private static BondDetails Bond(int id, string name) =>
+        new() { Id = id, Name = name, Type = BondType.InflationBond, Currency = new Currency(1, "PLN", "zł") };
 
     [Fact]
     public async Task GetDiversificationScore_EmptyPortfolio_ReturnsZero()
@@ -317,5 +343,105 @@ public class DiversificationServiceTests
     public void GetBand_MatchesScoreRanges(int score, string expectedBand)
     {
         Assert.Equal(expectedBand, DiversificationService.GetBand(score));
+    }
+
+    [Fact]
+    public async Task GetDiversificationBreakdown_EmptyPortfolio_ReturnsNoGroups()
+    {
+        SetupStockAccounts();
+        SetupBondAccounts();
+        SetupCurrencyAccounts();
+
+        var result = await _service.GetDiversificationBreakdown(1, _asOfDate, TestContext.Current.CancellationToken);
+
+        Assert.Empty(result.AssetClasses);
+    }
+
+    [Fact]
+    public async Task GetDiversificationBreakdown_GroupsHoldingsByClassWithResolvedNames()
+    {
+        var stockAccount = new StockAccount(1, 1, "stocks");
+        stockAccount.Add(new StockAccountEntry(1, 1, _asOfDate, 10, 10, "US0378331005", InvestmentType.Stock), false);
+        stockAccount.Add(new StockAccountEntry(1, 2, _asOfDate, 10, 10, "US5949181045", InvestmentType.Stock), false);
+
+        var bondAccount = new BondAccount(1, 2, "bonds",
+            [new BondAccountEntry(2, 1, _asOfDate, 10m, 10m, 7)], AccountLabel.Other);
+
+        var cashAccount = new CurrencyAccount(1, 3, "cash", AccountLabel.Cash);
+        cashAccount.Add(new CurrencyAccountEntry(3, 1, _asOfDate, 100, 100), false);
+
+        SetupStockAccounts(stockAccount);
+        SetupBondAccounts(bondAccount);
+        SetupCurrencyAccounts(cashAccount);
+        SetupStockDetails(Stock("US0378331005", "AAPL"), Stock("US5949181045", "MSFT"));
+        SetupBondDetails(Bond(7, "Treasury 2030"));
+
+        var result = await _service.GetDiversificationBreakdown(1, _asOfDate, TestContext.Current.CancellationToken);
+
+        Assert.Equal(["Stocks", "Bonds", "Cash"], result.AssetClasses.Select(g => g.AssetClass));
+        Assert.Equal(["AAPL", "MSFT"], result.AssetClasses[0].Holdings);
+        Assert.Equal(["Treasury 2030"], result.AssetClasses[1].Holdings);
+        Assert.Equal(["Cash"], result.AssetClasses[2].Holdings);
+    }
+
+    [Fact]
+    public async Task GetDiversificationBreakdown_UnknownStockIsin_FallsBackToIsin()
+    {
+        var stockAccount = new StockAccount(1, 1, "stocks");
+        stockAccount.Add(new StockAccountEntry(1, 1, _asOfDate, 10, 10, "US0378331005", InvestmentType.Stock), false);
+
+        SetupStockAccounts(stockAccount);
+        SetupBondAccounts();
+        SetupCurrencyAccounts();
+        // No matching StockDetails registered.
+
+        var result = await _service.GetDiversificationBreakdown(1, _asOfDate, TestContext.Current.CancellationToken);
+
+        var stocks = Assert.Single(result.AssetClasses);
+        Assert.Equal("Stocks", stocks.AssetClass);
+        Assert.Equal(["US0378331005"], stocks.Holdings);
+    }
+
+    [Fact]
+    public async Task GetDiversificationBreakdown_UnknownBondId_FallsBackToPlaceholderName()
+    {
+        var bondAccount = new BondAccount(1, 1, "bonds",
+            [new BondAccountEntry(1, 1, _asOfDate, 10m, 10m, 42)], AccountLabel.Other);
+
+        SetupStockAccounts();
+        SetupBondAccounts(bondAccount);
+        SetupCurrencyAccounts();
+        // No matching BondDetails registered → GetByIdAsync returns null.
+
+        var result = await _service.GetDiversificationBreakdown(1, _asOfDate, TestContext.Current.CancellationToken);
+
+        var bonds = Assert.Single(result.AssetClasses);
+        Assert.Equal(["Bond #42"], bonds.Holdings);
+    }
+
+    [Fact]
+    public async Task GetDiversificationBreakdown_SoldOutAndDuplicateHoldings_AreExcludedAndDeduped()
+    {
+        var sellDate = _asOfDate.AddDays(-5);
+
+        var account1 = new StockAccount(1, 1, "stocks-a");
+        account1.Add(new StockAccountEntry(1, 1, _asOfDate, 5, 5, "US0378331005", InvestmentType.Stock), false);
+        // Fully sold position must not appear.
+        account1.Add(new StockAccountEntry(1, 2, _asOfDate.AddDays(-10), 10, 10, "US38259P5089", InvestmentType.Stock), false);
+        account1.Add(new StockAccountEntry(1, 3, sellDate, 0, -10, "US38259P5089", InvestmentType.Stock), false);
+
+        // Same ISIN held in another account must be listed once.
+        var account2 = new StockAccount(1, 2, "stocks-b");
+        account2.Add(new StockAccountEntry(2, 1, _asOfDate, 3, 3, "US0378331005", InvestmentType.Stock), false);
+
+        SetupStockAccounts(account1, account2);
+        SetupBondAccounts();
+        SetupCurrencyAccounts();
+        SetupStockDetails(Stock("US0378331005", "AAPL"), Stock("US38259P5089", "GOOG"));
+
+        var result = await _service.GetDiversificationBreakdown(1, _asOfDate, TestContext.Current.CancellationToken);
+
+        var stocks = Assert.Single(result.AssetClasses);
+        Assert.Equal(["AAPL"], stocks.Holdings);
     }
 }


### PR DESCRIPTION
## Summary

Adds a **"Show holdings"** affordance to the Asset diversification card that expands the card into a list of the user's current holdings, grouped by asset class. Resolves #264.

The detail data is **lazy-loaded from a new endpoint only when the user expands** the card, so the existing score path and its behaviour are untouched.

## What you see

- A quiet **"Show holdings ›"** button in the card footer.
- Tapping it swaps the gauge view for a grouped list with a **"‹ Holdings"** back control:
  - **Stocks** → ticker symbols (e.g. `CSPX.LON`), resolved locally from `StockDetails`; falls back to the ISIN if unknown.
  - **Bonds** → bond names (e.g. `EDO1235`), resolved locally from `BondDetails`; falls back to `Bond #{id}`.
  - **Cash** → a single `Cash` entry.
- Only **currently held** positions appear (value > 0 as of the card's date), matching the scoring logic. The list is scrollable and theme-aware.

## Changes by layer

- **Domain:** `DiversificationBreakdown` / `AssetClassHoldings` DTOs.
- **Application:** `IDiversificationService.GetDiversificationBreakdown(...)` reuses the existing current-holdings enumeration and resolves names via `IStockDetailsRepository` / `IBondDetailsRepository` — **local DB only, no OpenFIGI**. Score calculation unchanged.
- **Api:** `GET /api/Diversification/{userId}/{asOfDate}/breakdown` with the same owner-only auth check as the score endpoint.
- **Components:** typed `DiversificationHttpClient.GetDiversificationBreakdown(...)` + the card's details view (fetched on first expand).

## Tests

- **Unit** (`DiversificationServiceTests`): grouping by class, local name resolution, ISIN / `Bond #id` fallbacks, cash as one entry, sold-out exclusion, cross-account dedup.
- **Integration** (`DiversificationControllerTests`): the endpoint returns the grouped breakdown for the authenticated user, and an empty portfolio returns no groups.
- Full suite green: **336 unit / 142 integration**, `dotnet build` clean (warnings-as-errors), `dotnet format` clean.

## Verified UI (guest account)

Rendered on the guest demo account in light **and** dark, at mobile and desktop widths — default face, and the expanded holdings view showing the resolved guest holdings (`CSPX.LON`, `EDO1235`, `Cash`).

## Note for review

The card height is fixed (≈380px, shared with the sibling Assets cards). On the **narrow desktop-column width** (≈1280px viewport with the nav drawer open), the gauge + breakdown + legend + insight + footer don't all fit at once, so the secondary insight line scrolls within the card while the score, breakdown, legend, and the new "Show holdings" CTA stay visible. On wider screens and on mobile (row layout) everything fits without scrolling. Happy to adjust the footer placement (e.g. move the trigger into the header) if you'd prefer the insight always visible.

closes #264

https://claude.ai/code/session_017xG2Hxo6FCChTmWa8LhjwE

---
_Generated by [Claude Code](https://claude.ai/code/session_017xG2Hxo6FCChTmWa8LhjwE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Diversification breakdown view now displays detailed portfolio holdings grouped by asset class (Stocks, Bonds, and Cash), helping you understand how your investments are distributed across different asset types.

* **Tests**
  * Added comprehensive test coverage for the new diversification breakdown functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->