### PR TITLE
Manage all repository labels as code

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,9 +1,12 @@
-# T-shirt size labels for issue/PR complexity estimation.
+# Repository labels, managed as code.
 # Synced to the repository by `.github/workflows/sync-labels.yml`
-# using EndBug/label-sync.
+# using EndBug/label-sync. The workflow runs on push to `main` (when this
+# file changes) and via manual dispatch. `delete-other-labels` is false, so
+# labels not listed here are left untouched rather than deleted.
 #
-# See CLAUDE.md ("T-Shirt Size Estimation") for the rubric agents and
-# humans should use when picking a size.
+# See CLAUDE.md ("T-Shirt Size Estimation") for the size rubric.
+
+# --- T-shirt size: issue/PR complexity estimation ---
 
 - name: size/XS
   color: c2e0c6
@@ -24,3 +27,75 @@
 - name: size/XL
   color: b60205
   description: "Extra large (> 5 days). Should likely be split into smaller issues before starting."
+
+# --- Type: what kind of work this is ---
+
+- name: bug
+  color: d73a4a
+  description: "Something isn't working"
+
+- name: enhancement
+  color: a2eeef
+  description: "New feature or request"
+
+- name: documentation
+  color: 0075ca
+  description: "Improvements or additions to documentation"
+
+- name: optimization
+  color: e603c9
+  description: "Performance or efficiency improvement"
+
+- name: security
+  color: a677c1
+  description: "Security hardening or vulnerability fix"
+
+# --- Area: which part of the stack ---
+
+- name: Backend
+  color: 9b03fc
+  description: "Backend / server-side work"
+
+- name: UI
+  color: 0d9c35
+  description: "Front-end / UI work"
+
+# --- Workflow: lifecycle / triage state ---
+
+- name: idea
+  color: fbca04
+  description: "Early-stage idea, not yet scoped for implementation"
+
+- name: "ready for implementation"
+  color: 1ea114
+  description: "Scoped and ready to be picked up"
+
+- name: "in progress"
+  color: 7d6993
+  description: "Actively being worked on"
+
+- name: "Nice to have"
+  color: 006b75
+  description: "Desirable but not prioritised"
+
+# --- Triage: standard GitHub dispositions ---
+
+- name: "help wanted"
+  color: 008672
+  description: "Extra attention is needed"
+
+- name: question
+  color: d876e3
+  description: "Further information is requested"
+
+- name: duplicate
+  color: cfd3d7
+  description: "This issue or pull request already exists"
+
+- name: invalid
+  color: e4e669
+  description: "This doesn't seem right"
+
+- name: wontfix
+  color: ffffff
+  description: "This will not be worked on"


### PR DESCRIPTION
Adds the non-size labels (type, area, workflow, triage) to `.github/labels.yml` so their colors and descriptions are version-controlled alongside the existing `size/*` labels.

- Colors mirror the current live labels exactly (no recoloring on sync).
- Descriptions added for the previously-blank custom labels (`Backend`, `idea`, `in progress`, `Nice to have`, `optimization`, `ready for implementation`, `UI`, `security`).

Config-only chore, no changelog entry. Note: the `sync-labels` workflow only runs on push to `main`, so this takes effect when `develop` is next promoted.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EW5RpPoyfpEKmrtMb4YMEN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub issue and pull request organization with an expanded label system. Added labels for work types (bug, enhancement, documentation, optimization, security), stack areas (Backend, UI), workflow lifecycle states, and triage dispositions to improve project management and issue tracking clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->