### PR TITLE
Remove hardcoded JWT signing key and fail fast when unset #273

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ rules agents must follow when updating this file.
 - Dashboard and asset pages no longer make an external OpenFIGI request for every stock price lookup — ticker→ISIN resolution is now cached in memory and served from local `StockDetails` first, with OpenFIGI as last-resort fallback.
 - Settings page no longer overflows on mobile — profile row, danger zone, and the unsaved-changes bar reflow vertically on narrow viewports while the desktop layout stays unchanged. #218
 
+### Security
+- The JWT signing key is no longer committed in `appsettings.json`; it must now be supplied via environment variable / User Secrets and the API refuses to start without it outside Development. The previously committed key has been treated as compromised and removed, so all existing access tokens are invalidated and users must sign in again. #273
+
 ## [26.5.25] - 2026-05-25
 
 ### Added

--- a/code/FinanceManager.Api/Program.cs
+++ b/code/FinanceManager.Api/Program.cs
@@ -30,6 +30,13 @@ if (string.IsNullOrWhiteSpace(jwtSigningKey))
     jwtSigningKey = "development-only-insecure-jwt-signing-key-do-not-use-in-production";
     builder.Configuration["JwtConfig:Key"] = jwtSigningKey;
 }
+else if (Encoding.UTF8.GetByteCount(jwtSigningKey) < 32)
+{
+    // HMAC-SHA256 needs a 256-bit (32-byte) key; reject anything weaker so a short
+    // env var can't silently produce forgeable tokens for both issuing and validation.
+    throw new InvalidOperationException(
+        "JwtConfig:Key must be at least 32 bytes (256 bits) for HMAC-SHA256 signing.");
+}
 
 
 builder.Services

--- a/code/FinanceManager.Api/Program.cs
+++ b/code/FinanceManager.Api/Program.cs
@@ -17,6 +17,20 @@ using System.Text;
 var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 
+// The JWT signing key must never be committed. It is supplied via environment variable / User Secrets.
+// Fail fast outside Development so we never silently fall back to an insecure default; in Development
+// fall back to a clearly-insecure local key so the app still runs without configured secrets.
+var jwtSigningKey = builder.Configuration["JwtConfig:Key"];
+if (string.IsNullOrWhiteSpace(jwtSigningKey))
+{
+    if (!builder.Environment.IsDevelopment())
+        throw new InvalidOperationException(
+            "JwtConfig:Key is not configured. Provide a signing key via the JwtConfig__Key environment variable or User Secrets.");
+
+    jwtSigningKey = "development-only-insecure-jwt-signing-key-do-not-use-in-production";
+    builder.Configuration["JwtConfig:Key"] = jwtSigningKey;
+}
+
 
 builder.Services
     .AddSingleton(typeof(IOptionsSnapshot<>), typeof(OptionsManager<>))
@@ -79,7 +93,7 @@ builder.Services.AddCors(options =>
     {
         ValidIssuer = builder.Configuration["JwtConfig:Issuer"],
         ValidAudience = builder.Configuration["JwtConfig:Audience"],
-        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["JwtConfig:Key"]!)),
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSigningKey)),
         ValidateIssuer = true,
         ValidateAudience = true,
         ValidateLifetime = true,

--- a/code/FinanceManager.Api/appsettings.json
+++ b/code/FinanceManager.Api/appsettings.json
@@ -8,7 +8,7 @@
   "JwtConfig": {
     "Issuer": "FinanceManager.api",
     "Audience": "FinanceManager.Frontend",
-    "Key": "c754f29dc84dfe4cf02ce28e91abe3f0c1d96ec50017a7b16309cd3c01a47d3496d9dfb41d390ecdc7214f1e4ec3fa319c215f5a38b361401a867a0d6fdca30f",
+    "Key": "",
     "TokenValidityMins": "15"
   },
   "RefreshToken": {

--- a/code/FinanceManager.Api/appsettings.test.json
+++ b/code/FinanceManager.Api/appsettings.test.json
@@ -9,7 +9,6 @@
   "JwtConfig": {
     "Issuer": "FinanceManager.api",
     "Audience": "FinanceManager.Frontend",
-    "Key": "111111111111111111111111111111111111111111111111111111111111111111111111",
     "TokenValidityMins": "60"
   },
   "Cors": {

--- a/code/FinanceManager.IntegrationTests/TestEnvironment.cs
+++ b/code/FinanceManager.IntegrationTests/TestEnvironment.cs
@@ -1,0 +1,15 @@
+using System.Runtime.CompilerServices;
+
+namespace FinanceManager.IntegrationTests;
+
+internal static class TestEnvironment
+{
+    // The JWT signing key is intentionally absent from appsettings.test.json (#273). The integration
+    // host runs in the non-Development "test" environment, where the startup guard requires a key to
+    // be supplied via environment variable / User Secrets. Set a deterministic, non-secret test key
+    // before any test runs so both the API host and the OptionsProvider-based token generator agree.
+    [ModuleInitializer]
+    internal static void SetJwtSigningKey()
+        => Environment.SetEnvironmentVariable("JwtConfig__Key",
+            "integration-test-only-insecure-jwt-signing-key-do-not-use-anywhere");
+}


### PR DESCRIPTION
- Empty JwtConfig:Key in appsettings.json; the previously committed key is
  treated as compromised and must be rotated/supplied via env or User Secrets.
- Add a startup guard that throws outside Development when the key is missing,
  with a clearly-insecure local fallback for Development only.
- Drop the dummy key from appsettings.test.json and inject a deterministic
  test key via a module initializer so integration tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JWT configuration initialization in the API startup process with improved fallback handling
  * Modified JWT key settings in application configuration files

* **Tests**
  * Enhanced integration test setup to ensure consistent JWT key handling across test environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/avresial/FinanceManager/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->