### PR TITLE
Add global API exception handling and surface dashboard fetch failures #275

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Dashboard cards now surface data-load failures instead of failing silently: a failed fetch shows an error toast (and a "Failed to load" indicator on the net worth, net cash flow, and closing balance cards) rather than leaving an empty card, and a top-level error boundary catches unexpected page errors with a friendly message. The API also now returns consistent RFC-7807 `ProblemDetails` responses for unhandled errors, without leaking stack traces in production. #275
 - Production-safe health endpoints: `/alive` (liveness) and `/health` (readiness, including a database connectivity check) now respond in every environment without exposing internal diagnostics, plus an authenticated `/health/detail` endpoint with a full per-check JSON breakdown for operators. #279
 - Sessions now persist across page reloads and browser restarts: signing in keeps you logged in for up to 14 days without re-entering your password, access tokens are refreshed transparently in the background, and when the session finally expires you're returned to the login page with a "Your session has expired, please sign in again." message. #226
 - Asset diversification card now has a "Show holdings" view that lists your current holdings grouped by asset class — stock tickers, bond names, and cash — loaded on demand when you expand the card. #264

--- a/code/FinanceManager.Api/Middleware/GlobalExceptionHandler.cs
+++ b/code/FinanceManager.Api/Middleware/GlobalExceptionHandler.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinanceManager.Api.Middleware;
+
+/// <summary>
+/// Catches any exception that escapes the MVC pipeline and turns it into an RFC-7807
+/// <see cref="ProblemDetails"/> response. Stack traces are only exposed in Development so
+/// production clients never receive internal implementation detail.
+/// </summary>
+public sealed class GlobalExceptionHandler(
+    IProblemDetailsService problemDetailsService,
+    IHostEnvironment environment,
+    ILogger<GlobalExceptionHandler> logger) : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+    {
+        logger.LogError(
+            exception,
+            "Unhandled exception while processing {Method} {Path}",
+            httpContext.Request.Method,
+            httpContext.Request.Path);
+
+        httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
+
+        var problemDetails = new ProblemDetails
+        {
+            Status = StatusCodes.Status500InternalServerError,
+            Title = "An unexpected error occurred.",
+            Type = "https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1",
+            Detail = environment.IsDevelopment()
+                ? exception.ToString()
+                : "An unexpected error occurred while processing your request.",
+        };
+
+        return await problemDetailsService.TryWriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = httpContext,
+            Exception = exception,
+            ProblemDetails = problemDetails,
+        });
+    }
+}

--- a/code/FinanceManager.Api/Middleware/GlobalExceptionHandler.cs
+++ b/code/FinanceManager.Api/Middleware/GlobalExceptionHandler.cs
@@ -15,11 +15,13 @@ public sealed class GlobalExceptionHandler(
 {
     public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
     {
+        // Strip line breaks from the request method/path before logging so a crafted URL can't forge
+        // additional log entries (CodeQL: log entries created from user input).
         logger.LogError(
             exception,
             "Unhandled exception while processing {Method} {Path}",
-            httpContext.Request.Method,
-            httpContext.Request.Path);
+            Sanitize(httpContext.Request.Method),
+            Sanitize(httpContext.Request.Path.Value));
 
         httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
 
@@ -40,4 +42,7 @@ public sealed class GlobalExceptionHandler(
             ProblemDetails = problemDetails,
         });
     }
+
+    private static string Sanitize(string? value) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value.Replace("\r", string.Empty).Replace("\n", string.Empty);
 }

--- a/code/FinanceManager.Api/Program.cs
+++ b/code/FinanceManager.Api/Program.cs
@@ -50,6 +50,8 @@ else if (Encoding.UTF8.GetByteCount(jwtSigningKey) < 32)
 
 
 builder.Services
+    .AddProblemDetails()
+    .AddExceptionHandler<FinanceManager.Api.Middleware.GlobalExceptionHandler>()
     .AddSingleton(typeof(IOptionsSnapshot<>), typeof(OptionsManager<>))
     .AddSingleton(typeof(IOptionsFactory<>), typeof(OptionsFactory<>))
     .AddOpenApi("v1", options =>
@@ -189,6 +191,10 @@ builder.Services.AddHostedService<LogEntryPersistenceBackgroundService>();
 builder.Services.AddHostedService<LogRetentionBackgroundService>();
 
 var app = builder.Build();
+
+// Registered first so it wraps the whole pipeline: any unhandled exception is turned into a
+// consistent ProblemDetails response by GlobalExceptionHandler instead of leaking framework defaults.
+app.UseExceptionHandler();
 
 if (app.Environment.IsDevelopment())
 {

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/ClosingBalanceOverviewCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/ClosingBalanceOverviewCard.razor
@@ -9,6 +9,10 @@
                 <StringSpinner CharactersCount="4" />
                 @_currency
             }
+            else if (_hasError)
+            {
+                <MudText Typo="Typo.subtitle1" Color="Color.Error">Failed to load</MudText>
+            }
             else if (_closingBalance is not null)
             {
                 @_closingBalance
@@ -35,7 +39,7 @@
         else
         {
             <div class="d-flex flex-grow-1 justify-center align-content-center flex-wrap">
-                <MudText Typo="Typo.button" HtmlTag="h3">No data</MudText>
+                <MudText Typo="Typo.button" HtmlTag="h3">@(_hasError ? "Failed to load" : "No data")</MudText>
             </div>
         }
     </MudPaper>

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/ClosingBalanceOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/ClosingBalanceOverviewCard.razor.cs
@@ -5,6 +5,7 @@ using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
+using MudBlazor;
 
 namespace FinanceManager.Components.Components.Dashboard.Cards;
 
@@ -14,12 +15,14 @@ public partial class ClosingBalanceOverviewCard
     private decimal? _closingBalance;
     private List<List<ChartJsLineDataPoint>> _series = [];
     private bool _isLoading = true;
+    private bool _hasError = false;
 
     [Parameter] public string Height { get; set; } = "300px";
     [Parameter] public DateTime StartDateTime { get; set; }
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
 
     [Inject] public required ILogger<ClosingBalanceOverviewCard> Logger { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
     [Inject] public required DashboardOverviewCardsCacheService DashboardOverviewCardsCacheService { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
@@ -27,6 +30,7 @@ public partial class ClosingBalanceOverviewCard
     protected override async Task OnParametersSetAsync()
     {
         _isLoading = true;
+        _hasError = false;
         _currency = SettingsService.GetCurrency();
         _closingBalance = null;
         _series.Clear();
@@ -58,7 +62,9 @@ public partial class ClosingBalanceOverviewCard
         }
         catch (Exception ex)
         {
+            _hasError = true;
             Logger.LogError(ex, "Error while getting closing balance");
+            Snackbar.Add("Unable to load closing balance.", Severity.Error);
         }
 
         _isLoading = false;

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/DiversificationProxyCard.razor.cs
@@ -3,6 +3,7 @@ using FinanceManager.Domain.Entities.MoneyFlowModels;
 using FinanceManager.Domain.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
+using MudBlazor;
 using System.Globalization;
 
 namespace FinanceManager.Components.Components.Dashboard.Cards;
@@ -45,6 +46,7 @@ public partial class DiversificationProxyCard
     [Parameter] public string Height { get; set; } = "300px";
 
     [Inject] public required ILogger<DiversificationProxyCard> Logger { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
     [Inject] public required DiversificationHttpClient DiversificationHttpClient { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
 
@@ -81,6 +83,7 @@ public partial class DiversificationProxyCard
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error loading diversification score");
+            Snackbar.Add("Unable to load diversification score.", Severity.Error);
         }
         finally
         {
@@ -106,6 +109,7 @@ public partial class DiversificationProxyCard
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error loading diversification breakdown");
+            Snackbar.Add("Unable to load diversification breakdown.", Severity.Error);
         }
         finally
         {

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/ExpenseDistributionOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/ExpenseDistributionOverviewCard.razor.cs
@@ -29,6 +29,7 @@ public partial class ExpenseDistributionOverviewCard
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
 
     [Inject] public required ILogger<ExpenseDistributionOverviewCard> Logger { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
     [Inject] public required MoneyFlowHttpClient MoneyFlowHttpClient { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
@@ -75,6 +76,7 @@ public partial class ExpenseDistributionOverviewCard
         catch (Exception ex)
         {
             Logger.LogError(ex, ex.Message);
+            Snackbar.Add("Unable to load expense distribution.", Severity.Error);
         }
         finally
         {

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/FinancialInsightsCarousel.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/FinancialInsightsCarousel.razor.cs
@@ -2,6 +2,7 @@ using FinanceManager.Components.HttpClients;
 using FinanceManager.Domain.Entities.Users;
 using FinanceManager.Domain.Services;
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
 
 namespace FinanceManager.Components.Components.Dashboard.Cards;
 
@@ -13,6 +14,7 @@ public partial class FinancialInsightsCarousel
 
     [Inject] public required FinancialInsightsHttpClient FinancialInsightsHttpClient { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
 
     [Parameter] public string Height { get; set; } = "300px";
     [Parameter] public int Count { get; set; } = 3;
@@ -39,6 +41,10 @@ public partial class FinancialInsightsCarousel
 
             _insights = await FinancialInsightsHttpClient.GetLatestAsync(Count, AccountId);
         }
+        catch
+        {
+            Snackbar.Add("Unable to load financial insights.", Severity.Error);
+        }
         finally
         {
             _isLoading = false;
@@ -64,6 +70,10 @@ public partial class FinancialInsightsCarousel
             _isLoggedIn = true;
             var generated = await FinancialInsightsHttpClient.GenerateAsync(Count, AccountId);
             _insights = generated.Count > 0 ? generated : await FinancialInsightsHttpClient.GetLatestAsync(Count, AccountId);
+        }
+        catch
+        {
+            Snackbar.Add("Unable to generate financial insights.", Severity.Error);
         }
         finally
         {

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/FinancialLabelsListCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/FinancialLabelsListCard.razor.cs
@@ -17,6 +17,7 @@ public partial class FinancialLabelsListCard
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required MoneyFlowHttpClient MoneyFlowHttpClient { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
 
     [Parameter] public string Height { get; set; } = "300px";
     [Parameter] public DateTime StartDateTime { get; set; }
@@ -34,6 +35,10 @@ public partial class FinancialLabelsListCard
             if (userId is not null)
                 _data = (await MoneyFlowHttpClient.GetLabelsValue(userId.UserId, StartDateTime, EndDateTime)).Where(x => x.Value != 0).ToList();
         }
+        catch
+        {
+            Snackbar.Add("Unable to load financial labels.", Severity.Error);
+        }
         finally
         {
             _isLoading = false;
@@ -50,6 +55,10 @@ public partial class FinancialLabelsListCard
         {
             if (userId is not null)
                 _data = (await MoneyFlowHttpClient.GetLabelsValue(userId.UserId, StartDateTime, EndDateTime)).Where(x => x.Value != 0).ToList();
+        }
+        catch
+        {
+            Snackbar.Add("Unable to load financial labels.", Severity.Error);
         }
         finally
         {

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/IncomeSourceOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/IncomeSourceOverviewCard.razor.cs
@@ -32,6 +32,7 @@ public partial class IncomeSourceOverviewCard
 
 
     [Inject] public required ILogger<IncomeSourceOverviewCard> Logger { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
     [Inject] public required IFinancialAccountService FinancalAccountService { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
@@ -97,6 +98,7 @@ public partial class IncomeSourceOverviewCard
         if (user is null) return;
 
         ChartData.Clear();
+        var hasError = false;
         if (_chart is not null) await _chart.UpdateSeriesAsync(true);
         await Task.Run(async () =>
         {
@@ -108,6 +110,7 @@ public partial class IncomeSourceOverviewCard
             }
             catch (Exception ex)
             {
+                hasError = true;
                 Logger.LogError(ex.ToString());
             }
 
@@ -147,6 +150,10 @@ public partial class IncomeSourceOverviewCard
             Total = ChartData.Sum(x => x.Value);
 
         });
+
+        if (hasError)
+            Snackbar.Add("Unable to load income sources.", Severity.Error);
+
         if (_chart is not null) await _chart.UpdateSeriesAsync(true);
     }
     public class IncomeSourceOverviewEntry

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/InflowVsOutflowOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/InflowVsOutflowOverviewCard.razor.cs
@@ -15,6 +15,7 @@ public partial class InflowVsOutflowOverviewCard
     private List<List<ChartJsLineDataPoint>> _series = [];
     private bool _isInitializing = true;
     private bool _isLoading = false;
+    private bool _hasError = false;
 
 
     [Parameter] public string Height { get; set; } = "300px";
@@ -27,6 +28,7 @@ public partial class InflowVsOutflowOverviewCard
 
     [Inject] public required MoneyFlowHttpClient MoneyFlowHttpClient { get; set; }
     [Inject] public required ILogger<InflowVsOutflowOverviewCard> Logger { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
     [Inject] public required IFinancialAccountService FinancalAccountService { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
@@ -42,6 +44,7 @@ public partial class InflowVsOutflowOverviewCard
         if (user is null) return;
 
         _series.Clear();
+        _hasError = false;
         try
         {
             if (DisplayInflow)
@@ -57,6 +60,7 @@ public partial class InflowVsOutflowOverviewCard
         }
         catch (Exception ex)
         {
+            _hasError = true;
             Logger.LogError(ex, ex.Message);
         }
 
@@ -74,6 +78,7 @@ public partial class InflowVsOutflowOverviewCard
         }
         catch (Exception ex)
         {
+            _hasError = true;
             Logger.LogError(ex, ex.Message);
         }
 
@@ -91,8 +96,12 @@ public partial class InflowVsOutflowOverviewCard
         }
         catch (Exception ex)
         {
+            _hasError = true;
             Logger.LogError(ex, ex.Message);
         }
+
+        if (_hasError)
+            Snackbar.Add("Unable to load inflow/outflow data.", Severity.Error);
 
         _isLoading = false;
         _isInitializing = false;

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/NetCashFlowOverviewCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/NetCashFlowOverviewCard.razor
@@ -9,6 +9,10 @@
                 <StringSpinner CharactersCount="4" />
                 @_currency
             }
+            else if (_hasError)
+            {
+                <MudText Typo="Typo.subtitle1" Color="Color.Error">Failed to load</MudText>
+            }
             else if (_totalNetCashFlow is not null)
             {
                 @_totalNetCashFlow.Value.ToString("0.00")
@@ -35,7 +39,7 @@
         else
         {
             <div class="d-flex flex-grow-1 justify-center align-content-center flex-wrap">
-                <MudText Typo="Typo.button" HtmlTag="h3">No data</MudText>
+                <MudText Typo="Typo.button" HtmlTag="h3">@(_hasError ? "Failed to load" : "No data")</MudText>
             </div>
         }
     </MudPaper>

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/NetCashFlowOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/NetCashFlowOverviewCard.razor.cs
@@ -5,6 +5,7 @@ using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
+using MudBlazor;
 
 namespace FinanceManager.Components.Components.Dashboard.Cards;
 
@@ -14,12 +15,14 @@ public partial class NetCashFlowOverviewCard
     private decimal? _totalNetCashFlow;
     private List<List<ChartJsLineDataPoint>> _series = [];
     private bool _isLoading = true;
+    private bool _hasError = false;
 
     [Parameter] public string Height { get; set; } = "300px";
     [Parameter] public DateTime StartDateTime { get; set; }
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
 
     [Inject] public required ILogger<NetCashFlowOverviewCard> Logger { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
     [Inject] public required DashboardOverviewCardsCacheService DashboardOverviewCardsCacheService { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
@@ -27,6 +30,7 @@ public partial class NetCashFlowOverviewCard
     protected override async Task OnParametersSetAsync()
     {
         _isLoading = true;
+        _hasError = false;
         _currency = SettingsService.GetCurrency();
         _totalNetCashFlow = null;
         _series.Clear();
@@ -58,7 +62,9 @@ public partial class NetCashFlowOverviewCard
         }
         catch (Exception ex)
         {
+            _hasError = true;
             Logger.LogError(ex, "Error while getting net cash flow");
+            Snackbar.Add("Unable to load net cash flow.", Severity.Error);
         }
 
         _isLoading = false;

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/NetWorthOverviewCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/NetWorthOverviewCard.razor
@@ -7,6 +7,10 @@
                 <StringSpinner CharactersCount="4" />
                 @_currency
             }
+            else if (_hasError)
+            {
+                <MudText Typo="Typo.subtitle1" Color="Color.Error">Failed to load</MudText>
+            }
             else
             {
                 @if (_totalNetWorth is not null)

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/NetWorthOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/NetWorthOverviewCard.razor.cs
@@ -4,6 +4,7 @@ using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
+using MudBlazor;
 
 namespace FinanceManager.Components.Components.Dashboard.Cards;
 
@@ -12,19 +13,27 @@ public partial class NetWorthOverviewCard
     private Currency _currency = DefaultCurrency.PLN;
     private decimal? _totalNetWorth = null;
     private bool _isLoading = false;
+    private bool _hasError = false;
+
+    // Exposed for the failure-path unit test (InternalsVisibleTo FinanceManager.UnitTests).
+    internal bool HasError => _hasError;
 
     [Parameter] public string Height { get; set; } = "300px";
     [Parameter] public DateTime StartDateTime { get; set; }
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
 
     [Inject] public required ILogger<NetWorthOverviewCard> Logger { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
     [Inject] public required DashboardOverviewCardsCacheService DashboardOverviewCardsCacheService { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
 
-    protected override async Task OnParametersSetAsync()
+    protected override Task OnParametersSetAsync() => LoadAsync();
+
+    internal async Task LoadAsync()
     {
         _isLoading = true;
+        _hasError = false;
 
         _currency = SettingsService.GetCurrency();
         _totalNetWorth = null;
@@ -51,7 +60,9 @@ public partial class NetWorthOverviewCard
         }
         catch (Exception ex)
         {
+            _hasError = true;
             Logger.LogError(ex, "Error while getting net worth");
+            Snackbar.Add("Unable to load net worth.", Severity.Error);
         }
 
         _isLoading = false;

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/RecurringTransactionDetectorCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/RecurringTransactionDetectorCard.razor.cs
@@ -4,6 +4,7 @@ using FinanceManager.Domain.Entities.MoneyFlowModels;
 using FinanceManager.Domain.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
+using MudBlazor;
 
 namespace FinanceManager.Components.Components.Dashboard.Cards;
 
@@ -20,6 +21,7 @@ public partial class RecurringTransactionDetectorCard
     [Parameter] public string Height { get; set; } = "300px";
 
     [Inject] public required ILogger<RecurringTransactionDetectorCard> Logger { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
     [Inject] public required RecurringTransactionDetectorHttpClient RecurringTransactionDetectorHttpClient { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
     [Inject] public required CurrencyEntryHttpClient CurrencyEntryHttpClient { get; set; }
@@ -50,6 +52,7 @@ public partial class RecurringTransactionDetectorCard
         catch (Exception ex)
         {
             Logger.LogError(ex, ex.Message);
+            Snackbar.Add("Unable to load recurring transactions.", Severity.Error);
         }
         finally
         {
@@ -78,6 +81,7 @@ public partial class RecurringTransactionDetectorCard
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to load entries for {Name}", item.Name);
+            Snackbar.Add("Unable to load transaction details.", Severity.Error);
         }
         finally
         {

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/RecurringTransactionDetectorCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/RecurringTransactionDetectorCard.razor.cs
@@ -81,7 +81,8 @@ public partial class RecurringTransactionDetectorCard
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to load entries for {Name}", item.Name);
-            Snackbar.Add("Unable to load transaction details.", Severity.Error);
+            if (requestVersion == _detailRequestVersion)
+                Snackbar.Add("Unable to load transaction details.", Severity.Error);
         }
         finally
         {

--- a/code/FinanceManager.Components/Components/Layout/MainLayout.razor
+++ b/code/FinanceManager.Components/Components/Layout/MainLayout.razor
@@ -24,7 +24,16 @@
             </MudDrawer>
 
             <MudMainContent>
-                @Body
+                <ErrorBoundary @ref="_errorBoundary">
+                    <ChildContent>
+                        @Body
+                    </ChildContent>
+                    <ErrorContent Context="exception">
+                        <MudAlert Severity="Severity.Error" Class="ma-4">
+                            Something went wrong while loading this page. Please try again.
+                        </MudAlert>
+                    </ErrorContent>
+                </ErrorBoundary>
             </MudMainContent>
         </MudLayout>
     </Authorized>
@@ -39,6 +48,13 @@
     private bool _drawerOpen = true;
     private bool _isMobile;
     private DrawerVariant _drawerVariant = DrawerVariant.Mini;
+    private ErrorBoundary? _errorBoundary;
+
+    protected override void OnInitialized() => Navigation.LocationChanged += OnLocationChanged;
+
+    // The ErrorBoundary latches its error state; recover on navigation so a failure on one page
+    // doesn't leave every subsequent page stuck on the fallback message.
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e) => _errorBoundary?.Recover();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -71,6 +87,7 @@
 
     public async ValueTask DisposeAsync()
     {
+        Navigation.LocationChanged -= OnLocationChanged;
         await BrowserViewportService.UnsubscribeAsync(_viewportSubscriptionId);
     }
 }

--- a/code/FinanceManager.Components/Services/DashboardOverviewCardsCacheService.cs
+++ b/code/FinanceManager.Components/Services/DashboardOverviewCardsCacheService.cs
@@ -21,7 +21,7 @@ public class DashboardOverviewCardsCacheService(
     private const string _cacheKeyPrefix = "dashboard-overview-cards-cache-v1";
     private static readonly TimeSpan _maxStale = TimeSpan.FromMinutes(5);
 
-    public Task<DashboardOverviewCardsCacheSnapshot> GetSnapshotAsync(DashboardOverviewCardsRefreshContext context)
+    public virtual Task<DashboardOverviewCardsCacheSnapshot> GetSnapshotAsync(DashboardOverviewCardsRefreshContext context)
         => GetOrRefreshAsync(context);
 
     protected override string GetCacheKey(DashboardOverviewCardsRefreshContext refreshContext)

--- a/code/FinanceManager.UnitTests/Api/Middleware/GlobalExceptionHandlerTests.cs
+++ b/code/FinanceManager.UnitTests/Api/Middleware/GlobalExceptionHandlerTests.cs
@@ -1,0 +1,71 @@
+using FinanceManager.Api.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace FinanceManager.UnitTests.Api.Middleware;
+
+[Trait("Category", "Unit")]
+public class GlobalExceptionHandlerTests
+{
+    private static (GlobalExceptionHandler Handler, List<ProblemDetailsContext> Written) CreateHandler(string environmentName)
+    {
+        var written = new List<ProblemDetailsContext>();
+
+        var problemDetailsService = new Mock<IProblemDetailsService>();
+        problemDetailsService
+            .Setup(s => s.TryWriteAsync(It.IsAny<ProblemDetailsContext>()))
+            .Callback<ProblemDetailsContext>(written.Add)
+            .Returns(ValueTask.FromResult(true));
+
+        var environment = new Mock<IHostEnvironment>();
+        environment.SetupGet(e => e.EnvironmentName).Returns(environmentName);
+
+        var handler = new GlobalExceptionHandler(
+            problemDetailsService.Object,
+            environment.Object,
+            NullLogger<GlobalExceptionHandler>.Instance);
+
+        return (handler, written);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_WritesProblemDetailsWith500AndReturnsTrue()
+    {
+        var (handler, written) = CreateHandler(Environments.Production);
+        var context = new DefaultHttpContext();
+
+        var handled = await handler.TryHandleAsync(context, new InvalidOperationException("boom"), CancellationToken.None);
+
+        Assert.True(handled);
+        Assert.Equal(StatusCodes.Status500InternalServerError, context.Response.StatusCode);
+
+        var problem = Assert.Single(written).ProblemDetails;
+        Assert.Equal(StatusCodes.Status500InternalServerError, problem.Status);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_InProduction_DoesNotLeakStackTrace()
+    {
+        var (handler, written) = CreateHandler(Environments.Production);
+
+        await handler.TryHandleAsync(new DefaultHttpContext(), new InvalidOperationException("boom"), CancellationToken.None);
+
+        var problem = Assert.Single(written).ProblemDetails;
+        Assert.DoesNotContain("InvalidOperationException", problem.Detail);
+        Assert.DoesNotContain("boom", problem.Detail);
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_InDevelopment_IncludesExceptionDetail()
+    {
+        var (handler, written) = CreateHandler(Environments.Development);
+
+        await handler.TryHandleAsync(new DefaultHttpContext(), new InvalidOperationException("boom"), CancellationToken.None);
+
+        var problem = Assert.Single(written).ProblemDetails;
+        Assert.Contains("boom", problem.Detail);
+    }
+}

--- a/code/FinanceManager.UnitTests/Components/Dashboard/Cards/NetWorthOverviewCardTests.cs
+++ b/code/FinanceManager.UnitTests/Components/Dashboard/Cards/NetWorthOverviewCardTests.cs
@@ -1,0 +1,104 @@
+using Blazored.LocalStorage;
+using FinanceManager.Components.Components.Dashboard.Cards;
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Components.Models;
+using FinanceManager.Components.Services;
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.Users;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MudBlazor;
+
+namespace FinanceManager.UnitTests.Components.Dashboard.Cards;
+
+[Trait("Category", "Unit")]
+public class NetWorthOverviewCardTests
+{
+    private static UserSession LoggedInUser => new()
+    {
+        UserId = 1,
+        UserName = "user",
+        Password = "password",
+        UserRole = UserRole.User,
+    };
+
+    private static Mock<DashboardOverviewCardsCacheService> CreateCacheServiceMock()
+    {
+        // GetSnapshotAsync is virtual so the failure/success paths can be simulated; the base
+        // constructor only stores its dependencies, so passing mocks/stubs here is safe.
+        var localStorage = new Mock<ILocalStorageService>();
+        var memoryCache = new Mock<IMemoryCache>();
+        var moneyFlowClient = new MoneyFlowHttpClient(new HttpClient { BaseAddress = new Uri("http://localhost") });
+
+        return new Mock<DashboardOverviewCardsCacheService>(
+            localStorage.Object,
+            memoryCache.Object,
+            moneyFlowClient,
+            NullLogger<DashboardOverviewCardsCacheService>.Instance);
+    }
+
+    private static NetWorthOverviewCard CreateCard(
+        DashboardOverviewCardsCacheService cacheService,
+        ISnackbar snackbar,
+        ILoginService loginService)
+    {
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(s => s.GetCurrency()).Returns(DefaultCurrency.PLN);
+
+        return new NetWorthOverviewCard
+        {
+            Logger = NullLogger<NetWorthOverviewCard>.Instance,
+            Snackbar = snackbar,
+            DashboardOverviewCardsCacheService = cacheService,
+            SettingsService = settings.Object,
+            LoginService = loginService,
+        };
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenSnapshotFetchThrows_SetsErrorAndShowsSnackbar()
+    {
+        var login = new Mock<ILoginService>();
+        login.Setup(l => l.GetLoggedUser()).ReturnsAsync(LoggedInUser);
+
+        var cache = CreateCacheServiceMock();
+        cache.Setup(c => c.GetSnapshotAsync(It.IsAny<DashboardOverviewCardsRefreshContext>()))
+            .ThrowsAsync(new HttpRequestException("boom"));
+
+        var snackbar = new Mock<ISnackbar>();
+
+        var card = CreateCard(cache.Object, snackbar.Object, login.Object);
+
+        await card.LoadAsync();
+
+        Assert.True(card.HasError);
+        snackbar.Verify(
+            s => s.Add(It.IsAny<string>(), Severity.Error, It.IsAny<Action<SnackbarOptions>?>(), It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenSnapshotFetchSucceeds_DoesNotErrorOrNotify()
+    {
+        var login = new Mock<ILoginService>();
+        login.Setup(l => l.GetLoggedUser()).ReturnsAsync(LoggedInUser);
+
+        var cache = CreateCacheServiceMock();
+        cache.Setup(c => c.GetSnapshotAsync(It.IsAny<DashboardOverviewCardsRefreshContext>()))
+            .ReturnsAsync(new DashboardOverviewCardsCacheSnapshot { NetWorth = 4321.99m });
+
+        var snackbar = new Mock<ISnackbar>();
+
+        var card = CreateCard(cache.Object, snackbar.Object, login.Object);
+
+        await card.LoadAsync();
+
+        Assert.False(card.HasError);
+        snackbar.Verify(
+            s => s.Add(It.IsAny<string>(), It.IsAny<Severity>(), It.IsAny<Action<SnackbarOptions>?>(), It.IsAny<string>()),
+            Times.Never);
+    }
+}


### PR DESCRIPTION
closes #275

## Summary

Closes the two gaps from #275: the API had no global exception handler, and dashboard cards caught fetch errors, logged them locally, then failed silently — leaving the user with an empty card and no indication anything went wrong.

### API — global exception handling
- New `GlobalExceptionHandler` (`IExceptionHandler`) that logs the exception and writes an RFC-7807 `ProblemDetails` 500 response.
- Stack traces are **only** exposed in Development; production returns a generic detail message.
- Wired in `Program.cs` via `AddProblemDetails()` + `AddExceptionHandler<GlobalExceptionHandler>()`, with `app.UseExceptionHandler()` registered first so it wraps the whole pipeline.

### Client — surface failures instead of silent empty cards
- Every dashboard card that fetches data now raises an **error toast** (`ISnackbar`, `Severity.Error`) on failure, keeping the existing local logging. Covered: NetWorth, NetCashFlow, ClosingBalance, ExpenseDistribution, Diversification, RecurringTransaction, InflowVsOutflow, IncomeSource, FinancialLabels, FinancialInsights.
- The three "value" cards (NetWorth, NetCashFlow, ClosingBalance) also render a persistent **"Failed to load"** indicator, so an error is visually distinct from a genuinely-empty "No data" state.
- Added a top-level **`ErrorBoundary`** in `MainLayout` as a global safety net for render-time errors, with a friendly fallback that auto-recovers on navigation.

## Tests
- `GlobalExceptionHandlerTests` — 500 + `ProblemDetails`, no stack-trace leak in Production, detail included in Development.
- `NetWorthOverviewCardTests` — failure path (fetch throws → error state + error snackbar) and happy path (no error/no snackbar). `GetSnapshotAsync` was made `virtual` to enable mocking.
- Full unit suite green (371 passing), `dotnet build` clean (0 warnings), `dotnet format` clean on all touched files.

## Acceptance criteria
- [x] Unhandled API exceptions return a consistent `ProblemDetails` payload (no stack traces in prod).
- [x] Failed dashboard-card fetches give a visible error indication (toast + "Failed to load") instead of a silently empty card.
- [x] Unit tests cover the failure path on at least one card.

## Verification
Dashboard rendered and screenshotted on mobile + desktop via the guest demo account — all cards render normally, no regression. The new error states are conditional on a fetch failure (not reproducible in the happy path) and are covered by unit tests.

https://claude.ai/code/session_019eskBAHZe7q4X8bVEJxCpU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard cards now display "Failed to load" messages when errors occur, providing clearer feedback on data unavailability.
  * Error notifications appear as dismissible messages when card data fails to load, guiding users on what went wrong.
  * Added error boundary to catch unexpected page loading failures, preventing complete application crashes.

* **Bug Fixes**
  * Improved error handling across all dashboard components for more graceful degradation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->