### PR TITLE
Translate duplicate-login race to a domain exception

### DIFF
--- a/code/FinanceManager.Api/Controllers/UserController.cs
+++ b/code/FinanceManager.Api/Controllers/UserController.cs
@@ -3,11 +3,11 @@ using FinanceManager.Application.Providers;
 using FinanceManager.Application.Services;
 using FinanceManager.Domain.Entities.Users;
 using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Exceptions;
 using FinanceManager.Domain.Repositories;
 using FinanceManager.Infrastructure.Dtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace FinanceManager.Api.Controllers;
 
@@ -34,10 +34,10 @@ public class UserController(IUserRepository userRepository, UsersService usersSe
             var result = await userRepository.AddUser(addUserCommand.UserName, encryptedPassword, addUserCommand.PricingLevel, UserRole.User, addUserCommand.FirstName, addUserCommand.LastName);
             return result ? Ok(result) : BadRequest();
         }
-        catch (DbUpdateException)
+        catch (DuplicateLoginException)
         {
-            // The unique index on Users.Login lost the check-then-insert race: another concurrent request created
-            // the same login between the lookup above and this insert. Surface it as a conflict, not a 500.
+            // A concurrent request created the same login between the lookup above and this insert. Surface it as a
+            // conflict, not a 500.
             return Conflict();
         }
     }

--- a/code/FinanceManager.Domain/Exceptions/DuplicateLoginException.cs
+++ b/code/FinanceManager.Domain/Exceptions/DuplicateLoginException.cs
@@ -1,0 +1,12 @@
+namespace FinanceManager.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when an attempt is made to persist a user whose login already exists. Lets callers react to a lost
+/// check-then-insert race (enforced by the unique login index) without depending on any persistence-specific
+/// exception type.
+/// </summary>
+public class DuplicateLoginException(string login)
+    : Exception($"A user with login '{login}' already exists.")
+{
+    public string Login { get; } = login;
+}

--- a/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
@@ -1,5 +1,6 @@
 ﻿using FinanceManager.Domain.Entities.Users;
 using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Exceptions;
 using FinanceManager.Domain.Repositories;
 using FinanceManager.Infrastructure.Contexts;
 using FinanceManager.Infrastructure.Dtos;
@@ -22,7 +23,21 @@ public class UserRepository(AppDbContext context) : IUserRepository
             CreationDate = DateTime.UtcNow,
         });
 
-        await context.SaveChangesAsync();
+        try
+        {
+            await context.SaveChangesAsync();
+        }
+        catch (DbUpdateException)
+        {
+            // The unique login index rejected the insert. If a row with this login now exists, a concurrent request
+            // created it between the caller's existence check and this insert; translate the persistence-specific
+            // failure into a domain concept so callers don't have to depend on EF Core. Otherwise the failure is
+            // something else and must surface unchanged.
+            context.ChangeTracker.Clear();
+            if (await context.Users.AsNoTracking().AnyAsync(x => x.Login == login))
+                throw new DuplicateLoginException(login);
+            throw;
+        }
 
         return true;
     }


### PR DESCRIPTION
## Summary

Fixes a layering violation introduced in #302: `UserController.Add` caught EF Core's `DbUpdateException` directly, leaking a persistence-specific type into the API/HTTP layer. Per the project's architecture (CLAUDE.md), EF Core is confined to `FinanceManager.Infrastructure` and controllers should depend on the repository abstraction, not the storage technology.

closes #303

## What changed

- Added `FinanceManager.Domain/Exceptions/DuplicateLoginException.cs` — a domain concept the API layer may depend on.
- `UserRepository.AddUser` (Infrastructure) catches `DbUpdateException` and, **only when a row with that login now exists**, translates it to `DuplicateLoginException`; otherwise it rethrows unchanged so genuine DB failures still surface (not swallowed).
- `UserController.Add` catches the domain `DuplicateLoginException` and returns `409 Conflict`; the `Microsoft.EntityFrameworkCore` using is removed.

## Behaviour

Unchanged — duplicate registration still returns `409 Conflict`. Pure internal refactor, so no changelog entry.

## Testing

- Build clean (warnings-as-errors); 371 unit + 152 integration tests pass.
- Verified `UserController` no longer references `Microsoft.EntityFrameworkCore`.

Note: the InMemory provider used by integration tests doesn't enforce the unique index, so the existing `Add_DuplicateLogin_ReturnsConflict` test exercises the pre-check → 409 path; the repository's `DbUpdateException` → `DuplicateLoginException` translation is the race fallback for a real relational DB.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9A4kMok3viGaU3x4jKLM4)_