### PR TITLE
Fix private const naming-rule violations and enforce naming in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ./code
 
+      # Naming-rule violations (IDE1006) are a hard failure: the .editorconfig naming rules
+      # are set to error severity, but the C# compiler does not run the naming analyzer during
+      # `dotnet build`, so this `dotnet format` check is what actually enforces them in CI.
+      - name: Enforce naming conventions
+        run: dotnet format style ./code --verify-no-changes --diagnostics IDE1006 --severity error
+
       - name: Check code formatting
         run: dotnet format ./code --verify-no-changes --verbosity diagnostic
         continue-on-error: true

--- a/code/.editorconfig
+++ b/code/.editorconfig
@@ -206,19 +206,19 @@ csharp_preserve_single_line_statements = true
 
 # Naming rules
 
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = warning
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = error
 dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
 dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
 
-dotnet_naming_rule.types_should_be_pascal_case.severity = warning
+dotnet_naming_rule.types_should_be_pascal_case.severity = error
 dotnet_naming_rule.types_should_be_pascal_case.symbols = types
 dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
 
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = error
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
-dotnet_naming_rule.private_or_internal_field_should_be__field.severity = warning
+dotnet_naming_rule.private_or_internal_field_should_be__field.severity = error
 dotnet_naming_rule.private_or_internal_field_should_be__field.symbols = private_or_internal_field
 dotnet_naming_rule.private_or_internal_field_should_be__field.style = _field
 

--- a/code/FinanceManager.Application/Services/Seeders/CurrencyAccountSeeder.cs
+++ b/code/FinanceManager.Application/Services/Seeders/CurrencyAccountSeeder.cs
@@ -13,11 +13,11 @@ public class CurrencyAccountSeeder(
     IFinancialLabelsRepository financialLabelsRepository,
     ILogger<CurrencyAccountSeeder> logger)
 {
-    private const decimal MonthlySalary = 5_000m;
-    private const decimal MonthlyRent = 1_000m;
-    private const decimal MonthlyUtilities = 100m;
-    private const int MaxRandomTransactionsPerDay = 10;
-    private const int MaxRandomTransactionAmount = 150;
+    private const decimal _monthlySalary = 5_000m;
+    private const decimal _monthlyRent = 1_000m;
+    private const decimal _monthlyUtilities = 100m;
+    private const int _maxRandomTransactionsPerDay = 10;
+    private const int _maxRandomTransactionAmount = 150;
 
     private record FakeMerchant(string Description, string LabelName);
 
@@ -83,7 +83,7 @@ public class CurrencyAccountSeeder(
 
         // Opening balance equals one month's salary so the partial first month can absorb random expenses
         // before the first day-1 paycheck lands.
-        account.AddEntry(new AddCurrencyEntryDto(start, MonthlySalary, "Opening balance", null, []), false);
+        account.AddEntry(new AddCurrencyEntryDto(start, _monthlySalary, "Opening balance", null, []), false);
 
         // The loan is taken out on the guest's very first day: its proceeds land in cash here while the loan
         // account books the matching debt (see SeedLoanAccount).
@@ -106,7 +106,7 @@ public class CurrencyAccountSeeder(
             switch (date.Day)
             {
                 case 1:
-                    account.AddEntry(new AddCurrencyEntryDto(date, MonthlySalary, "Monthly salary", null, salaryLabels), false);
+                    account.AddEntry(new AddCurrencyEntryDto(date, _monthlySalary, "Monthly salary", null, salaryLabels), false);
                     break;
                 case GuestInvestmentPlan.StockDayOfMonth:
                     // Pays for the matching stock purchase StockAccountSeeder books on the same day.
@@ -114,9 +114,9 @@ public class CurrencyAccountSeeder(
                     negativesThisMonth += GuestInvestmentPlan.StockMonthlyAmount;
                     break;
                 case 4:
-                    account.AddEntry(new AddCurrencyEntryDto(date, -MonthlyRent, "Rent payment", null, rentLabels), false);
-                    account.AddEntry(new AddCurrencyEntryDto(date, -MonthlyUtilities, "Utilities bill", null, utilitiesLabels), false);
-                    negativesThisMonth += MonthlyRent + MonthlyUtilities;
+                    account.AddEntry(new AddCurrencyEntryDto(date, -_monthlyRent, "Rent payment", null, rentLabels), false);
+                    account.AddEntry(new AddCurrencyEntryDto(date, -_monthlyUtilities, "Utilities bill", null, utilitiesLabels), false);
+                    negativesThisMonth += _monthlyRent + _monthlyUtilities;
                     break;
                 case GuestInvestmentPlan.BondDayOfMonth:
                     // Pays for the matching bond purchase BondAccountSeeder books on the same day.
@@ -140,14 +140,14 @@ public class CurrencyAccountSeeder(
 
     private static decimal AddRandomNegatives(CurrencyAccount account, DateTime date, Dictionary<string, FinancialLabel> labelByName, decimal negativesThisMonth)
     {
-        var transactions = Random.Shared.Next(0, MaxRandomTransactionsPerDay + 1);
+        var transactions = Random.Shared.Next(0, _maxRandomTransactionsPerDay + 1);
         for (var i = 0; i < transactions; i++)
         {
             // Rule from #240: total negatives within a month must stay strictly below the salary.
-            var remaining = MonthlySalary - 1m - negativesThisMonth;
+            var remaining = _monthlySalary - 1m - negativesThisMonth;
             if (remaining < 1m) break;
 
-            var max = (int)Math.Floor(Math.Min(MaxRandomTransactionAmount, remaining));
+            var max = (int)Math.Floor(Math.Min(_maxRandomTransactionAmount, remaining));
             if (max < 1) break;
             var amount = Random.Shared.Next(1, max + 1);
 

--- a/code/FinanceManager.Application/Services/Seeders/StockAccountSeeder.cs
+++ b/code/FinanceManager.Application/Services/Seeders/StockAccountSeeder.cs
@@ -18,8 +18,8 @@ public class StockAccountSeeder(
     // CSPX.LON is iShares Core S&P 500 UCITS ETF; its real ISIN is IE00B5BMR087.
     // Seeding a matching StockDetails row lets CachingIsinResolver resolve the ticker
     // from the local DB instead of falling through to OpenFIGI on every price lookup.
-    private const string DemoTicker = "CSPX.LON";
-    private const string DemoIsin = "IE00B5BMR087";
+    private const string _demoTicker = "CSPX.LON";
+    private const string _demoIsin = "IE00B5BMR087";
 
     public async Task Seed(int userId, DateTime start, DateTime end, CancellationToken cancellationToken = default)
     {
@@ -32,20 +32,20 @@ public class StockAccountSeeder(
         await SeedStockDetails(currency, cancellationToken);
 
         // Generate the price series before the account so each monthly buy can be sized from that day's price.
-        logger.LogTrace("Prefilling stock prices for {Isin}.", DemoIsin);
-        var prices = await SeedStockPrices(DemoIsin, currency, start, end, cancellationToken);
+        logger.LogTrace("Prefilling stock prices for {Isin}.", _demoIsin);
+        var prices = await SeedStockPrices(_demoIsin, currency, start, end, cancellationToken);
 
         await SeedStockAccount(userId, start, end, prices, cancellationToken);
     }
 
     private async Task SeedStockDetails(Currency currency, CancellationToken cancellationToken)
     {
-        if (await stockDetailsRepository.Get(DemoIsin, cancellationToken) is not null) return;
+        if (await stockDetailsRepository.Get(_demoIsin, cancellationToken) is not null) return;
 
         await stockDetailsRepository.Add(new StockDetails
         {
-            Isin = DemoIsin,
-            Ticker = DemoTicker,
+            Isin = _demoIsin,
+            Ticker = _demoTicker,
             Name = "iShares Core S&P 500 UCITS ETF",
             Type = "ETF",
             Region = "LSE",
@@ -70,9 +70,9 @@ public class StockAccountSeeder(
             var units = Math.Round(GuestInvestmentPlan.StockMonthlyAmount / price, 4, MidpointRounding.AwayFromZero);
             if (units <= 0) continue;
 
-            var entry = new StockAccountEntry(account.AccountId, 0, date, 0, units, DemoIsin, InvestmentType.Stock)
+            var entry = new StockAccountEntry(account.AccountId, 0, date, 0, units, _demoIsin, InvestmentType.Stock)
             {
-                Ticker = DemoTicker
+                Ticker = _demoTicker
             };
             account.Add(entry, false);
         }

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/AssetsDistributionOverviewCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/AssetsDistributionOverviewCard.razor
@@ -20,8 +20,8 @@
         </div>
         <MudToggleGroup T="string" Value="@_view" ValueChanged="OnViewChangedAsync"
                         Outlined="true" Dense="true" Class="flex-shrink-0 mt-1">
-            <MudToggleItem Value="@ViewByType" Text="By type" />
-            <MudToggleItem Value="@ViewByWallet" Text="By wallet" />
+            <MudToggleItem Value="@_viewByType" Text="By type" />
+            <MudToggleItem Value="@_viewByWallet" Text="By wallet" />
         </MudToggleGroup>
     </MudPaper>
 

--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/AssetsDistributionOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/AssetsDistributionOverviewCard.razor.cs
@@ -13,10 +13,10 @@ namespace FinanceManager.Components.Components.Dashboard.Cards.Assets;
 
 public partial class AssetsDistributionOverviewCard
 {
-    private const string ViewByType = "type";
-    private const string ViewByWallet = "wallet";
+    private const string _viewByType = "type";
+    private const string _viewByWallet = "wallet";
 
-    private string _view = ViewByType;
+    private string _view = _viewByType;
     private bool _isLoading;
     private Currency _currency = DefaultCurrency.PLN;
     private decimal _totalAssets;
@@ -33,7 +33,7 @@ public partial class AssetsDistributionOverviewCard
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
 
-    private List<NameValueResult> ActiveData => _view == ViewByWallet ? _walletData : _typeData;
+    private List<NameValueResult> ActiveData => _view == _viewByWallet ? _walletData : _typeData;
 
     private readonly ApexChartOptions<NameValueResult> _chartOptions = new()
     {

--- a/code/FinanceManager.UnitTests/Application/Services/Seeders/CurrencyAccountSeederTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/Seeders/CurrencyAccountSeederTests.cs
@@ -14,10 +14,10 @@ namespace FinanceManager.UnitTests.Application.Services.Seeders;
 [Trait("Category", "Unit")]
 public class CurrencyAccountSeederTests
 {
-    private const decimal MonthlySalary = 5_000m;
-    private const decimal MonthlyInvestment = 500m;
-    private const decimal MonthlyRent = 1_000m;
-    private const decimal MonthlyUtilities = 100m;
+    private const decimal _monthlySalary = 5_000m;
+    private const decimal _monthlyInvestment = 500m;
+    private const decimal _monthlyRent = 1_000m;
+    private const decimal _monthlyUtilities = 100m;
 
     private static readonly FinancialLabel[] _seededLabels =
     [
@@ -84,7 +84,7 @@ public class CurrencyAccountSeederTests
         Assert.All(salaryEntries, e =>
         {
             Assert.Equal(1, e.PostingDate.Day);
-            Assert.Equal(MonthlySalary, e.ValueChange);
+            Assert.Equal(_monthlySalary, e.ValueChange);
             Assert.Equal("Salary", Assert.Single(e.Labels).Name);
         });
 
@@ -127,13 +127,13 @@ public class CurrencyAccountSeederTests
         {
             var day3 = cashEntries.SingleOrDefault(e => e.PostingDate == month.AddDays(2));
             Assert.NotNull(day3);
-            Assert.Equal(-MonthlyInvestment, day3!.ValueChange);
+            Assert.Equal(-_monthlyInvestment, day3!.ValueChange);
             Assert.Contains(day3.Labels, l => l.Name == "Investment");
 
             var day4Entries = cashEntries.Where(e => e.PostingDate == month.AddDays(3)).ToList();
             Assert.Equal(2, day4Entries.Count);
-            Assert.Single(day4Entries, e => e.ValueChange == -MonthlyRent && e.Labels.Any(l => l.Name == "Rent"));
-            Assert.Single(day4Entries, e => e.ValueChange == -MonthlyUtilities && e.Labels.Any(l => l.Name == "Utilities"));
+            Assert.Single(day4Entries, e => e.ValueChange == -_monthlyRent && e.Labels.Any(l => l.Name == "Rent"));
+            Assert.Single(day4Entries, e => e.ValueChange == -_monthlyUtilities && e.Labels.Any(l => l.Name == "Utilities"));
         }
     }
 
@@ -151,8 +151,8 @@ public class CurrencyAccountSeederTests
             .GroupBy(e => new DateTime(e.PostingDate.Year, e.PostingDate.Month, 1))
             .Select(g => new { Month = g.Key, Total = -g.Sum(e => e.ValueChange) });
 
-        Assert.All(monthlyNegatives, m => Assert.True(m.Total < MonthlySalary,
-            $"Month {m.Month:yyyy-MM} negatives {m.Total} must be strictly below salary {MonthlySalary}."));
+        Assert.All(monthlyNegatives, m => Assert.True(m.Total < _monthlySalary,
+            $"Month {m.Month:yyyy-MM} negatives {m.Total} must be strictly below salary {_monthlySalary}."));
     }
 
     [Fact]

--- a/code/FinanceManager.UnitTests/Application/Services/Seeders/StockAccountSeederTests.cs
+++ b/code/FinanceManager.UnitTests/Application/Services/Seeders/StockAccountSeederTests.cs
@@ -14,8 +14,8 @@ namespace FinanceManager.UnitTests.Application.Services.Seeders;
 public class StockAccountSeederTests
 {
     // Mirrors the cash seeder's recurring "Investment" outflow that the stock buys are synced to.
-    private const decimal MonthlyInvestment = 500m;
-    private const int InvestmentDay = 3;
+    private const decimal _monthlyInvestment = 500m;
+    private const int _investmentDay = 3;
 
     private static readonly Currency _usd = new(1, "USD", "$");
 
@@ -76,7 +76,7 @@ public class StockAccountSeederTests
 
         // Feb–Jul: one buy on day 3 of each month whose investment day falls after the opening day.
         Assert.Equal(6, entries.Count);
-        Assert.All(entries, e => Assert.Equal(InvestmentDay, e.PostingDate.Day));
+        Assert.All(entries, e => Assert.Equal(_investmentDay, e.PostingDate.Day));
         var months = entries.Select(e => new DateTime(e.PostingDate.Year, e.PostingDate.Month, 1)).ToList();
         Assert.Equal(months.Count, months.Distinct().Count());
     }
@@ -107,8 +107,8 @@ public class StockAccountSeederTests
             var priceThatDay = _seededPrices[e.PostingDate.Date];
             var spent = e.ValueChange * priceThatDay;
             // Units are rounded to 4 dp, so the realised cash spend lands within a cent or two of the target.
-            Assert.True(Math.Abs(spent - MonthlyInvestment) < 0.05m,
-                $"Buy on {e.PostingDate:yyyy-MM-dd} spent {spent} at {priceThatDay}, expected ~{MonthlyInvestment}.");
+            Assert.True(Math.Abs(spent - _monthlyInvestment) < 0.05m,
+                $"Buy on {e.PostingDate:yyyy-MM-dd} spent {spent} at {priceThatDay}, expected ~{_monthlyInvestment}.");
         });
     }
 


### PR DESCRIPTION
- Rename 15 PascalCase private const fields to _camelCase to match the
  repo's prevailing convention (102 private consts already use _camelCase)
  and the existing editorconfig naming rule.
- Escalate all four .editorconfig naming rules from warning to error.
- Add a hard-gated 'dotnet format style --diagnostics IDE1006' CI step,
  since the C# compiler does not run the naming analyzer during build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code naming conventions to enforce stricter C# standards.
  * Enhanced CI workflow with additional code-quality checks.
  * Updated test utilities to align with new naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->