### PR TITLE
Add architecture tests to enforce layered monolith boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,12 +147,25 @@ jobs:
           mkdir -p ${{ github.workspace }}/TestResults
           ./code/FinanceManager.UnitTests/bin/Release/net10.0/FinanceManager.UnitTests -trx ${{ github.workspace }}/TestResults/unit-test-results.trx
 
+      - name: Run architecture tests
+        run: |
+          mkdir -p ${{ github.workspace }}/TestResults
+          ./code/FinanceManager.ArchitectureTests/bin/Release/net10.0/FinanceManager.ArchitectureTests -trx ${{ github.workspace }}/TestResults/architecture-test-results.trx
+
       - name: Publish unit test results
         uses: dorny/test-reporter@v1
         if: always()
         with:
           name: 'Unit Test Results'
           path: '${{ github.workspace }}/TestResults/**/unit-test-results.trx'
+          reporter: dotnet-trx
+
+      - name: Publish architecture test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: 'Architecture Test Results'
+          path: '${{ github.workspace }}/TestResults/**/architecture-test-results.trx'
           reporter: dotnet-trx
 
   integration-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,25 +147,12 @@ jobs:
           mkdir -p ${{ github.workspace }}/TestResults
           ./code/FinanceManager.UnitTests/bin/Release/net10.0/FinanceManager.UnitTests -trx ${{ github.workspace }}/TestResults/unit-test-results.trx
 
-      - name: Run architecture tests
-        run: |
-          mkdir -p ${{ github.workspace }}/TestResults
-          ./code/FinanceManager.ArchitectureTests/bin/Release/net10.0/FinanceManager.ArchitectureTests -trx ${{ github.workspace }}/TestResults/architecture-test-results.trx
-
       - name: Publish unit test results
         uses: dorny/test-reporter@v1
         if: always()
         with:
           name: 'Unit Test Results'
           path: '${{ github.workspace }}/TestResults/**/unit-test-results.trx'
-          reporter: dotnet-trx
-
-      - name: Publish architecture test results
-        uses: dorny/test-reporter@v1
-        if: always()
-        with:
-          name: 'Architecture Test Results'
-          path: '${{ github.workspace }}/TestResults/**/architecture-test-results.trx'
           reporter: dotnet-trx
 
   integration-tests:
@@ -205,9 +192,46 @@ jobs:
           path: '${{ github.workspace }}/TestResults/**/integration-test-results.trx'
           reporter: dotnet-trx
 
+  architecture-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore ./code
+
+      # ArchUnitNET analyzes compiled IL; Release optimizations (elided casts/locals,
+      # inlined typeof) can distort the dependency graph, so the maintainers recommend
+      # running architecture tests against a Debug build.
+      - name: Build architecture tests (Debug)
+        run: dotnet build ./code/FinanceManager.ArchitectureTests/FinanceManager.ArchitectureTests.csproj --configuration Debug
+
+      - name: Run architecture tests
+        run: |
+          mkdir -p ${{ github.workspace }}/TestResults
+          chmod +x ./code/FinanceManager.ArchitectureTests/bin/Debug/net10.0/FinanceManager.ArchitectureTests
+          ./code/FinanceManager.ArchitectureTests/bin/Debug/net10.0/FinanceManager.ArchitectureTests -trx ${{ github.workspace }}/TestResults/architecture-test-results.trx
+
+      - name: Publish architecture test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: 'Architecture Test Results'
+          path: '${{ github.workspace }}/TestResults/**/architecture-test-results.trx'
+          reporter: dotnet-trx
+
   publish:
     runs-on: ubuntu-latest
-    needs: [build, unit-tests, integration-tests, code-quality, security-scan]
+    needs: [build, unit-tests, integration-tests, architecture-tests, code-quality, security-scan]
     if: |
       always()
       && github.event_name == 'push'
@@ -215,6 +239,7 @@ jobs:
       && needs.build.result == 'success'
       && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'skipped')
       && (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped')
+      && (needs.architecture-tests.result == 'success' || needs.architecture-tests.result == 'skipped')
       && (needs.code-quality.result == 'success' || needs.code-quality.result == 'skipped')
       && (needs.security-scan.result == 'success' || needs.security-scan.result == 'skipped')
 

--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.3" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.3.3" />
+    <PackageVersion Include="TngTech.ArchUnitNET.xUnitV3" Version="0.13.3" />
     <PackageVersion Include="Blazor-ApexCharts" Version="6.1.0" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="Blazored.SessionStorage" Version="2.4.0" />

--- a/code/FinanceManager.ArchitectureTests/FinanceManager.ArchitectureTests.csproj
+++ b/code/FinanceManager.ArchitectureTests/FinanceManager.ArchitectureTests.csproj
@@ -23,6 +23,7 @@
 		<ProjectReference Include="..\FinanceManager.Infrastructure\FinanceManager.Infrastructure.csproj" />
 		<ProjectReference Include="..\FinanceManager.Api\FinanceManager.Api.csproj" />
 		<ProjectReference Include="..\FinanceManager.Components\FinanceManager.Components.csproj" />
+		<ProjectReference Include="..\FinanceManager\FinanceManager.WebUi.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/code/FinanceManager.ArchitectureTests/FinanceManager.ArchitectureTests.csproj
+++ b/code/FinanceManager.ArchitectureTests/FinanceManager.ArchitectureTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<RootNamespace>FinanceManager.ArchitectureTests</RootNamespace>
+		<OutputType>Exe</OutputType>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="TngTech.ArchUnitNET.xUnitV3" />
+		<PackageReference Include="xunit.runner.visualstudio">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="xunit.v3.mtp-v2" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\FinanceManager.Domain\FinanceManager.Domain.csproj" />
+		<ProjectReference Include="..\FinanceManager.Application\FinanceManager.Application.csproj" />
+		<ProjectReference Include="..\FinanceManager.Infrastructure\FinanceManager.Infrastructure.csproj" />
+		<ProjectReference Include="..\FinanceManager.Api\FinanceManager.Api.csproj" />
+		<ProjectReference Include="..\FinanceManager.Components\FinanceManager.Components.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+</Project>

--- a/code/FinanceManager.ArchitectureTests/FinanceManagerArchitecture.cs
+++ b/code/FinanceManager.ArchitectureTests/FinanceManagerArchitecture.cs
@@ -25,6 +25,7 @@ public static class FinanceManagerArchitecture
     private static readonly System.Reflection.Assembly _infrastructureAssembly = typeof(FinanceManager.Infrastructure.Repositories.AccountRepository).Assembly;
     private static readonly System.Reflection.Assembly _apiAssembly = typeof(FinanceManager.Api.Controllers.AssetsController).Assembly;
     private static readonly System.Reflection.Assembly _componentsAssembly = typeof(FinanceManager.Components.HttpClients.AdminAiProvidersHttpClient).Assembly;
+    private static readonly System.Reflection.Assembly _webUiAssembly = typeof(FinanceManager.WebUi.App).Assembly;
 
     public static readonly Architecture Architecture = new ArchLoader()
         .LoadAssemblies(
@@ -32,7 +33,8 @@ public static class FinanceManagerArchitecture
             _applicationAssembly,
             _infrastructureAssembly,
             _apiAssembly,
-            _componentsAssembly)
+            _componentsAssembly,
+            _webUiAssembly)
         .Build();
 
     public static readonly IObjectProvider<IType> DomainLayer =
@@ -49,6 +51,15 @@ public static class FinanceManagerArchitecture
 
     public static readonly IObjectProvider<IType> ComponentsLayer =
         Types().That().ResideInAssembly(_componentsAssembly).As("Components layer");
+
+    // FinanceManager.WebUi is the Blazor WASM bootstrap (Program.cs, App). It runs in the
+    // browser, so it is subject to the same constraints as Components.
+    public static readonly IObjectProvider<IType> WebUiLayer =
+        Types().That().ResideInAssembly(_webUiAssembly).As("WASM host (FinanceManager.WebUi)");
+
+    // The full browser-side surface: Blazor Components plus the WASM bootstrap host.
+    public static readonly IObjectProvider<IType> BrowserSideLayer =
+        Types().That().ResideInAssembly(_componentsAssembly, _webUiAssembly).As("Browser-side (Components + WASM host)");
 
     // External framework namespaces the inner layers must stay clear of. These live in
     // assemblies we deliberately do NOT load, so they are matched as dependency *targets*

--- a/code/FinanceManager.ArchitectureTests/FinanceManagerArchitecture.cs
+++ b/code/FinanceManager.ArchitectureTests/FinanceManagerArchitecture.cs
@@ -50,11 +50,12 @@ public static class FinanceManagerArchitecture
     public static readonly IObjectProvider<IType> ComponentsLayer =
         Types().That().ResideInAssembly(_componentsAssembly).As("Components layer");
 
-    // External infrastructure concerns the inner layers must stay clear of. These live in
-    // their own assemblies, so namespace matching is the right tool here.
-    public static readonly IObjectProvider<IType> EntityFrameworkCore =
-        Types().That().ResideInNamespaceMatching(@"^Microsoft\.EntityFrameworkCore").As("Entity Framework Core");
+    // External framework namespaces the inner layers must stay clear of. These live in
+    // assemblies we deliberately do NOT load, so they are matched as dependency *targets*
+    // (NotDependOnAnyTypesThat().ResideInNamespaceMatching(...)) rather than as loaded types.
+    // An IObjectProvider over Types() would be empty here — only the five FinanceManager
+    // assemblies are loaded — and the rule would pass vacuously.
+    public const string EntityFrameworkCoreNamespacePattern = @"^Microsoft\.EntityFrameworkCore";
 
-    public static readonly IObjectProvider<IType> AspNetCore =
-        Types().That().ResideInNamespaceMatching(@"^Microsoft\.AspNetCore").As("ASP.NET Core");
+    public const string AspNetCoreNamespacePattern = @"^Microsoft\.AspNetCore";
 }

--- a/code/FinanceManager.ArchitectureTests/FinanceManagerArchitecture.cs
+++ b/code/FinanceManager.ArchitectureTests/FinanceManagerArchitecture.cs
@@ -1,0 +1,60 @@
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using ArchUnitNET.Loader;
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+namespace FinanceManager.ArchitectureTests;
+
+/// <summary>
+/// Loads the FinanceManager assemblies once and exposes each architectural layer as a
+/// reusable <see cref="IObjectProvider{IType}"/> so the layer-leakage rules read declaratively.
+/// </summary>
+/// <remarks>
+/// Layers are defined by <b>assembly</b> (the real module/project boundary), not by namespace.
+/// Some types in this codebase are physically declared in one project but carry another
+/// project's namespace (e.g. DTOs in the Domain/Components projects sit under
+/// <c>FinanceManager.Infrastructure.Dtos</c>), so a namespace-based definition would
+/// misclassify them. Assembly-based definitions reflect the actual reference graph.
+/// </remarks>
+public static class FinanceManagerArchitecture
+{
+    // One marker type per project: locates the assembly and forces the compiler to keep the
+    // project reference (so the assembly is copied to the output dir for the loader).
+    private static readonly System.Reflection.Assembly _domainAssembly = typeof(FinanceManager.Domain.Entities.Logging.LogEntry).Assembly;
+    private static readonly System.Reflection.Assembly _applicationAssembly = typeof(FinanceManager.Application.Services.AdministrationUsersService).Assembly;
+    private static readonly System.Reflection.Assembly _infrastructureAssembly = typeof(FinanceManager.Infrastructure.Repositories.AccountRepository).Assembly;
+    private static readonly System.Reflection.Assembly _apiAssembly = typeof(FinanceManager.Api.Controllers.AssetsController).Assembly;
+    private static readonly System.Reflection.Assembly _componentsAssembly = typeof(FinanceManager.Components.HttpClients.AdminAiProvidersHttpClient).Assembly;
+
+    public static readonly Architecture Architecture = new ArchLoader()
+        .LoadAssemblies(
+            _domainAssembly,
+            _applicationAssembly,
+            _infrastructureAssembly,
+            _apiAssembly,
+            _componentsAssembly)
+        .Build();
+
+    public static readonly IObjectProvider<IType> DomainLayer =
+        Types().That().ResideInAssembly(_domainAssembly).As("Domain layer");
+
+    public static readonly IObjectProvider<IType> ApplicationLayer =
+        Types().That().ResideInAssembly(_applicationAssembly).As("Application layer");
+
+    public static readonly IObjectProvider<IType> InfrastructureLayer =
+        Types().That().ResideInAssembly(_infrastructureAssembly).As("Infrastructure layer");
+
+    public static readonly IObjectProvider<IType> ApiLayer =
+        Types().That().ResideInAssembly(_apiAssembly).As("Api layer");
+
+    public static readonly IObjectProvider<IType> ComponentsLayer =
+        Types().That().ResideInAssembly(_componentsAssembly).As("Components layer");
+
+    // External infrastructure concerns the inner layers must stay clear of. These live in
+    // their own assemblies, so namespace matching is the right tool here.
+    public static readonly IObjectProvider<IType> EntityFrameworkCore =
+        Types().That().ResideInNamespaceMatching(@"^Microsoft\.EntityFrameworkCore").As("Entity Framework Core");
+
+    public static readonly IObjectProvider<IType> AspNetCore =
+        Types().That().ResideInNamespaceMatching(@"^Microsoft\.AspNetCore").As("ASP.NET Core");
+}

--- a/code/FinanceManager.ArchitectureTests/LayerDependencyTests.cs
+++ b/code/FinanceManager.ArchitectureTests/LayerDependencyTests.cs
@@ -1,0 +1,110 @@
+using ArchUnitNET.Fluent;
+using ArchUnitNET.xUnitV3;
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+using static FinanceManager.ArchitectureTests.FinanceManagerArchitecture;
+
+namespace FinanceManager.ArchitectureTests;
+
+/// <summary>
+/// Enforces the layered modular monolith described in CLAUDE.md:
+/// Domain ← Application ← Infrastructure ← Api, with Components ← Application.
+/// Dependencies only ever point downward; the Domain stays free of infrastructure concerns
+/// and the browser-side Components never reach the database.
+/// </summary>
+[Trait("Category", "Architecture")]
+public class LayerDependencyTests
+{
+    // --- Domain is the pure leaf -------------------------------------------------------------
+
+    [Fact]
+    public void Domain_should_not_depend_on_any_other_layer()
+    {
+        IArchRule rule = Types().That().Are(DomainLayer)
+            .Should().NotDependOnAny(ApplicationLayer)
+            .AndShould().NotDependOnAny(InfrastructureLayer)
+            .AndShould().NotDependOnAny(ApiLayer)
+            .AndShould().NotDependOnAny(ComponentsLayer)
+            .Because("the Domain layer is the leaf of the dependency graph and must not reference outer layers.");
+
+        rule.Check(Architecture);
+    }
+
+    [Fact]
+    public void Domain_should_not_depend_on_entity_framework_core()
+    {
+        IArchRule rule = Types().That().Are(DomainLayer)
+            .Should().NotDependOnAny(EntityFrameworkCore)
+            .Because("the Domain layer must remain persistence-ignorant (no EF Core).");
+
+        rule.Check(Architecture);
+    }
+
+    [Fact]
+    public void Domain_should_not_depend_on_aspnet_core()
+    {
+        IArchRule rule = Types().That().Are(DomainLayer)
+            .Should().NotDependOnAny(AspNetCore)
+            .Because("the Domain layer must not reference ASP.NET Core.");
+
+        rule.Check(Architecture);
+    }
+
+    // --- Application sits directly above Domain ----------------------------------------------
+
+    [Fact]
+    public void Application_should_not_depend_on_outer_layers()
+    {
+        IArchRule rule = Types().That().Are(ApplicationLayer)
+            .Should().NotDependOnAny(InfrastructureLayer)
+            .AndShould().NotDependOnAny(ApiLayer)
+            .AndShould().NotDependOnAny(ComponentsLayer)
+            .Because("the Application layer orchestrates use cases and must not depend on Infrastructure, Api or Components.");
+
+        rule.Check(Architecture);
+    }
+
+    // --- Infrastructure may know Application/Domain but nothing above it ----------------------
+
+    [Fact]
+    public void Infrastructure_should_not_depend_on_presentation_layers()
+    {
+        IArchRule rule = Types().That().Are(InfrastructureLayer)
+            .Should().NotDependOnAny(ApiLayer)
+            .AndShould().NotDependOnAny(ComponentsLayer)
+            .Because("Infrastructure is an inner layer and must not depend on the Api or Components presentation layers.");
+
+        rule.Check(Architecture);
+    }
+
+    // --- Components is browser-side and must never touch the database -------------------------
+
+    [Fact]
+    public void Components_should_not_depend_on_infrastructure()
+    {
+        IArchRule rule = Types().That().Are(ComponentsLayer)
+            .Should().NotDependOnAny(InfrastructureLayer)
+            .Because("Blazor Components must reach the server through typed HttpClients, never the Infrastructure layer directly.");
+
+        rule.Check(Architecture);
+    }
+
+    [Fact]
+    public void Components_should_not_depend_on_entity_framework_core()
+    {
+        IArchRule rule = Types().That().Are(ComponentsLayer)
+            .Should().NotDependOnAny(EntityFrameworkCore)
+            .Because("Blazor Components run in the browser and must never access the database (no EF Core).");
+
+        rule.Check(Architecture);
+    }
+
+    [Fact]
+    public void Components_should_not_depend_on_api()
+    {
+        IArchRule rule = Types().That().Are(ComponentsLayer)
+            .Should().NotDependOnAny(ApiLayer)
+            .Because("Components talk to the Api over HTTP, not by referencing the Api host assembly.");
+
+        rule.Check(Architecture);
+    }
+}

--- a/code/FinanceManager.ArchitectureTests/LayerDependencyTests.cs
+++ b/code/FinanceManager.ArchitectureTests/LayerDependencyTests.cs
@@ -7,9 +7,10 @@ namespace FinanceManager.ArchitectureTests;
 
 /// <summary>
 /// Enforces the layered modular monolith described in CLAUDE.md:
-/// Domain ← Application ← Infrastructure ← Api, with Components ← Application.
+/// Domain ← Application ← Infrastructure ← Api, with the browser-side surface
+/// (Components + the FinanceManager.WebUi WASM host) ← Application.
 /// Dependencies only ever point downward; the Domain stays free of infrastructure concerns
-/// and the browser-side Components never reach the database.
+/// and the browser-side code never reaches the database.
 /// </summary>
 [Trait("Category", "Architecture")]
 public class LayerDependencyTests
@@ -24,6 +25,7 @@ public class LayerDependencyTests
             .AndShould().NotDependOnAny(InfrastructureLayer)
             .AndShould().NotDependOnAny(ApiLayer)
             .AndShould().NotDependOnAny(ComponentsLayer)
+            .AndShould().NotDependOnAny(WebUiLayer)
             .Because("the Domain layer is the leaf of the dependency graph and must not reference outer layers.");
 
         rule.Check(Architecture);
@@ -58,7 +60,8 @@ public class LayerDependencyTests
             .Should().NotDependOnAny(InfrastructureLayer)
             .AndShould().NotDependOnAny(ApiLayer)
             .AndShould().NotDependOnAny(ComponentsLayer)
-            .Because("the Application layer orchestrates use cases and must not depend on Infrastructure, Api or Components.");
+            .AndShould().NotDependOnAny(WebUiLayer)
+            .Because("the Application layer orchestrates use cases and must not depend on Infrastructure or the presentation layers.");
 
         rule.Check(Architecture);
     }
@@ -71,39 +74,40 @@ public class LayerDependencyTests
         IArchRule rule = Types().That().Are(InfrastructureLayer)
             .Should().NotDependOnAny(ApiLayer)
             .AndShould().NotDependOnAny(ComponentsLayer)
-            .Because("Infrastructure is an inner layer and must not depend on the Api or Components presentation layers.");
+            .AndShould().NotDependOnAny(WebUiLayer)
+            .Because("Infrastructure is an inner layer and must not depend on the Api or browser-side presentation layers.");
 
         rule.Check(Architecture);
     }
 
-    // --- Components is browser-side and must never touch the database -------------------------
+    // --- Browser-side (Components + WASM host) must never touch the database ------------------
 
     [Fact]
-    public void Components_should_not_depend_on_infrastructure()
+    public void Browser_side_should_not_depend_on_infrastructure()
     {
-        IArchRule rule = Types().That().Are(ComponentsLayer)
+        IArchRule rule = Types().That().Are(BrowserSideLayer)
             .Should().NotDependOnAny(InfrastructureLayer)
-            .Because("Blazor Components must reach the server through typed HttpClients, never the Infrastructure layer directly.");
+            .Because("browser-side code must reach the server through typed HttpClients, never the Infrastructure layer directly.");
 
         rule.Check(Architecture);
     }
 
     [Fact]
-    public void Components_should_not_depend_on_entity_framework_core()
+    public void Browser_side_should_not_depend_on_entity_framework_core()
     {
-        IArchRule rule = Types().That().Are(ComponentsLayer)
+        IArchRule rule = Types().That().Are(BrowserSideLayer)
             .Should().NotDependOnAnyTypesThat().ResideInNamespaceMatching(EntityFrameworkCoreNamespacePattern)
-            .Because("Blazor Components run in the browser and must never access the database (no EF Core).");
+            .Because("browser-side code runs in the browser and must never access the database (no EF Core).");
 
         rule.Check(Architecture);
     }
 
     [Fact]
-    public void Components_should_not_depend_on_api()
+    public void Browser_side_should_not_depend_on_api()
     {
-        IArchRule rule = Types().That().Are(ComponentsLayer)
+        IArchRule rule = Types().That().Are(BrowserSideLayer)
             .Should().NotDependOnAny(ApiLayer)
-            .Because("Components talk to the Api over HTTP, not by referencing the Api host assembly.");
+            .Because("browser-side code talks to the Api over HTTP, not by referencing the Api host assembly.");
 
         rule.Check(Architecture);
     }

--- a/code/FinanceManager.ArchitectureTests/LayerDependencyTests.cs
+++ b/code/FinanceManager.ArchitectureTests/LayerDependencyTests.cs
@@ -33,7 +33,7 @@ public class LayerDependencyTests
     public void Domain_should_not_depend_on_entity_framework_core()
     {
         IArchRule rule = Types().That().Are(DomainLayer)
-            .Should().NotDependOnAny(EntityFrameworkCore)
+            .Should().NotDependOnAnyTypesThat().ResideInNamespaceMatching(EntityFrameworkCoreNamespacePattern)
             .Because("the Domain layer must remain persistence-ignorant (no EF Core).");
 
         rule.Check(Architecture);
@@ -43,7 +43,7 @@ public class LayerDependencyTests
     public void Domain_should_not_depend_on_aspnet_core()
     {
         IArchRule rule = Types().That().Are(DomainLayer)
-            .Should().NotDependOnAny(AspNetCore)
+            .Should().NotDependOnAnyTypesThat().ResideInNamespaceMatching(AspNetCoreNamespacePattern)
             .Because("the Domain layer must not reference ASP.NET Core.");
 
         rule.Check(Architecture);
@@ -92,7 +92,7 @@ public class LayerDependencyTests
     public void Components_should_not_depend_on_entity_framework_core()
     {
         IArchRule rule = Types().That().Are(ComponentsLayer)
-            .Should().NotDependOnAny(EntityFrameworkCore)
+            .Should().NotDependOnAnyTypesThat().ResideInNamespaceMatching(EntityFrameworkCoreNamespacePattern)
             .Because("Blazor Components run in the browser and must never access the database (no EF Core).");
 
         rule.Check(Architecture);

--- a/code/FinanceManager.slnx
+++ b/code/FinanceManager.slnx
@@ -17,6 +17,7 @@
     <File Path="GlobalUsings.cs" />
   </Folder>
   <Project Path="FinanceManager.Application/FinanceManager.Application.csproj" />
+  <Project Path="FinanceManager.ArchitectureTests/FinanceManager.ArchitectureTests.csproj" />
   <Project Path="FinanceManager.Domain/FinanceManager.Domain.csproj" />
   <Project Path="FinanceManager.Infrastructure/FinanceManager.Infrastructure.csproj" />
   <Project Path="FinanceManager.IntegrationTests/FinanceManager.IntegrationTests.csproj" />


### PR DESCRIPTION
## Summary

Introduces a new `FinanceManager.ArchitectureTests` project that uses ArchUnitNET to enforce the layered modular monolith architecture described in CLAUDE.md. These tests prevent dependency violations and ensure the Domain layer remains free of infrastructure concerns while Blazor Components never directly access the database.

## Key Changes

- **New project**: `FinanceManager.ArchitectureTests` with xUnit + ArchUnitNET integration
- **Architecture definition** (`FinanceManagerArchitecture.cs`):
  - Loads all five projects (Domain, Application, Infrastructure, Api, Components) as a single `Architecture` instance
  - Defines each layer as an `IObjectProvider<IType>` based on assembly boundaries (not namespaces, to handle cross-project DTOs correctly)
  - Exposes external concerns (Entity Framework Core, ASP.NET Core) for negative dependency checks
  
- **Layer dependency tests** (`LayerDependencyTests.cs`):
  - Domain is a pure leaf: cannot depend on Application, Infrastructure, Api, Components, EF Core, or ASP.NET Core
  - Application sits above Domain: cannot depend on Infrastructure, Api, or Components
  - Infrastructure cannot depend on Api or Components presentation layers
  - Components (browser-side) cannot depend on Infrastructure, EF Core, or Api (communicates via HTTP instead)

## Implementation Details

- Assembly-based layer definitions reflect the actual reference graph and correctly classify types even when they carry a different project's namespace (e.g., DTOs)
- Each test includes a `Because()` clause explaining the architectural rationale
- Tests are marked with `[Trait("Category", "Architecture")]` for easy filtering
- All five projects are added as references to ensure assemblies are available at test runtime

https://claude.ai/code/session_017TTWj9Usj332iM6KZtxnyE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive architecture tests to enforce layered dependency rules across the application, ensuring Domain layer remains independent and other layers respect their boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->