### PR TITLE
Drop 'By' prefix from assets distribution toggle labels

### DIFF
--- a/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/AssetsDistributionOverviewCard.razor
+++ b/code/FinanceManager.Components/Components/Dashboard/Cards/Assets/AssetsDistributionOverviewCard.razor
@@ -20,8 +20,8 @@
         </div>
         <MudToggleGroup T="string" Value="@_view" ValueChanged="OnViewChangedAsync"
                         Outlined="true" Dense="true" Class="flex-shrink-0 mt-1">
-            <MudToggleItem Value="@_viewByType" Text="By type" />
-            <MudToggleItem Value="@_viewByWallet" Text="By wallet" />
+            <MudToggleItem Value="@_viewByType" Text="Type" />
+            <MudToggleItem Value="@_viewByWallet" Text="Wallet" />
         </MudToggleGroup>
     </MudPaper>
 


### PR DESCRIPTION
## Summary

Makes the **Assets distribution** card's view toggle match the **Liabilities distribution** card. The toggle previously read "By type" / "By wallet"; it now reads "Type" / "Wallet" (rendered uppercase as `TYPE` / `WALLET`), consistent with the Liabilities card's `TYPE` / `ACCOUNT`.

## Changes

- `AssetsDistributionOverviewCard.razor`: toggle item text `By type` → `Type`, `By wallet` → `Wallet`.

## Verification

- `dotnet build ./code/FinanceManager.slnx` — succeeds, no warnings.
- Rendered on the guest demo account; screenshot confirms the toggle now shows `TYPE | WALLET`.

| Before | After |
|---|---|
| `BY TYPE` / `BY WALLET` | `TYPE` / `WALLET` |


---
_Generated by [Claude Code](https://claude.ai/code/session_01QPiNZL9wX9drYtmqpZ3KF1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated toggle button labels in the Assets Distribution view from "By type" to "Type" and "By wallet" to "Wallet" for more concise labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->