### PR TITLE
Fix toolbar mobile overflow and action button style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ rules agents must follow when updating this file.
 
 ## [Unreleased]
 
+### Fixed
+- Account history toolbar no longer overflows on narrow mobile screens: the Income/Expense toggle items show only their arrow icons on mobile (text hidden), and the label filter button shows only its icon, keeping all controls within a 360 px viewport. #350
+- Transaction row Edit/Duplicate/Delete action buttons now share a consistent outlined style; Edit was previously filled amber while the others were outlined. #351
+
 ### Changed
 - Account transaction toolbar redesigned into a single wrapping row: search field, All/Income/Expense segmented toggle, multi-select label filter, and a split "Add entry" button that keeps Import, Export CSV, and Manage account in an attached dropdown — the whole bar now fits on one line at full width. #289
 - Expanded transaction row details now show a running balance field and a Duplicate action alongside Edit and Delete; the actions are styled as filled/outlined buttons; labels are displayed as chips with a "+ Add label" shortcut; a dashed divider and amber row tint signal the open state. #290

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountHistoryToolbar.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/AccountHistoryToolbar.razor
@@ -14,10 +14,12 @@
                         Outlined="true" Dense="true" CheckMark="false">
             <MudToggleItem Value="@("All")" Text="All" />
             <MudToggleItem Value="@("Income")">
-                <MudIcon Icon="@Icons.Material.Filled.ArrowUpward" Size="Size.Small" Class="mr-1" />Income
+                <MudIcon Icon="@Icons.Material.Filled.ArrowUpward" Size="Size.Small" Class="@(IsMobile ? "" : "mr-1")" />
+                @if (!IsMobile) { <text>Income</text> }
             </MudToggleItem>
             <MudToggleItem Value="@("Expense")">
-                <MudIcon Icon="@Icons.Material.Filled.ArrowDownward" Size="Size.Small" Class="mr-1" />Expense
+                <MudIcon Icon="@Icons.Material.Filled.ArrowDownward" Size="Size.Small" Class="@(IsMobile ? "" : "mr-1")" />
+                @if (!IsMobile) { <text>Expense</text> }
             </MudToggleItem>
         </MudToggleGroup>
 
@@ -31,7 +33,7 @@
                                StartIcon="@Icons.Material.Filled.Label"
                                EndIcon="@Icons.Material.Filled.KeyboardArrowDown"
                                Style="text-transform: none;">
-                        @LabelButtonText
+                        @(IsMobile ? null : LabelButtonText)
                     </MudButton>
                 </ActivatorContent>
                 <ChildContent>

--- a/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/TransactionRow.razor
+++ b/code/FinanceManager.Components/Components/FinancialAccounts/CurrencyAccountComponents/TransactionRow.razor
@@ -88,7 +88,7 @@
             </MudItem>
             <MudItem xs="12">
                 <MudStack Row="true" Spacing="2">
-                    <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small"
+                    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small"
                                StartIcon="@Icons.Material.Filled.Edit" OnClick="ShowEditOverlay">Edit</MudButton>
                     <MudButton Variant="Variant.Outlined" Size="Size.Small"
                                StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="DuplicateEntry">Duplicate</MudButton>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Toolbar controls (Income/Expense toggle + label filter button) now hide their text labels on mobile, showing only icons, so all controls fit within a 360 px viewport without clipping. closes #350
- Edit/Duplicate/Delete action buttons in expanded transaction rows now share a consistent outlined style — Edit was previously filled amber while the others were outlined. closes #351

## Test plan

- [ ] On a ~360 px mobile viewport, open a currency account and confirm the toolbar controls (toggle + label icon + add button) all fit without overflow
- [ ] Toggle Income/Expense — confirm only the arrow icon shows on mobile, full text on desktop
- [ ] Expand a transaction row — confirm Edit, Duplicate, and Delete all use outlined style; Delete is red-outlined, Edit and Duplicate are primary/default outlined
EOF
)"

---
_Generated by [Claude Code](https://claude.ai/code/session_01Puue6svt5GGHUFn4qTPyYk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **User Experience**
  * Enhanced mobile responsiveness: toolbar items now display as compact icons on mobile devices for better screen utilization, with full labels on desktop
  * Refined visual styling of action buttons to improve interface consistency and interaction clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->