### PR TITLE
Add live app link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
   <a href="https://github.com/avresial/FinanceManager/issues"><img src="https://img.shields.io/github/issues/avresial/FinanceManager" alt="GitHub issues"/></a>
   <img src="https://img.shields.io/badge/.NET-10-512BD4" alt=".NET 10"/>
   <img src="https://img.shields.io/badge/Blazor-WASM-blue" alt="Blazor WASM"/>
+  <a href="https://financemanager.mikikarkowski.dev/login"><img src="https://img.shields.io/badge/Live%20App-online-brightgreen" alt="Live App"/></a>
 </p>
 
 # FinanceManager
 
 **FinanceManager** is an open-source personal finance tracker built with Blazor WebAssembly and ASP.NET Core. It lets you manage all your accounts — cash, stocks, and bonds — in one place, with a rich analytics dashboard, AI-powered insights, and real-time market data.
 
-> **[Live Demo](https://avresial.github.io/FinanceManager/landingpage)**
+> **[Live App](https://financemanager.mikikarkowski.dev/login)**
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates the "Live Demo" link to the working live app URL: https://financemanager.mikikarkowski.dev/login
- Adds a "Live App" badge in the README header pointing to the same URL

## Test plan

- [ ] Verify the badge and link in the README render correctly on GitHub
- [ ] Confirm the link https://financemanager.mikikarkowski.dev/login is reachable

https://claude.ai/code/session_013N5magmHdQVe44BKvE71Li

---
_Generated by [Claude Code](https://claude.ai/code/session_013N5magmHdQVe44BKvE71Li)_