### PR TITLE
Migrate WASM JSON dependencies

### DIFF
--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -46,7 +46,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MudBlazor" Version="9.4.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />

--- a/code/FinanceManager.Application/FinanceManager.Application.csproj
+++ b/code/FinanceManager.Application/FinanceManager.Application.csproj
@@ -17,7 +17,6 @@
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-		<PackageReference Include="Newtonsoft.Json" />
 		<PackageReference Include="Scrutor" />
 		<PackageReference Include="System.Linq.Async" />
 	</ItemGroup>

--- a/code/FinanceManager.Components/FinanceManager.Components.csproj
+++ b/code/FinanceManager.Components/FinanceManager.Components.csproj
@@ -28,12 +28,6 @@
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" />
 		<PackageReference Include="Microsoft.Extensions.Localization" />
 		<PackageReference Include="MudBlazor" />
-		<PackageReference Include="Newtonsoft.Json" />
-		<PackageReference Include="System.Configuration.ConfigurationManager" />
-		<PackageReference Include="System.Memory.Data" />
-		<PackageReference Include="System.Security.Cryptography.Xml" />
-		<PackageReference Include="System.Security.Permissions" />
-		<PackageReference Include="System.Windows.Extensions" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/code/FinanceManager.Infrastructure/Services/Currencies/FawazAhmedCurrencyApiClient.cs
+++ b/code/FinanceManager.Infrastructure/Services/Currencies/FawazAhmedCurrencyApiClient.cs
@@ -1,7 +1,7 @@
 using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Services;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace FinanceManager.Infrastructure.Services.Currencies;
 
@@ -14,10 +14,15 @@ internal sealed class FawazAhmedCurrencyApiClient(
         try
         {
             var response = await httpClient.GetAsync($"https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@{date:yyyy-MM-dd}/v1/currencies/{fromCurrency.ShortName.ToLower()}.json");
-            var jObject = JObject.Parse(await response.Content.ReadAsStringAsync());
-            var tokenPath = $"$.{fromCurrency.ShortName.ToLower()}.{toCurrency.ShortName.ToLower()}";
+            await using var contentStream = await response.Content.ReadAsStreamAsync();
+            using var document = await JsonDocument.ParseAsync(contentStream);
 
-            return (decimal?)jObject.SelectToken(tokenPath);
+            if (document.RootElement.TryGetProperty(fromCurrency.ShortName.ToLower(), out var fromCurrencyRates) &&
+                fromCurrencyRates.TryGetProperty(toCurrency.ShortName.ToLower(), out var exchangeRate) &&
+                exchangeRate.TryGetDecimal(out var value))
+                return value;
+
+            return null;
         }
         catch (Exception ex)
         {

--- a/code/FinanceManager/FinanceManager.WebUi.csproj
+++ b/code/FinanceManager/FinanceManager.WebUi.csproj
@@ -18,7 +18,6 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" />
-		<PackageReference Include="System.Configuration.ConfigurationManager" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
### Motivation
- Remove server-side JSON and other system package references from WASM/Blazor components to shrink client bundle size and avoid shipping server-only assemblies to the browser. 
- Replace the last runtime use of `Newtonsoft.Json` in a WASM-relevant codepath with `System.Text.Json` for better compatibility and smaller output.

### Description
- Removed `Newtonsoft.Json` package version from `code/Directory.Packages.props` and removed direct `Newtonsoft.Json` and several server-only `System.*` package references from `code/FinanceManager.Components/FinanceManager.Components.csproj` and `code/FinanceManager/FinanceManager.WebUi.csproj`.
- Removed the unused `Newtonsoft.Json` package reference from `code/FinanceManager.Application/FinanceManager.Application.csproj`.
- Replaced `Newtonsoft.Json.Linq.JObject` parsing in `code/FinanceManager.Infrastructure/Services/Currencies/FawazAhmedCurrencyApiClient.cs` with `System.Text.Json.JsonDocument` and updated the exchange-rate extraction logic to use `TryGetProperty`/`TryGetDecimal` patterns and return `null` when absent.
- Opened a draft PR summarizing the changes (title: `Draft: Migrate WASM JSON dependencies`).

### Testing
- Ran `dotnet publish code/FinanceManager/FinanceManager.WebUi.csproj -c Release -o /tmp/fm-before` and `dotnet publish ... -o /tmp/fm-after` to compare output sizes, and confirmed Brotli assets decreased from `6,217,970` to `5,773,905` bytes and gzip assets decreased from `7,735,619` to `7,198,454` bytes.
- Ran unit tests with the Microsoft Test Platform opt-in and Copilot download disabled via `dotnet test --project code/FinanceManager.UnitTests/FinanceManager.UnitTests.csproj -c Release --no-restore -p:CopilotSkipCliDownload=true` (with a temporary `global.json` to opt in), and observed all tests passed: `total: 390, succeeded: 390, failed: 0`.
- Publish and test commands completed successfully as described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252096e21c8320932428e80ef3c3b6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused NuGet package dependencies from the project.
  * Migrated JSON parsing from a third-party library to built-in framework utilities for improved performance and reduced external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->