### PR TITLE
[codex] Secure password reset endpoints

### DIFF
--- a/code/FinanceManager.Api/Controllers/PasswordResetController.cs
+++ b/code/FinanceManager.Api/Controllers/PasswordResetController.cs
@@ -12,6 +12,7 @@ namespace FinanceManager.Api.Controllers;
 [EnableRateLimiting(RateLimitingServiceCollectionExtension.AuthPolicy)]
 public class PasswordResetController(
     IPasswordResetService passwordResetService,
+    IWebHostEnvironment environment,
     ILogger<PasswordResetController> logger) : ControllerBase
 {
     // Same wording regardless of whether the account exists, so the response carries no account-enumeration signal.
@@ -25,16 +26,15 @@ public class PasswordResetController(
     [AllowAnonymous]
     [HttpPost("forgot-password")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ForgotPasswordResponse))]
+    [ProducesResponseType(StatusCodes.Status501NotImplemented)]
     public async Task<IActionResult> ForgotPassword(ForgotPasswordRequest request, CancellationToken cancellationToken = default)
     {
-        var rawToken = await passwordResetService.RequestReset(request.Login, cancellationToken);
+        if (UnavailableOutsideDevelopment() is { } unavailable) return unavailable;
 
-        // TEMPORARY (issue #280): no email provider is wired up yet, so the raw token is returned in the response
-        // and the client renders a direct "reset password" link from it. A token is returned for *every* request —
-        // a real persisted one for registered accounts, a throwaway one otherwise — so neither the response nor the
-        // link reveals whether the email is registered (#342). Once transactional email is in place the token must
-        // stop being returned here and be delivered only via the emailed link.
-        return Ok(new ForgotPasswordResponse(_genericMessage, rawToken));
+        await passwordResetService.RequestReset(request.Login, cancellationToken);
+
+        // The raw token must never be returned over HTTP; issue #280 will add email-only delivery.
+        return Ok(new ForgotPasswordResponse(_genericMessage));
     }
 
     /// <summary>Validates and consumes a reset token, setting the account's new password on success.</summary>
@@ -42,12 +42,25 @@ public class PasswordResetController(
     [HttpPost("reset-password")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status501NotImplemented)]
     public async Task<IActionResult> ResetPassword(ResetPasswordRequest request, CancellationToken cancellationToken = default)
     {
+        if (UnavailableOutsideDevelopment() is { } unavailable) return unavailable;
+
         var result = await passwordResetService.ResetPassword(request.Token, request.NewPassword, cancellationToken);
         if (result.Succeeded) return Ok();
 
         logger.LogInformation("Password reset rejected with status {Status}.", result.Status);
         return BadRequest("This password reset link is invalid or has expired. Please request a new one.");
+    }
+
+    private IActionResult? UnavailableOutsideDevelopment()
+    {
+        if (environment.IsDevelopment()) return null;
+
+        logger.LogWarning(
+            "Password reset endpoint {Path} rejected because reset token delivery is not configured outside Development.",
+            HttpContext.Request.Path);
+        return StatusCode(StatusCodes.Status501NotImplemented, "Password reset is not available.");
     }
 }

--- a/code/FinanceManager.Api/Controllers/PasswordResetController.cs
+++ b/code/FinanceManager.Api/Controllers/PasswordResetController.cs
@@ -58,9 +58,13 @@ public class PasswordResetController(
     {
         if (environment.IsDevelopment()) return null;
 
+        var pathForLog = HttpContext.Request.Path.ToString()
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty);
+
         logger.LogWarning(
             "Password reset endpoint {Path} rejected because reset token delivery is not configured outside Development.",
-            HttpContext.Request.Path);
+            pathForLog);
         return StatusCode(StatusCodes.Status501NotImplemented, "Password reset is not available.");
     }
 }

--- a/code/FinanceManager.Api/Program.cs
+++ b/code/FinanceManager.Api/Program.cs
@@ -247,6 +247,10 @@ builder.Services.AddHostedService<LogRetentionBackgroundService>();
 
 var app = builder.Build();
 
+if (!app.Environment.IsDevelopment())
+    app.Logger.LogWarning(
+        "Password reset endpoints are disabled outside Development until transactional email delivery is implemented.");
+
 // Must run before any middleware that inspects the scheme or client IP (HTTPS redirect, CORS,
 // rate limiter): it rewrites Request.Scheme/IsHttps and the remote IP from the proxy's
 // X-Forwarded-* headers so the rest of the pipeline sees the original client request.

--- a/code/FinanceManager.Application/Services/PasswordResetService.cs
+++ b/code/FinanceManager.Application/Services/PasswordResetService.cs
@@ -18,9 +18,9 @@ public class PasswordResetService(
 
     public async Task<string> RequestReset(string login, CancellationToken cancellationToken = default)
     {
-        // Always mint a token so the return value (and therefore the API response and the link the client renders)
-        // looks the same for every request. For an unknown login the token is returned but never persisted, so it
-        // can't reset anything — the caller cannot tell a registered email from an unregistered one.
+        // Always mint a token so future email delivery can use the same caller path for registered and unknown
+        // accounts. For an unknown login the token is returned to backend code but never persisted, so it can't
+        // reset anything; controllers must not expose the raw token over HTTP.
         var rawToken = GenerateRawToken();
 
         if (string.IsNullOrWhiteSpace(login)) return rawToken;

--- a/code/FinanceManager.Components/Components/Features/User/Components/ForgotPasswordComponent.razor
+++ b/code/FinanceManager.Components/Components/Features/User/Components/ForgotPasswordComponent.razor
@@ -13,24 +13,6 @@
                         @_message
                     </MudAlert>
 
-                    @* TEMPORARY (issue #280): no email is sent yet, so we surface the reset link directly here.
-                       Once transactional email is wired up this block is removed and the link is emailed instead. *@
-                    @if (!string.IsNullOrEmpty(_resetLink))
-                    {
-                        <MudAlert Severity="Severity.Info" Class="my-3" data-testid="forgot-reset-link-hint">
-                            Email delivery isn't set up yet — use this link to reset your password:
-                        </MudAlert>
-                        <MudButton Href="@_resetLink" Class="my-2" Variant="Variant.Filled" Color="Color.Primary"
-                                   FullWidth data-testid="forgot-reset-link">
-                            <MudText Typo="Typo.h5">Reset password</MudText>
-                        </MudButton>
-                        <MudAlert Severity="Severity.Warning" Class="my-3" data-testid="forgot-reset-link-warning">
-                            Heads up: this on-screen link is a temporary convenience while email delivery isn't set
-                            up yet, and it is not secure. It will be removed once email is introduced, after which the
-                            link will only ever arrive in your inbox.
-                        </MudAlert>
-                    }
-
                     <MudLink Href="login" Class="mt-3" data-testid="forgot-back-to-login">
                         <MudText Typo="Typo.subtitle1">Back to sign in</MudText>
                     </MudLink>

--- a/code/FinanceManager.Components/Components/Features/User/Components/ForgotPasswordComponent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/User/Components/ForgotPasswordComponent.razor.cs
@@ -15,7 +15,6 @@ public partial class ForgotPasswordComponent
     private bool _isProcessing;
     private bool _requestSent;
     private string _message = string.Empty;
-    private string? _resetLink;
 
     [Inject] public required ILogger<ForgotPasswordComponent> Logger { get; set; }
     [Inject] public required PasswordResetHttpClient PasswordResetHttpClient { get; set; }
@@ -41,12 +40,6 @@ public partial class ForgotPasswordComponent
             }
 
             _message = response.Message;
-
-            // TEMPORARY (issue #280): with no email provider, the API hands back the raw token so we can build a
-            // direct reset link here. Once email delivery lands this returns null and the link disappears.
-            if (!string.IsNullOrEmpty(response.ResetToken))
-                _resetLink = $"reset-password?token={Uri.EscapeDataString(response.ResetToken)}";
-
             _requestSent = true;
         }
         catch (Exception ex)

--- a/code/FinanceManager.Components/HttpClients/PasswordResetHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/PasswordResetHttpClient.cs
@@ -7,8 +7,7 @@ public class PasswordResetHttpClient(HttpClient httpClient)
 {
     /// <summary>
     /// Requests a password reset link for the given login. Returns the server's response, whose message is identical
-    /// whether or not the account exists. While no email provider is wired up the response also carries the raw reset
-    /// token so the UI can show a direct link (issue #280).
+    /// whether or not the account exists.
     /// </summary>
     public async Task<ForgotPasswordResponse?> ForgotPassword(string login)
     {

--- a/code/FinanceManager.Domain/Commands/User/ForgotPasswordResponse.cs
+++ b/code/FinanceManager.Domain/Commands/User/ForgotPasswordResponse.cs
@@ -3,12 +3,5 @@ namespace FinanceManager.Domain.Commands.User;
 /// <summary>
 /// Response to a forgot-password request. <see cref="Message"/> is intentionally identical whether or not the
 /// account exists, so the response leaks no account-enumeration signal.
-/// <para>
-/// <see cref="ResetToken"/> is a TEMPORARY shortcut for the period before a transactional email provider is wired
-/// up (issue #280): with no email being sent, the client needs the token to show a direct "reset password" link.
-/// It is always populated — a real persisted token for registered accounts and a throwaway, non-persisted one for
-/// unknown emails — so its presence reveals nothing about whether the account exists (#342). Once email delivery
-/// lands this field must be removed so the token is only ever delivered out-of-band via the emailed link.
-/// </para>
 /// </summary>
-public record ForgotPasswordResponse(string Message, string? ResetToken = null);
+public record ForgotPasswordResponse(string Message);

--- a/code/FinanceManager.Domain/Services/IPasswordResetService.cs
+++ b/code/FinanceManager.Domain/Services/IPasswordResetService.cs
@@ -22,8 +22,8 @@ public interface IPasswordResetService
     /// <summary>
     /// Issues a raw reset token for the given login. For a registered account this is a single-use, time-limited
     /// token that is persisted; for an unknown login it is a throwaway, non-persisted token of the same shape that
-    /// can never validate. Either way a token is always returned, so the API response (and the on-screen link the
-    /// client builds from it) is identical whether or not the account exists — leaking no account-enumeration signal.
+    /// can never validate. Either way a token is always returned to backend code so future email delivery can avoid
+    /// leaking an account-enumeration signal; controllers must not expose the raw token over HTTP.
     /// </summary>
     Task<string> RequestReset(string login, CancellationToken cancellationToken = default);
 

--- a/code/FinanceManager.Tests.Integration/Controllers/ControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/ControllerTests.cs
@@ -11,6 +11,7 @@ namespace FinanceManager.Tests.Integration.Controllers;
 [Collection("api")]
 public abstract class ControllerTests : IClassFixture<OptionsProvider>, IDisposable
 {
+    private readonly FinanceManagerApiTestApp _app;
     private readonly JwtTokenGenerator? _jwtTokenGenerator;
     protected HttpClient Client { get; }
 
@@ -31,12 +32,12 @@ public abstract class ControllerTests : IClassFixture<OptionsProvider>, IDisposa
         Client.DefaultRequestHeaders.Authorization = null;
     }
 
-    public ControllerTests(OptionsProvider optionsProvider)
+    public ControllerTests(OptionsProvider optionsProvider, string environmentName = "test")
     {
         var authOptions = optionsProvider.Get<JwtAuthOptions>("JwtConfig");
         _jwtTokenGenerator = new JwtTokenGenerator(new OptionsWrapper<JwtAuthOptions>(authOptions));
-        var app = new FinanceManagerApiTestApp(ConfigureServices);
-        Client = app.Client;
+        _app = new FinanceManagerApiTestApp(ConfigureServices, environmentName);
+        Client = _app.Client;
     }
 
     protected virtual void ConfigureServices(IServiceCollection services)
@@ -46,5 +47,6 @@ public abstract class ControllerTests : IClassFixture<OptionsProvider>, IDisposa
     public virtual void Dispose()
     {
         ClearAuthorization();
+        _app.Dispose();
     }
 }

--- a/code/FinanceManager.Tests.Integration/Controllers/PasswordResetControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/PasswordResetControllerTests.cs
@@ -2,20 +2,32 @@ using FinanceManager.Domain.Commands.User;
 using FinanceManager.Domain.Entities.Users;
 using FinanceManager.Domain.Enums;
 using FinanceManager.Domain.Repositories;
+using FinanceManager.Domain.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Moq;
 using System.Net;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using Xunit;
 
 namespace FinanceManager.Tests.Integration.Controllers;
 
 [Collection("api")]
 [Trait("Category", "Integration")]
-public class PasswordResetControllerTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider)
+public class PasswordResetControllerTests : ControllerTests
 {
     private const string _login = "reset.user@example.com";
     private const int _userId = 7777;
+    private static readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
+    private InMemoryPasswordResetTokenRepository? _tokenRepository;
+
+    public PasswordResetControllerTests(OptionsProvider optionsProvider)
+        : base(optionsProvider, Environments.Development)
+    {
+    }
 
     protected override void ConfigureServices(IServiceCollection services)
     {
@@ -32,56 +44,85 @@ public class PasswordResetControllerTests(OptionsProvider optionsProvider) : Con
 
         // A real-but-in-memory token store so the full controller → service → repository flow runs without depending
         // on a configured database provider.
-        services.AddSingleton<IPasswordResetTokenRepository, InMemoryPasswordResetTokenRepository>();
+        _tokenRepository = new InMemoryPasswordResetTokenRepository();
+        services.AddSingleton<IPasswordResetTokenRepository>(_tokenRepository);
     }
 
     [Fact]
-    public async Task ForgotPassword_KnownUser_ReturnsMessageAndToken()
+    public async Task PasswordResetEndpoints_OutsideDevelopment_ReturnNotImplemented()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        using var app = new FinanceManagerApiTestApp(ConfigureServices);
+
+        var forgot = await app.Client.PostAsJsonAsync("api/PasswordReset/forgot-password", new ForgotPasswordRequest(_login), ct);
+        var reset = await app.Client.PostAsJsonAsync("api/PasswordReset/reset-password",
+            new ResetPasswordRequest("stolen-token", "brand-new-password"), ct);
+        var forgotBody = await forgot.Content.ReadAsStringAsync(ct);
+
+        Assert.Equal(HttpStatusCode.NotImplemented, forgot.StatusCode);
+        Assert.Equal(HttpStatusCode.NotImplemented, reset.StatusCode);
+        Assert.DoesNotContain("resetToken", forgotBody, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ForgotPassword_KnownUser_ReturnsMessageWithoutTokenField()
     {
         var ct = TestContext.Current.CancellationToken;
 
         var response = await Client.PostAsJsonAsync("api/PasswordReset/forgot-password", new ForgotPasswordRequest(_login), ct);
+        var json = await response.Content.ReadAsStringAsync(ct);
 
         response.EnsureSuccessStatusCode();
-        var body = await response.Content.ReadFromJsonAsync<ForgotPasswordResponse>(cancellationToken: ct);
+        var body = JsonSerializer.Deserialize<ForgotPasswordResponse>(json, _jsonOptions);
         Assert.NotNull(body);
         Assert.False(string.IsNullOrWhiteSpace(body.Message));
-        // While no email provider is wired up the token rides back on the response so the UI can show a link.
-        Assert.False(string.IsNullOrWhiteSpace(body.ResetToken));
+        Assert.DoesNotContain("resetToken", json, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public async Task ForgotPassword_KnownAndUnknownUser_ReturnIndistinguishableResponses()
+    public async Task ForgotPassword_DoesNotReturnRawTokenFromService()
+    {
+        const string rawToken = "known-raw-token-from-service";
+        var ct = TestContext.Current.CancellationToken;
+        using var app = new FinanceManagerApiTestApp(services =>
+        {
+            ConfigureServices(services);
+            services.AddSingleton<IPasswordResetService>(new StubPasswordResetService(rawToken));
+        }, Environments.Development);
+
+        var response = await app.Client.PostAsJsonAsync("api/PasswordReset/forgot-password", new ForgotPasswordRequest(_login), ct);
+        var json = await response.Content.ReadAsStringAsync(ct);
+
+        response.EnsureSuccessStatusCode();
+        Assert.DoesNotContain(rawToken, json, StringComparison.Ordinal);
+        Assert.DoesNotContain("resetToken", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ForgotPassword_KnownAndUnknownUser_ReturnIndistinguishableResponsesWithoutTokens()
     {
         var ct = TestContext.Current.CancellationToken;
 
         var known = await Client.PostAsJsonAsync("api/PasswordReset/forgot-password", new ForgotPasswordRequest(_login), ct);
         var unknown = await Client.PostAsJsonAsync("api/PasswordReset/forgot-password", new ForgotPasswordRequest("ghost@example.com"), ct);
 
-        var knownBody = await known.Content.ReadFromJsonAsync<ForgotPasswordResponse>(cancellationToken: ct);
-        var unknownBody = await unknown.Content.ReadFromJsonAsync<ForgotPasswordResponse>(cancellationToken: ct);
+        var knownBody = await known.Content.ReadAsStringAsync(ct);
+        var unknownBody = await unknown.Content.ReadAsStringAsync(ct);
 
-        Assert.NotNull(knownBody);
-        Assert.NotNull(unknownBody);
-        // No account-enumeration signal: identical status, message, and response shape (both carry a token) for both.
+        Assert.Equal(HttpStatusCode.OK, known.StatusCode);
         Assert.Equal(HttpStatusCode.OK, unknown.StatusCode);
-        Assert.Equal(knownBody.Message, unknownBody.Message);
-        Assert.False(string.IsNullOrWhiteSpace(knownBody.ResetToken));
-        Assert.False(string.IsNullOrWhiteSpace(unknownBody.ResetToken));
+        Assert.Equal(knownBody, unknownBody);
+        Assert.DoesNotContain("resetToken", knownBody, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("resetToken", unknownBody, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public async Task ResetPassword_WithTokenFromUnknownUser_IsRejected()
+    public async Task ResetPassword_WithUnpersistedToken_IsRejected()
     {
         var ct = TestContext.Current.CancellationToken;
 
-        // The throwaway token handed back for an unregistered email is never persisted, so it can't reset anything.
-        var forgot = await Client.PostAsJsonAsync("api/PasswordReset/forgot-password", new ForgotPasswordRequest("ghost@example.com"), ct);
-        var forgotBody = await forgot.Content.ReadFromJsonAsync<ForgotPasswordResponse>(cancellationToken: ct);
-        Assert.False(string.IsNullOrWhiteSpace(forgotBody!.ResetToken));
-
         var reset = await Client.PostAsJsonAsync("api/PasswordReset/reset-password",
-            new ResetPasswordRequest(forgotBody.ResetToken!, "brand-new-password"), ct);
+            new ResetPasswordRequest("unpersisted-token", "brand-new-password"), ct);
 
         Assert.Equal(HttpStatusCode.BadRequest, reset.StatusCode);
     }
@@ -90,13 +131,12 @@ public class PasswordResetControllerTests(OptionsProvider optionsProvider) : Con
     public async Task ResetPassword_WithIssuedToken_Succeeds()
     {
         var ct = TestContext.Current.CancellationToken;
+        const string rawToken = "issued-token";
 
-        var forgot = await Client.PostAsJsonAsync("api/PasswordReset/forgot-password", new ForgotPasswordRequest(_login), ct);
-        var forgotBody = await forgot.Content.ReadFromJsonAsync<ForgotPasswordResponse>(cancellationToken: ct);
-        Assert.NotNull(forgotBody?.ResetToken);
+        await AddResetToken(rawToken);
 
         var reset = await Client.PostAsJsonAsync("api/PasswordReset/reset-password",
-            new ResetPasswordRequest(forgotBody!.ResetToken!, "brand-new-password"), ct);
+            new ResetPasswordRequest(rawToken, "brand-new-password"), ct);
 
         reset.EnsureSuccessStatusCode();
     }
@@ -116,19 +156,47 @@ public class PasswordResetControllerTests(OptionsProvider optionsProvider) : Con
     public async Task ResetPassword_ReusedToken_IsRejectedOnSecondUse()
     {
         var ct = TestContext.Current.CancellationToken;
+        const string rawToken = "single-use-token";
 
-        var forgot = await Client.PostAsJsonAsync("api/PasswordReset/forgot-password", new ForgotPasswordRequest(_login), ct);
-        var forgotBody = await forgot.Content.ReadFromJsonAsync<ForgotPasswordResponse>(cancellationToken: ct);
-        var token = forgotBody!.ResetToken!;
+        await AddResetToken(rawToken);
 
         var first = await Client.PostAsJsonAsync("api/PasswordReset/reset-password",
-            new ResetPasswordRequest(token, "first-password"), ct);
+            new ResetPasswordRequest(rawToken, "first-password"), ct);
         var second = await Client.PostAsJsonAsync("api/PasswordReset/reset-password",
-            new ResetPasswordRequest(token, "second-password"), ct);
+            new ResetPasswordRequest(rawToken, "second-password"), ct);
 
         first.EnsureSuccessStatusCode();
         // Single-use: the consumed token can't be redeemed again.
         Assert.Equal(HttpStatusCode.BadRequest, second.StatusCode);
+    }
+
+    private async Task AddResetToken(string rawToken)
+    {
+        await _tokenRepository!.Add(new PasswordResetToken
+        {
+            UserId = _userId,
+            TokenHash = Hash(rawToken),
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(30),
+        });
+    }
+
+    private static string Hash(string rawToken)
+    {
+        var bytes = Encoding.UTF8.GetBytes(rawToken);
+        return Convert.ToHexString(SHA256.HashData(bytes));
+    }
+
+    private sealed class StubPasswordResetService(string rawToken) : IPasswordResetService
+    {
+        public Task<string> RequestReset(string login, CancellationToken cancellationToken = default) =>
+            Task.FromResult(rawToken);
+
+        public Task<PasswordResetResult> ResetPassword(
+            string rawToken,
+            string newPassword,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(PasswordResetResult.Failure(PasswordResetStatus.InvalidToken));
     }
 
     private sealed class InMemoryPasswordResetTokenRepository : IPasswordResetTokenRepository

--- a/code/FinanceManager.Tests.Integration/FinanceManagerApiTestApp.cs
+++ b/code/FinanceManager.Tests.Integration/FinanceManagerApiTestApp.cs
@@ -12,6 +12,9 @@ namespace FinanceManager.Tests.Integration;
 
 internal sealed class FinanceManagerApiTestApp : WebApplicationFactory<ApiEntryPoint>
 {
+    private readonly string _environmentName;
+    private readonly Action<IServiceCollection>? _services;
+
     static FinanceManagerApiTestApp()
     {
         // Each host built by WebApplicationFactory loads appsettings*.json with reloadOnChange=true,
@@ -24,49 +27,53 @@ internal sealed class FinanceManagerApiTestApp : WebApplicationFactory<ApiEntryP
 
     public HttpClient Client { get; }
 
-    public FinanceManagerApiTestApp(Action<IServiceCollection>? services = null)
+    public FinanceManagerApiTestApp(Action<IServiceCollection>? services = null, string environmentName = "test")
     {
-        Client = WithWebHostBuilder(builder =>
-        {
-            builder.ConfigureServices(s =>
-            {
-                // Remove hosted services that access DB on startup to avoid
-                // race conditions with the singleton in-memory test context.
-                var databaseInitializerDescriptor = s.FirstOrDefault(d => d.ImplementationType == typeof(DatabaseInitializer));
-                if (databaseInitializerDescriptor != null)
-                    s.Remove(databaseInitializerDescriptor);
-
-                var labelSetterDescriptor = s.FirstOrDefault(d => d.ImplementationType == typeof(LabelSetterStartupService));
-                if (labelSetterDescriptor != null)
-                    s.Remove(labelSetterDescriptor);
-
-                var logPersistenceDescriptor = s.FirstOrDefault(d => d.ImplementationType == typeof(LogEntryPersistenceBackgroundService));
-                if (logPersistenceDescriptor != null)
-                    s.Remove(logPersistenceDescriptor);
-
-                var logRetentionDescriptor = s.FirstOrDefault(d => d.ImplementationType == typeof(LogRetentionBackgroundService));
-                if (logRetentionDescriptor != null)
-                    s.Remove(logRetentionDescriptor);
-
-                services?.Invoke(s);
-            });
-
-            builder.ConfigureAppConfiguration((context, config) =>
-            {
-                var settings = new Dictionary<string, string?>
-                {
-                    // Rate limiting is off by default so the broader integration suite isn't throttled by
-                    // shared-loopback partitioning; RateLimitingTests re-enables it with tiny limits.
-                    ["RateLimiting:Enabled"] = "false",
-                    // appsettings.json restricts AllowedHosts to the production hostname; the test host serves
-                    // requests over http://localhost, so relax host filtering here or every request 400s.
-                    ["AllowedHosts"] = "*",
-                };
-                config.AddInMemoryCollection(settings);
-            });
-
-            builder.UseEnvironment("test");
-        }).CreateClient();
+        _services = services;
+        _environmentName = environmentName;
+        Client = CreateClient();
         Client.BaseAddress = new Uri("http://localhost/");
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(s =>
+        {
+            // Remove hosted services that access DB on startup to avoid
+            // race conditions with the singleton in-memory test context.
+            var databaseInitializerDescriptor = s.FirstOrDefault(d => d.ImplementationType == typeof(DatabaseInitializer));
+            if (databaseInitializerDescriptor != null)
+                s.Remove(databaseInitializerDescriptor);
+
+            var labelSetterDescriptor = s.FirstOrDefault(d => d.ImplementationType == typeof(LabelSetterStartupService));
+            if (labelSetterDescriptor != null)
+                s.Remove(labelSetterDescriptor);
+
+            var logPersistenceDescriptor = s.FirstOrDefault(d => d.ImplementationType == typeof(LogEntryPersistenceBackgroundService));
+            if (logPersistenceDescriptor != null)
+                s.Remove(logPersistenceDescriptor);
+
+            var logRetentionDescriptor = s.FirstOrDefault(d => d.ImplementationType == typeof(LogRetentionBackgroundService));
+            if (logRetentionDescriptor != null)
+                s.Remove(logRetentionDescriptor);
+
+            _services?.Invoke(s);
+        });
+
+        builder.ConfigureAppConfiguration((context, config) =>
+        {
+            var settings = new Dictionary<string, string?>
+            {
+                // Rate limiting is off by default so the broader integration suite isn't throttled by
+                // shared-loopback partitioning; RateLimitingTests re-enables it with tiny limits.
+                ["RateLimiting:Enabled"] = "false",
+                // appsettings.json restricts AllowedHosts to the production hostname; the test host serves
+                // requests over http://localhost, so relax host filtering here or every request 400s.
+                ["AllowedHosts"] = "*",
+            };
+            config.AddInMemoryCollection(settings);
+        });
+
+        builder.UseEnvironment(_environmentName);
     }
 }


### PR DESCRIPTION
## Summary

Closes #362.

- Disable password-reset issuance and redemption outside Development with explicit `501 Not Implemented` responses.
- Remove raw reset tokens from `ForgotPasswordResponse` and the forgot-password UI path.
- Add startup logging so non-Development hosts clearly report that password reset is disabled until transactional email delivery is implemented.
- Update integration tests to verify non-Development blocking and that raw tokens returned by the service never appear in HTTP responses.

## Validation

- `dotnet build ./FinanceManager.slnx --no-restore`
- `$env:UseInMemoryDatabase='true'; dotnet test --project ./FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj --no-build --filter-class FinanceManager.Tests.Integration.Controllers.PasswordResetControllerTests`
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --no-build`
- `$env:UseInMemoryDatabase='true'; dotnet test --project ./FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj --no-build`
- `dotnet format ./FinanceManager.slnx --verify-no-changes --verbosity minimal --no-restore`
- `dotnet format style ./FinanceManager.slnx --verify-no-changes --diagnostics IDE1006 --severity error --verbosity minimal --no-restore`