### PR TITLE
[codex] Add initial transaction history loading

### DIFF
--- a/code/FinanceManager.Api/Controllers/Accounts/BondAccountController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/BondAccountController.cs
@@ -53,16 +53,7 @@ public class BondAccountController(IAccountRepository<BondAccount> bondAccountRe
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Get(int accountId, DateTime startDate, DateTime endDate, [FromQuery] int minimumEntryCount = 0)
     {
-        var account = await bondAccountRepository.Get(accountId);
-
-        if (account is null) return NotFound();
-        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
-        if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
-        if (minimumEntryCount < 0) return BadRequest("Minimum entry count cannot be negative.");
-
-        var loadResult = await bondEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntryCount);
-
-        return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
+        return await GetAccountWithEntries(accountId, startDate, endDate, minimumEntryCount);
     }
 
     [HttpGet("{accountId:int}/GetInitialTransactionHistory")]
@@ -71,16 +62,21 @@ public class BondAccountController(IAccountRepository<BondAccount> bondAccountRe
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetInitialTransactionHistory(int accountId, [FromQuery] DateTime startDate,
-        [FromQuery] DateTime endDate, [FromQuery] int minimumEntriesCount = 100)
+        [FromQuery] DateTime endDate, [FromQuery] int minimumEntryCount = 100)
+    {
+        return await GetAccountWithEntries(accountId, startDate, endDate, minimumEntryCount);
+    }
+
+    private async Task<IActionResult> GetAccountWithEntries(int accountId, DateTime startDate, DateTime endDate, int minimumEntryCount)
     {
         var account = await bondAccountRepository.Get(accountId);
 
         if (account is null) return NotFound();
         if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
         if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
-        if (minimumEntriesCount < 0) return BadRequest("Minimum entries count cannot be negative.");
+        if (minimumEntryCount < 0) return BadRequest("Minimum entry count cannot be negative.");
 
-        var loadResult = await bondEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntriesCount);
+        var loadResult = await bondEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntryCount);
 
         return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
     }

--- a/code/FinanceManager.Api/Controllers/Accounts/BondAccountController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/BondAccountController.cs
@@ -57,9 +57,30 @@ public class BondAccountController(IAccountRepository<BondAccount> bondAccountRe
 
         if (account is null) return NotFound();
         if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+        if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
         if (minimumEntryCount < 0) return BadRequest("Minimum entry count cannot be negative.");
 
         var loadResult = await bondEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntryCount);
+
+        return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
+    }
+
+    [HttpGet("{accountId:int}/GetInitialTransactionHistory")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(BondAccountDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetInitialTransactionHistory(int accountId, [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate, [FromQuery] int minimumEntriesCount = 100)
+    {
+        var account = await bondAccountRepository.Get(accountId);
+
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+        if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
+        if (minimumEntriesCount < 0) return BadRequest("Minimum entries count cannot be negative.");
+
+        var loadResult = await bondEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntriesCount);
 
         return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
     }

--- a/code/FinanceManager.Api/Controllers/Accounts/CurrencyAccountController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/CurrencyAccountController.cs
@@ -53,16 +53,7 @@ public class CurrencyAccountController(ICurrencyAccountRepository<CurrencyAccoun
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Get(int accountId, DateTime startDate, DateTime endDate, [FromQuery] int minimumEntryCount = 0)
     {
-        var account = await accountRepository.Get(accountId);
-
-        if (account is null) return NotFound();
-        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
-        if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
-        if (minimumEntryCount < 0) return BadRequest("Minimum entry count cannot be negative.");
-
-        var loadResult = await currencyEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntryCount);
-
-        return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
+        return await GetAccountWithEntries(accountId, startDate, endDate, minimumEntryCount);
     }
 
     [HttpGet("{accountId:int}/GetInitialTransactionHistory")]
@@ -71,16 +62,21 @@ public class CurrencyAccountController(ICurrencyAccountRepository<CurrencyAccoun
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetInitialTransactionHistory(int accountId, [FromQuery] DateTime startDate,
-        [FromQuery] DateTime endDate, [FromQuery] int minimumEntriesCount = 100)
+        [FromQuery] DateTime endDate, [FromQuery] int minimumEntryCount = 100)
+    {
+        return await GetAccountWithEntries(accountId, startDate, endDate, minimumEntryCount);
+    }
+
+    private async Task<IActionResult> GetAccountWithEntries(int accountId, DateTime startDate, DateTime endDate, int minimumEntryCount)
     {
         var account = await accountRepository.Get(accountId);
 
         if (account is null) return NotFound();
         if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
         if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
-        if (minimumEntriesCount < 0) return BadRequest("Minimum entries count cannot be negative.");
+        if (minimumEntryCount < 0) return BadRequest("Minimum entry count cannot be negative.");
 
-        var loadResult = await currencyEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntriesCount);
+        var loadResult = await currencyEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntryCount);
 
         return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
     }

--- a/code/FinanceManager.Api/Controllers/Accounts/CurrencyAccountController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/CurrencyAccountController.cs
@@ -57,9 +57,30 @@ public class CurrencyAccountController(ICurrencyAccountRepository<CurrencyAccoun
 
         if (account is null) return NotFound();
         if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+        if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
         if (minimumEntryCount < 0) return BadRequest("Minimum entry count cannot be negative.");
 
         var loadResult = await currencyEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntryCount);
+
+        return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
+    }
+
+    [HttpGet("{accountId:int}/GetInitialTransactionHistory")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CurrencyAccountDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetInitialTransactionHistory(int accountId, [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate, [FromQuery] int minimumEntriesCount = 100)
+    {
+        var account = await accountRepository.Get(accountId);
+
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+        if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
+        if (minimumEntriesCount < 0) return BadRequest("Minimum entries count cannot be negative.");
+
+        var loadResult = await currencyEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntriesCount);
 
         return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
     }

--- a/code/FinanceManager.Api/Controllers/Accounts/StockAccountController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/StockAccountController.cs
@@ -57,15 +57,7 @@ public class StockAccountController(IAccountRepository<StockAccount> stockAccoun
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Get(int accountId, DateTime startDate, DateTime endDate, [FromQuery] int minimumEntryCount = 0)
     {
-        var account = await stockAccountRepository.Get(accountId);
-        if (account is null) return NotFound();
-        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
-        if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
-        if (minimumEntryCount < 0) return BadRequest("Minimum entry count cannot be negative.");
-
-        var loadResult = await stockEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntryCount);
-
-        return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
+        return await GetAccountWithEntries(accountId, startDate, endDate, minimumEntryCount);
     }
 
     [HttpGet("{accountId:int}/GetInitialTransactionHistory")]
@@ -74,15 +66,20 @@ public class StockAccountController(IAccountRepository<StockAccount> stockAccoun
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> GetInitialTransactionHistory(int accountId, [FromQuery] DateTime startDate,
-        [FromQuery] DateTime endDate, [FromQuery] int minimumEntriesCount = 100)
+        [FromQuery] DateTime endDate, [FromQuery] int minimumEntryCount = 100)
+    {
+        return await GetAccountWithEntries(accountId, startDate, endDate, minimumEntryCount);
+    }
+
+    private async Task<IActionResult> GetAccountWithEntries(int accountId, DateTime startDate, DateTime endDate, int minimumEntryCount)
     {
         var account = await stockAccountRepository.Get(accountId);
         if (account is null) return NotFound();
         if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
         if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
-        if (minimumEntriesCount < 0) return BadRequest("Minimum entries count cannot be negative.");
+        if (minimumEntryCount < 0) return BadRequest("Minimum entry count cannot be negative.");
 
-        var loadResult = await stockEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntriesCount);
+        var loadResult = await stockEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntryCount);
 
         return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
     }

--- a/code/FinanceManager.Api/Controllers/Accounts/StockAccountController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/StockAccountController.cs
@@ -60,9 +60,29 @@ public class StockAccountController(IAccountRepository<StockAccount> stockAccoun
         var account = await stockAccountRepository.Get(accountId);
         if (account is null) return NotFound();
         if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+        if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
         if (minimumEntryCount < 0) return BadRequest("Minimum entry count cannot be negative.");
 
         var loadResult = await stockEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntryCount);
+
+        return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
+    }
+
+    [HttpGet("{accountId:int}/GetInitialTransactionHistory")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(StockAccountDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetInitialTransactionHistory(int accountId, [FromQuery] DateTime startDate,
+        [FromQuery] DateTime endDate, [FromQuery] int minimumEntriesCount = 100)
+    {
+        var account = await stockAccountRepository.Get(accountId);
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+        if (startDate > endDate) return BadRequest("Start date cannot be after end date.");
+        if (minimumEntriesCount < 0) return BadRequest("Minimum entries count cannot be negative.");
+
+        var loadResult = await stockEntryProvider.GetEntriesAsync(accountId, startDate, endDate, minimumEntriesCount);
 
         return Ok(await CreateDtoAsync(account, loadResult.Entries, loadResult.EffectiveStartDate, endDate));
     }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor
@@ -9,9 +9,10 @@
 }
 else if (IsLoading || Account.Entries?.Any() == true)
 {
-    <AccountDetailsHero AccountName="@Account.Name" AccountTypeLabel="@_accountTypeLabel" Currency="@_currency.ShortName"
+                        <AccountDetailsHero AccountName="@Account.Name" AccountTypeLabel="@_accountTypeLabel" Currency="@_currency.ShortName"
                         Balance="@_currentBalance" BalanceChange="@_balanceChange" BalanceChangePercent="@_balanceChangePercent"
                         SelectedRange="@_selectedRange" SelectedRangeChanged="OnRangeChanged" IsChartLoading="@IsLoading"
+                        CustomDateRange="@_customDateRange" CustomDateRangeChanged="OnCustomDateRangeChanged"
                         ChartData="@ChartData" IsMobile="@_isMobile" />
 
     <MudContainer MaxWidth="MaxWidth.Large" Class="px-0">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Components.Components.Features.FinancialAccounts.Shared;
+using FinanceManager.Components.Helpers;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.Bonds;
@@ -18,7 +19,9 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     private bool _isMobile;
     private bool _insightsDrawerOpen;
 
-    private string _selectedRange = "3M";
+    private const int _initialMinimumEntriesCount = 100;
+
+    private string _selectedRange = "Month";
     private DateTime _dateStart;
     private DateTime _dateEnd = DateTime.UtcNow;
     private DateRange? _customDateRange;
@@ -171,7 +174,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
 
             SetDateRangeForSelection();
 
-            var loadTask = UpdateEntries();
+            var loadTask = UpdateEntries(initialLoad: true);
             var delayTask = Task.Delay(2000);
             var completedTask = await Task.WhenAny(loadTask, delayTask);
             if (completedTask == delayTask)
@@ -196,7 +199,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
             if (Account is not null && Account.AccountId == AccountId) return;
             IsLoading = true;
             SetDateRangeForSelection();
-            await UpdateEntries();
+            await UpdateEntries(initialLoad: true);
         }
         catch (Exception ex)
         {
@@ -208,17 +211,23 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
         }
     }
 
-    private async Task UpdateEntries()
+    private async Task UpdateEntries(bool initialLoad = false)
     {
         try
         {
             if (_user is null) return;
 
-            // Preset ranges always end "now"; a custom RANGE keeps the end picked in the hero
-            // (already set by SetDateRangeForSelection), so don't overwrite it here.
-            if (_selectedRange != "Range")
+            if (_selectedRange != AccountDetailsHero.CustomRangeKey)
                 _dateEnd = DateTime.UtcNow;
-            Account = await FinancialAccountService.GetAccount<BondAccount>(_user.UserId, AccountId, _dateStart, _dateEnd);
+
+            var selectedStart = _dateStart;
+            Account = initialLoad
+                ? await FinancialAccountService.GetInitialTransactionHistory<BondAccount>(_user.UserId, AccountId, _dateStart, _dateEnd,
+                    _initialMinimumEntriesCount)
+                : await FinancialAccountService.GetAccount<BondAccount>(_user.UserId, AccountId, _dateStart, _dateEnd);
+
+            if (initialLoad)
+                ApplyAutomaticCustomRange(selectedStart);
 
             if (Account?.Entries is not null)
                 await UpdateInfo();
@@ -276,7 +285,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     private async Task OnCustomDateRangeChanged(DateRange? range)
     {
         _customDateRange = range;
-        if (_selectedRange != "Range") return;
+        _selectedRange = AccountDetailsHero.CustomRangeKey;
         SetDateRangeForSelection();
         IsLoading = true;
         StateHasChanged();
@@ -347,21 +356,35 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     private void SetDateRangeForSelection()
     {
         var today = DateTime.UtcNow;
-        if (_selectedRange == "Range")
+        if (_selectedRange == AccountDetailsHero.CustomRangeKey)
         {
             _dateStart = _customDateRange?.Start ?? Account?.Start ?? today.AddMonths(-3);
             _dateEnd = _customDateRange?.End ?? today;
+            if (_dateEnd > today)
+                _dateEnd = today;
             return;
         }
 
         _dateStart = _selectedRange switch
         {
+            "Month" => DateRangeHelper.GetCurrentMonthRange().Start,
             "1M" => today.AddMonths(-1),
             "3M" => today.AddMonths(-3),
             "6M" => today.AddMonths(-6),
-            "1Y" => today.AddYears(-1),
-            _ => today.AddMonths(-3)
+            "YTD" => new DateTime(today.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            _ => DateRangeHelper.GetCurrentMonthRange().Start
         };
         _dateEnd = today;
+    }
+
+    private void ApplyAutomaticCustomRange(DateTime selectedStart)
+    {
+        var oldestFetchedEntryDate = Account?.Entries?.MinBy(x => x.PostingDate)?.PostingDate;
+        if (oldestFetchedEntryDate is null || oldestFetchedEntryDate.Value >= selectedStart)
+            return;
+
+        _selectedRange = AccountDetailsHero.CustomRangeKey;
+        _dateStart = oldestFetchedEntryDate.Value;
+        _customDateRange = new DateRange(_dateStart, _dateEnd);
     }
 }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor
@@ -7,9 +7,10 @@
 }
 else if (IsLoading || Account.Entries?.Any() == true)
 {
-    <AccountDetailsHero AccountName="@Account.Name" AccountTypeLabel="@_accountTypeLabel" Currency="@_currency.ShortName"
+                        <AccountDetailsHero AccountName="@Account.Name" AccountTypeLabel="@_accountTypeLabel" Currency="@_currency.ShortName"
                         Balance="@_currentBalance" BalanceChange="@_balanceChange" BalanceChangePercent="@_balanceChangePercent"
                         SelectedRange="@_selectedRange" SelectedRangeChanged="OnRangeChanged" IsChartLoading="@IsLoading"
+                        CustomDateRange="@_customDateRange" CustomDateRangeChanged="OnCustomDateRangeChanged"
                         ChartData="@ChartData" IsMobile="@_isMobile" />
 
     <MudContainer MaxWidth="MaxWidth.Large" Class="px-0">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Components.Components.Features.FinancialAccounts.Shared;
+using FinanceManager.Components.Helpers;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.Currencies;
@@ -19,9 +20,12 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
     private bool _isMobile;
     private bool _insightsDrawerOpen;
 
-    private string _selectedRange = "3M";
+    private const int _initialMinimumEntriesCount = 100;
+
+    private string _selectedRange = "Month";
     private DateTime _dateStart;
     private DateTime _dateEnd = DateTime.UtcNow;
+    private DateRange? _customDateRange;
 
     private bool _addEntryVisibility;
 
@@ -165,7 +169,7 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
 
             SetDateRangeForSelection();
 
-            var loadTask = UpdateEntries();
+            var loadTask = UpdateEntries(initialLoad: true);
             var delayTask = Task.Delay(2000);
             var completedTask = await Task.WhenAny(loadTask, delayTask);
             if (completedTask == delayTask)
@@ -190,7 +194,7 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
             if (Account is not null && Account.AccountId == AccountId) return;
             IsLoading = true;
             SetDateRangeForSelection();
-            await UpdateEntries();
+            await UpdateEntries(initialLoad: true);
         }
         catch (Exception ex)
         {
@@ -202,14 +206,23 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
         }
     }
 
-    private async Task UpdateEntries()
+    private async Task UpdateEntries(bool initialLoad = false)
     {
         try
         {
             if (_user is null) return;
 
-            _dateEnd = DateTime.UtcNow;
-            Account = await FinancialAccountService.GetAccount<CurrencyAccount>(_user.UserId, AccountId, _dateStart, _dateEnd);
+            if (_selectedRange != AccountDetailsHero.CustomRangeKey)
+                _dateEnd = DateTime.UtcNow;
+
+            var selectedStart = _dateStart;
+            Account = initialLoad
+                ? await FinancialAccountService.GetInitialTransactionHistory<CurrencyAccount>(_user.UserId, AccountId, _dateStart, _dateEnd,
+                    _initialMinimumEntriesCount)
+                : await FinancialAccountService.GetAccount<CurrencyAccount>(_user.UserId, AccountId, _dateStart, _dateEnd);
+
+            if (initialLoad)
+                ApplyAutomaticCustomRange(selectedStart);
 
             if (Account?.Entries is not null)
                 await UpdateInfo();
@@ -250,6 +263,24 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
     private async Task OnRangeChanged(string value)
     {
         _selectedRange = value;
+        SetDateRangeForSelection();
+        IsLoading = true;
+        StateHasChanged();
+        try
+        {
+            await UpdateEntries();
+        }
+        finally
+        {
+            IsLoading = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnCustomDateRangeChanged(DateRange? range)
+    {
+        _customDateRange = range;
+        _selectedRange = AccountDetailsHero.CustomRangeKey;
         SetDateRangeForSelection();
         IsLoading = true;
         StateHasChanged();
@@ -318,16 +349,35 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
     private void SetDateRangeForSelection()
     {
         var today = DateTime.UtcNow;
+        if (_selectedRange == AccountDetailsHero.CustomRangeKey)
+        {
+            _dateStart = _customDateRange?.Start ?? Account?.Start ?? today.AddMonths(-3);
+            _dateEnd = _customDateRange?.End ?? today;
+            if (_dateEnd > today)
+                _dateEnd = today;
+            return;
+        }
+
         _dateStart = _selectedRange switch
         {
-            "1W" => today.AddDays(-7),
+            "Month" => DateRangeHelper.GetCurrentMonthRange().Start,
             "1M" => today.AddMonths(-1),
             "3M" => today.AddMonths(-3),
             "6M" => today.AddMonths(-6),
             "YTD" => new DateTime(today.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-            "All" => Account?.Start ?? today.AddYears(-10),
-            _ => today.AddMonths(-3),
+            _ => DateRangeHelper.GetCurrentMonthRange().Start,
         };
         _dateEnd = today;
+    }
+
+    private void ApplyAutomaticCustomRange(DateTime selectedStart)
+    {
+        var oldestFetchedEntryDate = Account?.Entries?.MinBy(x => x.PostingDate)?.PostingDate;
+        if (oldestFetchedEntryDate is null || oldestFetchedEntryDate.Value >= selectedStart)
+            return;
+
+        _selectedRange = AccountDetailsHero.CustomRangeKey;
+        _dateStart = oldestFetchedEntryDate.Value;
+        _customDateRange = new DateRange(_dateStart, _dateEnd);
     }
 }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor
@@ -35,6 +35,17 @@
                                    Style="@($"min-width: 40px; font-weight: {(SelectedRange == range ? 700 : 500)};")"
                                    OnClick="@(() => OnRangeChanged(range))">@range</MudButton>
                     }
+                    <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight" Dense="true">
+                        <ActivatorContent>
+                            <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" Size="MudBlazor.Size.Small"
+                                           Color="@(SelectedRange == CustomRangeKey ? MudBlazor.Color.Primary : MudBlazor.Color.Default)"
+                                           aria-label="Select custom date range" />
+                        </ActivatorContent>
+                        <ChildContent>
+                            <MudDateRangePicker DateRange="CustomDateRange" DateRangeChanged="OnCustomDateRangeChanged"
+                                                RelativeWidth="DropdownWidth.Ignore" Class="px-2 pt-2" />
+                        </ChildContent>
+                    </MudMenu>
                 </div>
             </MudStack>
 
@@ -97,7 +108,17 @@
                            Style="@($"min-width: 44px; font-weight: {(SelectedRange == range ? 700 : 500)};")"
                            OnClick="@(() => OnRangeChanged(range))">@range</MudButton>
             }
+            <MudMenu AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" Dense="true">
+                <ActivatorContent>
+                    <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" Size="MudBlazor.Size.Small"
+                                   Color="@(SelectedRange == CustomRangeKey ? MudBlazor.Color.Primary : MudBlazor.Color.Default)"
+                                   aria-label="Select custom date range" />
+                </ActivatorContent>
+                <ChildContent>
+                    <MudDateRangePicker DateRange="CustomDateRange" DateRangeChanged="OnCustomDateRangeChanged"
+                                        RelativeWidth="DropdownWidth.Ignore" Class="px-2 pt-2" />
+                </ChildContent>
+            </MudMenu>
         </div>
     }
 </MudPaper>
-

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.cs
@@ -1,6 +1,7 @@
 using ApexCharts;
 using FinanceManager.Domain.Entities.MoneyFlowModels;
 using Microsoft.AspNetCore.Components;
+using MudBlazor;
 
 namespace FinanceManager.Components.Components.Features.FinancialAccounts.Shared;
 
@@ -14,11 +15,15 @@ public partial class AccountDetailsHero
     [Parameter] public decimal? BalanceChangePercent { get; set; }
     [Parameter] public string SelectedRange { get; set; } = "3M";
     [Parameter] public EventCallback<string> SelectedRangeChanged { get; set; }
+    [Parameter] public DateRange? CustomDateRange { get; set; }
+    [Parameter] public EventCallback<DateRange?> CustomDateRangeChanged { get; set; }
     [Parameter] public bool IsChartLoading { get; set; }
     [Parameter] public List<TimeSeriesModel> ChartData { get; set; } = [];
     [Parameter] public bool IsMobile { get; set; }
 
-    private readonly string[] _ranges = ["1W", "1M", "3M", "6M", "YTD", "All"];
+    public const string CustomRangeKey = "Range";
+
+    private readonly string[] _ranges = ["Month", "1M", "3M", "6M", "YTD"];
 
     private static readonly ApexChartOptions<TimeSeriesModel> _heroChartOptions = new()
     {
@@ -54,5 +59,12 @@ public partial class AccountDetailsHero
     {
         SelectedRange = value;
         await SelectedRangeChanged.InvokeAsync(value);
+    }
+
+    private async Task OnCustomDateRangeChanged(DateRange? value)
+    {
+        CustomDateRange = value;
+        SelectedRange = CustomRangeKey;
+        await CustomDateRangeChanged.InvokeAsync(value);
     }
 }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/TransactionHistory/StockAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/TransactionHistory/StockAccountDetailsPageContent.razor
@@ -9,9 +9,10 @@
 }
 else if (IsLoading || Account.Entries?.Any() == true)
 {
-    <AccountDetailsHero AccountName="@Account.Name" AccountTypeLabel="@_accountTypeLabel" Currency="@_currency.ShortName"
+                        <AccountDetailsHero AccountName="@Account.Name" AccountTypeLabel="@_accountTypeLabel" Currency="@_currency.ShortName"
                         Balance="@_currentBalance" BalanceChange="@_balanceChange" BalanceChangePercent="@_balanceChangePercent"
                         SelectedRange="@_selectedRange" SelectedRangeChanged="OnRangeChanged" IsChartLoading="@IsLoading"
+                        CustomDateRange="@_customDateRange" CustomDateRangeChanged="OnCustomDateRangeChanged"
                         ChartData="@ChartData" IsMobile="@_isMobile" />
 
     <MudContainer MaxWidth="MaxWidth.Large" Class="px-0">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/TransactionHistory/StockAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/TransactionHistory/StockAccountDetailsPageContent.razor.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Components.Components.Features.FinancialAccounts.Shared;
+using FinanceManager.Components.Helpers;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.Currencies;
@@ -18,7 +19,9 @@ public partial class StockAccountDetailsPageContent : ComponentBase, IAsyncDispo
     private bool _isMobile;
     private bool _insightsDrawerOpen;
 
-    private string _selectedRange = "3M";
+    private const int _initialMinimumEntriesCount = 100;
+
+    private string _selectedRange = "Month";
     private DateTime _dateStart;
     private DateTime _dateEnd = DateTime.UtcNow;
     private DateRange? _customDateRange;
@@ -162,7 +165,7 @@ public partial class StockAccountDetailsPageContent : ComponentBase, IAsyncDispo
 
             SetDateRangeForSelection();
 
-            var loadTask = UpdateEntries();
+            var loadTask = UpdateEntries(initialLoad: true);
             var delayTask = Task.Delay(2000);
             var completedTask = await Task.WhenAny(loadTask, delayTask);
             if (completedTask == delayTask)
@@ -190,7 +193,7 @@ public partial class StockAccountDetailsPageContent : ComponentBase, IAsyncDispo
             if (Account is not null && Account.AccountId == AccountId) return;
             IsLoading = true;
             SetDateRangeForSelection();
-            await UpdateEntries();
+            await UpdateEntries(initialLoad: true);
         }
         catch (Exception ex)
         {
@@ -202,17 +205,23 @@ public partial class StockAccountDetailsPageContent : ComponentBase, IAsyncDispo
         }
     }
 
-    private async Task UpdateEntries()
+    private async Task UpdateEntries(bool initialLoad = false)
     {
         try
         {
             if (_user is null) return;
 
-            // Preset ranges always end "now"; a custom RANGE keeps the end picked in the hero
-            // (already set by SetDateRangeForSelection), so don't overwrite it here.
-            if (_selectedRange != "Range")
+            if (_selectedRange != AccountDetailsHero.CustomRangeKey)
                 _dateEnd = DateTime.UtcNow;
-            Account = await FinancialAccountService.GetAccount<StockAccount>(_user.UserId, AccountId, _dateStart, _dateEnd);
+
+            var selectedStart = _dateStart;
+            Account = initialLoad
+                ? await FinancialAccountService.GetInitialTransactionHistory<StockAccount>(_user.UserId, AccountId, _dateStart, _dateEnd,
+                    _initialMinimumEntriesCount)
+                : await FinancialAccountService.GetAccount<StockAccount>(_user.UserId, AccountId, _dateStart, _dateEnd);
+
+            if (initialLoad)
+                ApplyAutomaticCustomRange(selectedStart);
 
             if (Account?.Entries is not null)
                 await UpdateInfo();
@@ -270,7 +279,7 @@ public partial class StockAccountDetailsPageContent : ComponentBase, IAsyncDispo
     private async Task OnCustomDateRangeChanged(DateRange? range)
     {
         _customDateRange = range;
-        if (_selectedRange != "Range") return;
+        _selectedRange = AccountDetailsHero.CustomRangeKey;
         SetDateRangeForSelection();
         IsLoading = true;
         StateHasChanged();
@@ -339,21 +348,35 @@ public partial class StockAccountDetailsPageContent : ComponentBase, IAsyncDispo
     private void SetDateRangeForSelection()
     {
         var today = DateTime.UtcNow;
-        if (_selectedRange == "Range")
+        if (_selectedRange == AccountDetailsHero.CustomRangeKey)
         {
             _dateStart = _customDateRange?.Start ?? Account?.Start ?? today.AddMonths(-3);
             _dateEnd = _customDateRange?.End ?? today;
+            if (_dateEnd > today)
+                _dateEnd = today;
             return;
         }
 
         _dateStart = _selectedRange switch
         {
+            "Month" => DateRangeHelper.GetCurrentMonthRange().Start,
             "1M" => today.AddMonths(-1),
             "3M" => today.AddMonths(-3),
             "6M" => today.AddMonths(-6),
-            "1Y" => today.AddYears(-1),
-            _ => today.AddMonths(-3)
+            "YTD" => new DateTime(today.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            _ => DateRangeHelper.GetCurrentMonthRange().Start
         };
         _dateEnd = today;
+    }
+
+    private void ApplyAutomaticCustomRange(DateTime selectedStart)
+    {
+        var oldestFetchedEntryDate = Account?.Entries?.MinBy(x => x.PostingDate)?.PostingDate;
+        if (oldestFetchedEntryDate is null || oldestFetchedEntryDate.Value >= selectedStart)
+            return;
+
+        _selectedRange = AccountDetailsHero.CustomRangeKey;
+        _dateStart = oldestFetchedEntryDate.Value;
+        _customDateRange = new DateRange(_dateStart, _dateEnd);
     }
 }

--- a/code/FinanceManager.Components/HttpClients/BondAccountHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/BondAccountHttpClient.cs
@@ -31,6 +31,16 @@ public class BondAccountHttpClient(HttpClient httpClient)
         return MapAccount(result);
     }
 
+    public async Task<BondAccount?> GetInitialTransactionHistoryAsync(int accountId, DateTime startDate, DateTime endDate,
+        int minimumEntriesCount = 100)
+    {
+        var encodedStartDate = Uri.EscapeDataString(startDate.ToString("O"));
+        var encodedEndDate = Uri.EscapeDataString(endDate.ToString("O"));
+        var result = await httpClient.GetFromJsonAsync<BondAccountDto>(
+            $"{httpClient.BaseAddress}api/BondAccount/{accountId}/GetInitialTransactionHistory?startDate={encodedStartDate}&endDate={encodedEndDate}&minimumEntriesCount={minimumEntriesCount}");
+        return MapAccount(result);
+    }
+
     public async Task<BondAccount?> GetAccountWithEntriesAsync(int accountId, DateTime date, int count, bool olderThenDate = true)
     {
         var encodedDate = Uri.EscapeDataString(date.ToString("O"));

--- a/code/FinanceManager.Components/HttpClients/BondAccountHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/BondAccountHttpClient.cs
@@ -32,12 +32,12 @@ public class BondAccountHttpClient(HttpClient httpClient)
     }
 
     public async Task<BondAccount?> GetInitialTransactionHistoryAsync(int accountId, DateTime startDate, DateTime endDate,
-        int minimumEntriesCount = 100)
+        int minimumEntryCount = 100)
     {
         var encodedStartDate = Uri.EscapeDataString(startDate.ToString("O"));
         var encodedEndDate = Uri.EscapeDataString(endDate.ToString("O"));
         var result = await httpClient.GetFromJsonAsync<BondAccountDto>(
-            $"{httpClient.BaseAddress}api/BondAccount/{accountId}/GetInitialTransactionHistory?startDate={encodedStartDate}&endDate={encodedEndDate}&minimumEntriesCount={minimumEntriesCount}");
+            $"{httpClient.BaseAddress}api/BondAccount/{accountId}/GetInitialTransactionHistory?startDate={encodedStartDate}&endDate={encodedEndDate}&minimumEntryCount={minimumEntryCount}");
         return MapAccount(result);
     }
 

--- a/code/FinanceManager.Components/HttpClients/CurrencyAccountHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/CurrencyAccountHttpClient.cs
@@ -33,6 +33,16 @@ public class CurrencyAccountHttpClient(HttpClient httpClient)
         return MapAccount(result);
     }
 
+    public async Task<CurrencyAccount?> GetInitialTransactionHistoryAsync(int accountId, DateTime startDate, DateTime endDate,
+        int minimumEntriesCount = 100)
+    {
+        var encodedStartDate = Uri.EscapeDataString(startDate.ToString("O"));
+        var encodedEndDate = Uri.EscapeDataString(endDate.ToString("O"));
+        var result = await httpClient.GetFromJsonAsync<CurrencyAccountDto>(
+            $"{httpClient.BaseAddress}api/CurrencyAccount/{accountId}/GetInitialTransactionHistory?startDate={encodedStartDate}&endDate={encodedEndDate}&minimumEntriesCount={minimumEntriesCount}");
+        return MapAccount(result);
+    }
+
     public async Task<CurrencyAccount?> GetAccountWithEntriesAsync(int accountId, DateTime date, int count, bool olderThenDate = true)
     {
         var encodedDate = Uri.EscapeDataString(date.ToString("O"));

--- a/code/FinanceManager.Components/HttpClients/CurrencyAccountHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/CurrencyAccountHttpClient.cs
@@ -34,12 +34,12 @@ public class CurrencyAccountHttpClient(HttpClient httpClient)
     }
 
     public async Task<CurrencyAccount?> GetInitialTransactionHistoryAsync(int accountId, DateTime startDate, DateTime endDate,
-        int minimumEntriesCount = 100)
+        int minimumEntryCount = 100)
     {
         var encodedStartDate = Uri.EscapeDataString(startDate.ToString("O"));
         var encodedEndDate = Uri.EscapeDataString(endDate.ToString("O"));
         var result = await httpClient.GetFromJsonAsync<CurrencyAccountDto>(
-            $"{httpClient.BaseAddress}api/CurrencyAccount/{accountId}/GetInitialTransactionHistory?startDate={encodedStartDate}&endDate={encodedEndDate}&minimumEntriesCount={minimumEntriesCount}");
+            $"{httpClient.BaseAddress}api/CurrencyAccount/{accountId}/GetInitialTransactionHistory?startDate={encodedStartDate}&endDate={encodedEndDate}&minimumEntryCount={minimumEntryCount}");
         return MapAccount(result);
     }
 

--- a/code/FinanceManager.Components/HttpClients/StockAccountHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/StockAccountHttpClient.cs
@@ -39,12 +39,12 @@ public class StockAccountHttpClient(HttpClient httpClient)
     }
 
     public async Task<StockAccount?> GetInitialTransactionHistoryAsync(int accountId, DateTime startDate, DateTime endDate,
-        int minimumEntriesCount = 100)
+        int minimumEntryCount = 100)
     {
         var encodedStartDate = Uri.EscapeDataString(startDate.ToString("O"));
         var encodedEndDate = Uri.EscapeDataString(endDate.ToString("O"));
         var result = await httpClient.GetFromJsonAsync<StockAccountDto>(
-            $"{httpClient.BaseAddress}api/StockAccount/{accountId}/GetInitialTransactionHistory?startDate={encodedStartDate}&endDate={encodedEndDate}&minimumEntriesCount={minimumEntriesCount}");
+            $"{httpClient.BaseAddress}api/StockAccount/{accountId}/GetInitialTransactionHistory?startDate={encodedStartDate}&endDate={encodedEndDate}&minimumEntryCount={minimumEntryCount}");
         return MapAccount(result);
     }
 

--- a/code/FinanceManager.Components/HttpClients/StockAccountHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/StockAccountHttpClient.cs
@@ -38,6 +38,16 @@ public class StockAccountHttpClient(HttpClient httpClient)
         return MapAccount(result);
     }
 
+    public async Task<StockAccount?> GetInitialTransactionHistoryAsync(int accountId, DateTime startDate, DateTime endDate,
+        int minimumEntriesCount = 100)
+    {
+        var encodedStartDate = Uri.EscapeDataString(startDate.ToString("O"));
+        var encodedEndDate = Uri.EscapeDataString(endDate.ToString("O"));
+        var result = await httpClient.GetFromJsonAsync<StockAccountDto>(
+            $"{httpClient.BaseAddress}api/StockAccount/{accountId}/GetInitialTransactionHistory?startDate={encodedStartDate}&endDate={encodedEndDate}&minimumEntriesCount={minimumEntriesCount}");
+        return MapAccount(result);
+    }
+
     public async Task<StockAccount?> GetAccountWithEntriesAsync(int accountId, DateTime date, int count, bool olderThenDate = true)
     {
         var encodedDate = Uri.EscapeDataString(date.ToString("O"));

--- a/code/FinanceManager.Components/Services/FinancialAccountService.cs
+++ b/code/FinanceManager.Components/Services/FinancialAccountService.cs
@@ -119,6 +119,20 @@ public class FinancialAccountService(CurrencyAccountHttpClient currencyAccountHt
         throw new NotSupportedException($"Account type {typeof(T)} not supported for getting start date.");
 
     }
+
+    public async Task<T?> GetInitialTransactionHistory<T>(int userId, int id, DateTime dateStart, DateTime dateEnd,
+        int minimumEntriesCount = 100) where T : BasicAccountInformation
+    {
+        if (typeof(T) == typeof(CurrencyAccount))
+            return await currencyAccountHttpClient.GetInitialTransactionHistoryAsync(id, dateStart, dateEnd, minimumEntriesCount) as T;
+        else if (typeof(T) == typeof(StockAccount))
+            return await stockAccountHttpClient.GetInitialTransactionHistoryAsync(id, dateStart, dateEnd, minimumEntriesCount) as T;
+        else if (typeof(T) == typeof(BondAccount))
+            return await bondAccountHttpClient.GetInitialTransactionHistoryAsync(id, dateStart, dateEnd, minimumEntriesCount) as T;
+
+        throw new NotSupportedException($"Account type {typeof(T)} not supported for getting initial transaction history.");
+    }
+
     public async Task<IEnumerable<T>> GetAccounts<T>(int userId, DateTime dateStart, DateTime dateEnd) where T : BasicAccountInformation
     {
         List<T> result = [];

--- a/code/FinanceManager.Components/Services/FinancialAccountService.cs
+++ b/code/FinanceManager.Components/Services/FinancialAccountService.cs
@@ -121,14 +121,14 @@ public class FinancialAccountService(CurrencyAccountHttpClient currencyAccountHt
     }
 
     public async Task<T?> GetInitialTransactionHistory<T>(int userId, int id, DateTime dateStart, DateTime dateEnd,
-        int minimumEntriesCount = 100) where T : BasicAccountInformation
+        int minimumEntryCount = 100) where T : BasicAccountInformation
     {
         if (typeof(T) == typeof(CurrencyAccount))
-            return await currencyAccountHttpClient.GetInitialTransactionHistoryAsync(id, dateStart, dateEnd, minimumEntriesCount) as T;
+            return await currencyAccountHttpClient.GetInitialTransactionHistoryAsync(id, dateStart, dateEnd, minimumEntryCount) as T;
         else if (typeof(T) == typeof(StockAccount))
-            return await stockAccountHttpClient.GetInitialTransactionHistoryAsync(id, dateStart, dateEnd, minimumEntriesCount) as T;
+            return await stockAccountHttpClient.GetInitialTransactionHistoryAsync(id, dateStart, dateEnd, minimumEntryCount) as T;
         else if (typeof(T) == typeof(BondAccount))
-            return await bondAccountHttpClient.GetInitialTransactionHistoryAsync(id, dateStart, dateEnd, minimumEntriesCount) as T;
+            return await bondAccountHttpClient.GetInitialTransactionHistoryAsync(id, dateStart, dateEnd, minimumEntryCount) as T;
 
         throw new NotSupportedException($"Account type {typeof(T)} not supported for getting initial transaction history.");
     }

--- a/code/FinanceManager.Components/Services/IFinancialAccountService.cs
+++ b/code/FinanceManager.Components/Services/IFinancialAccountService.cs
@@ -11,6 +11,8 @@ public interface IFinancialAccountService
 
     public Task<bool> AccountExists(int accountId);
     public Task<T?> GetAccount<T>(int userId, int id, DateTime dateStart, DateTime dateEnd, int minimumEntryCount = 0) where T : BasicAccountInformation;
+    public Task<T?> GetInitialTransactionHistory<T>(int userId, int id, DateTime dateStart, DateTime dateEnd,
+        int minimumEntriesCount = 100) where T : BasicAccountInformation;
     public Task<IEnumerable<T>> GetAccounts<T>(int userId, DateTime dateStart, DateTime dateEnd) where T : BasicAccountInformation;
 
     public Task AddAccount<T>(T account) where T : BasicAccountInformation;

--- a/code/FinanceManager.Components/Services/IFinancialAccountService.cs
+++ b/code/FinanceManager.Components/Services/IFinancialAccountService.cs
@@ -12,7 +12,7 @@ public interface IFinancialAccountService
     public Task<bool> AccountExists(int accountId);
     public Task<T?> GetAccount<T>(int userId, int id, DateTime dateStart, DateTime dateEnd, int minimumEntryCount = 0) where T : BasicAccountInformation;
     public Task<T?> GetInitialTransactionHistory<T>(int userId, int id, DateTime dateStart, DateTime dateEnd,
-        int minimumEntriesCount = 100) where T : BasicAccountInformation;
+        int minimumEntryCount = 100) where T : BasicAccountInformation;
     public Task<IEnumerable<T>> GetAccounts<T>(int userId, DateTime dateStart, DateTime dateEnd) where T : BasicAccountInformation;
 
     public Task AddAccount<T>(T account) where T : BasicAccountInformation;

--- a/code/FinanceManager.Tests.Integration/Controllers/BondAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/BondAccountControllerTests.cs
@@ -153,6 +153,22 @@ public class BondAccountControllerTests(OptionsProvider optionsProvider) : Contr
     }
 
     [Fact]
+    public async Task GetInitialTransactionHistory_BackfillsOlderEntriesWhenMinimumEntryCountRequiresIt()
+    {
+        await SeedAccountWithEntries();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new BondAccountHttpClient(Client);
+        var startDate = DateTime.UtcNow.Date.AddDays(-3);
+        var endDate = DateTime.UtcNow.Date;
+
+        var account = await client.GetInitialTransactionHistoryAsync(_testAccountId, startDate, endDate, minimumEntriesCount: 3);
+
+        Assert.NotNull(account);
+        Assert.Equal(new[] { 3, 2, 1 }, account!.Entries.Select(x => x.EntryId));
+        Assert.Empty(account.NextOlderEntries);
+    }
+
+    [Fact]
     public async Task GetRecentEntries_ReturnsMostRecentEntriesWithOlderMetadata()
     {
         await SeedAccountWithEntries();

--- a/code/FinanceManager.Tests.Integration/Controllers/BondAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/BondAccountControllerTests.cs
@@ -161,7 +161,7 @@ public class BondAccountControllerTests(OptionsProvider optionsProvider) : Contr
         var startDate = DateTime.UtcNow.Date.AddDays(-3);
         var endDate = DateTime.UtcNow.Date;
 
-        var account = await client.GetInitialTransactionHistoryAsync(_testAccountId, startDate, endDate, minimumEntriesCount: 3);
+        var account = await client.GetInitialTransactionHistoryAsync(_testAccountId, startDate, endDate, minimumEntryCount: 3);
 
         Assert.NotNull(account);
         Assert.Equal(new[] { 3, 2, 1 }, account!.Entries.Select(x => x.EntryId));

--- a/code/FinanceManager.Tests.Integration/Controllers/CurrencyAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/CurrencyAccountControllerTests.cs
@@ -162,6 +162,22 @@ public class CurrencyAccountControllerTests(OptionsProvider optionsProvider) : C
     }
 
     [Fact]
+    public async Task GetInitialTransactionHistory_BackfillsOlderEntriesWhenMinimumEntryCountRequiresIt()
+    {
+        await SeedAccountWithEntries();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new CurrencyAccountHttpClient(Client);
+        var startDate = DateTime.UtcNow.Date.AddDays(-3);
+        var endDate = DateTime.UtcNow.Date;
+
+        var account = await client.GetInitialTransactionHistoryAsync(_testAccountId, startDate, endDate, minimumEntriesCount: 3);
+
+        Assert.NotNull(account);
+        Assert.Equal(new[] { 3, 2, 1 }, account!.Entries.Select(x => x.EntryId));
+        Assert.Null(account.NextOlderEntry);
+    }
+
+    [Fact]
     public async Task GetRecentEntries_ReturnsMostRecentEntriesWithOlderMetadata()
     {
         await SeedAccountWithEntries();

--- a/code/FinanceManager.Tests.Integration/Controllers/CurrencyAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/CurrencyAccountControllerTests.cs
@@ -170,7 +170,7 @@ public class CurrencyAccountControllerTests(OptionsProvider optionsProvider) : C
         var startDate = DateTime.UtcNow.Date.AddDays(-3);
         var endDate = DateTime.UtcNow.Date;
 
-        var account = await client.GetInitialTransactionHistoryAsync(_testAccountId, startDate, endDate, minimumEntriesCount: 3);
+        var account = await client.GetInitialTransactionHistoryAsync(_testAccountId, startDate, endDate, minimumEntryCount: 3);
 
         Assert.NotNull(account);
         Assert.Equal(new[] { 3, 2, 1 }, account!.Entries.Select(x => x.EntryId));

--- a/code/FinanceManager.Tests.Integration/Controllers/StockAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/StockAccountControllerTests.cs
@@ -159,7 +159,7 @@ public class StockAccountControllerTests(OptionsProvider optionsProvider) : Cont
         var startDate = DateTime.UtcNow.Date.AddDays(-3);
         var endDate = DateTime.UtcNow.Date;
 
-        var account = await client.GetInitialTransactionHistoryAsync(_testAccountId, startDate, endDate, minimumEntriesCount: 3);
+        var account = await client.GetInitialTransactionHistoryAsync(_testAccountId, startDate, endDate, minimumEntryCount: 3);
 
         Assert.NotNull(account);
         Assert.Equal(new[] { 3, 2, 1 }, account!.Entries.Select(x => x.EntryId));

--- a/code/FinanceManager.Tests.Integration/Controllers/StockAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/StockAccountControllerTests.cs
@@ -151,6 +151,22 @@ public class StockAccountControllerTests(OptionsProvider optionsProvider) : Cont
     }
 
     [Fact]
+    public async Task GetInitialTransactionHistory_BackfillsOlderEntriesWhenMinimumEntryCountRequiresIt()
+    {
+        await SeedAccountWithEntries();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new StockAccountHttpClient(Client);
+        var startDate = DateTime.UtcNow.Date.AddDays(-3);
+        var endDate = DateTime.UtcNow.Date;
+
+        var account = await client.GetInitialTransactionHistoryAsync(_testAccountId, startDate, endDate, minimumEntriesCount: 3);
+
+        Assert.NotNull(account);
+        Assert.Equal(new[] { 3, 2, 1 }, account!.Entries.Select(x => x.EntryId));
+        Assert.Empty(account.NextOlderEntries);
+    }
+
+    [Fact]
     public async Task Add_CreatesNewAccount()
     {
         // arrange

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/BondAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/BondAccountControllerTests.cs
@@ -138,4 +138,55 @@ public class BondAccountControllerTests
         Assert.Equal(2, returnValue.Entries.Count());
         Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
     }
+
+    [Fact]
+    public async Task GetInitialTransactionHistory_BackfillsOlderEntriesUntilMinimumIsReached()
+    {
+        var userId = 1;
+        var accountId = 1;
+        var startDate = new DateTime(2026, 4, 1);
+        var endDate = new DateTime(2026, 4, 30);
+        var expandedStartDate = new DateTime(2026, 3, 15);
+        BondAccount account = new(userId, accountId, "Bond Account", AccountLabel.Other);
+        List<BondAccountEntry> initialEntries =
+        [
+            new(accountId, 2, new DateTime(2026, 4, 20), 10500m, 500m, 101),
+        ];
+        List<BondAccountEntry> expandedEntries =
+        [
+            new(accountId, 2, new DateTime(2026, 4, 20), 10500m, 500m, 101),
+            new(accountId, 1, expandedStartDate, 10000m, 10000m, 101),
+        ];
+
+        _mockBondAccountRepository.Setup(repo => repo.Get(accountId)).ReturnsAsync(account);
+        _mockBondAccountEntryRepository.Setup(repo => repo.Get(accountId, startDate, endDate)).Returns(initialEntries.ToAsyncEnumerable());
+        _mockBondAccountEntryRepository
+            .Setup(repo => repo.GetNextOlder(accountId, new DateTime(2026, 4, 20)))
+            .ReturnsAsync(new Dictionary<int, BondAccountEntry> { [101] = new(accountId, 1, expandedStartDate, 10000m, 10000m, 101) });
+        _mockBondAccountEntryRepository.Setup(repo => repo.Get(accountId, expandedStartDate, endDate)).Returns(expandedEntries.ToAsyncEnumerable());
+        _mockBondAccountEntryRepository
+            .Setup(repo => repo.GetNextOlder(accountId, expandedStartDate))
+            .ReturnsAsync(new Dictionary<int, BondAccountEntry>());
+        _mockBondAccountEntryRepository
+            .Setup(repo => repo.GetNextYounger(accountId, endDate))
+            .ReturnsAsync(new Dictionary<int, BondAccountEntry>());
+
+        var result = await _controller.GetInitialTransactionHistory(accountId, startDate, endDate, minimumEntriesCount: 2);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnValue = Assert.IsType<BondAccountDto>(okResult.Value);
+        Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
+    }
+
+    [Fact]
+    public async Task GetInitialTransactionHistory_ReturnsBadRequest_WhenDateRangeIsInvalid()
+    {
+        var accountId = 1;
+        BondAccount account = new(1, accountId, "Bond Account", AccountLabel.Other);
+        _mockBondAccountRepository.Setup(repo => repo.Get(accountId)).ReturnsAsync(account);
+
+        var result = await _controller.GetInitialTransactionHistory(accountId, new DateTime(2026, 5, 1), new DateTime(2026, 4, 1));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
 }

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/BondAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/BondAccountControllerTests.cs
@@ -102,34 +102,7 @@ public class BondAccountControllerTests
     [Fact]
     public async Task Get_WithMinimumEntryCount_BackfillsOlderEntriesUntilMinimumIsReached()
     {
-        var userId = 1;
-        var accountId = 1;
-        var startDate = new DateTime(2026, 4, 1);
-        var endDate = new DateTime(2026, 4, 30);
-        var expandedStartDate = new DateTime(2026, 3, 15);
-        BondAccount account = new(userId, accountId, "Bond Account", AccountLabel.Other);
-        List<BondAccountEntry> initialEntries =
-        [
-            new(accountId, 2, new DateTime(2026, 4, 20), 10500m, 500m, 101),
-        ];
-        List<BondAccountEntry> expandedEntries =
-        [
-            new(accountId, 2, new DateTime(2026, 4, 20), 10500m, 500m, 101),
-            new(accountId, 1, expandedStartDate, 10000m, 10000m, 101),
-        ];
-
-        _mockBondAccountRepository.Setup(repo => repo.Get(accountId)).ReturnsAsync(account);
-        _mockBondAccountEntryRepository.Setup(repo => repo.Get(accountId, startDate, endDate)).Returns(initialEntries.ToAsyncEnumerable());
-        _mockBondAccountEntryRepository
-            .Setup(repo => repo.GetNextOlder(accountId, new DateTime(2026, 4, 20)))
-            .ReturnsAsync(new Dictionary<int, BondAccountEntry> { [101] = new(accountId, 1, expandedStartDate, 10000m, 10000m, 101) });
-        _mockBondAccountEntryRepository.Setup(repo => repo.Get(accountId, expandedStartDate, endDate)).Returns(expandedEntries.ToAsyncEnumerable());
-        _mockBondAccountEntryRepository
-            .Setup(repo => repo.GetNextOlder(accountId, expandedStartDate))
-            .ReturnsAsync(new Dictionary<int, BondAccountEntry>());
-        _mockBondAccountEntryRepository
-            .Setup(repo => repo.GetNextYounger(accountId, endDate))
-            .ReturnsAsync(new Dictionary<int, BondAccountEntry>());
+        var (accountId, startDate, endDate) = SetupBackfillScenario();
 
         var result = await _controller.Get(accountId, startDate, endDate, minimumEntryCount: 2);
 
@@ -141,6 +114,18 @@ public class BondAccountControllerTests
 
     [Fact]
     public async Task GetInitialTransactionHistory_BackfillsOlderEntriesUntilMinimumIsReached()
+    {
+        var (accountId, startDate, endDate) = SetupBackfillScenario();
+
+        var result = await _controller.GetInitialTransactionHistory(accountId, startDate, endDate, minimumEntryCount: 2);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnValue = Assert.IsType<BondAccountDto>(okResult.Value);
+        Assert.Equal(2, returnValue.Entries.Count());
+        Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
+    }
+
+    private (int AccountId, DateTime StartDate, DateTime EndDate) SetupBackfillScenario()
     {
         var userId = 1;
         var accountId = 1;
@@ -171,11 +156,7 @@ public class BondAccountControllerTests
             .Setup(repo => repo.GetNextYounger(accountId, endDate))
             .ReturnsAsync(new Dictionary<int, BondAccountEntry>());
 
-        var result = await _controller.GetInitialTransactionHistory(accountId, startDate, endDate, minimumEntriesCount: 2);
-
-        var okResult = Assert.IsType<OkObjectResult>(result);
-        var returnValue = Assert.IsType<BondAccountDto>(okResult.Value);
-        Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
+        return (accountId, startDate, endDate);
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/CurrencyAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/CurrencyAccountControllerTests.cs
@@ -276,4 +276,55 @@ public class CurrencyAccountControllerTests
         Assert.Equal(2, returnValue.Entries.Count());
         Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
     }
+
+    [Fact]
+    public async Task GetInitialTransactionHistory_BackfillsOlderEntriesUntilMinimumIsReached()
+    {
+        var userId = 1;
+        var accountId = 1;
+        var startDate = new DateTime(2026, 4, 1);
+        var endDate = new DateTime(2026, 4, 30);
+        var expandedStartDate = new DateTime(2026, 3, 15);
+        CurrencyAccount account = new(userId, accountId, "Test Account");
+        List<CurrencyAccountEntry> initialEntries =
+        [
+            new(accountId, 2, new DateTime(2026, 4, 20), 900m, -100m),
+        ];
+        List<CurrencyAccountEntry> expandedEntries =
+        [
+            new(accountId, 2, new DateTime(2026, 4, 20), 900m, -100m),
+            new(accountId, 1, expandedStartDate, 1000m, 1000m),
+        ];
+
+        _mockAccountRepository.Setup(repo => repo.Get(accountId)).ReturnsAsync(account);
+        _mockAccountEntryRepository.Setup(repo => repo.Get(accountId, startDate, endDate)).Returns(initialEntries.ToAsyncEnumerable());
+        _mockAccountEntryRepository
+            .Setup(repo => repo.GetNextOlder(accountId, new DateTime(2026, 4, 20)))
+            .ReturnsAsync(new CurrencyAccountEntry(accountId, 1, expandedStartDate, 1000m, 1000m));
+        _mockAccountEntryRepository.Setup(repo => repo.Get(accountId, expandedStartDate, endDate)).Returns(expandedEntries.ToAsyncEnumerable());
+        _mockAccountEntryRepository
+            .Setup(repo => repo.GetNextOlder(accountId, expandedStartDate))
+            .ReturnsAsync((CurrencyAccountEntry?)null);
+        _mockAccountEntryRepository
+            .Setup(repo => repo.GetNextYounger(accountId, endDate))
+            .ReturnsAsync((CurrencyAccountEntry?)null);
+
+        var result = await _controller.GetInitialTransactionHistory(accountId, startDate, endDate, minimumEntriesCount: 2);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnValue = Assert.IsType<CurrencyAccountDto>(okResult.Value);
+        Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
+    }
+
+    [Fact]
+    public async Task GetInitialTransactionHistory_ReturnsBadRequest_WhenDateRangeIsInvalid()
+    {
+        var accountId = 1;
+        CurrencyAccount account = new(1, accountId, "Test Account");
+        _mockAccountRepository.Setup(repo => repo.Get(accountId)).ReturnsAsync(account);
+
+        var result = await _controller.GetInitialTransactionHistory(accountId, new DateTime(2026, 5, 1), new DateTime(2026, 4, 1));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
 }

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/CurrencyAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/CurrencyAccountControllerTests.cs
@@ -240,34 +240,7 @@ public class CurrencyAccountControllerTests
     [Fact]
     public async Task Get_WithMinimumEntryCount_BackfillsOlderEntriesUntilMinimumIsReached()
     {
-        var userId = 1;
-        var accountId = 1;
-        var startDate = new DateTime(2026, 4, 1);
-        var endDate = new DateTime(2026, 4, 30);
-        var expandedStartDate = new DateTime(2026, 3, 15);
-        CurrencyAccount account = new(userId, accountId, "Test Account");
-        List<CurrencyAccountEntry> initialEntries =
-        [
-            new(accountId, 2, new DateTime(2026, 4, 20), 900m, -100m),
-        ];
-        List<CurrencyAccountEntry> expandedEntries =
-        [
-            new(accountId, 2, new DateTime(2026, 4, 20), 900m, -100m),
-            new(accountId, 1, expandedStartDate, 1000m, 1000m),
-        ];
-
-        _mockAccountRepository.Setup(repo => repo.Get(accountId)).ReturnsAsync(account);
-        _mockAccountEntryRepository.Setup(repo => repo.Get(accountId, startDate, endDate)).Returns(initialEntries.ToAsyncEnumerable());
-        _mockAccountEntryRepository
-            .Setup(repo => repo.GetNextOlder(accountId, new DateTime(2026, 4, 20)))
-            .ReturnsAsync(new CurrencyAccountEntry(accountId, 1, expandedStartDate, 1000m, 1000m));
-        _mockAccountEntryRepository.Setup(repo => repo.Get(accountId, expandedStartDate, endDate)).Returns(expandedEntries.ToAsyncEnumerable());
-        _mockAccountEntryRepository
-            .Setup(repo => repo.GetNextOlder(accountId, expandedStartDate))
-            .ReturnsAsync((CurrencyAccountEntry?)null);
-        _mockAccountEntryRepository
-            .Setup(repo => repo.GetNextYounger(accountId, endDate))
-            .ReturnsAsync((CurrencyAccountEntry?)null);
+        var (accountId, startDate, endDate) = SetupBackfillScenario();
 
         var result = await _controller.Get(accountId, startDate, endDate, minimumEntryCount: 2);
 
@@ -279,6 +252,18 @@ public class CurrencyAccountControllerTests
 
     [Fact]
     public async Task GetInitialTransactionHistory_BackfillsOlderEntriesUntilMinimumIsReached()
+    {
+        var (accountId, startDate, endDate) = SetupBackfillScenario();
+
+        var result = await _controller.GetInitialTransactionHistory(accountId, startDate, endDate, minimumEntryCount: 2);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnValue = Assert.IsType<CurrencyAccountDto>(okResult.Value);
+        Assert.Equal(2, returnValue.Entries.Count());
+        Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
+    }
+
+    private (int AccountId, DateTime StartDate, DateTime EndDate) SetupBackfillScenario()
     {
         var userId = 1;
         var accountId = 1;
@@ -309,11 +294,7 @@ public class CurrencyAccountControllerTests
             .Setup(repo => repo.GetNextYounger(accountId, endDate))
             .ReturnsAsync((CurrencyAccountEntry?)null);
 
-        var result = await _controller.GetInitialTransactionHistory(accountId, startDate, endDate, minimumEntriesCount: 2);
-
-        var okResult = Assert.IsType<OkObjectResult>(result);
-        var returnValue = Assert.IsType<CurrencyAccountDto>(okResult.Value);
-        Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
+        return (accountId, startDate, endDate);
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/StockAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/StockAccountControllerTests.cs
@@ -254,4 +254,54 @@ public class StockAccountControllerTests
         Assert.Equal(2, returnValue.Entries.Count());
         Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
     }
+
+    [Fact]
+    public async Task GetInitialTransactionHistory_BackfillsOlderEntriesUntilMinimumIsReached()
+    {
+        var accountId = 1;
+        var startDate = new DateTime(2026, 4, 1);
+        var endDate = new DateTime(2026, 4, 30);
+        var expandedStartDate = new DateTime(2026, 3, 15);
+        StockAccount account = new(_testUserId, accountId, "Test Account");
+        List<StockAccountEntry> initialEntries =
+        [
+            new(accountId, 2, new DateTime(2026, 4, 20), 10500m, 500m, "AAPL", InvestmentType.Stock),
+        ];
+        List<StockAccountEntry> expandedEntries =
+        [
+            new(accountId, 2, new DateTime(2026, 4, 20), 10500m, 500m, "AAPL", InvestmentType.Stock),
+            new(accountId, 1, expandedStartDate, 10000m, 10000m, "AAPL", InvestmentType.Stock),
+        ];
+
+        _mockStockAccountRepository.Setup(repo => repo.Get(accountId)).ReturnsAsync(account);
+        _mockStockAccountEntryRepository.Setup(repo => repo.Get(accountId, startDate, endDate)).Returns(initialEntries.ToAsyncEnumerable());
+        _mockStockAccountEntryRepository
+            .Setup(repo => repo.GetNextOlder(accountId, new DateTime(2026, 4, 20)))
+            .ReturnsAsync(new Dictionary<string, StockAccountEntry> { ["AAPL"] = new(accountId, 1, expandedStartDate, 10000m, 10000m, "AAPL", InvestmentType.Stock) });
+        _mockStockAccountEntryRepository.Setup(repo => repo.Get(accountId, expandedStartDate, endDate)).Returns(expandedEntries.ToAsyncEnumerable());
+        _mockStockAccountEntryRepository
+            .Setup(repo => repo.GetNextOlder(accountId, expandedStartDate))
+            .ReturnsAsync(new Dictionary<string, StockAccountEntry>());
+        _mockStockAccountEntryRepository
+            .Setup(repo => repo.GetNextYounger(accountId, endDate))
+            .ReturnsAsync(new Dictionary<string, StockAccountEntry>());
+
+        var result = await _controller.GetInitialTransactionHistory(accountId, startDate, endDate, minimumEntriesCount: 2);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnValue = Assert.IsType<StockAccountDto>(okResult.Value);
+        Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
+    }
+
+    [Fact]
+    public async Task GetInitialTransactionHistory_ReturnsBadRequest_WhenDateRangeIsInvalid()
+    {
+        var accountId = 1;
+        StockAccount account = new(_testUserId, accountId, "Test Account");
+        _mockStockAccountRepository.Setup(repo => repo.Get(accountId)).ReturnsAsync(account);
+
+        var result = await _controller.GetInitialTransactionHistory(accountId, new DateTime(2026, 5, 1), new DateTime(2026, 4, 1));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
 }

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/StockAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/StockAccountControllerTests.cs
@@ -219,33 +219,7 @@ public class StockAccountControllerTests
     [Fact]
     public async Task GetWithDateRange_BackfillsOlderEntriesUntilMinimumIsReached()
     {
-        var accountId = 1;
-        var startDate = new DateTime(2026, 4, 1);
-        var endDate = new DateTime(2026, 4, 30);
-        var expandedStartDate = new DateTime(2026, 3, 15);
-        StockAccount account = new(_testUserId, accountId, "Test Account");
-        List<StockAccountEntry> initialEntries =
-        [
-            new(accountId, 2, new DateTime(2026, 4, 20), 10500m, 500m, "AAPL", InvestmentType.Stock),
-        ];
-        List<StockAccountEntry> expandedEntries =
-        [
-            new(accountId, 2, new DateTime(2026, 4, 20), 10500m, 500m, "AAPL", InvestmentType.Stock),
-            new(accountId, 1, expandedStartDate, 10000m, 10000m, "AAPL", InvestmentType.Stock),
-        ];
-
-        _mockStockAccountRepository.Setup(repo => repo.Get(accountId)).ReturnsAsync(account);
-        _mockStockAccountEntryRepository.Setup(repo => repo.Get(accountId, startDate, endDate)).Returns(initialEntries.ToAsyncEnumerable());
-        _mockStockAccountEntryRepository
-            .Setup(repo => repo.GetNextOlder(accountId, new DateTime(2026, 4, 20)))
-            .ReturnsAsync(new Dictionary<string, StockAccountEntry> { ["AAPL"] = new(accountId, 1, expandedStartDate, 10000m, 10000m, "AAPL", InvestmentType.Stock) });
-        _mockStockAccountEntryRepository.Setup(repo => repo.Get(accountId, expandedStartDate, endDate)).Returns(expandedEntries.ToAsyncEnumerable());
-        _mockStockAccountEntryRepository
-            .Setup(repo => repo.GetNextOlder(accountId, expandedStartDate))
-            .ReturnsAsync(new Dictionary<string, StockAccountEntry>());
-        _mockStockAccountEntryRepository
-            .Setup(repo => repo.GetNextYounger(accountId, endDate))
-            .ReturnsAsync(new Dictionary<string, StockAccountEntry>());
+        var (accountId, startDate, endDate) = SetupBackfillScenario();
 
         var result = await _controller.Get(accountId, startDate, endDate, minimumEntryCount: 2);
 
@@ -257,6 +231,18 @@ public class StockAccountControllerTests
 
     [Fact]
     public async Task GetInitialTransactionHistory_BackfillsOlderEntriesUntilMinimumIsReached()
+    {
+        var (accountId, startDate, endDate) = SetupBackfillScenario();
+
+        var result = await _controller.GetInitialTransactionHistory(accountId, startDate, endDate, minimumEntryCount: 2);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnValue = Assert.IsType<StockAccountDto>(okResult.Value);
+        Assert.Equal(2, returnValue.Entries.Count());
+        Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
+    }
+
+    private (int AccountId, DateTime StartDate, DateTime EndDate) SetupBackfillScenario()
     {
         var accountId = 1;
         var startDate = new DateTime(2026, 4, 1);
@@ -286,11 +272,7 @@ public class StockAccountControllerTests
             .Setup(repo => repo.GetNextYounger(accountId, endDate))
             .ReturnsAsync(new Dictionary<string, StockAccountEntry>());
 
-        var result = await _controller.GetInitialTransactionHistory(accountId, startDate, endDate, minimumEntriesCount: 2);
-
-        var okResult = Assert.IsType<OkObjectResult>(result);
-        var returnValue = Assert.IsType<StockAccountDto>(okResult.Value);
-        Assert.Equal([2, 1], returnValue.Entries.Select(x => x.EntryId));
+        return (accountId, startDate, endDate);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add `GetInitialTransactionHistory` endpoints for currency, stock, and bond account histories.
- Use the new initial-history flow from the frontend with a default minimum of 100 entries.
- Replace the `All` account-history range option with a calendar-backed custom range selector.
- Automatically switch the selector to custom range when initial loading backfills entries older than the selected current-month range.

## Why
When the newest account entry is older than the initially selected range, the UI could show an add/import prompt even though older entries existed. The new initial-history flow extends the loaded range enough to display existing data.

Closes #384.

## Validation
- `dotnet build code/FinanceManager.slnx --no-restore`
- `code/FinanceManager.Tests.Unit/bin/Debug/net10.0/FinanceManager.Tests.Unit.exe -class "FinanceManager.Tests.Unit.Api.Controllers.CurrencyAccountControllerTests" -class "FinanceManager.Tests.Unit.Api.Controllers.StockAccountControllerTests" -class "FinanceManager.Tests.Unit.Api.Controllers.BondAccountControllerTests"`
- `$env:UseInMemoryDatabase='true'; code/FinanceManager.Tests.Integration/bin/Debug/net10.0/FinanceManager.Tests.Integration.exe -class "FinanceManager.Tests.Integration.Controllers.CurrencyAccountControllerTests" -class "FinanceManager.Tests.Integration.Controllers.StockAccountControllerTests" -class "FinanceManager.Tests.Integration.Controllers.BondAccountControllerTests"`
- `dotnet format style code --verify-no-changes --diagnostics IDE1006 --severity error --no-restore`
- `dotnet format code --verify-no-changes --no-restore --verbosity minimal`
- `git diff --check`

Note: direct `dotnet test` is blocked by the repo's Microsoft.Testing.Platform/.NET 10 setup, so validation used the compiled xUnit executables, matching the CI pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom date range picker for transaction history filtering across all account types
  * Introduced intelligent backfilling of historical entries to meet configurable minimum entry requirements
  * Added comprehensive date range validation to prevent invalid queries

* **Tests**
  * Added unit and integration tests for custom date range functionality and entry backfilling behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->