### PR TITLE
[codex] Add antiforgery refresh protection

### DIFF
--- a/code/FinanceManager.Api/Controllers/AuthController.cs
+++ b/code/FinanceManager.Api/Controllers/AuthController.cs
@@ -3,6 +3,7 @@ using FinanceManager.Application.Commands.Login;
 using FinanceManager.Application.Options;
 using FinanceManager.Domain.Repositories;
 using FinanceManager.Domain.Services;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
@@ -19,9 +20,31 @@ public class AuthController(
     JwtTokenGenerator jwtTokenGenerator,
     IUserRepository userRepository,
     IOptions<RefreshTokenOptions> refreshOptions,
+    IAntiforgery antiforgery,
     ILogger<AuthController> logger) : ControllerBase
 {
+    public const string CsrfTokenCookieName = "fm_csrf";
+
     private RefreshTokenOptions Options => refreshOptions.Value;
+
+    /// <summary>Issues an antiforgery request token that the Blazor client echoes in the X-CSRF-Token header.</summary>
+    [AllowAnonymous]
+    [HttpGet("csrf-token")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public IActionResult GetCsrfToken()
+    {
+        var tokens = antiforgery.GetAndStoreTokens(HttpContext);
+        Response.Cookies.Append(CsrfTokenCookieName, tokens.RequestToken!, new CookieOptions
+        {
+            HttpOnly = false,
+            Secure = Request.IsHttps,
+            SameSite = SameSiteMode.Strict,
+            Path = "/",
+            IsEssential = true,
+        });
+
+        return NoContent();
+    }
 
     /// <summary>
     /// Exchanges the refresh-token cookie for a fresh access token, rotating the refresh token in the process.
@@ -30,9 +53,13 @@ public class AuthController(
     [AllowAnonymous]
     [HttpPost("refresh")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(LoginResponseModel))]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> Refresh(CancellationToken cancellationToken = default)
     {
+        if (!await ValidateAntiforgeryToken())
+            return Forbid();
+
         if (!Request.Cookies.TryGetValue(Options.CookieName, out var rawToken) || string.IsNullOrWhiteSpace(rawToken))
             return Unauthorized();
 
@@ -62,8 +89,12 @@ public class AuthController(
     [AllowAnonymous]
     [HttpPost("logout")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Logout(CancellationToken cancellationToken = default)
     {
+        if (!await ValidateAntiforgeryToken())
+            return Forbid();
+
         if (Request.Cookies.TryGetValue(Options.CookieName, out var rawToken) && !string.IsNullOrWhiteSpace(rawToken))
             await refreshTokenService.Revoke(rawToken, cancellationToken);
 
@@ -77,4 +108,18 @@ public class AuthController(
 
     private void ClearCookie() =>
         RefreshTokenCookie.Delete(Response, Request.IsHttps, Options.CookieName);
+
+    private async Task<bool> ValidateAntiforgeryToken()
+    {
+        try
+        {
+            await antiforgery.ValidateRequestAsync(HttpContext);
+            return true;
+        }
+        catch (AntiforgeryValidationException ex)
+        {
+            logger.LogWarning(ex, "Rejected auth request with an invalid antiforgery token.");
+            return false;
+        }
+    }
 }

--- a/code/FinanceManager.Api/Program.cs
+++ b/code/FinanceManager.Api/Program.cs
@@ -78,6 +78,14 @@ builder.WebHost.ConfigureKestrel(options =>
 builder.Services.Configure<JwtAuthOptions>(builder.Configuration.GetSection("JwtConfig"));
 builder.Services.Configure<RefreshTokenOptions>(builder.Configuration.GetSection(RefreshTokenOptions.SectionName));
 builder.Services.Configure<PasswordResetOptions>(builder.Configuration.GetSection(PasswordResetOptions.SectionName));
+builder.Services.AddAntiforgery(options =>
+{
+    options.HeaderName = "X-CSRF-Token";
+    options.Cookie.Name = "fm_antiforgery";
+    options.Cookie.HttpOnly = true;
+    options.Cookie.SameSite = SameSiteMode.Strict;
+    options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+});
 builder.Services.AddOptions<AccountLockoutOptions>()
     .Bind(builder.Configuration.GetSection(AccountLockoutOptions.SectionName))
     .Validate(o => o.MaxFailedAttempts > 0, "AccountLockout:MaxFailedAttempts must be greater than 0.")

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -13,7 +13,8 @@ public static class ServiceCollectionExtension
     {
         services.AddMemoryCache();
 
-        services.AddScoped<ILoginService, LoginService>()
+        services.AddScoped<IAntiforgeryTokenService, AntiforgeryTokenService>()
+                .AddScoped<ILoginService, LoginService>()
 
                 .AddScoped<StockPriceHttpClient>()
                 .AddScoped<StockAccountHttpClient>()

--- a/code/FinanceManager.Components/Services/AntiforgeryTokenService.cs
+++ b/code/FinanceManager.Components/Services/AntiforgeryTokenService.cs
@@ -1,0 +1,58 @@
+using Microsoft.JSInterop;
+
+namespace FinanceManager.Components.Services;
+
+public interface IAntiforgeryTokenService
+{
+    public const string HeaderName = "X-CSRF-Token";
+
+    Task<HttpRequestMessage> CreateRequest(HttpMethod method, string requestUri, CancellationToken cancellationToken);
+
+    void ClearToken();
+}
+
+public sealed class AntiforgeryTokenService(HttpClient httpClient, IJSRuntime jsRuntime) : IAntiforgeryTokenService
+{
+    public const string CookieName = "fm_csrf";
+
+    private readonly SemaphoreSlim _tokenLock = new(1, 1);
+    private string? _cachedToken;
+
+    public async Task<HttpRequestMessage> CreateRequest(HttpMethod method, string requestUri, CancellationToken cancellationToken)
+    {
+        var token = await GetToken(cancellationToken);
+
+        var request = new HttpRequestMessage(method, requestUri);
+        request.Headers.TryAddWithoutValidation(IAntiforgeryTokenService.HeaderName, token);
+        return request;
+    }
+
+    public void ClearToken() => _cachedToken = null;
+
+    private async Task<string> GetToken(CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(_cachedToken))
+            return _cachedToken;
+
+        await _tokenLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(_cachedToken))
+                return _cachedToken;
+
+            using var response = await httpClient.GetAsync("api/Auth/csrf-token", cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var token = await jsRuntime.InvokeAsync<string>("financeManager.getCookie", cancellationToken, CookieName);
+            if (string.IsNullOrWhiteSpace(token))
+                throw new InvalidOperationException("The antiforgery token cookie was not issued.");
+
+            _cachedToken = token;
+            return token;
+        }
+        finally
+        {
+            _tokenLock.Release();
+        }
+    }
+}

--- a/code/FinanceManager.Components/Services/LoginService.cs
+++ b/code/FinanceManager.Components/Services/LoginService.cs
@@ -22,6 +22,7 @@ public class LoginService : ILoginService
     private readonly IUserRepository _loginRepository;
     private readonly HttpClient _httpClient;
     private readonly ILogger<LoginService> _logger;
+    private readonly IAntiforgeryTokenService _antiforgeryTokenService;
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
 
     // Once we've tried (and failed) to silently restore a session we don't keep hammering the refresh endpoint on
@@ -36,7 +37,8 @@ public class LoginService : ILoginService
 
     private readonly AuthenticationStateProvider _authStateProvider;
     public LoginService(ISessionStorageService sessionStorageService, ILocalStorageService localStorageService,
-        AuthenticationStateProvider authState, IUserRepository loginRepository, HttpClient httpClient, ILogger<LoginService> logger)
+        AuthenticationStateProvider authState, IUserRepository loginRepository, HttpClient httpClient,
+        IAntiforgeryTokenService antiforgeryTokenService, ILogger<LoginService> logger)
     {
         _sessionStorageService = sessionStorageService;
         _localStorageService = localStorageService;
@@ -44,6 +46,7 @@ public class LoginService : ILoginService
 
         _loginRepository = loginRepository;
         _httpClient = httpClient;
+        _antiforgeryTokenService = antiforgeryTokenService;
         _logger = logger;
         _ = _loginRepository.AddUser("Guest", PasswordEncryptionProvider.EncryptPassword("GuestPassword"), PricingLevel.Basic, UserRole.User);
     }
@@ -125,7 +128,9 @@ public class LoginService : ILoginService
         await _refreshLock.WaitAsync();
         try
         {
-            using var response = await _httpClient.PostAsync($"{_httpClient.BaseAddress}api/Auth/refresh", content: null);
+            using var request = await _antiforgeryTokenService.CreateRequest(
+                HttpMethod.Post, "api/Auth/refresh", CancellationToken.None);
+            using var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode) return false;
 
             var result = await response.Content.ReadFromJsonAsync<LoginResponseModel>();
@@ -150,7 +155,9 @@ public class LoginService : ILoginService
     {
         try
         {
-            using var _ = await _httpClient.PostAsync($"{_httpClient.BaseAddress}api/Auth/logout", content: null);
+            using var request = await _antiforgeryTokenService.CreateRequest(
+                HttpMethod.Post, "api/Auth/logout", CancellationToken.None);
+            using var _ = await _httpClient.SendAsync(request);
         }
         catch (Exception ex)
         {
@@ -167,6 +174,7 @@ public class LoginService : ILoginService
         _httpClient.DefaultRequestHeaders.Authorization = null;
         await ((CustomAuthenticationStateProvider)_authStateProvider).Logout();
         _loggedUser = null;
+        _antiforgeryTokenService.ClearToken();
         // Block GetLoggedUser from silently re-authenticating with a stale cookie after the session has ended.
         _initialRefreshAttempted = true;
         LogginStateChanged?.Invoke(false);
@@ -193,6 +201,7 @@ public class LoginService : ILoginService
         _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", result.AccessToken);
         _loggedUser = session;
         _initialRefreshAttempted = true;
+        _antiforgeryTokenService.ClearToken();
 
         await ((CustomAuthenticationStateProvider)_authStateProvider)
             .ChangeUser(session.UserName, session.UserId.ToString(), session.UserRole.ToString());

--- a/code/FinanceManager.Components/Services/TokenRefreshRedirectHandler.cs
+++ b/code/FinanceManager.Components/Services/TokenRefreshRedirectHandler.cs
@@ -61,7 +61,8 @@ public sealed class TokenRefreshRedirectHandler(
         if (uri is null) return false;
 
         var path = uri.AbsolutePath;
-        return path.EndsWith("/api/Auth/refresh", StringComparison.OrdinalIgnoreCase)
+        return path.EndsWith("/api/Auth/csrf-token", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith("/api/Auth/refresh", StringComparison.OrdinalIgnoreCase)
             || path.EndsWith("/api/Auth/logout", StringComparison.OrdinalIgnoreCase)
             || path.EndsWith("/api/Login", StringComparison.OrdinalIgnoreCase);
     }

--- a/code/FinanceManager.Tests.Integration/Controllers/AuthControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/AuthControllerTests.cs
@@ -1,5 +1,7 @@
+using FinanceManager.Api.Controllers;
 using FinanceManager.Application.Commands.Login;
 using FinanceManager.Application.Providers;
+using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.Users;
 using FinanceManager.Domain.Enums;
 using FinanceManager.Domain.Repositories;
@@ -69,8 +71,10 @@ public class AuthControllerTests(OptionsProvider optionsProvider) : ControllerTe
         // Secure is intentionally NOT asserted here: the test client talks plain HTTP, and the cookie's Secure flag
         // tracks Request.IsHttps (verified over HTTPS in the AuthController unit tests instead).
 
-        // Refresh exchanges the cookie for a new access token without any credentials.
-        var refreshResponse = await Client.PostAsync("api/Auth/refresh", content: null, ct);
+        var csrfToken = await BootstrapCsrfToken(ct);
+
+        // Refresh exchanges the cookie plus CSRF header for a new access token without any credentials.
+        var refreshResponse = await PostWithCsrf("api/Auth/refresh", csrfToken, ct);
         refreshResponse.EnsureSuccessStatusCode();
         var refreshed = await refreshResponse.Content.ReadFromJsonAsync<LoginResponseModel>(ct);
         Assert.NotNull(refreshed);
@@ -78,18 +82,74 @@ public class AuthControllerTests(OptionsProvider optionsProvider) : ControllerTe
         Assert.False(string.IsNullOrWhiteSpace(refreshed.AccessToken));
 
         // Logout revokes the token server-side and clears the cookie.
-        var logoutResponse = await Client.PostAsync("api/Auth/logout", content: null, ct);
+        var logoutResponse = await PostWithCsrf("api/Auth/logout", csrfToken, ct);
         logoutResponse.EnsureSuccessStatusCode();
 
         // After logout there is no usable refresh cookie, so a further refresh is rejected.
-        var afterLogout = await Client.PostAsync("api/Auth/refresh", content: null, ct);
+        var afterLogout = await PostWithCsrf("api/Auth/refresh", csrfToken, ct);
         Assert.Equal(HttpStatusCode.Unauthorized, afterLogout.StatusCode);
     }
 
     [Fact]
-    public async Task Refresh_WithoutCookie_ReturnsUnauthorized()
+    public async Task Refresh_WithoutCsrfToken_ReturnsForbidden()
     {
-        var response = await Client.PostAsync("api/Auth/refresh", content: null, TestContext.Current.CancellationToken);
+        var ct = TestContext.Current.CancellationToken;
+        var loginRequest = new LoginRequestModel(_userName, _password);
+        var loginResponse = await Client.PostAsJsonAsync("api/Login", loginRequest, ct);
+        loginResponse.EnsureSuccessStatusCode();
+
+        var response = await Client.PostAsync("api/Auth/refresh", content: null, ct);
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Refresh_WithValidCsrfButWithoutCookie_ReturnsUnauthorized()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var csrfToken = await BootstrapCsrfToken(ct);
+
+        var response = await PostWithCsrf("api/Auth/refresh", csrfToken, ct);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CsrfToken_SetsReadableRequestTokenAndFrameworkCookie()
+    {
+        var response = await Client.GetAsync("api/Auth/csrf-token", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        var cookies = response.Headers.TryGetValues("Set-Cookie", out var values)
+            ? values.ToArray()
+            : [];
+        var setCookie = string.Join(";", cookies);
+        var requestTokenCookie = cookies.Single(value => value.StartsWith(
+            $"{AuthController.CsrfTokenCookieName}=", StringComparison.OrdinalIgnoreCase));
+
+        Assert.Contains(AuthController.CsrfTokenCookieName, setCookie);
+        Assert.Contains("fm_antiforgery", setCookie);
+        Assert.Contains("samesite=strict", setCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("httponly", requestTokenCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<string> BootstrapCsrfToken(CancellationToken cancellationToken)
+    {
+        var response = await Client.GetAsync("api/Auth/csrf-token", cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var setCookie = response.Headers.TryGetValues("Set-Cookie", out var values)
+            ? values
+            : throw new InvalidOperationException("CSRF endpoint did not return cookies.");
+
+        var csrfCookie = setCookie.Single(value => value.StartsWith(
+            $"{AuthController.CsrfTokenCookieName}=", StringComparison.OrdinalIgnoreCase));
+        return WebUtility.UrlDecode(csrfCookie.Split(';', 2)[0]
+            .Substring(AuthController.CsrfTokenCookieName.Length + 1));
+    }
+
+    private Task<HttpResponseMessage> PostWithCsrf(string requestUri, string csrfToken, CancellationToken cancellationToken)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+        request.Headers.TryAddWithoutValidation(IAntiforgeryTokenService.HeaderName, csrfToken);
+        return Client.SendAsync(request, cancellationToken);
     }
 }

--- a/code/FinanceManager.Tests.Integration/Controllers/RateLimitingTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/RateLimitingTests.cs
@@ -26,7 +26,7 @@ public class RateLimitingTests(OptionsProvider optionsProvider) : ControllerTest
     [Fact]
     public async Task AuthEndpoint_ReturnsTooManyRequestsWithRetryAfter_OnceLimitExceeded()
     {
-        // refresh is anonymous and dependency-free (no cookie => 401), so it exercises the auth policy
+        // refresh is anonymous and dependency-free (no CSRF token => 403), so it exercises the auth policy
         // with no setup. Sending one more request than the permit limit must trip the limiter.
         HttpResponseMessage? limited = null;
         for (var attempt = 0; attempt < _authPermitLimit + 1; attempt++)
@@ -38,7 +38,7 @@ public class RateLimitingTests(OptionsProvider optionsProvider) : ControllerTest
                 break;
             }
 
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
         }
 
         Assert.NotNull(limited);

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/AuthControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/AuthControllerTests.cs
@@ -6,6 +6,7 @@ using FinanceManager.Domain.Entities.Users;
 using FinanceManager.Domain.Enums;
 using FinanceManager.Domain.Repositories;
 using FinanceManager.Domain.Services;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -21,6 +22,7 @@ public class AuthControllerTests
 
     private readonly Mock<IRefreshTokenService> _refreshTokenService = new();
     private readonly Mock<IUserRepository> _userRepository = new();
+    private readonly Mock<IAntiforgery> _antiforgery = new();
     private readonly RefreshTokenOptions _options = new() { CookieName = _cookieName, SlidingValidityDays = 14 };
     private readonly JwtTokenGenerator _jwtTokenGenerator = new(Options.Create(new JwtAuthOptions
     {
@@ -38,8 +40,11 @@ public class AuthControllerTests
         if (cookieValue is not null)
             httpContext.Request.Headers["Cookie"] = $"{_cookieName}={cookieValue}";
 
+        var context = httpContext;
+        _antiforgery.Setup(a => a.ValidateRequestAsync(context)).Returns(Task.CompletedTask);
+
         return new AuthController(_refreshTokenService.Object, _jwtTokenGenerator, _userRepository.Object,
-            Options.Create(_options), NullLogger<AuthController>.Instance)
+            Options.Create(_options), _antiforgery.Object, NullLogger<AuthController>.Instance)
         {
             ControllerContext = new ControllerContext { HttpContext = httpContext }
         };
@@ -59,6 +64,19 @@ public class AuthControllerTests
         var result = await controller.Refresh(TestContext.Current.CancellationToken);
 
         Assert.IsType<UnauthorizedResult>(result);
+        _refreshTokenService.Verify(s => s.ValidateAndRotate(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Refresh_InvalidAntiforgeryToken_ReturnsForbidden()
+    {
+        var controller = CreateController("rawtoken", out var ctx);
+        _antiforgery.Setup(a => a.ValidateRequestAsync(ctx))
+            .ThrowsAsync(new AntiforgeryValidationException("invalid"));
+
+        var result = await controller.Refresh(TestContext.Current.CancellationToken);
+
+        Assert.IsType<ForbidResult>(result);
         _refreshTokenService.Verify(s => s.ValidateAndRotate(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/code/FinanceManager.Tests.Unit/Components/Services/AntiforgeryTokenServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Services/AntiforgeryTokenServiceTests.cs
@@ -1,0 +1,84 @@
+using FinanceManager.Components.Services;
+using Microsoft.JSInterop;
+using Moq;
+using System.Net;
+
+namespace FinanceManager.Tests.Unit.Components.Services;
+
+[Trait("Category", "Unit")]
+public class AntiforgeryTokenServiceTests
+{
+    [Fact]
+    public async Task CreateRequest_CachesTokenAndSerializesBootstrap()
+    {
+        var handler = new RecordingHandler();
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+
+        var jsRuntime = new Mock<IJSRuntime>();
+        jsRuntime
+            .Setup(js => js.InvokeAsync<string>(
+                "financeManager.getCookie",
+                It.IsAny<CancellationToken>(),
+                It.Is<object?[]>(args => args.Length == 1 && (string?)args[0] == AntiforgeryTokenService.CookieName)))
+            .Returns(new ValueTask<string>("csrf-token"));
+
+        var service = new AntiforgeryTokenService(httpClient, jsRuntime.Object);
+
+        var requests = await Task.WhenAll(
+            service.CreateRequest(HttpMethod.Post, "api/Auth/refresh", CancellationToken.None),
+            service.CreateRequest(HttpMethod.Post, "api/Auth/logout", CancellationToken.None),
+            service.CreateRequest(HttpMethod.Post, "api/Auth/refresh", CancellationToken.None));
+
+        Assert.Equal(3, requests.Length);
+        Assert.Equal(1, handler.RequestCount);
+        jsRuntime.Verify(js => js.InvokeAsync<string>(
+            "financeManager.getCookie",
+            It.IsAny<CancellationToken>(),
+            It.IsAny<object?[]>()), Times.Once);
+
+        foreach (var request in requests)
+        {
+            Assert.True(request.Headers.TryGetValues(IAntiforgeryTokenService.HeaderName, out var values));
+            Assert.Equal("csrf-token", Assert.Single(values));
+        }
+    }
+
+    [Fact]
+    public async Task ClearToken_ForcesNextRequestToBootstrapAgain()
+    {
+        var handler = new RecordingHandler();
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+
+        var jsRuntime = new Mock<IJSRuntime>();
+        jsRuntime
+            .Setup(js => js.InvokeAsync<string>(
+                "financeManager.getCookie",
+                It.IsAny<CancellationToken>(),
+                It.IsAny<object?[]>()))
+            .Returns(new ValueTask<string>("csrf-token"));
+
+        var service = new AntiforgeryTokenService(httpClient, jsRuntime.Object);
+
+        using var first = await service.CreateRequest(HttpMethod.Post, "api/Auth/refresh", CancellationToken.None);
+        service.ClearToken();
+        using var second = await service.CreateRequest(HttpMethod.Post, "api/Auth/logout", CancellationToken.None);
+
+        Assert.Equal(2, handler.RequestCount);
+        jsRuntime.Verify(js => js.InvokeAsync<string>(
+            "financeManager.getCookie",
+            It.IsAny<CancellationToken>(),
+            It.IsAny<object?[]>()), Times.Exactly(2));
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public int RequestCount { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            await Task.Delay(25, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.NoContent);
+        }
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/Services/LoginServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Services/LoginServiceTests.cs
@@ -1,0 +1,72 @@
+using Blazored.LocalStorage;
+using Blazored.SessionStorage;
+using FinanceManager.Application.Commands.Login;
+using FinanceManager.Application.Providers;
+using FinanceManager.Components.Services;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Tests.Unit.Components.Services;
+
+[Trait("Category", "Unit")]
+public class LoginServiceTests
+{
+    [Fact]
+    public async Task TryRefresh_SendsAntiforgeryHeader()
+    {
+        var handler = new RecordingHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent.Create(new LoginResponseModel
+            {
+                UserId = 1,
+                UserName = "user@example.com",
+                UserRole = UserRole.User,
+                AccessToken = "fresh-token",
+                ExpiresIn = 900,
+            }),
+        });
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+
+        var antiforgery = new Mock<IAntiforgeryTokenService>();
+        antiforgery
+            .Setup(service => service.CreateRequest(HttpMethod.Post, "api/Auth/refresh", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, "api/Auth/refresh");
+                request.Headers.TryAddWithoutValidation(IAntiforgeryTokenService.HeaderName, "csrf-token");
+                return request;
+            });
+
+        var loginService = new LoginService(
+            Mock.Of<ISessionStorageService>(),
+            Mock.Of<ILocalStorageService>(),
+            new CustomAuthenticationStateProvider(),
+            Mock.Of<IUserRepository>(),
+            httpClient,
+            antiforgery.Object,
+            NullLogger<LoginService>.Instance);
+
+        var refreshed = await loginService.TryRefresh();
+
+        Assert.True(refreshed);
+        var request = Assert.Single(handler.Requests);
+        Assert.True(request.Headers.TryGetValues(IAntiforgeryTokenService.HeaderName, out var values));
+        Assert.Equal("csrf-token", Assert.Single(values));
+        antiforgery.Verify(service => service.ClearToken(), Times.Once);
+    }
+
+    private sealed class RecordingHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        public List<HttpRequestMessage> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/code/FinanceManager/wwwroot/index.html
+++ b/code/FinanceManager/wwwroot/index.html
@@ -107,6 +107,17 @@
                     docEl.classList.remove('preload');
                 } catch (e) { console.warn(e); }
             },
+            getCookie: function (name) {
+                const prefix = name + '=';
+                const cookies = document.cookie ? document.cookie.split('; ') : [];
+                for (const cookie of cookies) {
+                    if (cookie.startsWith(prefix)) {
+                        return decodeURIComponent(cookie.substring(prefix.length));
+                    }
+                }
+
+                return null;
+            },
             downloadFileFromBase64: function (fileName, contentType, base64Content) {
                 const byteCharacters = atob(base64Content);
                 const byteNumbers = new Array(byteCharacters.length);


### PR DESCRIPTION
## Summary
- register ASP.NET Core antiforgery with `X-CSRF-Token`
- add `GET /api/Auth/csrf-token` to issue the framework antiforgery cookie and readable request-token cookie
- require valid antiforgery tokens for refresh and logout, returning `403` before refresh-token validation
- update the Blazor refresh/logout client flow and related tests

## Validation
- `dotnet format ./FinanceManager.slnx`
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj`
- `dotnet test --project ./FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSRF token endpoint to issue security tokens for authenticated requests
  * Session refresh and logout endpoints now require CSRF token validation
  * Requests without valid CSRF tokens are rejected with HTTP 403 Forbidden response

<!-- end of auto-generated comment: release notes by coderabbit.ai -->