### PR TITLE
Split LabelSetterAiService parsing and validation responsibilities #393

### DIFF
--- a/code/FinanceManager.Application/Labels/Registration.cs
+++ b/code/FinanceManager.Application/Labels/Registration.cs
@@ -13,6 +13,8 @@ internal static class Registration
     public static IServiceCollection AddLabelsApplication(this IServiceCollection services)
     {
         services.AddScoped<ILabelSetterAiService, LabelSetterAiService>()
+                .AddSingleton<LabelAssignmentResponseParser>()
+                .AddSingleton<LabelAssignmentValidator>()
                 .AddScoped<ILabelSuggestionAiService, LabelSuggestionAiService>()
                 .AddScoped<IRecurringTransactionDetectorService, RecurringTransactionDetectorService>()
                 .AddScoped<FinancialLabelSeeder>()

--- a/code/FinanceManager.Application/Labels/Setter/LabelAssignment.cs
+++ b/code/FinanceManager.Application/Labels/Setter/LabelAssignment.cs
@@ -1,0 +1,3 @@
+namespace FinanceManager.Application.Labels.Setter;
+
+internal sealed record LabelAssignment(int? EntryId, string? LabelName);

--- a/code/FinanceManager.Application/Labels/Setter/LabelAssignmentResponseParser.cs
+++ b/code/FinanceManager.Application/Labels/Setter/LabelAssignmentResponseParser.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FinanceManager.Application.Labels.Setter;
+
+internal sealed class LabelAssignmentResponseParser
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public IReadOnlyList<LabelAssignment> Parse(string content)
+    {
+        var trimmed = content.Trim();
+
+        if (TryDeserialize(trimmed, out var parsed))
+            return parsed;
+
+        var start = trimmed.IndexOf('{');
+        var end = trimmed.LastIndexOf('}');
+        if (start >= 0 && end > start)
+        {
+            var candidate = trimmed[start..(end + 1)];
+            if (TryDeserialize(candidate, out parsed))
+                return parsed;
+        }
+
+        return [];
+
+        static bool TryDeserialize(string json, out List<LabelAssignment> items)
+        {
+            items = [];
+            try
+            {
+                var root = JsonSerializer.Deserialize<AssignmentsRoot>(json, _jsonOptions);
+                if (root?.Assignments is null) return false;
+                items = root.Assignments;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    private sealed class AssignmentsRoot
+    {
+        [JsonPropertyName("assignments")]
+        public List<LabelAssignment> Assignments { get; set; } = [];
+    }
+}

--- a/code/FinanceManager.Application/Labels/Setter/LabelAssignmentValidator.cs
+++ b/code/FinanceManager.Application/Labels/Setter/LabelAssignmentValidator.cs
@@ -1,0 +1,43 @@
+using FinanceManager.Domain.Entities.Shared.Accounts;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Application.Labels.Setter;
+
+internal sealed class LabelAssignmentValidator(ILogger<LabelAssignmentValidator> logger)
+{
+    public Dictionary<int, string> Validate(
+        IReadOnlyCollection<LabelAssignment> assignments,
+        IReadOnlyCollection<int> requestedEntryIds,
+        IReadOnlySet<string> knownLabelNames)
+    {
+        var result = new Dictionary<int, string>();
+        var entryIdSet = new HashSet<int>(requestedEntryIds);
+        var hasNoMatchSentinel = knownLabelNames.Contains(WellKnownFinancialLabels.NoMatch);
+
+        foreach (var assignment in assignments)
+        {
+            if (assignment.EntryId is null) continue;
+            if (!entryIdSet.Contains(assignment.EntryId.Value)) continue;
+
+            // AI returned null / empty / unknown label → use the NoMatch sentinel so the entry
+            // still gets a label and won't be re-queued on the next startup scan.
+            var labelName = assignment.LabelName;
+            if (string.IsNullOrWhiteSpace(labelName) || !knownLabelNames.Contains(labelName))
+            {
+                if (!hasNoMatchSentinel)
+                {
+                    logger.LogWarning(
+                        "AI returned no fitting label for entry {EntryId} and the '{Sentinel}' label is missing — entry will stay unlabelled and be re-queued.",
+                        assignment.EntryId.Value,
+                        WellKnownFinancialLabels.NoMatch);
+                    continue;
+                }
+                labelName = WellKnownFinancialLabels.NoMatch;
+            }
+
+            result[assignment.EntryId.Value] = labelName;
+        }
+
+        return result;
+    }
+}

--- a/code/FinanceManager.Application/Labels/Setter/LabelSetterAiService.cs
+++ b/code/FinanceManager.Application/Labels/Setter/LabelSetterAiService.cs
@@ -1,11 +1,8 @@
 using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
-using FinanceManager.Domain.Entities.Shared.Accounts;
 using FinanceManager.Domain.Repositories;
 using FinanceManager.Domain.Repositories.Account;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace FinanceManager.Application.Labels.Setter;
 
@@ -13,16 +10,13 @@ internal sealed class LabelSetterAiService(
     IAccountEntryRepository<CurrencyAccountEntry> currencyEntryRepository,
     IFinancialLabelsRepository financialLabelsRepository,
     ILabelSetterPromptProvider promptProvider,
+    LabelAssignmentResponseParser responseParser,
+    LabelAssignmentValidator assignmentValidator,
     IChatClient chatClient,
     ILogger<LabelSetterAiService> logger) : ILabelSetterAiService
 {
     private const string _systemPrompt = "You are a finance assistant that outputs strict JSON.";
     private const string _modelId = "gpt-5-mini";
-
-    private static readonly JsonSerializerOptions _jsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
 
     public async Task<Dictionary<int, string>> AssignLabels(
         IReadOnlyCollection<int> entryIds,
@@ -77,36 +71,10 @@ internal sealed class LabelSetterAiService(
                 return [];
             }
 
-            var parsed = TryParseAssignments(content);
+            var parsed = responseParser.Parse(content);
             logger.LogDebug("Parsed {Count} assignments from AI response.", parsed.Count);
 
-            var result = new Dictionary<int, string>();
-            var entryIdSet = new HashSet<int>(entryIds);
-            var hasNoMatchSentinel = labelNameSet.Contains(WellKnownFinancialLabels.NoMatch);
-
-            foreach (var assignment in parsed)
-            {
-                if (assignment.EntryId is null) continue;
-                if (!entryIdSet.Contains(assignment.EntryId.Value)) continue;
-
-                // AI returned null / empty / unknown label → use the NoMatch sentinel so the entry
-                // still gets a label and won't be re-queued on the next startup scan.
-                var labelName = assignment.LabelName;
-                if (string.IsNullOrWhiteSpace(labelName) || !labelNameSet.Contains(labelName))
-                {
-                    if (!hasNoMatchSentinel)
-                    {
-                        logger.LogWarning(
-                            "AI returned no fitting label for entry {EntryId} and the '{Sentinel}' label is missing — entry will stay unlabelled and be re-queued.",
-                            assignment.EntryId.Value,
-                            WellKnownFinancialLabels.NoMatch);
-                        continue;
-                    }
-                    labelName = WellKnownFinancialLabels.NoMatch;
-                }
-
-                result[assignment.EntryId.Value] = labelName;
-            }
+            var result = assignmentValidator.Validate(parsed, entryIds, labelNameSet);
 
             logger.LogDebug("Valid assignments after filtering: {Count} out of {ParsedCount}.", result.Count, parsed.Count);
 
@@ -117,55 +85,5 @@ internal sealed class LabelSetterAiService(
             logger.LogError(ex, "AI model label assignment failed for batch of {Count} entries.", entryIds.Count);
             return [];
         }
-    }
-
-    private static List<AssignmentItem> TryParseAssignments(string content)
-    {
-        var trimmed = content.Trim();
-
-        if (TryDeserialize(trimmed, out var parsed))
-            return parsed;
-
-        var start = trimmed.IndexOf('{');
-        var end = trimmed.LastIndexOf('}');
-        if (start >= 0 && end > start)
-        {
-            var candidate = trimmed[start..(end + 1)];
-            if (TryDeserialize(candidate, out parsed))
-                return parsed;
-        }
-
-        return [];
-
-        static bool TryDeserialize(string json, out List<AssignmentItem> items)
-        {
-            items = [];
-            try
-            {
-                var root = JsonSerializer.Deserialize<AssignmentsRoot>(json, _jsonOptions);
-                if (root?.Assignments is null) return false;
-                items = root.Assignments;
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-    }
-
-    private sealed class AssignmentsRoot
-    {
-        [JsonPropertyName("assignments")]
-        public List<AssignmentItem> Assignments { get; set; } = [];
-    }
-
-    private sealed class AssignmentItem
-    {
-        [JsonPropertyName("entryId")]
-        public int? EntryId { get; set; }
-
-        [JsonPropertyName("labelName")]
-        public string? LabelName { get; set; }
     }
 }

--- a/code/FinanceManager.Tests.Unit/Application/Labels/Setter/LabelAssignmentResponseParserTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Labels/Setter/LabelAssignmentResponseParserTests.cs
@@ -1,0 +1,54 @@
+using FinanceManager.Application.Labels.Setter;
+
+namespace FinanceManager.Tests.Unit.Application.Labels.Setter;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class LabelAssignmentResponseParserTests
+{
+    private readonly LabelAssignmentResponseParser _parser = new();
+
+    [Fact]
+    public void Parse_ValidJson_ReturnsAssignments()
+    {
+        var content = """{"assignments":[{"entryId":1,"labelName":"Groceries"},{"entryId":2,"labelName":"Rent"}]}""";
+
+        var result = _parser.Parse(content);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(new LabelAssignment(1, "Groceries"), result[0]);
+        Assert.Equal(new LabelAssignment(2, "Rent"), result[1]);
+    }
+
+    [Fact]
+    public void Parse_JsonWrappedInProse_ExtractsEmbeddedObject()
+    {
+        var content = """Here is the result: {"assignments":[{"entryId":7,"labelName":"Utilities"}]} hope it helps!""";
+
+        var result = _parser.Parse(content);
+
+        var assignment = Assert.Single(result);
+        Assert.Equal(new LabelAssignment(7, "Utilities"), assignment);
+    }
+
+    [Theory]
+    [InlineData("not json at all")]
+    [InlineData("{\"unexpected\":true}")]
+    [InlineData("[]")]
+    public void Parse_InvalidOrMismatchedJson_ReturnsEmpty(string content)
+    {
+        Assert.Empty(_parser.Parse(content));
+    }
+
+    [Fact]
+    public void Parse_MissingFields_ReturnsNullValues()
+    {
+        var content = """{"assignments":[{"entryId":3},{"labelName":"Rent"}]}""";
+
+        var result = _parser.Parse(content);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(new LabelAssignment(3, null), result[0]);
+        Assert.Equal(new LabelAssignment(null, "Rent"), result[1]);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Labels/Setter/LabelAssignmentValidatorTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Labels/Setter/LabelAssignmentValidatorTests.cs
@@ -1,0 +1,61 @@
+using FinanceManager.Application.Labels.Setter;
+using FinanceManager.Domain.Entities.Shared.Accounts;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FinanceManager.Tests.Unit.Application.Labels.Setter;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class LabelAssignmentValidatorTests
+{
+    private readonly LabelAssignmentValidator _validator = new(NullLogger<LabelAssignmentValidator>.Instance);
+
+    private static readonly HashSet<string> _labelsWithSentinel =
+        new(["Groceries", "Rent", WellKnownFinancialLabels.NoMatch], StringComparer.Ordinal);
+
+    [Fact]
+    public void Validate_KnownLabelAndEntryId_IsAccepted()
+    {
+        var result = _validator.Validate([new LabelAssignment(1, "Groceries")], [1, 2], _labelsWithSentinel);
+
+        Assert.Equal(new Dictionary<int, string> { [1] = "Groceries" }, result);
+    }
+
+    [Fact]
+    public void Validate_UnknownEntryId_IsIgnored()
+    {
+        var result = _validator.Validate([new LabelAssignment(99, "Groceries")], [1, 2], _labelsWithSentinel);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Validate_NullEntryId_IsIgnored()
+    {
+        var result = _validator.Validate([new LabelAssignment(null, "Groceries")], [1, 2], _labelsWithSentinel);
+
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Unknown Label")]
+    public void Validate_MissingOrUnknownLabel_FallsBackToNoMatchSentinel(string? labelName)
+    {
+        var result = _validator.Validate([new LabelAssignment(1, labelName)], [1], _labelsWithSentinel);
+
+        Assert.Equal(new Dictionary<int, string> { [1] = WellKnownFinancialLabels.NoMatch }, result);
+    }
+
+    [Fact]
+    public void Validate_UnknownLabelWithoutSentinelDefined_IsSkipped()
+    {
+        var labelsWithoutSentinel = new HashSet<string>(["Groceries"], StringComparer.Ordinal);
+
+        var result = _validator.Validate([new LabelAssignment(1, "Unknown Label")], [1], labelsWithoutSentinel);
+
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
closes #393

## Summary

Keeps `LabelSetterAiService` as a pure orchestration service and extracts its embedded parsing/validation responsibilities into focused components under `Labels/Setter`:

- **`LabelAssignmentResponseParser`** — owns the AI JSON response parsing, including the fallback that extracts an embedded `{...}` object from prose-wrapped responses. The former nested DTOs move here; the parsed shape is exposed as the `LabelAssignment(int? EntryId, string? LabelName)` record.
- **`LabelAssignmentValidator`** — owns entry-ID filtering (unknown IDs ignored), label-name validation, and the `NoMatch` sentinel fallback (including the warning + skip when the sentinel label is missing).
- `Labels/Registration.cs` registers both new components.

Behavior is unchanged: empty AI responses still produce no assignments, unknown entry IDs are still ignored, invalid/missing labels still resolve to the `NoMatch` sentinel, and prompt/client/model usage is untouched.

## Tests

- New unit tests: `LabelAssignmentResponseParserTests` (valid JSON, prose-wrapped JSON, invalid/mismatched JSON, missing fields) and `LabelAssignmentValidatorTests` (accept, unknown/null entry ID, sentinel fallback, missing sentinel).
- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` (unit) — 426 passed.
- `dotnet format` — clean.

No changelog entry: pure refactor with no user-visible effect.

> Note: this branch was provisioned by the remote session as `claude/brave-fermat-37fe12`, so it doesn't follow the `393-…` naming convention; the issue link is carried by the commit message and the `closes #393` reference above.

https://claude.ai/code/session_01Q9BXW7K5mViLftcBB5aPTd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9BXW7K5mViLftcBB5aPTd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved label assignment accuracy through enhanced response parsing that handles various input formats and stricter validation of label-to-entry mappings.

* **Tests**
  * Added unit test coverage for label assignment parsing and validation, including edge cases such as invalid data formats and fallback behavior for unmapped labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->