### PR TITLE
Split MoneyFlowService by business capability #390

### DIFF
--- a/code/FinanceManager.Application/MoneyFlow/InvestmentRate/InvestmentRateService.cs
+++ b/code/FinanceManager.Application/MoneyFlow/InvestmentRate/InvestmentRateService.cs
@@ -1,0 +1,39 @@
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.Stocks;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Domain.Repositories.Account;
+using FinanceManager.Domain.Services;
+
+namespace FinanceManager.Application.MoneyFlow.InvestmentRate;
+
+public class InvestmentRateService(IFinancialAccountRepository financialAccountRepository, IFinancialLabelsRepository financialLabelsRepository,
+IStockPriceProvider stockPriceProvider) : IInvestmentRateService
+{
+    public async IAsyncEnumerable<Domain.Entities.MoneyFlowModels.InvestmentRate> GetInvestmentRate(int userId, DateTime start, DateTime end)
+    {
+        var labels = await financialLabelsRepository.GetLabels().ToListAsync();
+        var salaryLabel = labels.Single(x => x.Name.ToLower() == "salary");
+
+        Currency currency = DefaultCurrency.PLN; // TODO: use user currency settings
+
+        decimal salary = 0;
+        await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end))
+            salary += account.Entries.Where(x => x.Labels is not null && x.Labels.Any(y => y.Id == salaryLabel.Id)).Sum(x => x.ValueChange);
+
+        if (salary == 0) yield break;
+
+        decimal investmentsChange = 0;
+        await foreach (var account in financialAccountRepository.GetAccounts<StockAccount>(userId, start, end))
+            foreach (var entry in account.Entries)
+                investmentsChange += entry.ValueChange * await stockPriceProvider.GetPricePerUnitAsync(entry.Isin, currency, entry.PostingDate);
+
+        yield return new()
+        {
+            Start = start,
+            End = end,
+            Salary = salary,
+            InvestmentsChange = investmentsChange
+        };
+    }
+}

--- a/code/FinanceManager.Application/MoneyFlow/LabelsValue/LabelsValueService.cs
+++ b/code/FinanceManager.Application/MoneyFlow/LabelsValue/LabelsValueService.cs
@@ -1,0 +1,37 @@
+using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Domain.Repositories.Account;
+using FinanceManager.Domain.Services;
+
+namespace FinanceManager.Application.MoneyFlow.LabelsValue;
+
+public class LabelsValueService(IFinancialAccountRepository financialAccountRepository, IFinancialLabelsRepository financialLabelsRepository) : ILabelsValueService
+{
+    public async Task<List<NameValueResult>> GetLabelsValue(int userId, DateTime start, DateTime end)
+    {
+        if (end > DateTime.UtcNow) end = DateTime.UtcNow;
+
+        var labels = await financialLabelsRepository.GetLabels().ToListAsync();
+
+        var result = labels.ToDictionary(x => x.Id, x => new NameValueResult() { Name = x.Name, Value = 0 });
+        await foreach (CurrencyAccount account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end))
+        {
+            if (account is null || account.Entries is null) continue;
+            if (account.Entries is null || !account.Entries.Any()) continue;
+
+            foreach (var entry in account.Entries.Where(x => x.Labels is not null && x.Labels.Any()))
+            {
+                foreach (var label in entry.Labels)
+                {
+                    if (!result.ContainsKey(label.Id)) continue;
+                    result[label.Id].Value += entry.ValueChange;
+                }
+            }
+        }
+
+        // TODO: Add labels for stock accounts?
+
+        return result.Values.OrderByDescending(x => x.Value).ToList();
+    }
+}

--- a/code/FinanceManager.Application/MoneyFlow/MoneyFlowService.cs
+++ b/code/FinanceManager.Application/MoneyFlow/MoneyFlowService.cs
@@ -1,0 +1,25 @@
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using FinanceManager.Domain.Services;
+
+namespace FinanceManager.Application.MoneyFlow;
+
+/// <summary>
+/// Temporary facade kept for consumers of <see cref="IMoneyFlowService"/>;
+/// the calculations live in the focused NetWorth, LabelsValue and InvestmentRate services.
+/// </summary>
+public class MoneyFlowService(INetWorthService netWorthService, ILabelsValueService labelsValueService,
+IInvestmentRateService investmentRateService) : IMoneyFlowService
+{
+    public Task<decimal?> GetNetWorth(int userId, Currency currency, DateTime date) =>
+        netWorthService.GetNetWorth(userId, currency, date);
+
+    public Task<Dictionary<DateTime, decimal>> GetNetWorth(int userId, Currency currency, DateTime start, DateTime end) =>
+        netWorthService.GetNetWorth(userId, currency, start, end);
+
+    public Task<List<NameValueResult>> GetLabelsValue(int userId, DateTime start, DateTime end) =>
+        labelsValueService.GetLabelsValue(userId, start, end);
+
+    public IAsyncEnumerable<Domain.Entities.MoneyFlowModels.InvestmentRate> GetInvestmentRate(int userId, DateTime start, DateTime end) =>
+        investmentRateService.GetInvestmentRate(userId, start, end);
+}

--- a/code/FinanceManager.Application/MoneyFlow/NetWorth/NetWorthService.cs
+++ b/code/FinanceManager.Application/MoneyFlow/NetWorth/NetWorthService.cs
@@ -1,7 +1,6 @@
-﻿using FinanceManager.Domain.Entities.Bonds;
+using FinanceManager.Domain.Entities.Bonds;
 using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
-using FinanceManager.Domain.Entities.MoneyFlowModels;
 using FinanceManager.Domain.Entities.Shared.Accounts;
 using FinanceManager.Domain.Entities.Stocks;
 using FinanceManager.Domain.Repositories;
@@ -10,8 +9,8 @@ using FinanceManager.Domain.Services;
 
 namespace FinanceManager.Application.MoneyFlow.NetWorth;
 
-public class MoneyFlowService(IFinancialAccountRepository financialAccountRepository, IFinancialLabelsRepository financialLabelsRepository,
-IStockPriceProvider stockPriceProvider, IBondDetailsRepository bondDetailsRepository) : IMoneyFlowService
+public class NetWorthService(IFinancialAccountRepository financialAccountRepository, IStockPriceProvider stockPriceProvider,
+IBondDetailsRepository bondDetailsRepository) : INetWorthService
 {
     public async Task<decimal?> GetNetWorth(int userId, Currency currency, DateTime date)
     {
@@ -26,7 +25,7 @@ IStockPriceProvider stockPriceProvider, IBondDetailsRepository bondDetailsReposi
 
             result += newestEntry.Value;
         }
-;
+
         await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, date.Date, date))
         {
             foreach (var detailsId in account.GetStoredBondsIds())
@@ -133,57 +132,5 @@ IStockPriceProvider stockPriceProvider, IBondDetailsRepository bondDetailsReposi
             result.Add(date, Math.Round(dailyTotal, 2));
         }
         return result;
-    }
-    public async Task<List<NameValueResult>> GetLabelsValue(int userId, DateTime start, DateTime end)
-    {
-        if (end > DateTime.UtcNow) end = DateTime.UtcNow;
-
-        var labels = await financialLabelsRepository.GetLabels().ToListAsync();
-
-        var result = labels.ToDictionary(x => x.Id, x => new NameValueResult() { Name = x.Name, Value = 0 });
-        await foreach (CurrencyAccount account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end))
-        {
-            if (account is null || account.Entries is null) continue;
-            if (account.Entries is null || !account.Entries.Any()) continue;
-
-            foreach (var entry in account.Entries.Where(x => x.Labels is not null && x.Labels.Any()))
-            {
-                foreach (var label in entry.Labels)
-                {
-                    if (!result.ContainsKey(label.Id)) continue;
-                    result[label.Id].Value += entry.ValueChange;
-                }
-            }
-        }
-
-        // TODO: Add labels for stock accounts?
-
-        return result.Values.OrderByDescending(x => x.Value).ToList();
-    }
-    public async IAsyncEnumerable<InvestmentRate> GetInvestmentRate(int userId, DateTime start, DateTime end)
-    {
-        var labels = await financialLabelsRepository.GetLabels().ToListAsync();
-        var salaryLabel = labels.Single(x => x.Name.ToLower() == "salary");
-
-        Currency currency = DefaultCurrency.PLN; // TODO: use user currency settings
-
-        decimal salary = 0;
-        await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end))
-            salary += account.Entries.Where(x => x.Labels is not null && x.Labels.Any(y => y.Id == salaryLabel.Id)).Sum(x => x.ValueChange);
-
-        if (salary == 0) yield break;
-
-        decimal investmentsChange = 0;
-        await foreach (var account in financialAccountRepository.GetAccounts<StockAccount>(userId, start, end))
-            foreach (var entry in account.Entries)
-                investmentsChange += entry.ValueChange * await stockPriceProvider.GetPricePerUnitAsync(entry.Isin, currency, entry.PostingDate);
-
-        yield return new()
-        {
-            Start = start,
-            End = end,
-            Salary = salary,
-            InvestmentsChange = investmentsChange
-        };
     }
 }

--- a/code/FinanceManager.Application/MoneyFlow/Registration.cs
+++ b/code/FinanceManager.Application/MoneyFlow/Registration.cs
@@ -1,4 +1,6 @@
 using FinanceManager.Application.MoneyFlow.InvestmentPaycheck;
+using FinanceManager.Application.MoneyFlow.InvestmentRate;
+using FinanceManager.Application.MoneyFlow.LabelsValue;
 using FinanceManager.Application.MoneyFlow.NetWorth;
 using FinanceManager.Application.MoneyFlow.Spending;
 using FinanceManager.Domain.Services;
@@ -11,6 +13,9 @@ internal static class Registration
     public static IServiceCollection AddMoneyFlowApplication(this IServiceCollection services)
     {
         services.AddScoped<IMoneyFlowService, MoneyFlowService>()
+                .AddScoped<INetWorthService, NetWorthService>()
+                .AddScoped<ILabelsValueService, LabelsValueService>()
+                .AddScoped<IInvestmentRateService, InvestmentRateService>()
                 .AddScoped<ILiabilitiesService, LiabilitiesService>()
                 .AddScoped<IInvestmentPaycheckEstimatorService, InvestmentPaycheckEstimatorService>()
                 .AddScoped<IEssentialSpendingServiceTyped, CurrencyEssentialSpendingService>()

--- a/code/FinanceManager.Domain/Services/IInvestmentRateService.cs
+++ b/code/FinanceManager.Domain/Services/IInvestmentRateService.cs
@@ -1,0 +1,8 @@
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+
+namespace FinanceManager.Domain.Services;
+
+public interface IInvestmentRateService
+{
+    IAsyncEnumerable<InvestmentRate> GetInvestmentRate(int userId, DateTime start, DateTime end);
+}

--- a/code/FinanceManager.Domain/Services/ILabelsValueService.cs
+++ b/code/FinanceManager.Domain/Services/ILabelsValueService.cs
@@ -1,0 +1,8 @@
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+
+namespace FinanceManager.Domain.Services;
+
+public interface ILabelsValueService
+{
+    Task<List<NameValueResult>> GetLabelsValue(int userId, DateTime start, DateTime end);
+}

--- a/code/FinanceManager.Domain/Services/INetWorthService.cs
+++ b/code/FinanceManager.Domain/Services/INetWorthService.cs
@@ -1,0 +1,9 @@
+using FinanceManager.Domain.Entities.Currencies;
+
+namespace FinanceManager.Domain.Services;
+
+public interface INetWorthService
+{
+    Task<decimal?> GetNetWorth(int userId, Currency currency, DateTime date);
+    Task<Dictionary<DateTime, decimal>> GetNetWorth(int userId, Currency currency, DateTime start, DateTime end);
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/InvestmentRateServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/InvestmentRateServiceTests.cs
@@ -1,0 +1,91 @@
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Application.MoneyFlow.InvestmentRate;
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.Shared.Accounts;
+using FinanceManager.Domain.Entities.Stocks;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Domain.Repositories.Account;
+using FinanceManager.Domain.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class InvestmentRateServiceTests
+{
+    private readonly DateTime _startDate = new(DateTime.UtcNow.Year - 1, 1, 1);
+    private readonly DateTime _endDate = DateTime.UtcNow;
+
+    private readonly InvestmentRateService _investmentRateService;
+    private readonly Mock<IFinancialAccountRepository> _financialAccountRepositoryMock = new();
+    private readonly Mock<IFinancialLabelsRepository> _financialLabelsRepositoryMock = new();
+    private readonly Mock<IStockPriceRepository> _stockRepository = new();
+    private readonly Mock<ICurrencyExchangeService> _currencyExchangeService = new();
+
+    public InvestmentRateServiceTests()
+    {
+        _currencyExchangeService.Setup(x => x.GetExchangeRateAsync(It.IsAny<Currency>(), It.IsAny<Currency>(), It.IsAny<DateTime>())).ReturnsAsync(1);
+
+        IMemoryCache cache = new MemoryCache(new MemoryCacheOptions());
+        var stockDetailsRepoMock = new Mock<IStockDetailsRepository>();
+        stockDetailsRepoMock.Setup(x => x.Get(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string ticker, CancellationToken _) => new StockDetails
+            {
+                Isin = "US0000000001",
+                Ticker = ticker,
+                Currency = DefaultCurrency.PLN,
+                Name = ticker,
+                Type = "Stock",
+                Region = "US"
+            });
+        var isinResolverMock = new Mock<IIsinResolver>();
+        isinResolverMock.Setup(x => x.ResolveAsync("TICKER", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("US0000000001");
+        var stockPriceProvider = new StockPriceProvider(
+            _stockRepository.Object,
+            new Mock<IAlphaVantageClient>().Object,
+            stockDetailsRepoMock.Object,
+            new Mock<ICurrencyRepository>().Object,
+            _currencyExchangeService.Object,
+            cache,
+            isinResolverMock.Object);
+
+        _investmentRateService = new InvestmentRateService(_financialAccountRepositoryMock.Object, _financialLabelsRepositoryMock.Object, stockPriceProvider);
+    }
+
+    [Fact]
+    public async Task GetInvestmentRate_ReturnsInvestmentRate()
+    {
+        // Arrange
+        var userId = 1;
+        var salaryLabel = new FinancialLabel { Id = 1, Name = "Salary" };
+        _financialLabelsRepositoryMock.Setup(repo => repo.GetLabels(It.IsAny<CancellationToken>())).Returns(new[] { salaryLabel }.ToAsyncEnumerable());
+
+        var currencyAccount = new CurrencyAccount(userId, 1, "Currency Account 1", AccountLabel.Cash);
+        currencyAccount.Add(new CurrencyAccountEntry(1, 1, _startDate, 1000, 1000) { Labels = [salaryLabel] }, false);
+
+        var stockAccount = new StockAccount(userId, 2, "Stock Account 1");
+        stockAccount.Add(new StockAccountEntry(1, 1, _startDate, 10, 10, "TICKER", InvestmentType.Stock), false);
+
+        // Setup mock for TICKER
+        _stockRepository.Setup(x => x.GetThisOrNextOlder("US0000000001", It.IsAny<DateTime>()))
+            .ReturnsAsync(new StockPrice() { Isin = "US0000000001", Currency = DefaultCurrency.PLN, PricePerUnit = 1m });
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new[] { currencyAccount }.ToAsyncEnumerable());
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<StockAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new[] { stockAccount }.ToAsyncEnumerable());
+
+        // Act
+        var result = await _investmentRateService.GetInvestmentRate(userId, _startDate, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(1000, result.First().Salary);
+        Assert.Equal(10, result.First().InvestmentsChange);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/LabelsValueServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/LabelsValueServiceTests.cs
@@ -1,0 +1,47 @@
+using FinanceManager.Application.MoneyFlow.LabelsValue;
+using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
+using FinanceManager.Domain.Entities.Shared.Accounts;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Domain.Repositories.Account;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class LabelsValueServiceTests
+{
+    private readonly DateTime _startDate = new(DateTime.UtcNow.Year - 1, 1, 1);
+    private readonly DateTime _endDate = DateTime.UtcNow;
+
+    private readonly LabelsValueService _labelsValueService;
+    private readonly Mock<IFinancialAccountRepository> _financialAccountRepositoryMock = new();
+    private readonly Mock<IFinancialLabelsRepository> _financialLabelsRepositoryMock = new();
+
+    public LabelsValueServiceTests()
+    {
+        _labelsValueService = new LabelsValueService(_financialAccountRepositoryMock.Object, _financialLabelsRepositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task GetLabelsValue_ReturnsLabelsValue()
+    {
+        // Arrange
+        var userId = 1;
+        var label = new FinancialLabel { Id = 1, Name = "Salary" };
+        _financialLabelsRepositoryMock.Setup(repo => repo.GetLabels(It.IsAny<CancellationToken>())).Returns(new[] { label }.ToAsyncEnumerable());
+
+        var account = new CurrencyAccount(userId, 1, "Currency Account 1", AccountLabel.Cash);
+        account.Add(new CurrencyAccountEntry(1, 1, _startDate, 500, 500) { Labels = [label] });
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(new[] { account }.ToAsyncEnumerable());
+
+        // Act
+        var result = await _labelsValueService.GetLabelsValue(userId, _startDate, _endDate);
+
+        // Assert
+        Assert.NotEmpty(result);
+        Assert.Equal(500, result.First(x => x.Name == label.Name).Value);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/NetWorthServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/NetWorthServiceTests.cs
@@ -16,34 +16,20 @@ namespace FinanceManager.Tests.Unit.Application.Services;
 
 [Collection("Application")]
 [Trait("Category", "Unit")]
-public class MoneyFlowServiceTests
+public class NetWorthServiceTests
 {
     private readonly DateTime _startDate = new(DateTime.UtcNow.Year - 1, 1, 1);
     private readonly DateTime _endDate = DateTime.UtcNow;
 
-    private readonly MoneyFlowService _moneyFlowService;
+    private readonly NetWorthService _netWorthService;
     private readonly Mock<IFinancialAccountRepository> _financialAccountRepositoryMock = new();
     private readonly Mock<IStockPriceRepository> _stockRepository = new();
     private readonly Mock<ICurrencyExchangeService> _currencyExchangeService = new();
-    private readonly Mock<IFinancialLabelsRepository> _financialLabelsRepositoryMock = new();
     private readonly Mock<IBondDetailsRepository> _bondDetailsRepositoryMock = new();
-    private readonly List<CurrencyAccount> _currencyAccounts;
     private readonly List<StockAccount> _investmentAccountAccounts;
 
-    public MoneyFlowServiceTests()
+    public NetWorthServiceTests()
     {
-        CurrencyAccount currencyAccount1 = new(1, 1, "testCurrency1", AccountLabel.Cash);
-        currencyAccount1.Add(new CurrencyAccountEntry(1, 1, _startDate.AddYears(-1), 10, 10));
-        currencyAccount1.Add(new CurrencyAccountEntry(1, 2, _startDate, 20, 10));
-        currencyAccount1.Add(new CurrencyAccountEntry(1, 3, _startDate.AddDays(1), 30, 10));
-
-        CurrencyAccount currencyAccount2 = new(1, 2, "testCurrency2", AccountLabel.Cash);
-        currencyAccount2.Add(new CurrencyAccountEntry(1, 1, _endDate, 10, 10));
-
-        _currencyAccounts = [currencyAccount1, currencyAccount2];
-        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(1, _startDate, _endDate))
-                                      .Returns(_currencyAccounts.ToAsyncEnumerable());
-
         StockAccount investmentAccount1 = new(1, 3, "testInvestmentAccount1");
         investmentAccount1.Add(new StockAccountEntry(1, 1, _startDate, 10, 10, "testStock1", InvestmentType.Stock));
         investmentAccount1.Add(new StockAccountEntry(1, 2, _endDate, 10, 10, "testStock2", InvestmentType.Stock));
@@ -90,8 +76,6 @@ public class MoneyFlowServiceTests
             .ReturnsAsync("US5949181045");
         isinResolverMock.Setup(x => x.ResolveAsync("UNKNOWN", It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
-        isinResolverMock.Setup(x => x.ResolveAsync("TICKER", It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync("US0000000001");
         var stockPriceProvider = new StockPriceProvider(
             _stockRepository.Object,
             new Mock<IAlphaVantageClient>().Object,
@@ -103,7 +87,7 @@ public class MoneyFlowServiceTests
 
         _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Empty<BondDetails>());
 
-        _moneyFlowService = new MoneyFlowService(_financialAccountRepositoryMock.Object, _financialLabelsRepositoryMock.Object, stockPriceProvider, _bondDetailsRepositoryMock.Object);
+        _netWorthService = new NetWorthService(_financialAccountRepositoryMock.Object, stockPriceProvider, _bondDetailsRepositoryMock.Object);
     }
 
     private static BondDetails CreateBondDetails(int id, DateTime date, decimal unitValue = 1m) =>
@@ -119,8 +103,6 @@ public class MoneyFlowServiceTests
         {
             Id = id
         };
-
-
 
     [Fact]
     public async Task GetNetWorth_ReturnsNetWorth()
@@ -138,7 +120,7 @@ public class MoneyFlowServiceTests
             .Returns(bondAccounts.ToAsyncEnumerable());
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, date);
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, date);
 
         // Assert
         Assert.Equal(1000, result);
@@ -166,65 +148,12 @@ public class MoneyFlowServiceTests
             .Returns(_investmentAccountAccounts.ToAsyncEnumerable());
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, _startDate, _endDate);
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, _startDate, _endDate);
 
         // Assert
         Assert.NotEmpty(result);
         // Currency account: 1000, Stock account: testStock1 (10 * 2) + testStock2 (10 * 4) = 20 + 40 = 60
         Assert.Equal(1060m, result[_endDate]);
-    }
-
-    [Fact]
-    public async Task GetLabelsValue_ReturnsLabelsValue()
-    {
-        // Arrange
-        var userId = 1;
-        var label = new FinancialLabel { Id = 1, Name = "Salary" };
-        _financialLabelsRepositoryMock.Setup(repo => repo.GetLabels(It.IsAny<CancellationToken>())).Returns(new[] { label }.ToAsyncEnumerable());
-
-        var account = new CurrencyAccount(userId, 1, "Currency Account 1", AccountLabel.Cash);
-        account.Add(new CurrencyAccountEntry(1, 1, _startDate, 500, 500) { Labels = [label] });
-
-        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(new[] { account }.ToAsyncEnumerable());
-
-        // Act
-        var result = await _moneyFlowService.GetLabelsValue(userId, _startDate, _endDate);
-
-        // Assert
-        Assert.NotEmpty(result);
-        Assert.Equal(500, result.First(x => x.Name == label.Name).Value);
-    }
-
-    [Fact]
-    public async Task GetInvestmentRate_ReturnsInvestmentRate()
-    {
-        // Arrange
-        var userId = 1;
-        var salaryLabel = new FinancialLabel { Id = 1, Name = "Salary" };
-        _financialLabelsRepositoryMock.Setup(repo => repo.GetLabels(It.IsAny<CancellationToken>())).Returns(new[] { salaryLabel }.ToAsyncEnumerable());
-
-        var currencyAccount = new CurrencyAccount(userId, 1, "Currency Account 1", AccountLabel.Cash);
-        currencyAccount.Add(new CurrencyAccountEntry(1, 1, _startDate, 1000, 1000) { Labels = [salaryLabel] }, false);
-
-        var stockAccount = new StockAccount(userId, 2, "Stock Account 1");
-        stockAccount.Add(new StockAccountEntry(1, 1, _startDate, 10, 10, "TICKER", InvestmentType.Stock), false);
-
-        // Setup mock for TICKER
-        _stockRepository.Setup(x => x.GetThisOrNextOlder("US0000000001", It.IsAny<DateTime>()))
-            .ReturnsAsync(new StockPrice() { Isin = "US0000000001", Currency = DefaultCurrency.PLN, PricePerUnit = 1m });
-
-        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .Returns(new[] { currencyAccount }.ToAsyncEnumerable());
-        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<StockAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .Returns(new[] { stockAccount }.ToAsyncEnumerable());
-
-        // Act
-        var result = await _moneyFlowService.GetInvestmentRate(userId, _startDate, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
-
-        // Assert
-        Assert.Single(result);
-        Assert.Equal(1000, result.First().Salary);
-        Assert.Equal(10, result.First().InvestmentsChange);
     }
 
     [Fact]
@@ -259,7 +188,7 @@ public class MoneyFlowServiceTests
             .ReturnsAsync(new StockPrice { Isin = "US5949181045", Currency = DefaultCurrency.PLN, PricePerUnit = 100m });
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, date);
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, date);
 
         // Assert - Should be 5000 + 1000 + 3000 = 9000
         Assert.NotNull(result);
@@ -288,7 +217,7 @@ public class MoneyFlowServiceTests
             .ReturnsAsync((StockPrice?)null);
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, date);
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, date);
 
         // Assert - Should be 0 (10 shares * 0 price)
         Assert.NotNull(result);
@@ -315,7 +244,7 @@ public class MoneyFlowServiceTests
             .Returns(new[] { bondAccount }.ToAsyncEnumerable());
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, date);
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, date);
 
         // Assert
         Assert.NotNull(result);
@@ -340,7 +269,7 @@ public class MoneyFlowServiceTests
             .Returns(AsyncEnumerable.Empty<BondAccount>());
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, futureDate);
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, futureDate);
 
         // Assert - Should calculate using DateTime.UtcNow instead
         Assert.NotNull(result);
@@ -377,7 +306,7 @@ public class MoneyFlowServiceTests
             .ReturnsAsync(new StockPrice { Isin = "US5949181045", Currency = DefaultCurrency.PLN, PricePerUnit = 1.11m });
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, date);
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, date);
 
         // Assert - Should handle large values: 999999999.99 + (1000000 * 1.11) + 888888888.88
         Assert.NotNull(result);
@@ -412,7 +341,7 @@ public class MoneyFlowServiceTests
             .ReturnsAsync(new StockPrice { Isin = "US5949181045", Currency = DefaultCurrency.PLN, PricePerUnit = 200m });
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, date);
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, date);
 
         // Assert - (10 * 150) + (20 * 100) + (15 * 200) = 1500 + 2000 + 3000 = 6500
         Assert.NotNull(result);
@@ -446,7 +375,7 @@ public class MoneyFlowServiceTests
             }.ToAsyncEnumerable());
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, date);
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, date);
 
         // Assert - 1000 + 2000 + 1500 = 4500
         Assert.NotNull(result);
@@ -472,7 +401,7 @@ public class MoneyFlowServiceTests
             .Returns(AsyncEnumerable.Empty<BondAccount>());
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, queryDate);
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, queryDate);
 
         // Assert - GetThisOrNextOlder should return null for dates before all entries
         Assert.NotNull(result);
@@ -499,7 +428,7 @@ public class MoneyFlowServiceTests
             .Returns(AsyncEnumerable.Empty<BondAccount>());
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, date.AddDays(1));
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, date.AddDays(1));
 
         // Assert - Should be -500 (1000 - 1500)
         Assert.NotNull(result);
@@ -525,7 +454,7 @@ public class MoneyFlowServiceTests
             .Returns(AsyncEnumerable.Empty<BondAccount>());
 
         // Act
-        var result = await _moneyFlowService.GetNetWorth(userId, DefaultCurrency.PLN, startDate, endDate);
+        var result = await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, startDate, endDate);
 
         // Assert - Should have 5 days (Jan 1-5)
         Assert.Equal(5, result.Count);


### PR DESCRIPTION
closes #390

## Summary

Splits the monolithic `MoneyFlowService` into focused services grouped by business capability, per the target shape in the issue:

- **`MoneyFlow/NetWorth/NetWorthService.cs`** — both net worth overloads (single date + date range), moved verbatim.
- **`MoneyFlow/LabelsValue/LabelsValueService.cs`** — label value aggregation, moved verbatim.
- **`MoneyFlow/InvestmentRate/InvestmentRateService.cs`** — investment rate calculation, moved verbatim.
- **`MoneyFlow/MoneyFlowService.cs`** — kept as a temporary facade implementing `IMoneyFlowService` (which `MoneyFlowController` still depends on); it now only delegates to the three focused services.

New contracts `INetWorthService`, `ILabelsValueService` and `IInvestmentRateService` live in `FinanceManager.Domain/Services`, following the existing convention for service interfaces. All MoneyFlow DI registrations stay in `MoneyFlow/Registration.cs`; the root `ServiceCollectionExtension.cs` already only composed `AddMoneyFlowApplication()` and is untouched.

`MoneyFlowController`, API routes and response contracts are unchanged. No changelog entry — pure refactor with no user-visible effect.

## Tests

- `MoneyFlowServiceTests` split into `NetWorthServiceTests`, `LabelsValueServiceTests` and `InvestmentRateServiceTests`, each testing the focused service directly; all original test cases preserved.
- `dotnet build`: 0 warnings, 0 errors
- `dotnet format`: applied, clean
- Unit tests: 426 passed
- Integration tests: 244 passed

## Note on branch name

The repo convention asks for `390-split-moneyflowservice-by-business-capability`, but this session is restricted to pushing only to `claude/confident-archimedes-qcyajn`. The issue number is carried in the commit message and PR title so the changelog/issue chain stays intact.

https://claude.ai/code/session_019j9JPzXuKMiM9t9MyvD4jJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019j9JPzXuKMiM9t9MyvD4jJ)_