### PR TITLE
Add backend DashboardOverview read model endpoint #397

### DIFF
--- a/code/FinanceManager.Api/Controllers/DashboardController.cs
+++ b/code/FinanceManager.Api/Controllers/DashboardController.cs
@@ -1,0 +1,29 @@
+using FinanceManager.Api.Helpers;
+using FinanceManager.Domain.Dtos.Dashboard;
+using FinanceManager.Domain.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinanceManager.Api.Controllers;
+
+[Authorize]
+[Route("api/[controller]")]
+[ApiController]
+[Tags("Financial Analysis")]
+public class DashboardController(IDashboardQueryService dashboardQueryService) : ControllerBase
+{
+    /// <summary>
+    /// Returns the dashboard first-paint read model in a single response so the
+    /// frontend can initialize dashboard state once instead of fanning out to the
+    /// individual card-level endpoints.
+    /// </summary>
+    [HttpGet("overview")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DashboardOverviewDto))]
+    public async Task<IActionResult> GetOverview([FromQuery] int userId, [FromQuery] int currencyId, [FromQuery] DateTime start, [FromQuery] DateTime end, CancellationToken cancellationToken = default)
+    {
+        if (!ApiAuthenticationHelper.IsAuthenticatedUser(User, userId)) return Forbid();
+
+        var overview = await dashboardQueryService.GetOverview(userId, currencyId, start, end, cancellationToken);
+        return overview is null ? NotFound() : Ok(overview);
+    }
+}

--- a/code/FinanceManager.Application/Dashboard/DashboardQueryService.cs
+++ b/code/FinanceManager.Application/Dashboard/DashboardQueryService.cs
@@ -1,0 +1,56 @@
+using FinanceManager.Domain.Dtos.Dashboard;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Domain.Services;
+
+namespace FinanceManager.Application.Dashboard;
+
+/// <summary>
+/// Read/query service that composes the dashboard first-paint data from the
+/// existing per-card services into a single <see cref="DashboardOverviewDto"/>.
+/// The underlying services share a scoped EF Core DbContext, which is not
+/// thread-safe, so the queries are awaited sequentially rather than in parallel.
+/// </summary>
+public class DashboardQueryService(
+    IMoneyFlowService moneyFlowService,
+    IBalanceService balanceService,
+    IAssetsService assetsService,
+    ILiabilitiesService liabilitiesService,
+    IExpenseDistributionService expenseDistributionService,
+    ICurrencyRepository currencyRepository) : IDashboardQueryService
+{
+    public async Task<DashboardOverviewDto?> GetOverview(int userId, int currencyId, DateTime start, DateTime end, CancellationToken cancellationToken = default)
+    {
+        var currency = await currencyRepository.GetCurrency(currencyId, cancellationToken);
+        if (currency is null) return null;
+
+        var netWorth = await moneyFlowService.GetNetWorth(userId, currency, start, end);
+        var netCashFlow = await balanceService.GetNetCashFlow(userId, currency, start, end);
+        var closingBalance = await balanceService.GetClosingBalance(userId, currency, start, end);
+        var liabilitiesPerType = await liabilitiesService.GetEndLiabilitiesPerType(userId, start, end).ToListAsync(cancellationToken);
+        var liabilitiesPerAccount = await liabilitiesService.GetEndLiabilitiesPerAccount(userId, start, end).ToListAsync(cancellationToken);
+        var labelsValue = await moneyFlowService.GetLabelsValue(userId, start, end);
+        var assetsPerType = await assetsService.GetEndAssetsPerType(userId, currency, end).ToListAsync(cancellationToken);
+        var assetsPerAccount = await assetsService.GetEndAssetsPerAccount(userId, currency, end).ToListAsync(cancellationToken);
+        var expenseDistribution = await expenseDistributionService.GetExpenseDistribution(userId, currency, start, end);
+
+        return new DashboardOverviewDto
+        {
+            UserId = userId,
+            CurrencyId = currencyId,
+            StartDate = start,
+            EndDate = end,
+            NetWorthSeries = netWorth.OrderBy(x => x.Key)
+                                     .Select(x => new TimeSeriesModel(x.Key, x.Value))
+                                     .ToList(),
+            NetCashFlowSeries = netCashFlow,
+            ClosingBalanceSeries = closingBalance,
+            LiabilitiesPerType = liabilitiesPerType,
+            LiabilitiesPerAccount = liabilitiesPerAccount,
+            LabelsValue = labelsValue,
+            AssetsPerType = assetsPerType,
+            AssetsPerAccount = assetsPerAccount,
+            ExpenseDistribution = expenseDistribution,
+        };
+    }
+}

--- a/code/FinanceManager.Application/Dashboard/Registration.cs
+++ b/code/FinanceManager.Application/Dashboard/Registration.cs
@@ -1,0 +1,13 @@
+using FinanceManager.Domain.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FinanceManager.Application.Dashboard;
+
+internal static class Registration
+{
+    public static IServiceCollection AddDashboardApplication(this IServiceCollection services)
+    {
+        services.AddScoped<IDashboardQueryService, DashboardQueryService>();
+        return services;
+    }
+}

--- a/code/FinanceManager.Application/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Application/ServiceCollectionExtension.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Application.Administration;
+using FinanceManager.Application.Dashboard;
 using FinanceManager.Application.FinancialAccounts;
 using FinanceManager.Application.Identity;
 using FinanceManager.Application.Identity.Users;
@@ -32,6 +33,7 @@ public static class ServiceCollectionExtension
             .AddLabelsApplication()
             .AddInsightsApplication()
             .AddMoneyFlowApplication()
+            .AddDashboardApplication()
             .AddAdministrationApplication();
 
         return services;

--- a/code/FinanceManager.Domain/Dtos/Dashboard/DashboardOverviewDto.cs
+++ b/code/FinanceManager.Domain/Dtos/Dashboard/DashboardOverviewDto.cs
@@ -1,0 +1,30 @@
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+
+namespace FinanceManager.Domain.Dtos.Dashboard;
+
+/// <summary>
+/// Dashboard-shaped read model composing the data loaded by the dashboard
+/// first-paint cards into a single response, so the frontend can initialize
+/// dashboard state once instead of fanning out to many card-level endpoints.
+/// </summary>
+public class DashboardOverviewDto
+{
+    public int UserId { get; set; }
+    public int CurrencyId { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+
+    public List<TimeSeriesModel> NetWorthSeries { get; set; } = [];
+    public List<TimeSeriesModel> NetCashFlowSeries { get; set; } = [];
+    public List<TimeSeriesModel> ClosingBalanceSeries { get; set; } = [];
+
+    public List<NameValueResult> LiabilitiesPerType { get; set; } = [];
+    public List<NameValueResult> LiabilitiesPerAccount { get; set; } = [];
+
+    public List<NameValueResult> LabelsValue { get; set; } = [];
+
+    public List<NameValueResult> AssetsPerType { get; set; } = [];
+    public List<NameValueResult> AssetsPerAccount { get; set; } = [];
+
+    public List<NameValueResult> ExpenseDistribution { get; set; } = [];
+}

--- a/code/FinanceManager.Domain/Services/IDashboardQueryService.cs
+++ b/code/FinanceManager.Domain/Services/IDashboardQueryService.cs
@@ -1,0 +1,12 @@
+using FinanceManager.Domain.Dtos.Dashboard;
+
+namespace FinanceManager.Domain.Services;
+
+public interface IDashboardQueryService
+{
+    /// <summary>
+    /// Builds the dashboard overview read model for the given user, currency and
+    /// date range. Returns <c>null</c> when the currency cannot be resolved.
+    /// </summary>
+    Task<DashboardOverviewDto?> GetOverview(int userId, int currencyId, DateTime start, DateTime end, CancellationToken cancellationToken = default);
+}

--- a/code/FinanceManager.Tests.Integration/Controllers/DashboardControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/DashboardControllerTests.cs
@@ -1,0 +1,64 @@
+using FinanceManager.Domain.Dtos.Dashboard;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Net;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public class DashboardControllerTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider)
+{
+    private const int _testUserId = 733;
+    private readonly Mock<IDashboardQueryService> _dashboardQueryServiceMock = new();
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        _dashboardQueryServiceMock
+            .Setup(x => x.GetOverview(_testUserId, It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DashboardOverviewDto
+            {
+                UserId = _testUserId,
+                ExpenseDistribution = [new NameValueResult("Groceries", -42m)],
+            });
+
+        services.AddSingleton(_dashboardQueryServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task GetOverview_ForAuthenticatedUser_ReturnsOverview()
+    {
+        Authorize("user", _testUserId, UserRole.User);
+
+        var response = await Client.GetAsync($"api/Dashboard/overview?userId={_testUserId}&currencyId=0&start={DateTime.UtcNow.Date.AddDays(-7):O}&end={DateTime.UtcNow.Date:O}", TestContext.Current.CancellationToken);
+
+        Assert.True(response.IsSuccessStatusCode);
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("Groceries", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetOverview_ForOtherUser_ReturnsForbidden()
+    {
+        Authorize("user", _testUserId, UserRole.User);
+
+        var response = await Client.GetAsync($"api/Dashboard/overview?userId=999&currencyId=0&start={DateTime.UtcNow.Date.AddDays(-7):O}&end={DateTime.UtcNow.Date:O}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        _dashboardQueryServiceMock.Verify(x => x.GetOverview(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetOverview_WithoutAuthorization_ReturnsUnauthorized()
+    {
+        ClearAuthorization();
+
+        var response = await Client.GetAsync($"api/Dashboard/overview?userId={_testUserId}&currencyId=0&start={DateTime.UtcNow.Date.AddDays(-7):O}&end={DateTime.UtcNow.Date:O}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/DashboardControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/DashboardControllerTests.cs
@@ -1,0 +1,71 @@
+using FinanceManager.Api.Controllers;
+using FinanceManager.Domain.Dtos.Dashboard;
+using FinanceManager.Domain.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using System.Security.Claims;
+
+namespace FinanceManager.Tests.Unit.Api.Controllers;
+
+[Collection("Api")]
+[Trait("Category", "Unit")]
+public class DashboardControllerTests
+{
+    private const int _testUserId = 1;
+    private readonly DateTime _start = new(2024, 1, 1);
+    private readonly DateTime _end = new(2024, 2, 1);
+
+    private readonly Mock<IDashboardQueryService> _dashboardQueryService = new();
+    private readonly DashboardController _controller;
+
+    public DashboardControllerTests()
+    {
+        _controller = new DashboardController(_dashboardQueryService.Object);
+
+        var user = new ClaimsPrincipal(new ClaimsIdentity([new(ClaimTypes.NameIdentifier, _testUserId.ToString())], "mock"));
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = user }
+        };
+    }
+
+    [Fact]
+    public async Task GetOverview_ReturnsOk_ForAuthenticatedUser()
+    {
+        // Arrange
+        var dto = new DashboardOverviewDto { UserId = _testUserId, CurrencyId = 0, StartDate = _start, EndDate = _end };
+        _dashboardQueryService.Setup(s => s.GetOverview(_testUserId, 0, _start, _end, It.IsAny<CancellationToken>())).ReturnsAsync(dto);
+
+        // Act
+        var result = await _controller.GetOverview(_testUserId, 0, _start, _end, TestContext.Current.CancellationToken);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        Assert.Same(dto, okResult.Value);
+    }
+
+    [Fact]
+    public async Task GetOverview_ReturnsNotFound_WhenServiceReturnsNull()
+    {
+        // Arrange
+        _dashboardQueryService.Setup(s => s.GetOverview(_testUserId, 999, _start, _end, It.IsAny<CancellationToken>())).ReturnsAsync((DashboardOverviewDto?)null);
+
+        // Act
+        var result = await _controller.GetOverview(_testUserId, 999, _start, _end, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task GetOverview_ReturnsForbid_ForDifferentUser()
+    {
+        // Act
+        var result = await _controller.GetOverview(_testUserId + 1, 0, _start, _end, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.IsType<ForbidResult>(result);
+        _dashboardQueryService.Verify(s => s.GetOverview(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/DashboardQueryServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/DashboardQueryServiceTests.cs
@@ -1,0 +1,98 @@
+using FinanceManager.Application.Dashboard;
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Domain.Services;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class DashboardQueryServiceTests
+{
+    private const int _userId = 1;
+    private readonly DateTime _start = new(2024, 1, 1);
+    private readonly DateTime _end = new(2024, 2, 1);
+
+    private readonly Mock<IMoneyFlowService> _moneyFlowService = new();
+    private readonly Mock<IBalanceService> _balanceService = new();
+    private readonly Mock<IAssetsService> _assetsService = new();
+    private readonly Mock<ILiabilitiesService> _liabilitiesService = new();
+    private readonly Mock<IExpenseDistributionService> _expenseDistributionService = new();
+    private readonly Mock<ICurrencyRepository> _currencyRepository = new();
+    private readonly DashboardQueryService _service;
+
+    public DashboardQueryServiceTests()
+    {
+        _service = new DashboardQueryService(
+            _moneyFlowService.Object,
+            _balanceService.Object,
+            _assetsService.Object,
+            _liabilitiesService.Object,
+            _expenseDistributionService.Object,
+            _currencyRepository.Object);
+    }
+
+    [Fact]
+    public async Task GetOverview_ComposesAllFirstPaintData()
+    {
+        // Arrange
+        var currency = DefaultCurrency.PLN;
+        _currencyRepository.Setup(r => r.GetCurrency(currency.Id, It.IsAny<CancellationToken>())).ReturnsAsync(currency);
+
+        var netWorth = new Dictionary<DateTime, decimal>
+        {
+            { _end, 200 },
+            { _start, 100 },
+        };
+        _moneyFlowService.Setup(s => s.GetNetWorth(_userId, currency, _start, _end)).ReturnsAsync(netWorth);
+        _balanceService.Setup(s => s.GetNetCashFlow(_userId, currency, _start, _end)).ReturnsAsync([new(_start, 50)]);
+        _balanceService.Setup(s => s.GetClosingBalance(_userId, currency, _start, _end)).ReturnsAsync([new(_start, 75)]);
+        _liabilitiesService.Setup(s => s.GetEndLiabilitiesPerType(_userId, _start, _end)).Returns(new[] { new NameValueResult("Mortgage", -1000) }.ToAsyncEnumerable());
+        _liabilitiesService.Setup(s => s.GetEndLiabilitiesPerAccount(_userId, _start, _end)).Returns(new[] { new NameValueResult("Bank A", -1000) }.ToAsyncEnumerable());
+        _moneyFlowService.Setup(s => s.GetLabelsValue(_userId, _start, _end)).ReturnsAsync([new("Salary", 5000)]);
+        _assetsService.Setup(s => s.GetEndAssetsPerType(_userId, currency, _end)).Returns(new[] { new NameValueResult("Cash", 3000) }.ToAsyncEnumerable());
+        _assetsService.Setup(s => s.GetEndAssetsPerAccount(_userId, currency, _end)).Returns(new[] { new NameValueResult("Bank A", 3000) }.ToAsyncEnumerable());
+        _expenseDistributionService.Setup(s => s.GetExpenseDistribution(_userId, currency, _start, _end)).ReturnsAsync([new("Food", 400)]);
+
+        // Act
+        var result = await _service.GetOverview(_userId, currency.Id, _start, _end, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(_userId, result.UserId);
+        Assert.Equal(currency.Id, result.CurrencyId);
+        Assert.Equal(_start, result.StartDate);
+        Assert.Equal(_end, result.EndDate);
+
+        // Net worth dictionary is projected and ordered ascending by date.
+        Assert.Equal([_start, _end], result.NetWorthSeries.Select(x => x.DateTime));
+        Assert.Equal([100, 200], result.NetWorthSeries.Select(x => x.Value));
+
+        Assert.Single(result.NetCashFlowSeries);
+        Assert.Single(result.ClosingBalanceSeries);
+        Assert.Single(result.LiabilitiesPerType);
+        Assert.Single(result.LiabilitiesPerAccount);
+        Assert.Single(result.LabelsValue);
+        Assert.Single(result.AssetsPerType);
+        Assert.Single(result.AssetsPerAccount);
+        Assert.Single(result.ExpenseDistribution);
+        Assert.Equal("Salary", result.LabelsValue[0].Name);
+        Assert.Equal("Food", result.ExpenseDistribution[0].Name);
+    }
+
+    [Fact]
+    public async Task GetOverview_ReturnsNull_WhenCurrencyNotFound()
+    {
+        // Arrange
+        _currencyRepository.Setup(r => r.GetCurrency(It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync((Currency?)null);
+
+        // Act
+        var result = await _service.GetOverview(_userId, 999, _start, _end, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(result);
+        _moneyFlowService.Verify(s => s.GetNetWorth(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.Never);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 of the dashboard performance optimization (#395): a backend dashboard read-model endpoint that composes all dashboard first-paint data into a single response, so the frontend can later initialize dashboard state once instead of fanning out to many card-level endpoints.

closes #397

## What's added

- **`GET /api/dashboard/overview?userId=...&currencyId=...&start=...&end=...`** (`DashboardController`) — `[Authorize]`d, rejects access for any user other than the authenticated one (`Forbid`), returns `404` when the currency can't be resolved.
- **`IDashboardQueryService` / `DashboardQueryService`** (Application layer) — a read/query service that composes the existing per-card services into one DTO. Because the underlying services share a scoped EF Core `DbContext` (not thread-safe), the queries are awaited sequentially rather than fanned out in parallel.
- **`DashboardOverviewDto`** (Domain) — flat, dashboard-shaped read model carrying the existing `TimeSeriesModel` / `NameValueResult` domain models.
- DI wiring via `Application/Dashboard/Registration.cs` → `AddApplicationApi`.
- Unit tests for both the controller (auth / OK / NotFound) and the query service (composition + currency-not-found short-circuit).

## First-paint data composed

net worth series, net cash flow series, closing balance series, liabilities by type, liabilities by account, financial labels summary, assets by type, assets by account, expense distribution.

Optional/deferred data (financial insights, recurring transaction detection) intentionally remains separately loaded, per the issue.

## Notes / scope

- Read model only — no generic CRUD. Authorization happens once at the endpoint boundary.
- Existing card-level endpoints are untouched and remain available for standalone card usage.
- No frontend transition in this issue (Phase 3 is tracked separately), so there is no user-visible behaviour change and no changelog entry.

## Validation

- `dotnet build ./code/FinanceManager.slnx` — succeeds, 0 warnings/errors.
- `dotnet test FinanceManager.Tests.Unit` — 445 passed (incl. the new tests).
- `dotnet format ./code --verify-no-changes` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JN5gPNDsdvevktBd3ytzXC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dashboard overview endpoint providing comprehensive financial summaries including net worth, cash flow, closing balance, asset and liability breakdowns, expense distribution, and label valuations for authenticated users within specified date ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->