### PR TITLE
Transition dashboard to DashboardOverview endpoint with explicit card model parameters #398

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ rules agents must follow when updating this file.
 - Admin page (`/Admin/ServiceKeys`) for managing external service API credentials (Alpha Vantage, OpenFIGI); keys are persisted in the database and take effect immediately without redeployment. #358
 
 ### Changed
+- Dashboard first-paint data now loads through a single `/api/Dashboard/overview` request instead of each card fetching its own endpoint: the page fetches one overview model and passes prepared data to the net worth, net cash flow, closing balance, liabilities, financial labels, assets, and expense cards, reducing dashboard load chattiness. Cards still self-load when used standalone outside the dashboard. #398
 - Account history toolbar redesigned to match design spec: Income and Expense are now separate toggle buttons (green/red when active), the label filter is renamed to Category, Import/Export/Settings are surfaced as inline toolbar buttons, and the Add entry button is a standalone filled primary button; the toolbar container no longer has an outlined border. #355
 - Account hero range selector repositioned to the top-right corner on desktop (same row as account name) and updated to offer 1W, 1M, 3M, 6M, YTD, and All presets; the custom date-range picker has been removed. #355
 - Account history toolbar wrapping layout now groups search + type filter together on the first row and label filter + add-entry button together on the second row when the toolbar is too narrow to fit on one line; Income/Expense toggle always shows full text at all viewport widths. #353

--- a/code/AppHost/AppHost.csproj
+++ b/code/AppHost/AppHost.csproj
@@ -10,6 +10,9 @@
 	<ItemGroup>
 		<PackageReference Include="Aspire.Hosting.AppHost" />
 		<PackageReference Include="Aspire.Hosting.PostgreSQL" />
+		<!-- Direct reference to lift the transitive MessagePack to a patched version
+		     (GHSA-hv8m-jj95-wg3x); transitive pinning is disabled solution-wide. -->
+		<PackageReference Include="MessagePack" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -15,6 +15,9 @@
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.0-beta.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
+    <!-- Pinned to patch the transitive MessagePack pulled in by Aspire.Hosting: versions
+         below 2.5.301 carry the high-severity LZ4 out-of-bounds read (GHSA-hv8m-jj95-wg3x). -->
+    <PackageVersion Include="MessagePack" Version="2.5.301" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.8" />

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/AssetsDistributionOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/AssetsDistributionOverviewCard.razor.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Application.Identity.Users;
+using FinanceManager.Components.Components.Features.Dashboard.Models;
 using FinanceManager.Components.Models;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.Currencies;
@@ -20,6 +21,10 @@ public partial class AssetsDistributionOverviewCard
     [Parameter] public DateTime StartDateTime { get; set; }
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
 
+    // When the dashboard supplies a prepared model the card renders it directly;
+    // otherwise it self-loads from the cache service as in standalone usage.
+    [Parameter] public DistributionCardModel? Model { get; set; }
+
     [Inject] public required ILogger<AssetsDistributionOverviewCard> Logger { get; set; }
     [Inject] public required AssetsPageCardsCacheService AssetsPageCardsCacheService { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
@@ -37,6 +42,13 @@ public partial class AssetsDistributionOverviewCard
 
         try
         {
+            if (Model is not null)
+            {
+                _typeData = [.. Model.TypeData];
+                _walletData = [.. Model.AccountData];
+                return;
+            }
+
             var user = await LoginService.GetLoggedUser();
             if (user is null)
             {

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/ClosingBalanceOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/ClosingBalanceOverviewCard.razor.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Application.Identity.Users;
+using FinanceManager.Components.Components.Features.Dashboard.Models;
 using FinanceManager.Components.Models;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.MoneyFlowModels;
@@ -19,6 +20,10 @@ public partial class ClosingBalanceOverviewCard
     [Parameter] public DateTime StartDateTime { get; set; }
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
 
+    // When the dashboard supplies a prepared model the card renders it directly;
+    // otherwise it self-loads from the cache service as in standalone usage.
+    [Parameter] public TimeSeriesCardModel? Model { get; set; }
+
     [Inject] public required ILogger<ClosingBalanceOverviewCard> Logger { get; set; }
     [Inject] public required DashboardOverviewCardsCacheService DashboardOverviewCardsCacheService { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
@@ -30,6 +35,14 @@ public partial class ClosingBalanceOverviewCard
     {
         var currency = SettingsService.GetCurrency();
         _currency = currency.ShortName;
+
+        if (Model is not null)
+        {
+            _series = [.. Model.Series.OrderBy(x => x.DateTime).Select(x => new TimeSeriesModel(x.DateTime, Math.Round(x.Value, 2)))];
+            _hasError = false;
+            _isLoading = false;
+            return;
+        }
 
         var user = await LoginService.GetLoggedUser();
         if (user is null)

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/ExpenseDistributionOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/ExpenseDistributionOverviewCard.razor.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Application.Identity.Users;
+using FinanceManager.Components.Components.Features.Dashboard.Models;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Entities.MoneyFlowModels;
@@ -19,6 +20,10 @@ public partial class ExpenseDistributionOverviewCard
     [Parameter] public DateTime StartDateTime { get; set; }
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
 
+    // When the dashboard supplies a prepared model the card renders it directly;
+    // otherwise it self-loads from the API as in standalone usage.
+    [Parameter] public NameValueListCardModel? Model { get; set; }
+
     [Inject] public required ILogger<ExpenseDistributionOverviewCard> Logger { get; set; }
     [Inject] public required ISnackbar Snackbar { get; set; }
     [Inject] public required MoneyFlowHttpClient MoneyFlowHttpClient { get; set; }
@@ -37,6 +42,12 @@ public partial class ExpenseDistributionOverviewCard
 
         try
         {
+            if (Model is not null)
+            {
+                _data = [.. Model.Items];
+                return;
+            }
+
             var user = await LoginService.GetLoggedUser();
             if (user is null)
             {

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/FinancialLabelsListCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/FinancialLabelsListCard.razor.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Application.Identity.Users;
+using FinanceManager.Components.Components.Features.Dashboard.Models;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Entities.MoneyFlowModels;
@@ -24,6 +25,10 @@ public partial class FinancialLabelsListCard
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
     [Parameter] public CardMode CardMode { get; set; } = CardMode.List;
 
+    // When the dashboard supplies a prepared model the card renders it directly;
+    // otherwise it self-loads from the API as in standalone usage.
+    [Parameter] public NameValueListCardModel? Model { get; set; }
+
     protected override Task OnParametersSetAsync() => LoadData();
 
     private async Task LoadData()
@@ -31,6 +36,14 @@ public partial class FinancialLabelsListCard
         _isLoading = true;
         _hasError = false;
         _currency = SettingsService.GetCurrency();
+
+        if (Model is not null)
+        {
+            _data = Model.Items.Where(x => x.Value != 0).ToList();
+            _isLoading = false;
+            return;
+        }
+
         var userId = await LoginService.GetLoggedUser();
 
         try

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Liabilities/LiabilitiesDistributionOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Liabilities/LiabilitiesDistributionOverviewCard.razor.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Application.Identity.Users;
+using FinanceManager.Components.Components.Features.Dashboard.Models;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Domain.Entities.Currencies;
 using FinanceManager.Domain.Entities.MoneyFlowModels;
@@ -19,6 +20,10 @@ public partial class LiabilitiesDistributionOverviewCard
     [Parameter] public DateTime StartDateTime { get; set; }
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
 
+    // When the dashboard supplies a prepared model the card renders it directly;
+    // otherwise it self-loads from the API as in standalone usage.
+    [Parameter] public DistributionCardModel? Model { get; set; }
+
     [Inject] public required ILogger<LiabilitiesDistributionOverviewCard> Logger { get; set; }
     [Inject] public required LiabilitiesHttpClient LiabilitiesHttpClient { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
@@ -36,6 +41,13 @@ public partial class LiabilitiesDistributionOverviewCard
 
         try
         {
+            if (Model is not null)
+            {
+                _typeData = ToPositive(Model.TypeData);
+                _accountData = ToPositive(Model.AccountData);
+                return;
+            }
+
             if (StartDateTime == new DateTime())
             {
                 _typeData = [];

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/NetCashFlowOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/NetCashFlowOverviewCard.razor.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Application.Identity.Users;
+using FinanceManager.Components.Components.Features.Dashboard.Models;
 using FinanceManager.Components.Models;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.MoneyFlowModels;
@@ -20,6 +21,10 @@ public partial class NetCashFlowOverviewCard
     [Parameter] public string Height { get; set; } = "300px";
     [Parameter] public DateTime StartDateTime { get; set; }
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
+
+    // When the dashboard supplies a prepared model the card renders it directly;
+    // otherwise it self-loads from the cache service as in standalone usage.
+    [Parameter] public TimeSeriesCardModel? Model { get; set; }
 
     [Inject] public required ILogger<NetCashFlowOverviewCard> Logger { get; set; }
     [Inject] public required DashboardOverviewCardsCacheService DashboardOverviewCardsCacheService { get; set; }
@@ -49,6 +54,15 @@ public partial class NetCashFlowOverviewCard
         var currency = SettingsService.GetCurrency();
         _currency = currency.ShortName;
         _totalNetCashFlow = null;
+
+        if (Model is not null)
+        {
+            _series = [.. Model.Series.OrderBy(x => x.DateTime).Select(x => new TimeSeriesModel(x.DateTime, Math.Round(x.Value, 2)))];
+            _totalNetCashFlow = Math.Round(_series.Sum(x => x.Value), 2);
+            _hasError = false;
+            _isLoading = false;
+            return;
+        }
 
         var user = await LoginService.GetLoggedUser();
         if (user is null)

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/TimeSeries/NetWorthTimeSeriesCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/TimeSeries/NetWorthTimeSeriesCard.razor.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Application.Identity.Users;
+using FinanceManager.Components.Components.Features.Dashboard.Models;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Domain.Entities.MoneyFlowModels;
 using FinanceManager.Domain.Services;
@@ -18,6 +19,10 @@ public partial class NetWorthTimeSeriesCard
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
     [Parameter] public string Height { get; set; } = "250px";
 
+    // When the dashboard supplies a prepared model the card renders it directly;
+    // otherwise it self-loads from the API as in standalone usage.
+    [Parameter] public TimeSeriesCardModel? Model { get; set; }
+
     [Inject] public required ILogger<NetWorthTimeSeriesCard> Logger { get; set; }
     [Inject] public required MoneyFlowHttpClient MoneyFlowHttpClient { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
@@ -27,6 +32,15 @@ public partial class NetWorthTimeSeriesCard
 
     private async Task Reload()
     {
+        if (Model is not null)
+        {
+            _currency = SettingsService.GetCurrency().ShortName;
+            _series = [.. Model.Series.OrderBy(x => x.DateTime).Select(x => new TimeSeriesModel(x.DateTime, x.Value))];
+            _hasError = false;
+            _isLoading = false;
+            return;
+        }
+
         var user = await LoginService.GetLoggedUser();
         if (user is null)
         {

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor
@@ -4,51 +4,87 @@
 @using FinanceManager.Components.Components.Features.Dashboard.Cards.TimeSeries
 
 <MudContainer Class="py-2">
-    <MudGrid Spacing="2">
+    @if (_overview is null && _isLoading)
+    {
+        <MudGrid Spacing="2">
+            <MudItem xs="12">
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="@($"{_unitHeight * 2}px")" />
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="@($"{_unitHeight * 2}px")" />
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="@($"{_unitHeight * 2}px")" />
+            </MudItem>
+            <MudItem xs="12" md="6" lg="4">
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="@($"{_unitHeight * 3}px")" />
+            </MudItem>
+            <MudItem xs="12" md="6" lg="4">
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="@($"{_unitHeight * 3}px")" />
+            </MudItem>
+            <MudItem xs="12" md="6" lg="4">
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="@($"{_unitHeight * 3}px")" />
+            </MudItem>
+        </MudGrid>
+    }
+    else
+    {
+        @if (_hasError)
+        {
+            <MudAlert Severity="Severity.Error" Class="mb-2" ShowCloseIcon="false">
+                <div class="d-flex align-center justify-space-between" style="width:100%">
+                    <span>Unable to load dashboard data.</span>
+                    <MudButton Variant="Variant.Text" Color="Color.Inherit" OnClick="LoadOverview">Retry</MudButton>
+                </div>
+            </MudAlert>
+        }
 
-        <MudItem xs="12">
-            <NetWorthTimeSeriesCard StartDateTime="@StartDate" EndDateTime="@EndDate" />
-        </MudItem>
+        <MudGrid Spacing="2">
 
-        <MudItem xs="12" md="6">
-            <NetCashFlowOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@StartDate"
-                                     EndDateTime="@EndDate" />
-        </MudItem>
+            <MudItem xs="12">
+                <NetWorthTimeSeriesCard StartDateTime="@StartDate" EndDateTime="@EndDate" Model="@NetWorthModel" />
+            </MudItem>
 
-        <MudItem xs="12" md="6">
-            <ClosingBalanceOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@StartDate"
-                                        EndDateTime="@EndDate" />
-        </MudItem>
+            <MudItem xs="12" md="6">
+                <NetCashFlowOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@StartDate"
+                                         EndDateTime="@EndDate" Model="@NetCashFlowModel" />
+            </MudItem>
 
-        <MudItem xs="12" md="6" lg="4">
-            <LiabilitiesDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
-                                                 EndDateTime="@EndDate" />
-        </MudItem>
+            <MudItem xs="12" md="6">
+                <ClosingBalanceOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@StartDate"
+                                            EndDateTime="@EndDate" Model="@ClosingBalanceModel" />
+            </MudItem>
 
-        <MudItem xs="12" md="6" lg="4">
-            <FinancialLabelsListCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
-                                     EndDateTime="@EndDate" />
-        </MudItem>
+            <MudItem xs="12" md="6" lg="4">
+                <LiabilitiesDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
+                                                     EndDateTime="@EndDate" Model="@LiabilitiesModel" />
+            </MudItem>
 
-        <MudItem xs="12" md="6" lg="4">
-            <AssetsDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
-                                            EndDateTime="@EndDate" />
-        </MudItem>
+            <MudItem xs="12" md="6" lg="4">
+                <FinancialLabelsListCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
+                                         EndDateTime="@EndDate" Model="@LabelsModel" />
+            </MudItem>
 
-        <MudItem xs="12" md="6" lg="4">
-            <ExpenseDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
-                                             EndDateTime="@EndDate" />
-        </MudItem>
+            <MudItem xs="12" md="6" lg="4">
+                <AssetsDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
+                                                EndDateTime="@EndDate" Model="@AssetsModel" />
+            </MudItem>
 
-        <MudItem xs="12" md="6" lg="4">
-            <FinancialInsightsCarousel Height="@($"{_unitHeight * 3}px")" Count="3" />
-        </MudItem>
+            <MudItem xs="12" md="6" lg="4">
+                <ExpenseDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
+                                                 EndDateTime="@EndDate" Model="@ExpenseModel" />
+            </MudItem>
 
-        <MudItem xs="12" md="6" lg="4">
-            <RecurringTransactionDetectorCard Height="@($"{_unitHeight * 3}px")" />
-        </MudItem>
+            <MudItem xs="12" md="6" lg="4">
+                <FinancialInsightsCarousel Height="@($"{_unitHeight * 3}px")" Count="3" />
+            </MudItem>
 
-    </MudGrid>
+            <MudItem xs="12" md="6" lg="4">
+                <RecurringTransactionDetectorCard Height="@($"{_unitHeight * 3}px")" />
+            </MudItem>
+
+        </MudGrid>
+    }
 </MudContainer>
 
 <DashboardDatePicker DateChanged=DateChanged StartingOption="ThisMonth" />

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor
@@ -42,37 +42,37 @@
         <MudGrid Spacing="2">
 
             <MudItem xs="12">
-                <NetWorthTimeSeriesCard StartDateTime="@StartDate" EndDateTime="@EndDate" Model="@NetWorthModel" />
+                <NetWorthTimeSeriesCard StartDateTime="@DisplayStartDate" EndDateTime="@DisplayEndDate" Model="@NetWorthModel" />
             </MudItem>
 
             <MudItem xs="12" md="6">
-                <NetCashFlowOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@StartDate"
-                                         EndDateTime="@EndDate" Model="@NetCashFlowModel" />
+                <NetCashFlowOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@DisplayStartDate"
+                                         EndDateTime="@DisplayEndDate" Model="@NetCashFlowModel" />
             </MudItem>
 
             <MudItem xs="12" md="6">
-                <ClosingBalanceOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@StartDate"
-                                            EndDateTime="@EndDate" Model="@ClosingBalanceModel" />
+                <ClosingBalanceOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@DisplayStartDate"
+                                            EndDateTime="@DisplayEndDate" Model="@ClosingBalanceModel" />
             </MudItem>
 
             <MudItem xs="12" md="6" lg="4">
-                <LiabilitiesDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
-                                                     EndDateTime="@EndDate" Model="@LiabilitiesModel" />
+                <LiabilitiesDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
+                                                     EndDateTime="@DisplayEndDate" Model="@LiabilitiesModel" />
             </MudItem>
 
             <MudItem xs="12" md="6" lg="4">
-                <FinancialLabelsListCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
-                                         EndDateTime="@EndDate" Model="@LabelsModel" />
+                <FinancialLabelsListCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
+                                         EndDateTime="@DisplayEndDate" Model="@LabelsModel" />
             </MudItem>
 
             <MudItem xs="12" md="6" lg="4">
-                <AssetsDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
-                                                EndDateTime="@EndDate" Model="@AssetsModel" />
+                <AssetsDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
+                                                EndDateTime="@DisplayEndDate" Model="@AssetsModel" />
             </MudItem>
 
             <MudItem xs="12" md="6" lg="4">
-                <ExpenseDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@StartDate"
-                                                 EndDateTime="@EndDate" Model="@ExpenseModel" />
+                <ExpenseDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
+                                                 EndDateTime="@DisplayEndDate" Model="@ExpenseModel" />
             </MudItem>
 
             <MudItem xs="12" md="6" lg="4">

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
@@ -17,6 +17,12 @@ public partial class Dashboard : ComponentBase
     private bool _isLoading = true;
     private bool _hasError;
 
+    // The date range that the currently-held _overview was loaded for. Cards render
+    // these (via DisplayStartDate/DisplayEndDate) rather than the live selection so
+    // the displayed period label always matches the displayed amounts, even mid-reload.
+    private DateTime _overviewStart;
+    private DateTime _overviewEnd;
+
     // Guards against a slower, earlier reload overwriting a newer date selection:
     // every LoadOverview claims an incrementing version and only commits its result
     // if it is still the latest in-flight request.
@@ -24,6 +30,12 @@ public partial class Dashboard : ComponentBase
 
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; } = DateTime.UtcNow;
+
+    // Dates handed to the cards: while an overview is held they track that overview's
+    // range so amounts and period labels stay paired during a reload; with no overview
+    // (first paint / self-load fallback) they fall back to the live selection.
+    private DateTime DisplayStartDate => _overview is null ? StartDate : _overviewStart;
+    private DateTime DisplayEndDate => _overview is null ? EndDate : _overviewEnd;
 
     [Inject] public required IFinancialAccountService FinancialAccountService { get; set; }
     [Inject] public required DashboardHttpClient DashboardHttpClient { get; set; }
@@ -88,10 +100,13 @@ public partial class Dashboard : ComponentBase
 
             // Swap the held overview only after the call succeeds, and only if this is
             // still the latest reload, so cards keep rendering the previous data (and
-            // never self-load) during a reload and stay in sync with the date range.
+            // never self-load) during a reload. The matching range is committed in the
+            // same step so the displayed dates and amounts always move together.
             if (requestVersion == _loadOverviewVersion)
             {
                 _overview = overview;
+                _overviewStart = startDate;
+                _overviewEnd = endDate;
             }
         }
         catch (Exception ex)

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
@@ -1,32 +1,91 @@
+using FinanceManager.Components.Components.Features.Dashboard.Models;
 using FinanceManager.Components.Helpers;
+using FinanceManager.Components.HttpClients;
 using FinanceManager.Components.Services;
+using FinanceManager.Domain.Dtos.Dashboard;
+using FinanceManager.Domain.Services;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 
 namespace FinanceManager.Components.Components.Features.Dashboard;
 
 public partial class Dashboard : ComponentBase
 {
     private const int _unitHeight = 130;
+
+    private DashboardOverviewDto? _overview;
+    private bool _isLoading = true;
+    private bool _hasError;
+
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; } = DateTime.UtcNow;
 
     [Inject] public required IFinancialAccountService FinancialAccountService { get; set; }
+    [Inject] public required DashboardHttpClient DashboardHttpClient { get; set; }
+    [Inject] public required ISettingsService SettingsService { get; set; }
+    [Inject] public required ILoginService LoginService { get; set; }
+    [Inject] public required ILogger<Dashboard> Logger { get; set; }
 
-    protected override void OnInitialized()
+    // Card-specific models mapped from the single overview response. They are null
+    // until the first load resolves (and when the overview is unavailable), in which
+    // case the cards fall back to their existing standalone self-loading behavior.
+    private TimeSeriesCardModel? NetWorthModel => _overview is null ? null : new(_overview.NetWorthSeries);
+    private TimeSeriesCardModel? NetCashFlowModel => _overview is null ? null : new(_overview.NetCashFlowSeries);
+    private TimeSeriesCardModel? ClosingBalanceModel => _overview is null ? null : new(_overview.ClosingBalanceSeries);
+    private DistributionCardModel? LiabilitiesModel => _overview is null ? null : new(_overview.LiabilitiesPerType, _overview.LiabilitiesPerAccount);
+    private NameValueListCardModel? LabelsModel => _overview is null ? null : new(_overview.LabelsValue);
+    private DistributionCardModel? AssetsModel => _overview is null ? null : new(_overview.AssetsPerType, _overview.AssetsPerAccount);
+    private NameValueListCardModel? ExpenseModel => _overview is null ? null : new(_overview.ExpenseDistribution);
+
+    protected override async Task OnInitializedAsync()
     {
         var (Start, End) = DateRangeHelper.GetCurrentMonthRange();
-
         StartDate = Start;
         EndDate = End;
 
-        base.OnInitialized();
+        await LoadOverview();
     }
 
+    // DashboardDatePicker exposes a synchronous Action callback, so kick off the
+    // reload without awaiting; LoadOverview owns its own state and error handling.
     public void DateChanged((DateTime Start, DateTime End) changed)
     {
         StartDate = changed.Start;
         EndDate = changed.End;
-        StateHasChanged();
+        _ = LoadOverview();
     }
 
+    private async Task LoadOverview()
+    {
+        _isLoading = true;
+        _hasError = false;
+        StateHasChanged();
+
+        try
+        {
+            var user = await LoginService.GetLoggedUser();
+            if (user is null)
+            {
+                _overview = null;
+                return;
+            }
+
+            var currency = SettingsService.GetCurrency();
+
+            // Swap the held overview only after the call succeeds so cards keep
+            // rendering the previous data (and never self-load) during a reload.
+            _overview = await DashboardHttpClient.GetOverview(user.UserId, currency.Id, StartDate, EndDate);
+        }
+        catch (Exception ex)
+        {
+            _overview = null;
+            _hasError = true;
+            Logger.LogError(ex, "Error loading dashboard overview");
+        }
+        finally
+        {
+            _isLoading = false;
+            StateHasChanged();
+        }
+    }
 }

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
@@ -17,6 +17,11 @@ public partial class Dashboard : ComponentBase
     private bool _isLoading = true;
     private bool _hasError;
 
+    // Guards against a slower, earlier reload overwriting a newer date selection:
+    // every LoadOverview claims an incrementing version and only commits its result
+    // if it is still the latest in-flight request.
+    private int _loadOverviewVersion;
+
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; } = DateTime.UtcNow;
 
@@ -57,6 +62,10 @@ public partial class Dashboard : ComponentBase
 
     private async Task LoadOverview()
     {
+        var requestVersion = Interlocked.Increment(ref _loadOverviewVersion);
+        var startDate = StartDate;
+        var endDate = EndDate;
+
         _isLoading = true;
         _hasError = false;
         StateHasChanged();
@@ -66,26 +75,41 @@ public partial class Dashboard : ComponentBase
             var user = await LoginService.GetLoggedUser();
             if (user is null)
             {
-                _overview = null;
+                if (requestVersion == _loadOverviewVersion)
+                {
+                    _overview = null;
+                }
                 return;
             }
 
             var currency = SettingsService.GetCurrency();
 
-            // Swap the held overview only after the call succeeds so cards keep
-            // rendering the previous data (and never self-load) during a reload.
-            _overview = await DashboardHttpClient.GetOverview(user.UserId, currency.Id, StartDate, EndDate);
+            var overview = await DashboardHttpClient.GetOverview(user.UserId, currency.Id, startDate, endDate);
+
+            // Swap the held overview only after the call succeeds, and only if this is
+            // still the latest reload, so cards keep rendering the previous data (and
+            // never self-load) during a reload and stay in sync with the date range.
+            if (requestVersion == _loadOverviewVersion)
+            {
+                _overview = overview;
+            }
         }
         catch (Exception ex)
         {
-            _overview = null;
-            _hasError = true;
+            if (requestVersion == _loadOverviewVersion)
+            {
+                _overview = null;
+                _hasError = true;
+            }
             Logger.LogError(ex, "Error loading dashboard overview");
         }
         finally
         {
-            _isLoading = false;
-            StateHasChanged();
+            if (requestVersion == _loadOverviewVersion)
+            {
+                _isLoading = false;
+                StateHasChanged();
+            }
         }
     }
 }

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Models/DashboardCardModels.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Models/DashboardCardModels.cs
@@ -1,0 +1,17 @@
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+
+namespace FinanceManager.Components.Components.Features.Dashboard.Models;
+
+// Card-specific read models the dashboard prepares from the single overview
+// response and passes to the first-paint cards through explicit [Parameter]
+// values. Each card applies its existing presentation transform to this data,
+// so the smart cards can keep working standalone when no model is supplied.
+
+/// <summary>Prepared data for the time-series cards (net worth, net cash flow, closing balance).</summary>
+public record TimeSeriesCardModel(List<TimeSeriesModel> Series);
+
+/// <summary>Prepared data for the distribution cards that toggle between a type and an account/wallet view (liabilities, assets).</summary>
+public record DistributionCardModel(List<NameValueResult> TypeData, List<NameValueResult> AccountData);
+
+/// <summary>Prepared data for the name/value list cards (financial labels, expense distribution).</summary>
+public record NameValueListCardModel(List<NameValueResult> Items);

--- a/code/FinanceManager.Components/HttpClients/DashboardHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/DashboardHttpClient.cs
@@ -12,7 +12,12 @@ public class DashboardHttpClient(HttpClient httpClient)
 {
     public async Task<DashboardOverviewDto?> GetOverview(int userId, int currencyId, DateTime start, DateTime end)
     {
-        string endpoint = $"{httpClient.BaseAddress}api/Dashboard/overview?userId={userId}&currencyId={currencyId}&start={start:O}&end={end:O}";
+        // Encode the round-trip dates: the "O" format contains '+' and ':', which a
+        // query-string decoder would otherwise misread (e.g. '+' becomes a space).
+        var encodedStart = Uri.EscapeDataString(start.ToString("O"));
+        var encodedEnd = Uri.EscapeDataString(end.ToString("O"));
+
+        string endpoint = $"{httpClient.BaseAddress}api/Dashboard/overview?userId={userId}&currencyId={currencyId}&start={encodedStart}&end={encodedEnd}";
         return await httpClient.GetFromJsonAsync<DashboardOverviewDto>(endpoint);
     }
 }

--- a/code/FinanceManager.Components/HttpClients/DashboardHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/DashboardHttpClient.cs
@@ -1,0 +1,18 @@
+using FinanceManager.Domain.Dtos.Dashboard;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Components.HttpClients;
+
+/// <summary>
+/// Reads the dashboard first-paint composite model from the single
+/// <c>api/Dashboard/overview</c> endpoint so the dashboard can initialize its
+/// state once instead of fanning out to the individual card-level endpoints.
+/// </summary>
+public class DashboardHttpClient(HttpClient httpClient)
+{
+    public async Task<DashboardOverviewDto?> GetOverview(int userId, int currencyId, DateTime start, DateTime end)
+    {
+        string endpoint = $"{httpClient.BaseAddress}api/Dashboard/overview?userId={userId}&currencyId={currencyId}&start={start:O}&end={end:O}";
+        return await httpClient.GetFromJsonAsync<DashboardOverviewDto>(endpoint);
+    }
+}

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -49,6 +49,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<CsvHeaderMappingHttpClient>()
                 .AddScoped<AccountDataSynchronizationService>()
                 .AddScoped<NavMenuStateCacheService>()
+                .AddScoped<DashboardHttpClient>()
                 .AddScoped<DashboardOverviewCardsCacheService>()
                 .AddScoped<AssetsPageCardsCacheService>()
                 .AddScoped<InvestmentPaycheckEstimateCacheService>()


### PR DESCRIPTION
Closes #398

Phase 3 of the dashboard load-time optimization (#395). Builds on the card/view split (#396) and the backend `GET /api/Dashboard/overview` read model (#397), both merged.

## What changed

The dashboard now performs **one** data load for first paint instead of letting every card fetch its own endpoint.

- **`DashboardHttpClient`** (new) calls `GET /api/Dashboard/overview?userId&currencyId&start&end` and returns the existing `DashboardOverviewDto` (the Domain DTO is reused; no separate frontend model needed). Registered scoped in `ServiceCollectionExtension`.
- **`Dashboard.razor.cs`** loads the overview once on init and on date change, holding `DashboardOverviewDto? _overview` plus `_isLoading`/`_hasError`. It maps the response into small card-specific models and passes them to each first-paint card via explicit `[Parameter]` values.
- **Card models** (`DashboardCardModels.cs`, new): `TimeSeriesCardModel`, `DistributionCardModel`, `NameValueListCardModel` — so cards receive prepared data without depending on the whole DTO.
- **Cards** (NetWorth, NetCashFlow, ClosingBalance, Liabilities, FinancialLabels, Assets, Expense): each gains an optional `[Parameter] Model`. **If a model is provided the card renders it (applying the same transform it already used); otherwise it self-loads exactly as before.** `FinancialInsightsCarousel` and `RecurringTransactionDetectorCard` stay self-loading — they are deferred from the overview per #397.
- **`Dashboard.razor`** shows a dashboard-level loading skeleton until the first overview load resolves, then renders the grid with mapped models, plus an error alert with Retry. Held overview data is swapped atomically at the end of a reload, so cards keep their UI state (e.g. the type/account toggle) and never double-fetch on first paint.

## Behaviour

- One overview request on first paint; first-paint cards no longer fetch their own data when a model is provided.
- Cards still self-load when used standalone outside the dashboard (null model → existing behaviour).
- Date changes reload the overview and remap the card models.
- Not authenticated / fetch failure → null models → existing self-load fallback, with an error/retry surfaced at the dashboard level.

## Verification

- `dotnet build` clean (warnings-as-errors), `dotnet format` applied.
- Unit tests: 445 passed. Architecture tests: 9 passed.
- Rendered on the guest account and screenshotted on mobile + desktop; all cards populate from the single overview load and the layout is equivalent to before. (Booting the guest flow in the cloud sandbox required supplying the otherwise-unset dev `JwtConfig` Issuer/Audience/TokenValidityMins via environment variables — a sandbox config gap, not a code change.)

Changelog updated under `[Unreleased] → Changed`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJMAT78dEeTinWxyuN1RzU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dashboard displays loading skeleton placeholders while fetching data.
  * Error alerts with retry button when dashboard load fails.
  * Dashboard cards now coordinate better for consistent data display.

* **Improvements**
  * Optimized dashboard performance and loading efficiency.
  * Enhanced error handling with clearer feedback to users.
  * Improved data synchronization across dashboard components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->