### PR TITLE
Fix AccountRepository.GetAccount calling GetNextOlder twice for CurrencyAccount #415

### DIFF
--- a/code/FinanceManager.Infrastructure/Repositories/AccountRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/AccountRepository.cs
@@ -76,7 +76,7 @@ public class AccountRepository(ICurrencyAccountRepository<CurrencyAccount> curre
                 var entries = await currencyEntryRepository.Get(resultAccount.AccountId, dateStart, dateEnd).ToListAsync();
 
                 var nextOlderEntry = await currencyEntryRepository.GetNextOlder(resultAccount.AccountId, dateStart);
-                var nextYoungerEntry = await currencyEntryRepository.GetNextOlder(resultAccount.AccountId, dateStart);
+                var nextYoungerEntry = await currencyEntryRepository.GetNextYounger(resultAccount.AccountId, dateStart);
 
                 if (entries.Count == 0 && nextOlderEntry is not null)
                     entries = [nextOlderEntry];

--- a/code/FinanceManager.Tests.Integration/Controllers/CurrencyAccountControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/CurrencyAccountControllerTests.cs
@@ -294,6 +294,25 @@ public class CurrencyAccountControllerTests(OptionsProvider optionsProvider) : C
     }
 
     [Fact]
+    public async Task GetWithDateRange_PopulatesDistinctYoungerAndOlderBoundaryEntries()
+    {
+        await SeedAccountWithEntries();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new CurrencyAccountHttpClient(Client);
+        var startDate = DateTime.UtcNow.Date.AddDays(-3);
+        var endDate = DateTime.UtcNow.Date;
+
+        var account = await client.GetAccountWithEntriesAsync(_testAccountId, startDate, endDate);
+
+        Assert.NotNull(account);
+        // NextOlderEntry should be entry 2 (from -5 days, before the range starting at -3)
+        Assert.NotNull(account!.NextOlderEntry);
+        Assert.Equal(2, account.NextOlderEntry!.EntryId);
+        // NextYoungerEntry should be null (no entries after the range ending at today)
+        Assert.Null(account.NextYoungerEntry);
+    }
+
+    [Fact]
     public async Task ExportCsv_ReturnsCsvFile()
     {
         await SeedAccountWithEntries();


### PR DESCRIPTION
## Summary

Fixes a correctness bug in `AccountRepository.GetAccount` where the `CurrencyAccount` branch was incorrectly calling `GetNextOlder` twice instead of calling `GetNextYounger` for the second boundary entry. This caused:
1. A correctness bug where both `NextOlderEntry` and `NextYoungerEntry` contained the same data
2. A wasted duplicate database query on every currency account fetch

The stock and bond branches already correctly call `GetNextYounger` for the second boundary entry.

## Test plan

- [x] All 248 integration tests pass, including new test validating distinct younger/older boundary entries
- [x] All 445 unit tests pass
- [x] Build succeeds with no warnings
- [x] Code formatting verified

Closes #415

---
_Generated by [Claude Code](https://claude.ai/code/session_0138pifZk6bJkfmxVcauJZxa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an issue in currency account data retrieval where boundary entries were being fetched using incorrect logic, ensuring accurate results when querying account information.

* **Tests**
  * Added integration test to validate that currency account queries with date range filters properly handle and display boundary entry information for entries just outside the specified range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->