### PR TITLE
Use ExecuteDeleteAsync for account-wide entry deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ rules agents must follow when updating this file.
 
 ## [Unreleased]
 
+### Changed
+- Deleting an account with many entries is now significantly faster; the server no longer loads every entry into memory before deleting. #413
+
 ### Added
 - Admin page (`/Admin/ServiceKeys`) for managing external service API credentials (Alpha Vantage, OpenFIGI); keys are persisted in the database and take effect immediately without redeployment. #358
 

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
@@ -63,6 +63,14 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
 
     public async Task<bool> Delete(int accountId)
     {
+        if (context.Database.IsRelational())
+        {
+            var deleted = await context.BondEntries
+                .Where(e => e.AccountId == accountId)
+                .ExecuteDeleteAsync();
+            return deleted > 0;
+        }
+
         var entriesToRemove = await context.BondEntries.Where(e => e.AccountId == accountId).ToListAsync();
         context.BondEntries.RemoveRange(entriesToRemove);
         await context.SaveChangesAsync();

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryRepository.cs
@@ -60,6 +60,14 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
 
     public async Task<bool> Delete(int accountId)
     {
+        if (context.Database.IsRelational())
+        {
+            var deleted = await context.CurrencyEntries
+                .Where(e => e.AccountId == accountId)
+                .ExecuteDeleteAsync();
+            return deleted > 0;
+        }
+
         var entriesToRemove = await context.CurrencyEntries.Where(e => e.AccountId == accountId).ToListAsync();
         context.CurrencyEntries.RemoveRange(entriesToRemove);
         await context.SaveChangesAsync();

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/StockEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/StockEntryRepository.cs
@@ -61,6 +61,14 @@ public class StockEntryRepository(AppDbContext context) : IStockAccountEntryRepo
     }
     public async Task<bool> Delete(int accountId)
     {
+        if (context.Database.IsRelational())
+        {
+            var deleted = await context.StockEntries
+                .Where(e => e.AccountId == accountId)
+                .ExecuteDeleteAsync();
+            return deleted > 0;
+        }
+
         var entries = await context.StockEntries.Where(e => e.AccountId == accountId).ToListAsync();
         context.StockEntries.RemoveRange(entries);
         await context.SaveChangesAsync();

--- a/code/FinanceManager.Infrastructure/Repositories/Account/StockAccountRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/StockAccountRepository.cs
@@ -27,6 +27,14 @@ internal class StockAccountRepository(AppDbContext context) : IAccountRepository
 
     public async Task<bool> Delete(int accountId)
     {
+        if (context.Database.IsRelational())
+        {
+            var deleted = await context.Accounts
+                .Where(x => x.AccountId == accountId)
+                .ExecuteDeleteAsync();
+            return deleted > 0;
+        }
+
         var toRemove = await context.Accounts.Where(x => x.AccountId == accountId).ToListAsync();
         if (toRemove.Count == 0) return false;
         context.Accounts.RemoveRange(toRemove);


### PR DESCRIPTION
## Summary

- Replace load-then-`RemoveRange` with `ExecuteDeleteAsync` in `CurrencyEntryRepository`, `StockEntryRepository`, `BondEntryRepository`, and `StockAccountRepository`
- Uses the `IsRelational()` fallback pattern (same as `UserRepository` and `PasswordResetTokenRepository`) so integration tests on the InMemory provider continue using the tracked path
- `CurrencyAccountEntryFinancialLabel` join table is cleaned up automatically by the DB-level cascade that EF Core already configures on that FK

## Test plan

- [ ] Unit tests pass (`dotnet test --project FinanceManager.Tests.Unit`)
- [ ] Integration tests pass (`dotnet test --project FinanceManager.Tests.Integration`)
- [ ] Manually delete an account with many entries and verify it completes without error

closes #413

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6Z9V1bFymVroe5h9m5GNz)_