### PR TITLE
Batch admin user list capacity counting with grouped query #414

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ rules agents must follow when updating this file.
 - Stock price queries (`Get`, `GetRange`, `Update`, bulk import) now use sargable date predicates so the `(StockIsin, Date)` index is used for seeks instead of full scans; the gap-search look-back is bounded to two years; and bulk import preloads all required data in two queries instead of two per price. #409
 - Adding, editing, or deleting a historical transaction on a large account is now significantly faster; the running-balance recalculation is performed as a single database statement instead of one update per row. #412
 - Deleting an account with many entries is now significantly faster; the server no longer loads every entry into memory before deleting. #413
+- The admin user list now loads its used-record-capacity column with a single grouped count query for the whole page instead of one count query per account per user, and fetches the page of users in one query; the previous code also blocked a thread on a synchronous `.Result` call per row. #414
 
 ### Added
 - Admin page (`/Admin/ServiceKeys`) for managing external service API credentials (Alpha Vantage, OpenFIGI); keys are persisted in the database and take effect immediately without redeployment. #358

--- a/code/FinanceManager.Application/Administration/Users/AdministrationUsersService.cs
+++ b/code/FinanceManager.Application/Administration/Users/AdministrationUsersService.cs
@@ -42,12 +42,13 @@ public class AdministrationUsersService(IFinancialAccountRepository financialAcc
     public Task<int?> GetTotalTrackedMoney() => Task.FromResult<int?>(null);
     public async IAsyncEnumerable<UserDetails> GetUsers(int recordIndex, int recordsCount)
     {
+        var users = await userRepository.GetUsers(recordIndex, recordsCount).ToListAsync();
+        if (users.Count == 0) yield break;
 
-        foreach (var userId in await userRepository.GetUsersIds(recordIndex, recordsCount).ToListAsync())
+        var usedCapacities = await userPlanVerifier.GetUsedRecordsCapacity(users.Select(x => x.UserId).ToList());
+
+        foreach (var user in users)
         {
-            var user = await userRepository.GetUser(userId);
-            if (user is null) continue;
-
             yield return new()
             {
                 UserId = user.UserId,
@@ -55,7 +56,7 @@ public class AdministrationUsersService(IFinancialAccountRepository financialAcc
                 PricingLevel = user.PricingLevel,
                 RecordCapacity = new RecordCapacity()
                 {
-                    UsedCapacity = userPlanVerifier.GetUsedRecordsCapacity(user.UserId).Result,
+                    UsedCapacity = usedCapacities.TryGetValue(user.UserId, out var used) ? used : 0,
                     TotalCapacity = PricingProvider.GetMaxAllowedEntries(user.PricingLevel)
                 }
             };

--- a/code/FinanceManager.Application/Identity/Users/IUserPlanVerifier.cs
+++ b/code/FinanceManager.Application/Identity/Users/IUserPlanVerifier.cs
@@ -6,4 +6,10 @@ public interface IUserPlanVerifier
     Task<bool> CanAddMoreAccounts(int userId);
     Task<bool> CanAddMoreEntries(int userId, int entriesCount = 1);
     Task<int> GetUsedRecordsCapacity(int userId);
+
+    /// <summary>
+    /// Returns the used record capacity for each supplied user, computed with a single grouped count
+    /// query. Every requested user id is present in the result; users with no entries map to zero.
+    /// </summary>
+    Task<IReadOnlyDictionary<int, int>> GetUsedRecordsCapacity(IReadOnlyCollection<int> userIds);
 }

--- a/code/FinanceManager.Application/Identity/Users/UserPlanVerifier.cs
+++ b/code/FinanceManager.Application/Identity/Users/UserPlanVerifier.cs
@@ -5,17 +5,20 @@ using FinanceManager.Domain.Repositories.Account;
 namespace FinanceManager.Application.Identity.Users;
 
 public class UserPlanVerifier(ICurrencyAccountRepository<CurrencyAccount> currencyAccountRepository,
-    IAccountEntryRepository<CurrencyAccountEntry> currencyAccountEntryRepository,
     IUserRepository userRepository) : IUserPlanVerifier
 {
     public async Task<int> GetUsedRecordsCapacity(int userId)
     {
-        int totalEntries = 0;
+        var counts = await currencyAccountRepository.GetEntriesCountPerUser([userId]);
+        return counts.TryGetValue(userId, out var count) ? count : 0;
+    }
 
-        foreach (var account in await currencyAccountRepository.GetAvailableAccounts(userId).ToListAsync())
-            totalEntries += await currencyAccountEntryRepository.GetCount(account.AccountId);
+    public async Task<IReadOnlyDictionary<int, int>> GetUsedRecordsCapacity(IReadOnlyCollection<int> userIds)
+    {
+        if (userIds.Count == 0) return new Dictionary<int, int>();
 
-        return await Task.FromResult(totalEntries);
+        var counts = await currencyAccountRepository.GetEntriesCountPerUser(userIds);
+        return userIds.Distinct().ToDictionary(id => id, id => counts.TryGetValue(id, out var count) ? count : 0);
     }
 
     public async Task<bool> CanAddMoreEntries(int userId, int entriesCount = 1)

--- a/code/FinanceManager.Domain/Repositories/Account/ICurrencyAccountRepository.cs
+++ b/code/FinanceManager.Domain/Repositories/Account/ICurrencyAccountRepository.cs
@@ -6,4 +6,11 @@ public interface ICurrencyAccountRepository<T> : IAccountRepository<T>
 {
     Task<int?> Add(int userId, string accountName, AccountLabel accountType);
     Task<bool> Update(int accountId, string accountName, AccountLabel accountType);
+
+    /// <summary>
+    /// Counts currency-account entries for each of the supplied users in a single grouped query.
+    /// Users with no currency entries are omitted from the result, so callers should treat a missing
+    /// key as a count of zero. Replaces the previous one-COUNT-per-account fan-out.
+    /// </summary>
+    Task<IReadOnlyDictionary<int, int>> GetEntriesCountPerUser(IReadOnlyCollection<int> userIds, CancellationToken cancellationToken = default);
 }

--- a/code/FinanceManager.Infrastructure/Repositories/Account/CurrencyAccountRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/CurrencyAccountRepository.cs
@@ -46,6 +46,21 @@ internal class CurrencyAccountRepository(AppDbContext context) : ICurrencyAccoun
         .Select(x => new AvailableAccount(x.AccountId, x.Name))
         .AsAsyncEnumerable();
 
+    public async Task<IReadOnlyDictionary<int, int>> GetEntriesCountPerUser(IReadOnlyCollection<int> userIds, CancellationToken cancellationToken = default)
+    {
+        if (userIds.Count == 0) return new Dictionary<int, int>();
+
+        var counts = await (
+            from account in context.Accounts
+            where account.AccountType == AccountType.Currency && userIds.Contains(account.UserId)
+            join entry in context.CurrencyEntries on account.AccountId equals entry.AccountId
+            group entry by account.UserId into grouped
+            select new { UserId = grouped.Key, Count = grouped.Count() })
+            .ToDictionaryAsync(x => x.UserId, x => x.Count, cancellationToken);
+
+        return counts;
+    }
+
     public Task<bool> Exists(int accountId) => context.Accounts.AnyAsync(x => x.AccountId == accountId && x.AccountType == AccountType.Currency);
 
     public async Task<CurrencyAccount?> Get(int accountId)

--- a/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
@@ -82,6 +82,7 @@ public class UserRepository(AppDbContext context) : IUserRepository
         return userDto.ToUser();
     }
     public IAsyncEnumerable<User> GetUsers(int recordIndex, int recordsCount) => context.Users
+        .OrderBy(x => x.Id)
         .Skip(recordIndex)
         .Take(recordsCount)
         .Select(x => x.ToUser())

--- a/code/FinanceManager.Tests.Unit/Application/Services/AdministrationUsersServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/AdministrationUsersServiceTests.cs
@@ -1,0 +1,88 @@
+using FinanceManager.Application.Administration.Users;
+using FinanceManager.Application.Identity.Users;
+using FinanceManager.Domain.Entities.Users;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories;
+using FinanceManager.Domain.Repositories.Account;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class AdministrationUsersServiceTests
+{
+    private readonly Mock<IFinancialAccountRepository> _financialAccountRepositoryMock = new();
+    private readonly Mock<IUserRepository> _userRepositoryMock = new();
+    private readonly Mock<IActiveUsersRepository> _activeUsersRepositoryMock = new();
+    private readonly Mock<IUserPlanVerifier> _userPlanVerifierMock = new();
+    private readonly AdministrationUsersService _service;
+
+    public AdministrationUsersServiceTests() => _service = new(
+        _financialAccountRepositoryMock.Object, _userRepositoryMock.Object,
+        _activeUsersRepositoryMock.Object, _userPlanVerifierMock.Object);
+
+    [Fact]
+    public async Task GetUsers_FetchesPageOnce_AndBatchesUsedCapacity()
+    {
+        // Arrange
+        var users = new[]
+        {
+            new User { UserId = 1, Login = "alice", CreationDate = DateTime.UtcNow, PricingLevel = PricingLevel.Free },
+            new User { UserId = 2, Login = "bob", CreationDate = DateTime.UtcNow, PricingLevel = PricingLevel.Premium },
+        };
+
+        _userRepositoryMock.Setup(repo => repo.GetUsers(0, 10)).Returns(users.ToAsyncEnumerable());
+        _userPlanVerifierMock.Setup(v => v.GetUsedRecordsCapacity(It.IsAny<IReadOnlyCollection<int>>()))
+            .ReturnsAsync(new Dictionary<int, int> { [1] = 42, [2] = 100 });
+
+        // Act
+        var result = await _service.GetUsers(0, 10).ToListAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Equal(42, result[0].RecordCapacity.UsedCapacity);
+        Assert.Equal(PricingProvider.GetMaxAllowedEntries(PricingLevel.Free), result[0].RecordCapacity.TotalCapacity);
+        Assert.Equal(100, result[1].RecordCapacity.UsedCapacity);
+
+        // Capacity is resolved with a single batched call, and there is no per-user GetUser lookup.
+        _userPlanVerifierMock.Verify(v => v.GetUsedRecordsCapacity(It.IsAny<IReadOnlyCollection<int>>()), Times.Once);
+        _userPlanVerifierMock.Verify(v => v.GetUsedRecordsCapacity(It.IsAny<int>()), Times.Never);
+        _userRepositoryMock.Verify(repo => repo.GetUser(It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetUsers_MissingCapacityEntry_DefaultsToZero()
+    {
+        // Arrange
+        var users = new[]
+        {
+            new User { UserId = 5, Login = "carol", CreationDate = DateTime.UtcNow, PricingLevel = PricingLevel.Basic },
+        };
+
+        _userRepositoryMock.Setup(repo => repo.GetUsers(0, 10)).Returns(users.ToAsyncEnumerable());
+        _userPlanVerifierMock.Setup(v => v.GetUsedRecordsCapacity(It.IsAny<IReadOnlyCollection<int>>()))
+            .ReturnsAsync(new Dictionary<int, int>());
+
+        // Act
+        var result = await _service.GetUsers(0, 10).ToListAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var single = Assert.Single(result);
+        Assert.Equal(0, single.RecordCapacity.UsedCapacity);
+    }
+
+    [Fact]
+    public async Task GetUsers_NoUsers_DoesNotQueryCapacity()
+    {
+        // Arrange
+        _userRepositoryMock.Setup(repo => repo.GetUsers(0, 10)).Returns(Array.Empty<User>().ToAsyncEnumerable());
+
+        // Act
+        var result = await _service.GetUsers(0, 10).ToListAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(result);
+        _userPlanVerifierMock.Verify(v => v.GetUsedRecordsCapacity(It.IsAny<IReadOnlyCollection<int>>()), Times.Never);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/CurrencyAccountImportServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/CurrencyAccountImportServiceTests.cs
@@ -33,7 +33,11 @@ public class CurrencyAccountImportServiceTests
         _mockUserRepository.Setup(x => x.GetUser(It.IsAny<int>())).ReturnsAsync(user);
 
         // create a real UserPlanVerifier so its CanAddMoreEntries method can be used in test
-        _userPlanVerifier = new UserPlanVerifier(_mockAccountRepository.Object, _mockAccountEntryRepository.Object, _mockUserRepository.Object);
+        _userPlanVerifier = new UserPlanVerifier(_mockAccountRepository.Object, _mockUserRepository.Object);
+
+        // Default: users have no recorded entries, so plan checks pass unless a test overrides this.
+        _mockAccountRepository.Setup(x => x.GetEntriesCountPerUser(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, int>());
 
         var mockLogger = new Mock<ILogger<CurrencyAccountImportService>>();
         var importAccountValidator = new ImportAccountValidator(_userPlanVerifier);
@@ -114,11 +118,10 @@ public class CurrencyAccountImportServiceTests
 
         var account = new CurrencyAccount(userId, accountId, "Test");
         _mockAccountRepository.Setup(x => x.Get(accountId)).ReturnsAsync(account);
-        _mockAccountRepository.Setup(x => x.GetAvailableAccounts(userId))
-            .Returns(new[] { new AvailableAccount(accountId, "Test") }.ToAsyncEnumerable());
 
-        // Already at limit
-        _mockAccountEntryRepository.Setup(x => x.GetCount(accountId)).ReturnsAsync(1000);
+        // Already at the Free plan limit
+        _mockAccountRepository.Setup(x => x.GetEntriesCountPerUser(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, int> { [userId] = 1000 });
 
         var entries = new[] { new CurrencyEntryImport(DateTime.UtcNow, 100m, "Test") };
 

--- a/code/FinanceManager.Tests.Unit/Application/Services/UserPlanVerifierTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/UserPlanVerifierTests.cs
@@ -14,31 +14,75 @@ namespace FinanceManager.Tests.Unit.Application.Services;
 public class UserPlanVerifierTests
 {
     private readonly Mock<ICurrencyAccountRepository<CurrencyAccount>> _currencyAccountRepositoryMock = new();
-    private readonly Mock<IAccountEntryRepository<CurrencyAccountEntry>> _accountEntryRepositoryMock = new();
     private readonly Mock<IUserRepository> _userRepositoryMock = new();
     private readonly UserPlanVerifier _userPlanVerifier;
 
-    public UserPlanVerifierTests() => _userPlanVerifier = new(_currencyAccountRepositoryMock.Object, _accountEntryRepositoryMock.Object, _userRepositoryMock.Object);
+    public UserPlanVerifierTests() => _userPlanVerifier = new(_currencyAccountRepositoryMock.Object, _userRepositoryMock.Object);
+
+    private void SetupUsedCapacity(int userId, int usedEntries) =>
+        _currencyAccountRepositoryMock.Setup(repo => repo.GetEntriesCountPerUser(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.Contains(userId)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, int> { [userId] = usedEntries });
 
     [Fact]
-    public async Task GetUsedRecordsCapacity_ReturnsTotalEntriesAcrossAccounts()
+    public async Task GetUsedRecordsCapacity_ReturnsGroupedCountForUser()
     {
         // Arrange
         var userId = 1;
-        var account1 = new AvailableAccount(1, "Account1");
-        var account2 = new AvailableAccount(2, "Account2");
-
-        _currencyAccountRepositoryMock.Setup(repo => repo.GetAvailableAccounts(userId))
-        .Returns(new[] { account1, account2 }.ToAsyncEnumerable());
-
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(1)).ReturnsAsync(10);
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(2)).ReturnsAsync(5);
+        SetupUsedCapacity(userId, 15);
 
         // Act
         var result = await _userPlanVerifier.GetUsedRecordsCapacity(userId);
 
         // Assert
         Assert.Equal(15, result);
+    }
+
+    [Fact]
+    public async Task GetUsedRecordsCapacity_NoEntries_ReturnsZero()
+    {
+        // Arrange
+        var userId = 1;
+        _currencyAccountRepositoryMock.Setup(repo => repo.GetEntriesCountPerUser(
+                It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, int>());
+
+        // Act
+        var result = await _userPlanVerifier.GetUsedRecordsCapacity(userId);
+
+        // Assert
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task GetUsedRecordsCapacity_Batch_ReturnsZeroForUsersWithoutEntries()
+    {
+        // Arrange
+        var userIds = new[] { 1, 2, 3 };
+        _currencyAccountRepositoryMock.Setup(repo => repo.GetEntriesCountPerUser(
+                It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, int> { [1] = 250, [3] = 125 });
+
+        // Act
+        var result = await _userPlanVerifier.GetUsedRecordsCapacity(userIds);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(250, result[1]);
+        Assert.Equal(0, result[2]);
+        Assert.Equal(125, result[3]);
+    }
+
+    [Fact]
+    public async Task GetUsedRecordsCapacity_Batch_EmptyInput_ReturnsEmpty()
+    {
+        // Act
+        var result = await _userPlanVerifier.GetUsedRecordsCapacity(Array.Empty<int>());
+
+        // Assert
+        Assert.Empty(result);
+        _currencyAccountRepositoryMock.Verify(repo => repo.GetEntriesCountPerUser(
+            It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Theory]
@@ -52,11 +96,7 @@ public class UserPlanVerifierTests
         var user = new User { UserId = userId, Login = "test", CreationDate = DateTime.UtcNow, PricingLevel = pricingLevel };
 
         _userRepositoryMock.Setup(repo => repo.GetUser(userId)).ReturnsAsync(user);
-
-        var account = new AvailableAccount(1, "Account1");
-        _currencyAccountRepositoryMock.Setup(repo => repo.GetAvailableAccounts(userId))
-        .Returns(new[] { account }.ToAsyncEnumerable());
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(1)).ReturnsAsync(5);
+        SetupUsedCapacity(userId, 5);
 
         // Act
         var result = await _userPlanVerifier.CanAddMoreEntries(userId, 1);
@@ -98,11 +138,7 @@ public class UserPlanVerifierTests
         var user = new User { UserId = userId, Login = "test", CreationDate = DateTime.UtcNow, PricingLevel = pricingLevel };
 
         _userRepositoryMock.Setup(repo => repo.GetUser(userId)).ReturnsAsync(user);
-
-        var account = new AvailableAccount(1, "Account1");
-        _currencyAccountRepositoryMock.Setup(repo => repo.GetAvailableAccounts(userId))
-        .Returns(new[] { account }.ToAsyncEnumerable());
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(1)).ReturnsAsync(PricingProvider.GetMaxAllowedEntries(user.PricingLevel) + 1);
+        SetupUsedCapacity(userId, PricingProvider.GetMaxAllowedEntries(user.PricingLevel) + 1);
 
         // Act
         var result = await _userPlanVerifier.CanAddMoreEntries(userId, 1);
@@ -146,13 +182,7 @@ public class UserPlanVerifierTests
         var user = new User { UserId = userId, Login = "test", CreationDate = DateTime.UtcNow, PricingLevel = pricingLevel };
 
         _userRepositoryMock.Setup(repo => repo.GetUser(userId)).ReturnsAsync(user);
-
-        var account = new AvailableAccount(1, "Account1");
-        _currencyAccountRepositoryMock.Setup(repo => repo.GetAvailableAccounts(userId))
-        .Returns(new[] { account }.ToAsyncEnumerable());
-
-        var limit = PricingProvider.GetMaxAllowedEntries(user.PricingLevel);
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(1)).ReturnsAsync(limit);
+        SetupUsedCapacity(userId, PricingProvider.GetMaxAllowedEntries(user.PricingLevel));
 
         // Act
         var result = await _userPlanVerifier.CanAddMoreEntries(userId, 1);
@@ -173,12 +203,8 @@ public class UserPlanVerifierTests
 
         _userRepositoryMock.Setup(repo => repo.GetUser(userId)).ReturnsAsync(user);
 
-        var account = new AvailableAccount(1, "Account1");
-        _currencyAccountRepositoryMock.Setup(repo => repo.GetAvailableAccounts(userId))
-        .Returns(new[] { account }.ToAsyncEnumerable());
-
         var limit = PricingProvider.GetMaxAllowedEntries(user.PricingLevel);
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(1)).ReturnsAsync(limit - 5);
+        SetupUsedCapacity(userId, limit - 5);
 
         // Act - trying to add 10 entries when only 5 can fit
         var result = await _userPlanVerifier.CanAddMoreEntries(userId, 10);
@@ -199,12 +225,8 @@ public class UserPlanVerifierTests
 
         _userRepositoryMock.Setup(repo => repo.GetUser(userId)).ReturnsAsync(user);
 
-        var account = new AvailableAccount(1, "Account1");
-        _currencyAccountRepositoryMock.Setup(repo => repo.GetAvailableAccounts(userId))
-        .Returns(new[] { account }.ToAsyncEnumerable());
-
         var limit = PricingProvider.GetMaxAllowedEntries(user.PricingLevel);
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(1)).ReturnsAsync(limit - 10);
+        SetupUsedCapacity(userId, limit - 10);
 
         // Act - adding exactly 10 to reach limit
         var result = await _userPlanVerifier.CanAddMoreEntries(userId, 10);
@@ -239,44 +261,6 @@ public class UserPlanVerifierTests
 
         // Assert
         Assert.False(result);
-    }
-
-    [Fact]
-    public async Task GetUsedRecordsCapacity_MultipleAccounts_SumsCorrectly()
-    {
-        // Arrange
-        var userId = 1;
-        var account1 = new AvailableAccount(1, "Account1");
-        var account2 = new AvailableAccount(2, "Account2");
-        var account3 = new AvailableAccount(3, "Account3");
-
-        _currencyAccountRepositoryMock.Setup(repo => repo.GetAvailableAccounts(userId))
-        .Returns(new[] { account1, account2, account3 }.ToAsyncEnumerable());
-
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(1)).ReturnsAsync(250);
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(2)).ReturnsAsync(375);
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(3)).ReturnsAsync(125);
-
-        // Act
-        var result = await _userPlanVerifier.GetUsedRecordsCapacity(userId);
-
-        // Assert
-        Assert.Equal(750, result);
-    }
-
-    [Fact]
-    public async Task GetUsedRecordsCapacity_NoAccounts_ReturnsZero()
-    {
-        // Arrange
-        var userId = 1;
-        _currencyAccountRepositoryMock.Setup(repo => repo.GetAvailableAccounts(userId))
-        .Returns(Array.Empty<AvailableAccount>().ToAsyncEnumerable());
-
-        // Act
-        var result = await _userPlanVerifier.GetUsedRecordsCapacity(userId);
-
-        // Assert
-        Assert.Equal(0, result);
     }
 
     [Fact]
@@ -330,12 +314,8 @@ public class UserPlanVerifierTests
 
         _userRepositoryMock.Setup(repo => repo.GetUser(userId)).ReturnsAsync(user);
 
-        var account = new AvailableAccount(1, "Account1");
-        _currencyAccountRepositoryMock.Setup(repo => repo.GetAvailableAccounts(userId))
-        .Returns(new[] { account }.ToAsyncEnumerable());
-
         var limit = PricingProvider.GetMaxAllowedEntries(user.PricingLevel);
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(1)).ReturnsAsync(limit);
+        SetupUsedCapacity(userId, limit);
 
         // Act - trying to add 0 entries when at limit
         var result = await _userPlanVerifier.CanAddMoreEntries(userId, 0);
@@ -355,11 +335,7 @@ public class UserPlanVerifierTests
         var user = new User { UserId = userId, Login = "test", CreationDate = DateTime.UtcNow, PricingLevel = pricingLevel };
 
         _userRepositoryMock.Setup(repo => repo.GetUser(userId)).ReturnsAsync(user);
-
-        var account = new AvailableAccount(1, "Account1");
-        _currencyAccountRepositoryMock.Setup(repo => repo.GetAvailableAccounts(userId))
-        .Returns(new[] { account }.ToAsyncEnumerable());
-        _accountEntryRepositoryMock.Setup(repo => repo.GetCount(1)).ReturnsAsync(0);
+        SetupUsedCapacity(userId, 0);
 
         // Act - trying to add exactly the limit
         var result = await _userPlanVerifier.CanAddMoreEntries(userId, expectedLimit);


### PR DESCRIPTION
## Summary

Fixes the two performance problems in the admin users / plan-capacity path described in #414:

1. **Sync-over-async `.Result`** — `AdministrationUsersService.GetUsers` blocked a thread-pool thread per user row by calling `userPlanVerifier.GetUsedRecordsCapacity(...).Result` inside an `async` iterator. It now `await`s a batched call.
2. **N+1 capacity counting** — `UserPlanVerifier.GetUsedRecordsCapacity` listed a user's accounts and ran one `COUNT` query per account, and the admin service additionally ran a `GetUser` query per user id on top of the id page it had just fetched. The page cost `N users × (1 + accounts per user)` round trips.

## Changes

- **Infrastructure**: added `ICurrencyAccountRepository.GetEntriesCountPerUser(IReadOnlyCollection<int> userIds)`, implemented in `CurrencyAccountRepository` as a single query that joins accounts to currency entries and groups by `UserId`. Users with no entries are omitted (callers treat a missing key as `0`).
- **Application**: `UserPlanVerifier` now has a batched `GetUsedRecordsCapacity(IReadOnlyCollection<int> userIds)` overload (every requested id present, defaulting to `0`) and the single-user path and `CanAddMoreEntries` both collapse to one grouped count query. The now-unused `IAccountEntryRepository<CurrencyAccountEntry>` dependency was dropped.
- **Application**: `AdministrationUsersService.GetUsers` fetches the page of users in one query (`GetUsers(recordIndex, recordsCount)`) and resolves used capacity for the whole page with a single batched call — no more per-id `GetUser` lookups or `.Result` blocking.
- **Infrastructure**: `UserRepository.GetUsers(recordIndex, recordsCount)` now orders by id for deterministic paging.

## Tests

- Rewrote `UserPlanVerifierTests` to cover the grouped single-user and batched multi-user paths (including zero-defaulting and empty input).
- Added `AdministrationUsersServiceTests` verifying the page is fetched once, capacity is resolved with a single batched call, there is no per-user `GetUser` lookup, and missing capacity entries default to zero.
- Updated `CurrencyAccountImportServiceTests` for the new verifier constructor and capacity source.
- Full unit suite (463) and integration suite (253) pass.

closes #414

https://claude.ai/code/session_014xCX2eGpGtSJyUqWMxRYxX

---
_Generated by [Claude Code](https://claude.ai/code/session_014xCX2eGpGtSJyUqWMxRYxX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of user list pagination by ensuring deterministic result ordering

* **Chores**
  * Optimized performance of user data retrieval and associated capacity calculations

* **Tests**
  * Added comprehensive unit tests for user administration services and plan verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->