### PR TITLE
Collapse per-ISIN N+1 in StockEntryRepository boundary lookups #410

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ rules agents must follow when updating this file.
 - Adding, editing, or deleting a historical transaction on a large account is now significantly faster; the running-balance recalculation is performed as a single database statement instead of one update per row. #412
 - Deleting an account with many entries is now significantly faster; the server no longer loads every entry into memory before deleting. #413
 - The admin user list now loads its used-record-capacity column with a single grouped count query for the whole page instead of one count query per account per user, and fetches the page of users in one query; the previous code also blocked a thread on a synchronous `.Result` call per row. #414
+- Stock account per-ISIN boundary lookups (`GetNextOlder`/`GetNextYounger`), used on the running-balance recalculation hot write path, now resolve every ISIN with one grouped query plus a single fetch instead of one query per ISIN; `GetNextYounger` also gains the missing account filter so it no longer scans every account's entries for the ISIN list. #410
 
 ### Added
 - Admin page (`/Admin/ServiceKeys`) for managing external service API credentials (Alpha Vantage, OpenFIGI); keys are persisted in the database and take effect immediately without redeployment. #358

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/StockEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/StockEntryRepository.cs
@@ -148,27 +148,15 @@ public class StockEntryRepository(AppDbContext context) : IStockAccountEntryRepo
 
     async Task<Dictionary<string, StockAccountEntry>> IStockAccountEntryRepository<StockAccountEntry>.GetNextOlder(int accountId, DateTime date)
     {
-        Dictionary<string, StockAccountEntry> result = [];
+        // Per ISIN held by this account, find the boundary date of the youngest entry
+        // strictly older than the cutoff. One grouped query instead of one query per ISIN.
+        var boundaries = await context.StockEntries
+            .Where(e => e.AccountId == accountId && e.PostingDate < date)
+            .GroupBy(e => e.Isin)
+            .Select(g => new { Isin = g.Key, Date = g.Max(e => e.PostingDate) })
+            .ToListAsync();
 
-        var isins = await context.StockEntries
-                                .Where(e => e.AccountId == accountId)
-                                .Select(m => m.Isin)
-                                .Distinct()
-                                .ToListAsync();
-
-        foreach (var isin in isins)
-        {
-            var nextOlder = await context.StockEntries
-                   .Where(e => e.Isin == isin && e.AccountId == accountId && e.PostingDate < date)
-                   .OrderByDescending(e => e.PostingDate)
-                   .FirstOrDefaultAsync();
-
-            if (nextOlder is null) continue;
-
-            result.Add(isin, nextOlder);
-        }
-
-        return result;
+        return await ResolveBoundaryEntries(accountId, boundaries.Select(b => (b.Isin, b.Date)).ToList());
     }
 
     public async Task<StockAccountEntry?> GetNextYounger(int accountId, int entryId)
@@ -189,19 +177,41 @@ public class StockEntryRepository(AppDbContext context) : IStockAccountEntryRepo
 
     async Task<Dictionary<string, StockAccountEntry>> IStockAccountEntryRepository<StockAccountEntry>.GetNextYounger(int accountId, DateTime date)
     {
+        // Per ISIN held by this account, find the boundary date of the oldest entry
+        // strictly younger than the cutoff. The AccountId filter is essential: without
+        // it the ISIN scan leaks across every account in the table.
+        var boundaries = await context.StockEntries
+            .Where(e => e.AccountId == accountId && e.PostingDate > date)
+            .GroupBy(e => e.Isin)
+            .Select(g => new { Isin = g.Key, Date = g.Min(e => e.PostingDate) })
+            .ToListAsync();
+
+        return await ResolveBoundaryEntries(accountId, boundaries.Select(b => (b.Isin, b.Date)).ToList());
+    }
+
+    // Resolves each (ISIN, boundary date) pair to its entry with a single fetch of the
+    // candidate rows, replacing the previous per-ISIN N+1 round trips.
+    private async Task<Dictionary<string, StockAccountEntry>> ResolveBoundaryEntries(
+        int accountId,
+        IReadOnlyList<(string Isin, DateTime Date)> boundaries)
+    {
         Dictionary<string, StockAccountEntry> result = [];
-        var isins = await context.StockEntries.Select(m => m.Isin).Distinct().ToListAsync();
+        if (boundaries.Count == 0) return result;
 
-        foreach (var isin in isins)
+        var dates = boundaries.Select(b => b.Date).Distinct().ToList();
+
+        var rows = await context.StockEntries
+            .Where(e => e.AccountId == accountId && dates.Contains(e.PostingDate))
+            .ToListAsync();
+
+        var byIsinDate = rows
+            .GroupBy(e => (e.Isin, e.PostingDate))
+            .ToDictionary(g => g.Key, g => g.First());
+
+        foreach (var (isin, date) in boundaries)
         {
-            var nextOlder = await context.StockEntries
-                   .Where(e => e.Isin == isin && e.AccountId == accountId && e.PostingDate > date)
-                   .OrderBy(e => e.PostingDate)
-                   .FirstOrDefaultAsync();
-
-            if (nextOlder is null) continue;
-
-            result.Add(isin, nextOlder);
+            if (byIsinDate.TryGetValue((isin, date), out var entry))
+                result[isin] = entry;
         }
 
         return result;

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/StockEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/StockEntryRepository.cs
@@ -146,10 +146,13 @@ public class StockEntryRepository(AppDbContext context) : IStockAccountEntryRepo
             .FirstOrDefaultAsync();
     }
 
+    /// <summary>
+    /// For each ISIN held by this account, returns the youngest entry strictly older than the given date.
+    /// Uses a single grouped query to find all per-ISIN boundary dates, then resolves them in one fetch,
+    /// eliminating the previous N+1 pattern of one query per ISIN.
+    /// </summary>
     async Task<Dictionary<string, StockAccountEntry>> IStockAccountEntryRepository<StockAccountEntry>.GetNextOlder(int accountId, DateTime date)
     {
-        // Per ISIN held by this account, find the boundary date of the youngest entry
-        // strictly older than the cutoff. One grouped query instead of one query per ISIN.
         var boundaries = await context.StockEntries
             .Where(e => e.AccountId == accountId && e.PostingDate < date)
             .GroupBy(e => e.Isin)
@@ -175,11 +178,14 @@ public class StockEntryRepository(AppDbContext context) : IStockAccountEntryRepo
             .FirstOrDefaultAsync();
 
 
+    /// <summary>
+    /// For each ISIN held by this account, returns the oldest entry strictly younger than the given date.
+    /// Uses a single grouped query scoped by AccountId to find all per-ISIN boundary dates, then resolves
+    /// them in one fetch. The AccountId filter is essential to prevent leaking across all accounts' ISINs.
+    /// Previously only applied at the inner query, causing the ISIN list to be sourced from the entire table.
+    /// </summary>
     async Task<Dictionary<string, StockAccountEntry>> IStockAccountEntryRepository<StockAccountEntry>.GetNextYounger(int accountId, DateTime date)
     {
-        // Per ISIN held by this account, find the boundary date of the oldest entry
-        // strictly younger than the cutoff. The AccountId filter is essential: without
-        // it the ISIN scan leaks across every account in the table.
         var boundaries = await context.StockEntries
             .Where(e => e.AccountId == accountId && e.PostingDate > date)
             .GroupBy(e => e.Isin)
@@ -189,8 +195,10 @@ public class StockEntryRepository(AppDbContext context) : IStockAccountEntryRepo
         return await ResolveBoundaryEntries(accountId, boundaries.Select(b => (b.Isin, b.Date)).ToList());
     }
 
-    // Resolves each (ISIN, boundary date) pair to its entry with a single fetch of the
-    // candidate rows, replacing the previous per-ISIN N+1 round trips.
+    /// <summary>
+    /// Resolves a list of (ISIN, boundary date) pairs to their corresponding entries with a single fetch,
+    /// avoiding N+1 round trips. Groups candidate rows by (ISIN, PostingDate) for O(1) lookup.
+    /// </summary>
     private async Task<Dictionary<string, StockAccountEntry>> ResolveBoundaryEntries(
         int accountId,
         IReadOnlyList<(string Isin, DateTime Date)> boundaries)

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/StockEntryRepositoryTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/StockEntryRepositoryTests.cs
@@ -1,0 +1,128 @@
+using FinanceManager.Domain.Entities.Stocks;
+using FinanceManager.Domain.Enums;
+using FinanceManager.Domain.Repositories.Account;
+using FinanceManager.Infrastructure.Contexts;
+using FinanceManager.Infrastructure.Repositories.Account.Entry;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Tests.Unit.Infrastructure.Repositories;
+
+[Collection("Infrastructure")]
+[Trait("Category", "Unit")]
+public class StockEntryRepositoryTests
+{
+    private const int _accountId = 1;
+    private const int _otherAccountId = 2;
+    private const string _apple = "US0378331005";
+    private const string _microsoft = "US5949181045";
+
+    private static readonly DateTime _jan10 = new(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime _jan15 = new(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime _jan20 = new(2025, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AppDbContext(options);
+    }
+
+    private static StockAccountEntry Entry(int accountId, DateTime date, string isin, decimal value) =>
+        new(accountId, 0, date, value, value, isin, InvestmentType.Stock);
+
+    // -------------------------------------------------------------------------
+    // GetNextOlder (per-ISIN, date) — account isolation + per-ISIN boundary
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetNextOlder_ReturnsYoungestEntryOlderThanDate_PerIsin()
+    {
+        await using var ctx = CreateContext();
+        var repo = new StockEntryRepository(ctx);
+        await repo.Add(Entry(_accountId, _jan10, _apple, 100m));
+        await repo.Add(Entry(_accountId, _jan15, _apple, 130m));
+        await repo.Add(Entry(_accountId, _jan10, _microsoft, 200m));
+
+        var result = await ((IStockAccountEntryRepository<StockAccountEntry>)repo).GetNextOlder(_accountId, _jan20);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(_jan15, result[_apple].PostingDate);   // youngest apple older than jan20
+        Assert.Equal(_jan10, result[_microsoft].PostingDate);
+    }
+
+    [Fact]
+    public async Task GetNextOlder_ExcludesEntriesFromOtherAccounts()
+    {
+        await using var ctx = CreateContext();
+        var repo = new StockEntryRepository(ctx);
+        await repo.Add(Entry(_accountId, _jan10, _apple, 100m));
+        await repo.Add(Entry(_otherAccountId, _jan15, _microsoft, 999m));
+
+        var result = await ((IStockAccountEntryRepository<StockAccountEntry>)repo).GetNextOlder(_accountId, _jan20);
+
+        Assert.True(result.ContainsKey(_apple));
+        Assert.False(result.ContainsKey(_microsoft)); // belongs to another account
+        Assert.All(result.Values, e => Assert.Equal(_accountId, e.AccountId));
+    }
+
+    [Fact]
+    public async Task GetNextOlder_ReturnsEmpty_WhenNoEntriesOlderThanDate()
+    {
+        await using var ctx = CreateContext();
+        var repo = new StockEntryRepository(ctx);
+        await repo.Add(Entry(_accountId, _jan20, _apple, 100m));
+
+        var result = await ((IStockAccountEntryRepository<StockAccountEntry>)repo).GetNextOlder(_accountId, _jan10);
+
+        Assert.Empty(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // GetNextYounger (per-ISIN, date) — the account-isolation bug from #410
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetNextYounger_ReturnsOldestEntryYoungerThanDate_PerIsin()
+    {
+        await using var ctx = CreateContext();
+        var repo = new StockEntryRepository(ctx);
+        await repo.Add(Entry(_accountId, _jan15, _apple, 100m));
+        await repo.Add(Entry(_accountId, _jan20, _apple, 130m));
+        await repo.Add(Entry(_accountId, _jan20, _microsoft, 200m));
+
+        var result = await ((IStockAccountEntryRepository<StockAccountEntry>)repo).GetNextYounger(_accountId, _jan10);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(_jan15, result[_apple].PostingDate);   // oldest apple younger than jan10
+        Assert.Equal(_jan20, result[_microsoft].PostingDate);
+    }
+
+    [Fact]
+    public async Task GetNextYounger_ExcludesEntriesFromOtherAccounts()
+    {
+        await using var ctx = CreateContext();
+        var repo = new StockEntryRepository(ctx);
+        await repo.Add(Entry(_accountId, _jan15, _apple, 100m));
+        // Another account holds a different ISIN — must not leak into the result.
+        await repo.Add(Entry(_otherAccountId, _jan20, _microsoft, 999m));
+
+        var result = await ((IStockAccountEntryRepository<StockAccountEntry>)repo).GetNextYounger(_accountId, _jan10);
+
+        Assert.True(result.ContainsKey(_apple));
+        Assert.False(result.ContainsKey(_microsoft)); // belongs to another account
+        Assert.All(result.Values, e => Assert.Equal(_accountId, e.AccountId));
+    }
+
+    [Fact]
+    public async Task GetNextYounger_ReturnsEmpty_WhenNoEntriesYoungerThanDate()
+    {
+        await using var ctx = CreateContext();
+        var repo = new StockEntryRepository(ctx);
+        await repo.Add(Entry(_accountId, _jan10, _apple, 100m));
+
+        var result = await ((IStockAccountEntryRepository<StockAccountEntry>)repo).GetNextYounger(_accountId, _jan20);
+
+        Assert.Empty(result);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the N+1 query pattern and account-isolation bug in `StockEntryRepository`'s per-ISIN boundary lookups (`GetNextOlder`/`GetNextYounger`), which run on the running-balance recalculation hot write path.

### Changes
- Both interface implementations of `GetNextOlder(int, DateTime)` and `GetNextYounger(int, DateTime)` now resolve every ISIN's boundary entry with **one grouped query** (`GroupBy(Isin).Select(Max/Min(PostingDate))`) plus a **single targeted fetch** of the candidate rows, instead of one query per distinct ISIN.
- `GetNextYounger` gains the missing `AccountId` filter on its ISIN list. Previously it gathered distinct ISINs across the **whole** `StockEntries` table and then issued a per-ISIN query for ISINs the account doesn't hold — wasted round trips that grew with total table size, not account size.
- New shared private helper `ResolveBoundaryEntries` maps each `(ISIN, boundary date)` pair back to its entry in memory.

### Tests
Added `StockEntryRepositoryTests` (unit, InMemory provider) covering per-ISIN boundary selection, empty results, and — per the issue — **account isolation**: entries from another account must not appear in either method's result.

- `dotnet build`: clean (0 warnings).
- Unit tests: 473 passed.
- The 4 failing `LoginControllerTests.Login_AsGuest_*` integration tests are pre-existing on `develop` (verified by stashing this change) and unrelated to this work.

closes #410

---
_Generated by [Claude Code](https://claude.ai/code/session_017sNgVnRnbY4uxRtaN6CsAV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for stock entry boundary queries to ensure accuracy and correctness of historical data retrieval across multiple security types and accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->