### PR TITLE
Fix custom date range picker on account details #436

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Fixed
+- The custom date-range icon in the account-details range selector now works: clicking the calendar icon opens a date-range picker (previously it was embedded in a menu and never appeared), letting users pick an arbitrary start/end range for the account history and chart. #436
 - The next-younger boundary entry attached to a loaded account (used to extend balance series past the selected window) is now resolved from the end of the date range instead of the start, so it correctly points at the first entry *after* the window rather than the earliest in-range entry. Affects both single-account and whole-portfolio loads. #411
 
 ### Changed

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor
@@ -35,17 +35,10 @@
                                    Style="@($"min-width: 40px; font-weight: {(SelectedRange == range ? 700 : 500)};")"
                                    OnClick="@(() => OnRangeChanged(range))">@range</MudButton>
                     }
-                    <MudMenu AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight" Dense="true">
-                        <ActivatorContent>
-                            <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" Size="MudBlazor.Size.Small"
-                                           Color="@(SelectedRange == CustomRangeKey ? MudBlazor.Color.Primary : MudBlazor.Color.Default)"
-                                           aria-label="Select custom date range" />
-                        </ActivatorContent>
-                        <ChildContent>
-                            <MudDateRangePicker DateRange="CustomDateRange" DateRangeChanged="OnCustomDateRangeChanged"
-                                                RelativeWidth="DropdownWidth.Ignore" Class="px-2 pt-2" />
-                        </ChildContent>
-                    </MudMenu>
+                    <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" Size="MudBlazor.Size.Small"
+                                   Color="@(SelectedRange == CustomRangeKey ? MudBlazor.Color.Primary : MudBlazor.Color.Default)"
+                                   OnClick="OpenCustomDateRangePicker"
+                                   aria-label="Select custom date range" />
                 </div>
             </MudStack>
 
@@ -108,17 +101,17 @@
                            Style="@($"min-width: 44px; font-weight: {(SelectedRange == range ? 700 : 500)};")"
                            OnClick="@(() => OnRangeChanged(range))">@range</MudButton>
             }
-            <MudMenu AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" Dense="true">
-                <ActivatorContent>
-                    <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" Size="MudBlazor.Size.Small"
-                                   Color="@(SelectedRange == CustomRangeKey ? MudBlazor.Color.Primary : MudBlazor.Color.Default)"
-                                   aria-label="Select custom date range" />
-                </ActivatorContent>
-                <ChildContent>
-                    <MudDateRangePicker DateRange="CustomDateRange" DateRangeChanged="OnCustomDateRangeChanged"
-                                        RelativeWidth="DropdownWidth.Ignore" Class="px-2 pt-2" />
-                </ChildContent>
-            </MudMenu>
+            <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" Size="MudBlazor.Size.Small"
+                           Color="@(SelectedRange == CustomRangeKey ? MudBlazor.Color.Primary : MudBlazor.Color.Default)"
+                           OnClick="OpenCustomDateRangePicker"
+                           aria-label="Select custom date range" />
         </div>
     }
+
+    @* Hidden picker opened programmatically by the calendar icon; Dialog variant avoids
+       the broken nested-popover behaviour of embedding the picker inside a MudMenu. *@
+    <div class="fm-custom-range-picker">
+        <MudDateRangePicker @ref="_customDateRangePicker" DateRange="CustomDateRange"
+                            DateRangeChanged="OnCustomDateRangeChanged" PickerVariant="PickerVariant.Dialog" />
+    </div>
 </MudPaper>

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.cs
@@ -25,6 +25,11 @@ public partial class AccountDetailsHero
 
     private readonly string[] _ranges = ["Month", "1M", "3M", "6M", "YTD"];
 
+    private MudDateRangePicker? _customDateRangePicker;
+
+    private Task OpenCustomDateRangePicker() =>
+        _customDateRangePicker?.OpenAsync() ?? Task.CompletedTask;
+
     private static readonly ApexChartOptions<TimeSeriesModel> _heroChartOptions = new()
     {
         Chart = new Chart

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.css
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.css
@@ -1,0 +1,7 @@
+/* The custom date-range picker is driven entirely by the calendar icon button and
+   opened programmatically as a dialog. Hide only its own inline input field so just
+   the icon acts as the trigger. The dialog overlay is rendered separately when opened
+   and is unaffected by this rule. */
+.fm-custom-range-picker ::deep .mud-picker > .mud-input-control {
+    display: none;
+}


### PR DESCRIPTION
## Summary

The calendar icon in the account-details range selector (`AccountDetailsHero`) was meant to let users pick a **custom date range**, but clicking it did nothing — no picker appeared.

The icon was the `ActivatorContent` of a `MudMenu` with a `MudDateRangePicker` nested in the menu's `ChildContent`. Nesting a popover-opening picker inside a menu popover is a broken combination in MudBlazor, so no working calendar ever surfaced.

## Fix

- Removed the `MudMenu` wrapper on both desktop and mobile layouts.
- The calendar icon button now calls `OpenAsync()` on a single hidden `MudDateRangePicker` (`PickerVariant.Dialog`), opened programmatically.
- Scoped CSS hides the picker's own inline input field so only the icon acts as the trigger; the dialog overlay renders separately and is unaffected.
- The existing `Range` selection state and `CustomDateRangeChanged` wiring are reused, so picking a range updates the account history and chart as before.

Applies to the currency, stock, and bond account detail pages via the shared `AccountDetailsHero` component.

## Verification

- `dotnet build` — clean (0 warnings, 0 errors).
- `dotnet format` — no changes.
- `dotnet test` (unit) — 480 passed.
- Rendered on the guest demo account and confirmed on both desktop and mobile viewports: toolbar shows only the calendar icon (no stray input), clicking it opens a working date-range picker dialog.

closes #436

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScQ6VPfiUJnFXLhgpLyx9L)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the custom date range control to open from a dedicated calendar button on both desktop and mobile.
  * The date range picker now appears in a dialog-style overlay, providing a cleaner and more consistent selection experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->