### PR TITLE
Add manual balance recalculation for financial accounts #435

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ rules agents must follow when updating this file.
 - Stock account per-ISIN boundary lookups (`GetNextOlder`/`GetNextYounger`), used on the running-balance recalculation hot write path, now resolve every ISIN with one grouped query plus a single fetch instead of one query per ISIN; `GetNextYounger` also gains the missing account filter so it no longer scans every account's entries for the ISIN list. #410
 
 ### Added
+- "Recalculate balance" action on the account management screen for currency, stock and bond accounts that rebuilds every entry's running balance from its value-change series (per instrument for stock/bond), repairing accounts whose stored balances drifted — e.g. legacy imports where each entry's value equals its value change. #435
 - Admin page (`/Admin/ServiceKeys`) for managing external service API credentials (Alpha Vantage, OpenFIGI); keys are persisted in the database and take effect immediately without redeployment. #358
 
 ### Changed

--- a/code/FinanceManager.Api/Controllers/Accounts/BondEntryController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/BondEntryController.cs
@@ -98,6 +98,20 @@ public class BondEntryController(
         return Ok(await bondAccountEntryRepository.Delete(accountId, entryId));
     }
 
+    [HttpPost("Recalculate/{accountId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RecalculateBalance(int accountId)
+    {
+        var account = await bondAccountRepository.Get(accountId);
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+
+        await bondAccountEntryRepository.RecalculateValues(accountId);
+        return Ok();
+    }
+
     [HttpPut]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(BondAccountEntryDto))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/code/FinanceManager.Api/Controllers/Accounts/CurrencyEntryController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/CurrencyEntryController.cs
@@ -98,6 +98,20 @@ public class CurrencyEntryController(
         return Ok(await accountEntryRepository.Delete(accountId, entryId));
     }
 
+    [HttpPost("Recalculate/{accountId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RecalculateBalance(int accountId)
+    {
+        var account = await accountRepository.Get(accountId);
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+
+        await accountEntryRepository.RecalculateValues(accountId);
+        return Ok();
+    }
+
     [HttpPut]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CurrencyAccountEntryDto))]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]

--- a/code/FinanceManager.Api/Controllers/Accounts/StockEntryController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/StockEntryController.cs
@@ -78,6 +78,20 @@ public class StockEntryController(
         return Ok(await stockAccountEntryRepository.Delete(accountId, entryId));
     }
 
+    [HttpPost("Recalculate/{accountId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RecalculateBalance(int accountId)
+    {
+        var account = await stockAccountRepository.Get(accountId);
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+
+        await stockAccountEntryRepository.RecalculateValues(accountId);
+        return Ok();
+    }
+
     [HttpPut("Update")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(StockAccountEntryDto))]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/ManageBondAccount.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/ManageBondAccount.razor
@@ -24,6 +24,7 @@
                 <MudItem xs="12">
                     <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick=Update>Update</MudButton>
                     <MudButton Variant="Variant.Filled" Color="Color.Error" DropShadow="false" OnClick=Remove>Delete</MudButton>
+                    <MudButton Variant="Variant.Outlined" Color="Color.Secondary" DropShadow="false" OnClick=Recalculate Disabled="_isRecalculating" StartIcon="@Icons.Material.Filled.Calculate">Recalculate balance</MudButton>
                     <MudButton Variant="Variant.Outlined" Color="Color.Primary" href="@($"AccountDetails/{AccountId}")" Class="ml-auto">Cancel</MudButton>
                 </MudItem>
             </MudGrid>

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/ManageBondAccount.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/ManageBondAccount.razor.cs
@@ -1,5 +1,6 @@
 using FinanceManager.Components.Components.Shared;
 using FinanceManager.Components.Components.Shared.Dialogs;
+using FinanceManager.Components.HttpClients;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.Bonds;
 using FinanceManager.Domain.Services;
@@ -15,6 +16,7 @@ public partial class ManageBondAccount
     private bool _success;
     private string[] _errors = [];
     private BondAccount? _bondAccount = null;
+    private bool _isRecalculating;
 
     public string AccountName { get; set; } = string.Empty;
 
@@ -26,6 +28,8 @@ public partial class ManageBondAccount
     [Inject] public required ILoginService LoginService { get; set; }
     [Inject] public required ILogger<ManageBondAccount> Logger { get; set; }
     [Inject] public required AccountDataSynchronizationService AccountDataSynchronizationService { get; set; }
+    [Inject] public required BondEntryHttpClient BondEntryHttpClient { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
 
     protected override async Task OnParametersSetAsync()
     {
@@ -94,6 +98,35 @@ public partial class ManageBondAccount
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error removing bond account with ID {AccountId}", AccountId);
+        }
+    }
+
+    public async Task Recalculate()
+    {
+        if (_bondAccount is null) return;
+
+        try
+        {
+            _isRecalculating = true;
+
+            if (await BondEntryHttpClient.RecalculateBalanceAsync(AccountId))
+            {
+                Snackbar.Add("Account balance recalculated.", Severity.Success);
+                await AccountDataSynchronizationService.AccountChanged();
+            }
+            else
+            {
+                Snackbar.Add("Failed to recalculate account balance.", Severity.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error recalculating balance for bond account with ID {AccountId}", AccountId);
+            Snackbar.Add("Failed to recalculate account balance.", Severity.Error);
+        }
+        finally
+        {
+            _isRecalculating = false;
         }
     }
 }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/ManageBondAccount.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/ManageBondAccount.razor.cs
@@ -103,7 +103,7 @@ public partial class ManageBondAccount
 
     public async Task Recalculate()
     {
-        if (_bondAccount is null) return;
+        if (_isRecalculating || _bondAccount is null) return;
 
         try
         {

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/ManageCurrencyAccount.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/ManageCurrencyAccount.razor
@@ -32,6 +32,7 @@
                 <MudItem xs="12">
                     <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick=Update>Update</MudButton>
                     <MudButton Variant="Variant.Filled" Color="Color.Error" DropShadow="false" OnClick=Remove>Delete</MudButton>
+                    <MudButton Variant="Variant.Outlined" Color="Color.Secondary" DropShadow="false" OnClick=Recalculate Disabled="_isRecalculating" StartIcon="@Icons.Material.Filled.Calculate">Recalculate balance</MudButton>
                     <MudButton Variant="Variant.Outlined" Color="Color.Primary" href="@($"AccountDetails/{AccountId}")" Class="ml-auto">Cancel</MudButton>
                 </MudItem>
             </MudGrid>

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/ManageCurrencyAccount.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/ManageCurrencyAccount.razor.cs
@@ -106,7 +106,7 @@ public partial class ManageCurrencyAccount
 
     public async Task Recalculate()
     {
-        if (_currencyAccount is null) return;
+        if (_isRecalculating || _currencyAccount is null) return;
 
         try
         {

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/ManageCurrencyAccount.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/ManageCurrencyAccount.razor.cs
@@ -1,5 +1,6 @@
 using FinanceManager.Components.Components.Shared;
 using FinanceManager.Components.Components.Shared.Dialogs;
+using FinanceManager.Components.HttpClients;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.FinancialAccounts.Currencies;
 using FinanceManager.Domain.Enums;
@@ -16,6 +17,7 @@ public partial class ManageCurrencyAccount
     private bool _success;
     private string[] _errors = [];
     private CurrencyAccount? _currencyAccount = null;
+    private bool _isRecalculating;
 
     public string AccountName { get; set; } = string.Empty;
     public AccountLabel AccountType { get; set; }
@@ -28,6 +30,8 @@ public partial class ManageCurrencyAccount
     [Inject] public required ILoginService LoginService { get; set; }
     [Inject] public required ILogger<ManageCurrencyAccount> Logger { get; set; }
     [Inject] public required AccountDataSynchronizationService AccountDataSynchronizationService { get; set; }
+    [Inject] public required CurrencyEntryHttpClient CurrencyEntryHttpClient { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
 
     protected override async Task OnParametersSetAsync()
     {
@@ -97,6 +101,35 @@ public partial class ManageCurrencyAccount
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error removing currency account with ID {AccountId}", AccountId);
+        }
+    }
+
+    public async Task Recalculate()
+    {
+        if (_currencyAccount is null) return;
+
+        try
+        {
+            _isRecalculating = true;
+
+            if (await CurrencyEntryHttpClient.RecalculateBalanceAsync(AccountId))
+            {
+                Snackbar.Add("Account balance recalculated.", Severity.Success);
+                await AccountDataSynchronizationService.AccountChanged();
+            }
+            else
+            {
+                Snackbar.Add("Failed to recalculate account balance.", Severity.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error recalculating balance for currency account with ID {AccountId}", AccountId);
+            Snackbar.Add("Failed to recalculate account balance.", Severity.Error);
+        }
+        finally
+        {
+            _isRecalculating = false;
         }
     }
 }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/ManageStockAccount.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/ManageStockAccount.razor
@@ -24,6 +24,7 @@
                 <MudItem xs="12">
                     <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick=Update>Update</MudButton>
                     <MudButton Variant="Variant.Filled" Color="Color.Error" DropShadow="false" OnClick=Remove>Delete</MudButton>
+                    <MudButton Variant="Variant.Outlined" Color="Color.Secondary" DropShadow="false" OnClick=Recalculate Disabled="_isRecalculating" StartIcon="@Icons.Material.Filled.Calculate">Recalculate balance</MudButton>
                     <MudButton Variant="Variant.Outlined" Color="Color.Primary" href="@($"AccountDetails/{AccountId}")" Class="ml-auto">Cancel</MudButton>
                 </MudItem>
             </MudGrid>

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/ManageStockAccount.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/ManageStockAccount.razor.cs
@@ -1,5 +1,6 @@
 using FinanceManager.Components.Components.Shared;
 using FinanceManager.Components.Components.Shared.Dialogs;
+using FinanceManager.Components.HttpClients;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.Stocks;
 using FinanceManager.Domain.Services;
@@ -16,6 +17,7 @@ public partial class ManageStockAccount : ComponentBase
     private string[] _errors = [];
 
     private StockAccount? _stockAccount;
+    private bool _isRecalculating;
 
     public string AccountName { get; set; } = string.Empty;
 
@@ -27,6 +29,8 @@ public partial class ManageStockAccount : ComponentBase
     [Inject] public required ILoginService LoginService { get; set; }
     [Inject] public required AccountDataSynchronizationService AccountDataSynchronizationService { get; set; }
     [Inject] public required ILogger<ManageStockAccount> Logger { get; set; }
+    [Inject] public required StockEntryHttpClient StockEntryHttpClient { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
 
     protected override async Task OnParametersSetAsync()
     {
@@ -96,6 +100,35 @@ public partial class ManageStockAccount : ComponentBase
         {
             Logger.LogError(ex, "Error removing Stock Account with AccountId {AccountId}", AccountId);
             _errors = [ex.Message];
+        }
+    }
+
+    public async Task Recalculate()
+    {
+        if (_stockAccount is null) return;
+
+        try
+        {
+            _isRecalculating = true;
+
+            if (await StockEntryHttpClient.RecalculateBalanceAsync(AccountId))
+            {
+                Snackbar.Add("Account balance recalculated.", Severity.Success);
+                await AccountDataSynchronizationService.AccountChanged();
+            }
+            else
+            {
+                Snackbar.Add("Failed to recalculate account balance.", Severity.Error);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error recalculating balance for Stock Account with AccountId {AccountId}", AccountId);
+            Snackbar.Add("Failed to recalculate account balance.", Severity.Error);
+        }
+        finally
+        {
+            _isRecalculating = false;
         }
     }
 }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/ManageStockAccount.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/ManageStockAccount.razor.cs
@@ -105,7 +105,7 @@ public partial class ManageStockAccount : ComponentBase
 
     public async Task Recalculate()
     {
-        if (_stockAccount is null) return;
+        if (_isRecalculating || _stockAccount is null) return;
 
         try
         {

--- a/code/FinanceManager.Components/HttpClients/BondEntryHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/BondEntryHttpClient.cs
@@ -43,6 +43,12 @@ public class BondEntryHttpClient(HttpClient httpClient)
         return response.IsSuccessStatusCode;
     }
 
+    public async Task<bool> RecalculateBalanceAsync(int accountId)
+    {
+        var response = await httpClient.PostAsync($"{httpClient.BaseAddress}api/BondEntry/Recalculate/{accountId}", null);
+        return response.IsSuccessStatusCode;
+    }
+
     public async Task<bool> UpdateEntryAsync(UpdateBondAccountEntry entry)
     {
         var response = await httpClient.PutAsJsonAsync($"{httpClient.BaseAddress}api/BondEntry", entry);

--- a/code/FinanceManager.Components/HttpClients/CurrencyEntryHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/CurrencyEntryHttpClient.cs
@@ -64,6 +64,12 @@ public class CurrencyEntryHttpClient(HttpClient httpClient)
         return response.IsSuccessStatusCode;
     }
 
+    public async Task<bool> RecalculateBalanceAsync(int accountId)
+    {
+        var response = await httpClient.PostAsync($"{httpClient.BaseAddress}api/CurrencyEntry/Recalculate/{accountId}", null);
+        return response.IsSuccessStatusCode;
+    }
+
     public async Task<bool> UpdateEntryAsync(CurrencyAccountEntry entry)
     {
         var updateCommand = new UpdateCurrencyAccountEntry(

--- a/code/FinanceManager.Components/HttpClients/StockEntryHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/StockEntryHttpClient.cs
@@ -33,6 +33,12 @@ public class StockEntryHttpClient(HttpClient httpClient)
         return response.IsSuccessStatusCode;
     }
 
+    public async Task<bool> RecalculateBalanceAsync(int accountId)
+    {
+        var response = await httpClient.PostAsync($"{httpClient.BaseAddress}api/StockEntry/Recalculate/{accountId}", null);
+        return response.IsSuccessStatusCode;
+    }
+
     public async Task<bool> UpdateEntryAsync(UpdateStockAccountEntry entry)
     {
         var response = await httpClient.PutAsJsonAsync($"{httpClient.BaseAddress}api/StockEntry/Update", entry);

--- a/code/FinanceManager.Domain/Repositories/Account/IAccountEntryRepository.cs
+++ b/code/FinanceManager.Domain/Repositories/Account/IAccountEntryRepository.cs
@@ -43,6 +43,14 @@ public interface IAccountEntryRepository<T>
     Task<IReadOnlyDictionary<int, int>> GetEntriesCountPerUser(IReadOnlyCollection<int> userIds, CancellationToken cancellationToken = default);
 
     Task RecalculateValues(int accountId, int entryId);
+
+    /// <summary>
+    /// Recomputes the running <c>Value</c> of every entry in the account from its <c>ValueChange</c>
+    /// series, anchored at zero from the oldest entry. Instrument-aware repositories (stock/bond)
+    /// recalculate each instrument independently. Used to repair accounts whose stored balances drifted
+    /// (e.g. legacy imports that never ran a recalculation pass).
+    /// </summary>
+    Task RecalculateValues(int accountId);
     Task<bool> Add(T entry, bool recalculate = true);
     Task<bool> Add(IEnumerable<T> entries, bool recalculate = true);
     Task<bool> AddLabel(int entryId, int labelId);

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
@@ -290,6 +290,23 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
         await RecalculateValues(accountId, date);
     }
 
+    public async Task RecalculateValues(int accountId)
+    {
+        // Recalculate from the oldest entry: every bond's anchor before it is empty, so each instrument
+        // is rebuilt from a zero running balance.
+        var startDate = await context.BondEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == accountId)
+            .OrderBy(e => e.PostingDate)
+            .ThenBy(e => e.EntryId)
+            .Select(e => (DateTime?)e.PostingDate)
+            .FirstOrDefaultAsync();
+
+        if (startDate is not DateTime date) return;
+
+        await RecalculateValues(accountId, date);
+    }
+
     private async Task RecalculateValues(int accountId, DateTime startDate)
     {
         if (!context.Database.IsRelational())

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryRepository.cs
@@ -341,6 +341,23 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
         await RecalculateValues(accountId, date);
     }
 
+    public async Task RecalculateValues(int accountId)
+    {
+        // Recalculate from the oldest entry: the anchor before it is empty, so the whole account is
+        // rebuilt from a zero running balance.
+        var startDate = await context.CurrencyEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == accountId)
+            .OrderBy(e => e.PostingDate)
+            .ThenBy(e => e.EntryId)
+            .Select(e => (DateTime?)e.PostingDate)
+            .FirstOrDefaultAsync();
+
+        if (startDate is not DateTime date) return;
+
+        await RecalculateValues(accountId, date);
+    }
+
     private async Task RecalculateValues(int accountId, DateTime startDate)
     {
         var anchor = await context.CurrencyEntries

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/StockEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/StockEntryRepository.cs
@@ -330,6 +330,32 @@ public class StockEntryRepository(AppDbContext context) : IStockAccountEntryRepo
         return true;
     }
 
+    public async Task RecalculateValues(int accountId)
+    {
+        // Each ISIN holds an independent running balance, so recalculate every instrument separately
+        // from its own oldest entry (which anchors at a zero running balance).
+        var isins = await context.StockEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == accountId)
+            .Select(e => e.Isin)
+            .Distinct()
+            .ToListAsync();
+
+        foreach (var isin in isins)
+        {
+            var oldestEntryId = await context.StockEntries
+                .AsNoTracking()
+                .Where(e => e.AccountId == accountId && e.Isin == isin)
+                .OrderBy(e => e.PostingDate)
+                .ThenBy(e => e.EntryId)
+                .Select(e => (int?)e.EntryId)
+                .FirstOrDefaultAsync();
+
+            if (oldestEntryId is int entryId)
+                await RecalculateValues(accountId, entryId);
+        }
+    }
+
     public async Task RecalculateValues(int accountId, int entryId)
     {
         var entryInfo = await context.StockEntries

--- a/code/FinanceManager.Tests.Integration/Repositories/RecalculateValuesTests.cs
+++ b/code/FinanceManager.Tests.Integration/Repositories/RecalculateValuesTests.cs
@@ -65,6 +65,33 @@ public sealed class RecalculateValuesTests : IDisposable
     }
 
     [Fact]
+    public async Task Currency_RecalculateWholeAccount_RebuildsDriftedBalances()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repo = new CurrencyEntryRepository(_context);
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan15 = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var jan20 = new DateTime(2025, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        // Simulate legacy import drift: each entry's Value equals its ValueChange and no recalc ran.
+        await repo.Add(new CurrencyAccountEntry(_accountId, 0, jan10, 1000m, 1000m), recalculate: false);
+        await repo.Add(new CurrencyAccountEntry(_accountId, 0, jan15, 200m, 200m), recalculate: false);
+        await repo.Add(new CurrencyAccountEntry(_accountId, 0, jan20, 500m, 500m), recalculate: false);
+
+        await repo.RecalculateValues(_accountId);
+
+        var entries = await _context.CurrencyEntries
+            .Where(e => e.AccountId == _accountId)
+            .OrderBy(e => e.PostingDate)
+            .ToListAsync(ct);
+
+        Assert.Equal(3, entries.Count);
+        Assert.Equal(1000m, entries[0].Value); // jan10
+        Assert.Equal(1200m, entries[1].Value); // jan15: 1000 + 200
+        Assert.Equal(1700m, entries[2].Value); // jan20: 1200 + 500
+    }
+
+    [Fact]
     public async Task Currency_Update_RecalculatesFromUpdatedEntry()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -146,6 +173,36 @@ public sealed class RecalculateValuesTests : IDisposable
         Assert.Equal(200m, msftEntries[0].Value);   // unaffected
     }
 
+    [Fact]
+    public async Task Stock_RecalculateWholeAccount_RebuildsDriftedBalancesPerIsin()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repo = new StockEntryRepository(_context);
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan20 = new DateTime(2025, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        // Simulate legacy import drift: Value equals ValueChange across two instruments, no recalc.
+        await repo.Add(new StockAccountEntry(_accountId, 0, jan10, 100m, 100m, "US0378331005", InvestmentType.Stock), recalculate: false);
+        await repo.Add(new StockAccountEntry(_accountId, 0, jan20, 50m, 50m, "US0378331005", InvestmentType.Stock), recalculate: false);
+        await repo.Add(new StockAccountEntry(_accountId, 0, jan10, 200m, 200m, "US5949181045", InvestmentType.Stock), recalculate: false);
+
+        await repo.RecalculateValues(_accountId);
+
+        var appleEntries = await _context.StockEntries
+            .Where(e => e.AccountId == _accountId && e.Isin == "US0378331005")
+            .OrderBy(e => e.PostingDate)
+            .ToListAsync(ct);
+
+        var msftEntries = await _context.StockEntries
+            .Where(e => e.AccountId == _accountId && e.Isin == "US5949181045")
+            .ToListAsync(ct);
+
+        Assert.Equal(100m, appleEntries[0].Value); // jan10
+        Assert.Equal(150m, appleEntries[1].Value); // jan20: 100 + 50
+        Assert.Single(msftEntries);
+        Assert.Equal(200m, msftEntries[0].Value);   // single entry → value = valueChange
+    }
+
     // ── Bond ──────────────────────────────────────────────────────────────────
 
     [Fact]
@@ -184,5 +241,38 @@ public sealed class RecalculateValuesTests : IDisposable
 
         Assert.Single(bondBEntries);
         Assert.Equal(1000m, bondBEntries[0].Value); // unaffected
+    }
+
+    [Fact]
+    public async Task Bond_RecalculateWholeAccount_RebuildsDriftedBalancesPerBondDetailsId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repo = new BondEntryRepository(_context);
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan20 = new DateTime(2025, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        const int bondA = 1;
+        const int bondB = 2;
+
+        // Simulate legacy import drift: Value equals ValueChange across two bonds, no recalc.
+        await repo.Add(new BondAccountEntry(_accountId, 0, jan10, 500m, 500m, bondA), recalculate: false);
+        await repo.Add(new BondAccountEntry(_accountId, 0, jan20, 300m, 300m, bondA), recalculate: false);
+        await repo.Add(new BondAccountEntry(_accountId, 0, jan10, 1000m, 1000m, bondB), recalculate: false);
+
+        await repo.RecalculateValues(_accountId);
+
+        var bondAEntries = await _context.BondEntries
+            .Where(e => e.AccountId == _accountId && e.BondDetailsId == bondA)
+            .OrderBy(e => e.PostingDate)
+            .ToListAsync(ct);
+
+        var bondBEntries = await _context.BondEntries
+            .Where(e => e.AccountId == _accountId && e.BondDetailsId == bondB)
+            .ToListAsync(ct);
+
+        Assert.Equal(500m, bondAEntries[0].Value); // jan10
+        Assert.Equal(800m, bondAEntries[1].Value); // jan20: 500 + 300
+        Assert.Single(bondBEntries);
+        Assert.Equal(1000m, bondBEntries[0].Value); // single entry → value = valueChange
     }
 }


### PR DESCRIPTION
## Summary

Adds a **"Recalculate balance"** action under financial account management (the `ManageAccount` screens) for currency, stock and bond accounts. It rebuilds every entry's running `Value` from its `ValueChange` series, anchored at zero from the oldest entry (per instrument — ISIN / bond — for stock and bond accounts).

This repairs accounts whose stored balances drifted, e.g. **legacy imports where each entry's `Value` equals its `ValueChange`** (impossible for a cumulative running balance).

## Why

The import pipeline (`CurrencyAccountImportService`) *does* trigger a `RecalculateValues` pass after a batch import, so this is **stale historical data**, not a live pipeline bug. There was previously no way for a user to repair an already-corrupted account — this adds one.

## Changes

- **Domain**: `IAccountEntryRepository<T>.RecalculateValues(int accountId)` whole-account overload.
- **Infrastructure**: implemented for `CurrencyEntryRepository`, `StockEntryRepository` (per ISIN), `BondEntryRepository` (per bond), reusing the existing per-entry recalc paths.
- **Api**: owner-authorized `POST .../Recalculate/{accountId}` endpoints on the currency/stock/bond entry controllers.
- **Components**: `RecalculateBalanceAsync` typed HTTP-client methods + a "Recalculate balance" button on each `Manage*Account` component (success/error snackbar, refreshes account data).
- **Tests**: integration tests covering the drift-repair path for each account type.

## Verification

- `dotnet build` clean (warnings-as-errors); 480 unit tests + 256 integration tests pass.
- Rendered on the guest demo account (desktop + mobile); clicking the button returned HTTP 200 and showed "Account balance recalculated."

closes #435


---
_Generated by [Claude Code](https://claude.ai/code/session_01KzBhfJ7eQ5ddQ8gKoajU3o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Recalculate balance" action buttons to Bond, Currency, and Stock account management interfaces. Users can now manually recalculate and synchronize account balances to ensure accurate running values across all entries.

* **Tests**
  * Added comprehensive integration tests validating balance recalculation accuracy across all account types and entry groupings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->