### PR TITLE
ISIN-centric instrument resolver: auto-resolve, confirm on ambiguity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ rules agents must follow when updating this file.
 - Stock account per-ISIN boundary lookups (`GetNextOlder`/`GetNextYounger`), used on the running-balance recalculation hot write path, now resolve every ISIN with one grouped query plus a single fetch instead of one query per ISIN; `GetNextYounger` also gains the missing account filter so it no longer scans every account's entries for the ISIN list. #410
 
 ### Added
+- ISIN-centric instrument resolver that auto-resolves unambiguous securities or returns candidates for user confirmation, reconciling Alpha Vantage and OpenFIGI data sources; handles broker suffix normalization and GBX/GBP currency conversions with configurable quote factors. #432
 - Stock details now store a dedicated Alpha Vantage price symbol separate from the broker display ticker, enabling accurate price resolution when the two differ (e.g. broker shows `CSPX.UK`, Alpha Vantage uses `CSPX.LON`). ISIN is now the authoritative key for stock account entries; the broker ticker is a display-only alias. #431
 - "Recalculate balance" action on the account management screen for currency, stock and bond accounts that rebuilds every entry's running balance from its value-change series (per instrument for stock/bond), repairing accounts whose stored balances drifted — e.g. legacy imports where each entry's value equals its value change. #435
 - Admin page (`/Admin/ServiceKeys`) for managing external service API credentials (Alpha Vantage, OpenFIGI); keys are persisted in the database and take effect immediately without redeployment. #358

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/BrokerSymbol.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/BrokerSymbol.cs
@@ -1,0 +1,51 @@
+namespace FinanceManager.Application.FinancialAccounts.Stock.Resolution;
+
+/// <summary>
+/// Normalizes a broker ticker (e.g., "CSPX.UK") into base ticker + exchange hint.
+/// Maintains a lookup table of broker suffixes to OpenFIGI exchange codes and Alpha Vantage regions.
+/// </summary>
+public sealed class BrokerSymbol
+{
+    public required string BaseTicker { get; set; }
+    public string? ExchangeHint { get; set; }
+
+    private static readonly Dictionary<string, (string OpenFigiExchCode, string AlphaVantageRegion)> _suffixMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        { "UK", ("LN", "GB") },         // London Stock Exchange
+        { "DE", ("GY", "DE") },         // Xetra (Deutsche Börse)
+        { "PL", ("WA", "PL") },         // Warsaw Stock Exchange
+        { "US", ("US", "US") },         // US (NASDAQ/NYSE)
+        { "CA", ("CT", "CA") },         // Canada
+        { "AU", ("AU", "AU") },         // Australia
+        { "JP", ("TT", "JP") },         // Tokyo
+        { "HK", ("HK", "HK") },         // Hong Kong
+        { "SG", ("SI", "SG") },         // Singapore
+        { "CH", ("VX", "CH") },         // Swiss SIX
+    };
+
+    public static BrokerSymbol Parse(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return new BrokerSymbol { BaseTicker = string.Empty };
+
+        var normalized = input.Trim().ToUpperInvariant();
+        var parts = normalized.Split('.');
+
+        if (parts.Length == 1)
+            return new BrokerSymbol { BaseTicker = parts[0] };
+
+        return new BrokerSymbol
+        {
+            BaseTicker = parts[0],
+            ExchangeHint = parts[1]
+        };
+    }
+
+    public (string OpenFigiExchCode, string AlphaVantageRegion)? TryLookupExchange()
+    {
+        if (string.IsNullOrWhiteSpace(ExchangeHint))
+            return null;
+
+        return _suffixMap.TryGetValue(ExchangeHint, out var mapping) ? mapping : null;
+    }
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/BrokerSymbol.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/BrokerSymbol.cs
@@ -9,18 +9,21 @@ public sealed class BrokerSymbol
     public required string BaseTicker { get; set; }
     public string? ExchangeHint { get; set; }
 
-    private static readonly Dictionary<string, (string OpenFigiExchCode, string AlphaVantageRegion)> _suffixMap = new(StringComparer.OrdinalIgnoreCase)
+    // Broker suffix → (OpenFIGI exchange code, Alpha Vantage region aliases).
+    // Alpha Vantage's SYMBOL_SEARCH "region" is a free-form label ("United Kingdom", not "GB"),
+    // so each suffix carries the aliases we accept when correlating an AV match to the hint.
+    private static readonly Dictionary<string, ExchangeMapping> _suffixMap = new(StringComparer.OrdinalIgnoreCase)
     {
-        { "UK", ("LN", "GB") },         // London Stock Exchange
-        { "DE", ("GY", "DE") },         // Xetra (Deutsche Börse)
-        { "PL", ("WA", "PL") },         // Warsaw Stock Exchange
-        { "US", ("US", "US") },         // US (NASDAQ/NYSE)
-        { "CA", ("CT", "CA") },         // Canada
-        { "AU", ("AU", "AU") },         // Australia
-        { "JP", ("TT", "JP") },         // Tokyo
-        { "HK", ("HK", "HK") },         // Hong Kong
-        { "SG", ("SI", "SG") },         // Singapore
-        { "CH", ("VX", "CH") },         // Swiss SIX
+        { "UK", new("LN", ["United Kingdom", "GB", "UK", "London"]) },         // London Stock Exchange
+        { "DE", new("GY", ["Germany", "XETRA", "Frankfurt", "DE"]) },          // Xetra (Deutsche Börse)
+        { "PL", new("WA", ["Poland", "Warsaw", "PL"]) },                       // Warsaw Stock Exchange
+        { "US", new("US", ["United States", "US", "USA"]) },                   // US (NASDAQ/NYSE)
+        { "CA", new("CT", ["Canada", "Toronto", "CA"]) },                      // Canada
+        { "AU", new("AU", ["Australia", "AU"]) },                              // Australia
+        { "JP", new("TT", ["Japan", "Tokyo", "JP"]) },                         // Tokyo
+        { "HK", new("HK", ["Hong Kong", "HK"]) },                              // Hong Kong
+        { "SG", new("SI", ["Singapore", "SG"]) },                              // Singapore
+        { "CH", new("VX", ["Switzerland", "Swiss", "CH"]) },                   // Swiss SIX
     };
 
     public static BrokerSymbol Parse(string? input)
@@ -29,23 +32,48 @@ public sealed class BrokerSymbol
             return new BrokerSymbol { BaseTicker = string.Empty };
 
         var normalized = input.Trim().ToUpperInvariant();
-        var parts = normalized.Split('.');
+        var lastDot = normalized.LastIndexOf('.');
 
-        if (parts.Length == 1)
-            return new BrokerSymbol { BaseTicker = parts[0] };
-
-        return new BrokerSymbol
+        // Only treat the trailing segment as an exchange hint when it is a known broker suffix.
+        // This preserves legitimately dotted tickers such as "BRK.B".
+        if (lastDot > 0 && lastDot < normalized.Length - 1)
         {
-            BaseTicker = parts[0],
-            ExchangeHint = parts[1]
-        };
+            var hintCandidate = normalized[(lastDot + 1)..];
+            if (_suffixMap.ContainsKey(hintCandidate))
+            {
+                return new BrokerSymbol
+                {
+                    BaseTicker = normalized[..lastDot],
+                    ExchangeHint = hintCandidate
+                };
+            }
+        }
+
+        return new BrokerSymbol { BaseTicker = normalized };
     }
 
-    public (string OpenFigiExchCode, string AlphaVantageRegion)? TryLookupExchange()
+    public ExchangeMapping? TryLookupExchange()
     {
         if (string.IsNullOrWhiteSpace(ExchangeHint))
             return null;
 
         return _suffixMap.TryGetValue(ExchangeHint, out var mapping) ? mapping : null;
+    }
+
+    /// <summary>
+    /// Maps a broker suffix to the OpenFIGI exchange code and the Alpha Vantage region labels
+    /// that identify the same venue.
+    /// </summary>
+    public sealed record ExchangeMapping(string OpenFigiExchCode, string[] AlphaVantageRegions)
+    {
+        public bool MatchesRegion(string? avRegion)
+        {
+            if (string.IsNullOrWhiteSpace(avRegion))
+                return false;
+
+            return AlphaVantageRegions.Any(alias =>
+                avRegion.Contains(alias, StringComparison.OrdinalIgnoreCase) ||
+                alias.Contains(avRegion, StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/IInstrumentResolver.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/IInstrumentResolver.cs
@@ -1,0 +1,16 @@
+namespace FinanceManager.Application.FinancialAccounts.Stock.Resolution;
+
+/// <summary>
+/// Resolves a search term (broker ticker, symbol, or name) to an instrument.
+/// Returns either a single auto-resolved match or a list of candidates for user confirmation.
+/// </summary>
+public interface IInstrumentResolver
+{
+    /// <summary>
+    /// Resolve an instrument search term.
+    /// </summary>
+    /// <param name="brokerTickerOrTerm">A broker ticker (e.g., "CSPX.UK"), base ticker, or search term.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Resolution result with Kind and either Match or Candidates.</returns>
+    Task<InstrumentResolution> ResolveAsync(string brokerTickerOrTerm, CancellationToken ct = default);
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/IOpenFigiClient.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/IOpenFigiClient.cs
@@ -1,0 +1,28 @@
+namespace FinanceManager.Application.FinancialAccounts.Stock.Resolution;
+
+/// <summary>
+/// OpenFIGI API client abstraction.
+/// Resolves base tickers + exchange codes and ISINs to metadata and listing information.
+/// </summary>
+public interface IOpenFigiClient
+{
+    /// <summary>
+    /// Maps a base ticker and optional exchange code to OpenFIGI listing metadata.
+    /// </summary>
+    Task<IReadOnlyList<OpenFigiListing>> MapByTickerAsync(string baseTicker, string? exchCode = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Maps an ISIN to all known listing venues and metadata.
+    /// </summary>
+    Task<IReadOnlyList<OpenFigiListing>> MapByIsinAsync(string isin, CancellationToken ct = default);
+}
+
+/// <summary>
+/// A single listing result from OpenFIGI, representing one venue for an instrument.
+/// </summary>
+public sealed record OpenFigiListing(
+    string? Isin,
+    string Ticker,
+    string Name,
+    string ExchCode,
+    string? Currency);

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/IQuoteFactorResolver.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/IQuoteFactorResolver.cs
@@ -1,0 +1,17 @@
+namespace FinanceManager.Application.FinancialAccounts.Stock.Resolution;
+
+/// <summary>
+/// Resolves conversion factors between currency pairs.
+/// Handles known cases (e.g., GBX ↔ GBP) efficiently, falls back to exchange rate API for others.
+/// </summary>
+public interface IQuoteFactorResolver
+{
+    /// <summary>
+    /// Determine the conversion factor from one currency to another.
+    /// </summary>
+    /// <param name="fromCurrency">Source currency code (e.g., "GBX", "USD")</param>
+    /// <param name="toCurrency">Target currency code (e.g., "GBP", "EUR")</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Conversion factor (multiply from-amount by this to get to-amount). Returns 1.0 on failure.</returns>
+    Task<decimal> ResolveAsync(string fromCurrency, string toCurrency, CancellationToken ct = default);
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentListing.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentListing.cs
@@ -1,0 +1,14 @@
+namespace FinanceManager.Application.FinancialAccounts.Stock.Resolution;
+
+/// <summary>
+/// Reconciled candidate instrument listing after cross-referencing Alpha Vantage and OpenFIGI data.
+/// Represents a single venue or entry for an instrument.
+/// </summary>
+public sealed record InstrumentListing(
+    string? Isin,
+    string? AlphaVantageSymbol,
+    string Name,
+    string Exchange,
+    string Currency,
+    string Type,
+    decimal QuoteFactor = 1m);

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentResolution.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentResolution.cs
@@ -1,0 +1,23 @@
+namespace FinanceManager.Application.FinancialAccounts.Stock.Resolution;
+
+/// <summary>
+/// Result of instrument resolution: either an auto-resolved match or a list of candidates for user confirmation.
+/// </summary>
+public sealed class InstrumentResolution
+{
+    public required ResolutionKind Kind { get; set; }
+    public InstrumentListing? Match { get; set; }
+    public IReadOnlyList<InstrumentListing> Candidates { get; set; } = [];
+}
+
+public enum ResolutionKind
+{
+    /// <summary>Single unambiguous match found and persisted automatically.</summary>
+    AutoResolved = 0,
+
+    /// <summary>Multiple candidates found; user must confirm which one.</summary>
+    Ambiguous = 1,
+
+    /// <summary>No match found across all providers.</summary>
+    NoMatch = 2
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentResolver.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentResolver.cs
@@ -1,0 +1,232 @@
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Domain.Dtos;
+using FinanceManager.Domain.Repositories;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Application.FinancialAccounts.Stock.Resolution;
+
+public sealed class InstrumentResolver(
+    IOpenFigiClient openFigiClient,
+    IAlphaVantageClient avClient,
+    IStockDetailsRepository stockDetailsRepository,
+    IMemoryCache cache,
+    ILogger<InstrumentResolver> logger) : IInstrumentResolver
+{
+    private static readonly TimeSpan _positiveTtl = TimeSpan.FromHours(24);
+    private static readonly TimeSpan _negativeTtl = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan _openFigiFailureCooldown = TimeSpan.FromMinutes(10);
+    private DateTime? _openFigiCooldownUntilUtc;
+
+    public async Task<InstrumentResolution> ResolveAsync(string brokerTickerOrTerm, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(brokerTickerOrTerm))
+            return NoMatch();
+
+        var input = brokerTickerOrTerm.Trim().ToUpperInvariant();
+        var cacheKey = $"INSTRUMENT_RESOLUTION_{input}";
+
+        if (cache.TryGetValue(cacheKey, out InstrumentResolution? cached) && cached is not null)
+            return cached;
+
+        var brokerSymbol = BrokerSymbol.Parse(input);
+        var baseTicker = brokerSymbol.BaseTicker;
+
+        if (string.IsNullOrWhiteSpace(baseTicker))
+            return NoMatch();
+
+        // Short-circuit: check if already resolved in StockDetails
+        var existing = await stockDetailsRepository.GetByTicker(baseTicker, ct);
+        if (existing?.Isin is not null && existing.AlphaVantageSymbol is not null)
+        {
+            logger.LogDebug("Found cached StockDetails for {BaseTicker}: ISIN={Isin}, AvSymbol={AvSymbol}", baseTicker, existing.Isin, existing.AlphaVantageSymbol);
+            var cached2 = new InstrumentResolution
+            {
+                Kind = ResolutionKind.AutoResolved,
+                Match = new InstrumentListing(
+                    existing.Isin,
+                    existing.AlphaVantageSymbol,
+                    existing.Name,
+                    existing.Region,
+                    existing.Currency.ShortName,
+                    existing.Type)
+            };
+            cache.Set(cacheKey, cached2, _positiveTtl);
+            return cached2;
+        }
+
+        // Fan out: AV search + OpenFIGI ticker mapping
+        var avTask = avClient.SearchTicker(baseTicker, ct);
+        var ofTask = OpenFigiCallWithFallback(baseTicker, brokerSymbol.ExchangeHint, ct);
+        await Task.WhenAll(avTask, ofTask);
+
+        var avMatches = avTask.Result;
+        var ofListings = ofTask.Result;
+
+        // Reconcile: pair AV symbol/currency/region against OpenFIGI ISIN/venue
+        var candidates = Reconcile(baseTicker, brokerSymbol.ExchangeHint, avMatches, ofListings);
+
+        if (candidates.Count == 0)
+        {
+            var result = NoMatch();
+            cache.Set(cacheKey, result, _negativeTtl);
+            return result;
+        }
+
+        if (candidates.Count == 1)
+        {
+            var single = candidates[0];
+            if (single.Isin is not null && single.AlphaVantageSymbol is not null)
+            {
+                logger.LogDebug("Auto-resolving single match: ISIN={Isin}, AvSymbol={AvSymbol}", single.Isin, single.AlphaVantageSymbol);
+                var autoResult = new InstrumentResolution
+                {
+                    Kind = ResolutionKind.AutoResolved,
+                    Match = single
+                };
+                cache.Set(cacheKey, autoResult, _positiveTtl);
+                return autoResult;
+            }
+        }
+
+        var ambiguousResult = new InstrumentResolution
+        {
+            Kind = ResolutionKind.Ambiguous,
+            Candidates = candidates
+        };
+        cache.Set(cacheKey, ambiguousResult, _negativeTtl);
+        return ambiguousResult;
+    }
+
+    private List<InstrumentListing> Reconcile(
+        string baseTicker,
+        string? exchangeHint,
+        IReadOnlyList<TickerSearchMatch> avMatches,
+        IReadOnlyList<OpenFigiListing> ofListings)
+    {
+        var candidates = new List<InstrumentListing>();
+        var seen = new HashSet<string>();
+
+        var brokerSymbolInput = exchangeHint is not null ? $"{baseTicker}.{exchangeHint}" : baseTicker;
+        var lookupMapping = BrokerSymbol.Parse(brokerSymbolInput).TryLookupExchange();
+
+        // For each AV match, reconcile with OpenFIGI data
+        foreach (var avMatch in avMatches)
+        {
+            if (string.IsNullOrWhiteSpace(avMatch.Symbol))
+                continue;
+
+            // Filter by exchange hint if provided
+            if (exchangeHint is not null && lookupMapping.HasValue)
+            {
+                var (_, expectedAvRegion) = lookupMapping.Value;
+                if (!string.Equals(avMatch.Region, expectedAvRegion, StringComparison.OrdinalIgnoreCase))
+                    continue;
+            }
+
+            // Extract base ticker from AV symbol (e.g., "CSPX.LON" → "CSPX")
+            var avBaseTicker = avMatch.Symbol.Split('.')[0];
+
+            // Find matching OpenFIGI listing: match by base ticker or by exchange hint
+            OpenFigiListing? matchingOf = null;
+
+            if (exchangeHint is not null && lookupMapping.HasValue)
+            {
+                // If we have an exchange hint, find OF listing with matching exchange
+                var (ofExchCode, _) = lookupMapping.Value;
+                matchingOf = ofListings.FirstOrDefault(x =>
+                    string.Equals(x.Ticker, baseTicker, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(x.ExchCode, ofExchCode, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (matchingOf is null)
+            {
+                // Fall back to matching by base ticker (any exchange)
+                matchingOf = ofListings.FirstOrDefault(x =>
+                    string.Equals(x.Ticker, baseTicker, StringComparison.OrdinalIgnoreCase));
+            }
+
+            var isin = matchingOf?.Isin;
+            var avSymbol = avMatch.Symbol;
+
+            // Handle GBX vs GBP currency reconciliation
+            var currency = avMatch.Currency ?? matchingOf?.Currency ?? "USD";
+            var quoteFactor = 1m;
+            if (string.Equals(currency, "GBX", StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.Equals(matchingOf?.Currency, "GBP", StringComparison.OrdinalIgnoreCase))
+                {
+                    quoteFactor = 100m;
+                    currency = "GBP";
+                }
+            }
+
+            var candidateKey = $"{isin}_{avSymbol}_{currency}";
+            if (seen.Add(candidateKey))
+            {
+                candidates.Add(new InstrumentListing(
+                    Isin: isin,
+                    AlphaVantageSymbol: avSymbol,
+                    Name: avMatch.Name ?? matchingOf?.Name ?? string.Empty,
+                    Exchange: matchingOf?.ExchCode ?? avMatch.Region ?? string.Empty,
+                    Currency: currency,
+                    Type: avMatch.Type ?? matchingOf?.Name ?? "Unknown",
+                    QuoteFactor: quoteFactor));
+            }
+        }
+
+        // If no AV matches, include AV-less OpenFIGI listings (for confirmation-only, won't auto-persist)
+        if (candidates.Count == 0)
+        {
+            foreach (var ofListing in ofListings.Where(x => x.Isin is not null).DistinctBy(x => x.Isin))
+            {
+                var candidateKey = $"{ofListing.Isin}___{ofListing.Currency ?? "USD"}";
+                if (seen.Add(candidateKey))
+                {
+                    candidates.Add(new InstrumentListing(
+                        Isin: ofListing.Isin,
+                        AlphaVantageSymbol: null,
+                        Name: ofListing.Name,
+                        Exchange: ofListing.ExchCode,
+                        Currency: ofListing.Currency ?? "USD",
+                        Type: "Unknown"));
+                }
+            }
+        }
+
+        return candidates;
+    }
+
+    private async Task<IReadOnlyList<OpenFigiListing>> OpenFigiCallWithFallback(string baseTicker, string? exchCode, CancellationToken ct)
+    {
+        if (IsInOpenFigiCooldown())
+        {
+            logger.LogDebug("OpenFIGI in failure cooldown; skipping call");
+            return [];
+        }
+
+        try
+        {
+            var results = await openFigiClient.MapByTickerAsync(baseTicker, exchCode, ct);
+            return results;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "OpenFIGI call failed for {BaseTicker}; entering cooldown", baseTicker);
+            _openFigiCooldownUntilUtc = DateTime.UtcNow.Add(_openFigiFailureCooldown);
+            return [];
+        }
+    }
+
+    private bool IsInOpenFigiCooldown()
+    {
+        var until = _openFigiCooldownUntilUtc;
+        return until.HasValue && DateTime.UtcNow < until.Value;
+    }
+
+    private static InstrumentResolution NoMatch() => new()
+    {
+        Kind = ResolutionKind.NoMatch,
+        Candidates = []
+    };
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentResolver.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentResolver.cs
@@ -10,6 +10,7 @@ public sealed class InstrumentResolver(
     IOpenFigiClient openFigiClient,
     IAlphaVantageClient avClient,
     IStockDetailsRepository stockDetailsRepository,
+    IQuoteFactorResolver quoteFactorResolver,
     IMemoryCache cache,
     ILogger<InstrumentResolver> logger) : IInstrumentResolver
 {
@@ -64,7 +65,7 @@ public sealed class InstrumentResolver(
         var ofListings = ofTask.Result;
 
         // Reconcile: pair AV symbol/currency/region against OpenFIGI ISIN/venue
-        var candidates = Reconcile(baseTicker, brokerSymbol.ExchangeHint, avMatches, ofListings);
+        var candidates = await Reconcile(baseTicker, brokerSymbol.ExchangeHint, avMatches, ofListings, ct);
 
         if (candidates.Count == 0)
         {
@@ -98,11 +99,12 @@ public sealed class InstrumentResolver(
         return ambiguousResult;
     }
 
-    private List<InstrumentListing> Reconcile(
+    private async Task<List<InstrumentListing>> Reconcile(
         string baseTicker,
         string? exchangeHint,
         IReadOnlyList<TickerSearchMatch> avMatches,
-        IReadOnlyList<OpenFigiListing> ofListings)
+        IReadOnlyList<OpenFigiListing> ofListings,
+        CancellationToken ct)
     {
         var candidates = new List<InstrumentListing>();
         var seen = new HashSet<string>();
@@ -149,17 +151,10 @@ public sealed class InstrumentResolver(
             var isin = matchingOf?.Isin;
             var avSymbol = avMatch.Symbol;
 
-            // Handle GBX vs GBP currency reconciliation
-            var currency = avMatch.Currency ?? matchingOf?.Currency ?? "USD";
-            var quoteFactor = 1m;
-            if (string.Equals(currency, "GBX", StringComparison.OrdinalIgnoreCase))
-            {
-                if (string.Equals(matchingOf?.Currency, "GBP", StringComparison.OrdinalIgnoreCase))
-                {
-                    quoteFactor = 100m;
-                    currency = "GBP";
-                }
-            }
+            var avCurrency = avMatch.Currency ?? "USD";
+            var ofCurrency = matchingOf?.Currency ?? "USD";
+            var quoteFactor = await quoteFactorResolver.ResolveAsync(avCurrency, ofCurrency, ct);
+            var currency = ofCurrency;  // Use OF currency as the canonical one after conversion
 
             var candidateKey = $"{isin}_{avSymbol}_{currency}";
             if (seen.Add(candidateKey))

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentResolver.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentResolver.cs
@@ -1,5 +1,6 @@
 using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
 using FinanceManager.Domain.Dtos;
+using FinanceManager.Domain.Entities.Stocks;
 using FinanceManager.Domain.Repositories;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -10,6 +11,7 @@ public sealed class InstrumentResolver(
     IOpenFigiClient openFigiClient,
     IAlphaVantageClient avClient,
     IStockDetailsRepository stockDetailsRepository,
+    ICurrencyRepository currencyRepository,
     IQuoteFactorResolver quoteFactorResolver,
     IMemoryCache cache,
     ILogger<InstrumentResolver> logger) : IInstrumentResolver
@@ -36,8 +38,11 @@ public sealed class InstrumentResolver(
         if (string.IsNullOrWhiteSpace(baseTicker))
             return NoMatch();
 
-        // Short-circuit: check if already resolved in StockDetails
-        var existing = await stockDetailsRepository.GetByTicker(baseTicker, ct);
+        // Short-circuit: check if already resolved in StockDetails. The stored ticker is the
+        // broker-facing alias (e.g. "CSPX.UK"), so try the full input first, then the base ticker.
+        var existing = await stockDetailsRepository.GetByTicker(input, ct);
+        if (existing is null && !string.Equals(input, baseTicker, StringComparison.OrdinalIgnoreCase))
+            existing = await stockDetailsRepository.GetByTicker(baseTicker, ct);
         if (existing?.Isin is not null && existing.AlphaVantageSymbol is not null)
         {
             logger.LogDebug("Found cached StockDetails for {BaseTicker}: ISIN={Isin}, AvSymbol={AvSymbol}", baseTicker, existing.Isin, existing.AlphaVantageSymbol);
@@ -83,6 +88,7 @@ public sealed class InstrumentResolver(
             if (single.Isin is not null && single.AlphaVantageSymbol is not null)
             {
                 logger.LogDebug("Auto-resolving single match: ISIN={Isin}, AvSymbol={AvSymbol}", single.Isin, single.AlphaVantageSymbol);
+                await PersistStockDetails(single, input, ct);
                 var autoResult = new InstrumentResolution
                 {
                     Kind = ResolutionKind.AutoResolved,
@@ -122,10 +128,9 @@ public sealed class InstrumentResolver(
                 continue;
 
             // Filter by exchange hint if provided
-            if (exchangeHint is not null && lookupMapping.HasValue)
+            if (exchangeHint is not null && lookupMapping is not null)
             {
-                var (_, expectedAvRegion) = lookupMapping.Value;
-                if (!string.Equals(avMatch.Region, expectedAvRegion, StringComparison.OrdinalIgnoreCase))
+                if (!lookupMapping.MatchesRegion(avMatch.Region))
                     continue;
             }
 
@@ -134,11 +139,10 @@ public sealed class InstrumentResolver(
                 .Where(x => string.Equals(x.Ticker, baseTicker, StringComparison.OrdinalIgnoreCase))
                 .ToList();
 
-            if (exchangeHint is not null && lookupMapping.HasValue)
+            if (exchangeHint is not null && lookupMapping is not null)
             {
-                var (ofExchCode, _) = lookupMapping.Value;
                 var narrowed = ofMatches
-                    .Where(x => string.Equals(x.ExchCode, ofExchCode, StringComparison.OrdinalIgnoreCase))
+                    .Where(x => string.Equals(x.ExchCode, lookupMapping.OpenFigiExchCode, StringComparison.OrdinalIgnoreCase))
                     .ToList();
                 if (narrowed.Count > 0)
                     ofMatches = narrowed;
@@ -228,6 +232,32 @@ public sealed class InstrumentResolver(
         }
     }
 
+    // Persist the auto-resolved (ISIN, AlphaVantageSymbol) pair so future lookups hit the DB
+    // layer instead of fanning out to external providers again. Best-effort: a persistence
+    // failure must not fail the resolution itself.
+    private async Task PersistStockDetails(InstrumentListing match, string brokerTicker, CancellationToken ct)
+    {
+        try
+        {
+            var currency = await currencyRepository.GetOrAdd(match.Currency, match.Currency, ct);
+            var details = new StockDetails
+            {
+                Isin = match.Isin!,
+                Ticker = brokerTicker,
+                AlphaVantageSymbol = match.AlphaVantageSymbol,
+                Name = match.Name,
+                Type = match.Type,
+                Region = match.Exchange,
+                Currency = currency
+            };
+            await stockDetailsRepository.Add(details, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "Failed to persist auto-resolved StockDetails for ISIN {Isin}", match.Isin);
+        }
+    }
+
     private async Task<IReadOnlyList<OpenFigiListing>> OpenFigiCallWithFallback(string baseTicker, string? exchCode, CancellationToken ct)
     {
         if (IsInOpenFigiCooldown())
@@ -240,6 +270,10 @@ public sealed class InstrumentResolver(
         {
             var results = await openFigiClient.MapByTickerAsync(baseTicker, exchCode, ct);
             return results;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentResolver.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/InstrumentResolver.cs
@@ -56,9 +56,12 @@ public sealed class InstrumentResolver(
             return cached2;
         }
 
-        // Fan out: AV search + OpenFIGI ticker mapping
+        // Fan out: AV search + OpenFIGI ticker mapping.
+        // Translate the broker suffix to the OpenFIGI exchange code (e.g. "UK" → "LN")
+        // before querying OpenFIGI, which keys on its own exchange codes, not broker suffixes.
+        var openFigiExchCode = brokerSymbol.TryLookupExchange()?.OpenFigiExchCode;
         var avTask = avClient.SearchTicker(baseTicker, ct);
-        var ofTask = OpenFigiCallWithFallback(baseTicker, brokerSymbol.ExchangeHint, ct);
+        var ofTask = OpenFigiCallWithFallback(baseTicker, openFigiExchCode, ct);
         await Task.WhenAll(avTask, ofTask);
 
         var avMatches = avTask.Result;
@@ -126,47 +129,40 @@ public sealed class InstrumentResolver(
                     continue;
             }
 
-            // Extract base ticker from AV symbol (e.g., "CSPX.LON" → "CSPX")
-            var avBaseTicker = avMatch.Symbol.Split('.')[0];
-
-            // Find matching OpenFIGI listing: match by base ticker or by exchange hint
-            OpenFigiListing? matchingOf = null;
+            // Gather all OpenFIGI listings for this base ticker; narrow to the hinted exchange when possible.
+            var ofMatches = ofListings
+                .Where(x => string.Equals(x.Ticker, baseTicker, StringComparison.OrdinalIgnoreCase))
+                .ToList();
 
             if (exchangeHint is not null && lookupMapping.HasValue)
             {
-                // If we have an exchange hint, find OF listing with matching exchange
                 var (ofExchCode, _) = lookupMapping.Value;
-                matchingOf = ofListings.FirstOrDefault(x =>
-                    string.Equals(x.Ticker, baseTicker, StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(x.ExchCode, ofExchCode, StringComparison.OrdinalIgnoreCase));
+                var narrowed = ofMatches
+                    .Where(x => string.Equals(x.ExchCode, ofExchCode, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                if (narrowed.Count > 0)
+                    ofMatches = narrowed;
             }
 
-            if (matchingOf is null)
+            var distinctIsins = ofMatches
+                .Where(x => !string.IsNullOrWhiteSpace(x.Isin))
+                .Select(x => x.Isin!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (distinctIsins.Count > 1)
             {
-                // Fall back to matching by base ticker (any exchange)
-                matchingOf = ofListings.FirstOrDefault(x =>
-                    string.Equals(x.Ticker, baseTicker, StringComparison.OrdinalIgnoreCase));
+                // Ambiguous: the same ticker maps to several distinct instruments and we cannot
+                // confidently pick one — emit a candidate per ISIN so the caller disambiguates.
+                foreach (var dIsin in distinctIsins)
+                {
+                    var of = ofMatches.First(x => string.Equals(x.Isin, dIsin, StringComparison.OrdinalIgnoreCase));
+                    await AddCandidate(candidates, seen, avMatch, of, ct);
+                }
             }
-
-            var isin = matchingOf?.Isin;
-            var avSymbol = avMatch.Symbol;
-
-            var avCurrency = avMatch.Currency ?? "USD";
-            var ofCurrency = matchingOf?.Currency ?? "USD";
-            var quoteFactor = await quoteFactorResolver.ResolveAsync(avCurrency, ofCurrency, ct);
-            var currency = ofCurrency;  // Use OF currency as the canonical one after conversion
-
-            var candidateKey = $"{isin}_{avSymbol}_{currency}";
-            if (seen.Add(candidateKey))
+            else
             {
-                candidates.Add(new InstrumentListing(
-                    Isin: isin,
-                    AlphaVantageSymbol: avSymbol,
-                    Name: avMatch.Name ?? matchingOf?.Name ?? string.Empty,
-                    Exchange: matchingOf?.ExchCode ?? avMatch.Region ?? string.Empty,
-                    Currency: currency,
-                    Type: avMatch.Type ?? matchingOf?.Name ?? "Unknown",
-                    QuoteFactor: quoteFactor));
+                await AddCandidate(candidates, seen, avMatch, ofMatches.FirstOrDefault(), ct);
             }
         }
 
@@ -190,6 +186,46 @@ public sealed class InstrumentResolver(
         }
 
         return candidates;
+    }
+
+    private async Task AddCandidate(
+        List<InstrumentListing> candidates,
+        HashSet<string> seen,
+        TickerSearchMatch avMatch,
+        OpenFigiListing? matchingOf,
+        CancellationToken ct)
+    {
+        var avSymbol = avMatch.Symbol;
+        var avCurrency = string.IsNullOrWhiteSpace(avMatch.Currency) ? "USD" : avMatch.Currency;
+
+        // When OpenFIGI matched, treat its currency as canonical and convert the AV quote into it.
+        // When there is no OpenFIGI match (cooldown/outage/no listing), keep the AV currency as-is.
+        string currency;
+        decimal quoteFactor;
+        if (!string.IsNullOrWhiteSpace(matchingOf?.Currency))
+        {
+            currency = matchingOf.Currency;
+            quoteFactor = await quoteFactorResolver.ResolveAsync(avCurrency, currency, ct);
+        }
+        else
+        {
+            currency = avCurrency;
+            quoteFactor = 1m;
+        }
+
+        var isin = matchingOf?.Isin;
+        var candidateKey = $"{isin}_{avSymbol}_{currency}";
+        if (seen.Add(candidateKey))
+        {
+            candidates.Add(new InstrumentListing(
+                Isin: isin,
+                AlphaVantageSymbol: avSymbol,
+                Name: string.IsNullOrWhiteSpace(avMatch.Name) ? matchingOf?.Name ?? string.Empty : avMatch.Name,
+                Exchange: matchingOf?.ExchCode ?? avMatch.Region ?? string.Empty,
+                Currency: currency,
+                Type: string.IsNullOrWhiteSpace(avMatch.Type) ? "Unknown" : avMatch.Type,
+                QuoteFactor: quoteFactor));
+        }
     }
 
     private async Task<IReadOnlyList<OpenFigiListing>> OpenFigiCallWithFallback(string baseTicker, string? exchCode, CancellationToken ct)

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/QuoteFactorResolver.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/QuoteFactorResolver.cs
@@ -1,0 +1,53 @@
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Services;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Application.FinancialAccounts.Stock.Resolution;
+
+public sealed class QuoteFactorResolver(
+    ICurrencyExchangeRateProvider exchangeRateProvider,
+    ILogger<QuoteFactorResolver> logger) : IQuoteFactorResolver
+{
+    private static readonly Dictionary<(string, string), decimal> KnownFactors = new()
+    {
+        { ("GBX", "GBP"), 100m },
+        { ("GBP", "GBX"), 0.01m },
+    };
+
+    public async Task<decimal> ResolveAsync(string fromCurrency, string toCurrency, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(fromCurrency) || string.IsNullOrWhiteSpace(toCurrency))
+            return 1m;
+
+        if (string.Equals(fromCurrency, toCurrency, StringComparison.OrdinalIgnoreCase))
+            return 1m;
+
+        var key = (fromCurrency, toCurrency);
+        if (KnownFactors.TryGetValue(key, out var knownFactor))
+        {
+            logger.LogDebug("Using known quote factor {From}→{To}: {Factor}", fromCurrency, toCurrency, knownFactor);
+            return knownFactor;
+        }
+
+        try
+        {
+            var fromCurr = new Currency { ShortName = fromCurrency, Symbol = fromCurrency };
+            var toCurr = new Currency { ShortName = toCurrency, Symbol = toCurrency };
+            var rate = await exchangeRateProvider.GetExchangeRateAsync(fromCurr, toCurr, DateTime.UtcNow);
+
+            if (rate.HasValue && rate.Value > 0)
+            {
+                logger.LogDebug("Resolved exchange rate {From}→{To}: {Rate}", fromCurrency, toCurrency, rate.Value);
+                return rate.Value;
+            }
+
+            logger.LogWarning("Exchange rate service returned null/invalid for {From}→{To}; using 1.0", fromCurrency, toCurrency);
+            return 1m;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to resolve exchange rate {From}→{To}; using 1.0", fromCurrency, toCurrency);
+            return 1m;
+        }
+    }
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/QuoteFactorResolver.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/QuoteFactorResolver.cs
@@ -8,10 +8,13 @@ public sealed class QuoteFactorResolver(
     ICurrencyExchangeRateProvider exchangeRateProvider,
     ILogger<QuoteFactorResolver> logger) : IQuoteFactorResolver
 {
-    private static readonly Dictionary<(string, string), decimal> KnownFactors = new()
+    // Conversion factors for currency pairs that share a base unit but differ in scale (not FX rates).
+    // Contract: multiply a from-amount by the factor to get the to-amount.
+    // 1 GBX (penny) = 0.01 GBP; 1 GBP = 100 GBX.
+    private static readonly Dictionary<(string, string), decimal> _knownFactors = new()
     {
-        { ("GBX", "GBP"), 100m },
-        { ("GBP", "GBX"), 0.01m },
+        { ("GBX", "GBP"), 0.01m },
+        { ("GBP", "GBX"), 100m },
     };
 
     public async Task<decimal> ResolveAsync(string fromCurrency, string toCurrency, CancellationToken ct = default)
@@ -23,7 +26,7 @@ public sealed class QuoteFactorResolver(
             return 1m;
 
         var key = (fromCurrency, toCurrency);
-        if (KnownFactors.TryGetValue(key, out var knownFactor))
+        if (_knownFactors.TryGetValue(key, out var knownFactor))
         {
             logger.LogDebug("Using known quote factor {From}→{To}: {Factor}", fromCurrency, toCurrency, knownFactor);
             return knownFactor;

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/QuoteFactorResolver.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/QuoteFactorResolver.cs
@@ -22,34 +22,40 @@ public sealed class QuoteFactorResolver(
         if (string.IsNullOrWhiteSpace(fromCurrency) || string.IsNullOrWhiteSpace(toCurrency))
             return 1m;
 
-        if (string.Equals(fromCurrency, toCurrency, StringComparison.OrdinalIgnoreCase))
+        var from = fromCurrency.Trim().ToUpperInvariant();
+        var to = toCurrency.Trim().ToUpperInvariant();
+
+        if (from == to)
             return 1m;
 
-        var key = (fromCurrency, toCurrency);
-        if (_knownFactors.TryGetValue(key, out var knownFactor))
+        if (_knownFactors.TryGetValue((from, to), out var knownFactor))
         {
-            logger.LogDebug("Using known quote factor {From}→{To}: {Factor}", fromCurrency, toCurrency, knownFactor);
+            logger.LogDebug("Using known quote factor {From}→{To}: {Factor}", from, to, knownFactor);
             return knownFactor;
         }
 
         try
         {
-            var fromCurr = new Currency { ShortName = fromCurrency, Symbol = fromCurrency };
-            var toCurr = new Currency { ShortName = toCurrency, Symbol = toCurrency };
+            var fromCurr = new Currency { ShortName = from, Symbol = from };
+            var toCurr = new Currency { ShortName = to, Symbol = to };
             var rate = await exchangeRateProvider.GetExchangeRateAsync(fromCurr, toCurr, DateTime.UtcNow);
 
             if (rate.HasValue && rate.Value > 0)
             {
-                logger.LogDebug("Resolved exchange rate {From}→{To}: {Rate}", fromCurrency, toCurrency, rate.Value);
+                logger.LogDebug("Resolved exchange rate {From}→{To}: {Rate}", from, to, rate.Value);
                 return rate.Value;
             }
 
-            logger.LogWarning("Exchange rate service returned null/invalid for {From}→{To}; using 1.0", fromCurrency, toCurrency);
+            logger.LogWarning("Exchange rate service returned null/invalid for {From}→{To}; using 1.0", from, to);
             return 1m;
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to resolve exchange rate {From}→{To}; using 1.0", fromCurrency, toCurrency);
+            logger.LogWarning(ex, "Failed to resolve exchange rate {From}→{To}; using 1.0", from, to);
             return 1m;
         }
     }

--- a/code/FinanceManager.Infrastructure/Repositories/StockDetailsRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/StockDetailsRepository.cs
@@ -57,6 +57,8 @@ internal class StockDetailsRepository(AppDbContext context) : IStockDetailsRepos
             existing.Region = details.Region;
             existing.Currency = details.Currency;
             existing.Ticker = normalized;
+            if (!string.IsNullOrWhiteSpace(details.AlphaVantageSymbol))
+                existing.AlphaVantageSymbol = details.AlphaVantageSymbol;
         }
 
         await context.SaveChangesAsync(ct);

--- a/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
@@ -50,6 +50,7 @@ public static class ServiceCollectionExtension
                 sp.GetRequiredService<IOpenFigiClient>(),
                 sp.GetRequiredService<IAlphaVantageClient>(),
                 sp.GetRequiredService<IStockDetailsRepository>(),
+                sp.GetRequiredService<ICurrencyRepository>(),
                 sp.GetRequiredService<IQuoteFactorResolver>(),
                 sp.GetRequiredService<IMemoryCache>(),
                 sp.GetRequiredService<ILogger<InstrumentResolver>>()));

--- a/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
@@ -41,11 +41,16 @@ public static class ServiceCollectionExtension
         services.AddHttpClient<OpenFigiClient>();
         services.AddScoped<IOpenFigiClient>(sp => sp.GetRequiredService<OpenFigiClient>());
         services.AddScoped<IIsinResolver, CachingIsinResolver>();
+        services.AddScoped<IQuoteFactorResolver>(sp =>
+            new QuoteFactorResolver(
+                sp.GetRequiredService<ICurrencyExchangeRateProvider>(),
+                sp.GetRequiredService<ILogger<QuoteFactorResolver>>()));
         services.AddScoped<IInstrumentResolver>(sp =>
             new InstrumentResolver(
                 sp.GetRequiredService<IOpenFigiClient>(),
                 sp.GetRequiredService<IAlphaVantageClient>(),
                 sp.GetRequiredService<IStockDetailsRepository>(),
+                sp.GetRequiredService<IQuoteFactorResolver>(),
                 sp.GetRequiredService<IMemoryCache>(),
                 sp.GetRequiredService<ILogger<InstrumentResolver>>()));
         services.AddHttpClient<ICurrencyExchangeRateProvider, FawazAhmedCurrencyApiClient>();

--- a/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
@@ -1,5 +1,6 @@
 ﻿using FinanceManager.Application.FinancialAccounts.Stock.Market;
 using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Application.FinancialAccounts.Stock.Resolution;
 using FinanceManager.Application.Insights.Generation;
 using FinanceManager.Application.Labels.Setter;
 using FinanceManager.Application.Labels.Suggestions;
@@ -24,6 +25,7 @@ using FinanceManager.Infrastructure.Services.ExternalServices;
 using FinanceManager.Infrastructure.Services.Stocks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -37,7 +39,15 @@ public static class ServiceCollectionExtension
         services.AddSingleton<IExternalServiceConfigService, ExternalServiceConfigService>();
         services.AddHttpClient<IAlphaVantageClient, AlphaVantageClient>();
         services.AddHttpClient<OpenFigiClient>();
+        services.AddScoped<IOpenFigiClient>(sp => sp.GetRequiredService<OpenFigiClient>());
         services.AddScoped<IIsinResolver, CachingIsinResolver>();
+        services.AddScoped<IInstrumentResolver>(sp =>
+            new InstrumentResolver(
+                sp.GetRequiredService<IOpenFigiClient>(),
+                sp.GetRequiredService<IAlphaVantageClient>(),
+                sp.GetRequiredService<IStockDetailsRepository>(),
+                sp.GetRequiredService<IMemoryCache>(),
+                sp.GetRequiredService<ILogger<InstrumentResolver>>()));
         services.AddHttpClient<ICurrencyExchangeRateProvider, FawazAhmedCurrencyApiClient>();
 
         services.AddAI();

--- a/code/FinanceManager.Infrastructure/Services/Stocks/OpenFigiClient.cs
+++ b/code/FinanceManager.Infrastructure/Services/Stocks/OpenFigiClient.cs
@@ -33,7 +33,7 @@ internal sealed class OpenFigiClient(
             ExchCode = exchCode ?? string.Empty
         };
 
-        return await ExecuteMapping([request], $"ticker {baseTicker} / exchCode {exchCode ?? "(any)"}", ct);
+        return await ExecuteMapping([request], $"ticker {Sanitize(baseTicker)} / exchCode {Sanitize(exchCode) ?? "(any)"}", ct);
     }
 
     public async Task<IReadOnlyList<OpenFigiListing>> MapByIsinAsync(string isin, CancellationToken ct = default)
@@ -48,7 +48,7 @@ internal sealed class OpenFigiClient(
             ExchCode = string.Empty
         };
 
-        return await ExecuteMapping([request], $"ISIN {isin}", ct);
+        return await ExecuteMapping([request], $"ISIN {Sanitize(isin)}", ct);
     }
 
     public async Task<string?> ResolveAsync(string ticker, string? region = null, CancellationToken ct = default)
@@ -56,22 +56,32 @@ internal sealed class OpenFigiClient(
         if (string.IsNullOrWhiteSpace(ticker))
             return null;
 
-        var results = await MapByTickerAsync(ticker, region, ct);
-        var first = results.FirstOrDefault();
-        if (first is null)
+        try
         {
-            logger.LogDebug("OpenFIGI returned no results for ticker {Ticker}", ticker);
+            var results = await MapByTickerAsync(ticker, region, ct);
+            var first = results.FirstOrDefault();
+            if (first is null)
+            {
+                logger.LogDebug("OpenFIGI returned no results for ticker {Ticker}", Sanitize(ticker));
+                return null;
+            }
+
+            if (string.IsNullOrWhiteSpace(first.Isin))
+            {
+                logger.LogDebug("OpenFIGI returned no ISIN for ticker {Ticker}", Sanitize(ticker));
+                return null;
+            }
+
+            logger.LogDebug("Resolved ticker {Ticker} to ISIN {Isin}", Sanitize(ticker), Sanitize(first.Isin));
+            return first.Isin;
+        }
+        catch (Exception ex)
+        {
+            // Legacy IIsinResolver contract returns null on failure; the decorating
+            // CachingIsinResolver handles its own cooldown when null is returned.
+            logger.LogWarning(ex, "OpenFIGI resolve failed for ticker {Ticker}", Sanitize(ticker));
             return null;
         }
-
-        if (string.IsNullOrWhiteSpace(first.Isin))
-        {
-            logger.LogDebug("OpenFIGI returned no ISIN for ticker {Ticker}", ticker);
-            return null;
-        }
-
-        logger.LogDebug("Resolved ticker {Ticker} to ISIN {Isin}", ticker, first.Isin);
-        return first.Isin;
     }
 
     private async Task<IReadOnlyList<OpenFigiListing>> ExecuteMapping(List<OpenFigiMappingRequest> requests, string debugLabel, CancellationToken ct)
@@ -79,49 +89,67 @@ internal sealed class OpenFigiClient(
         var serviceConfig = await configService.GetServiceAsync("OpenFigi", ct);
         var url = $"{serviceConfig.BaseUrl.TrimEnd('/')}/mapping";
 
+        var content = JsonSerializer.Serialize(requests);
+        var httpContent = new StringContent(content, System.Text.Encoding.UTF8, "application/json");
+
+        if (!string.IsNullOrWhiteSpace(serviceConfig.ApiKey))
+            httpContent.Headers.Add("X-OPENFIGI-APIKEY", serviceConfig.ApiKey);
+
+        var response = await httpClient.PostAsync(url, httpContent, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            // Surface transport-level failures (rate limits, outages) so callers can back off /
+            // enter cooldown. Distinct from a successful response that simply contains no listings.
+            logger.LogWarning("OpenFIGI mapping request failed with status {StatusCode} for {DebugLabel}", response.StatusCode, debugLabel);
+            throw new HttpRequestException($"OpenFIGI mapping request failed with status {response.StatusCode}");
+        }
+
+        var responseContent = await response.Content.ReadAsStringAsync(ct);
+
+        List<OpenFigiMappingResponse>? jobs;
         try
         {
-            var content = JsonSerializer.Serialize(requests);
-            var httpContent = new StringContent(content, System.Text.Encoding.UTF8, "application/json");
-
-            if (!string.IsNullOrWhiteSpace(serviceConfig.ApiKey))
-                httpContent.Headers.Add("X-OPENFIGI-APIKEY", serviceConfig.ApiKey);
-
-            var response = await httpClient.PostAsync(url, httpContent, ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                logger.LogWarning("OpenFIGI mapping request failed with status {StatusCode} for {DebugLabel}", response.StatusCode, debugLabel);
-                return [];
-            }
-
-            var responseContent = await response.Content.ReadAsStringAsync(ct);
-            var results = JsonSerializer.Deserialize<List<OpenFigiMappingResponse>>(responseContent, _jsonOptions);
-
-            if (results is null || results.Count == 0)
-            {
-                logger.LogDebug("OpenFIGI returned no results for {DebugLabel}", debugLabel);
-                return [];
-            }
-
-            var listings = new List<OpenFigiListing>(results.Count);
-            foreach (var result in results)
-            {
-                listings.Add(new OpenFigiListing(
-                    Isin: result.Isin,
-                    Ticker: result.Ticker ?? string.Empty,
-                    Name: result.Name ?? string.Empty,
-                    ExchCode: result.ExchCode ?? string.Empty,
-                    Currency: result.Currency));
-            }
-
-            return listings;
+            jobs = JsonSerializer.Deserialize<List<OpenFigiMappingResponse>>(responseContent, _jsonOptions);
         }
-        catch (Exception ex)
+        catch (JsonException ex)
         {
-            logger.LogError(ex, "OpenFIGI mapping request failed for {DebugLabel}", debugLabel);
+            logger.LogWarning(ex, "OpenFIGI returned unparseable content for {DebugLabel}", debugLabel);
             return [];
         }
+
+        if (jobs is null || jobs.Count == 0)
+        {
+            logger.LogDebug("OpenFIGI returned no results for {DebugLabel}", debugLabel);
+            return [];
+        }
+
+        // OpenFIGI v3 wraps each job's matches inside a "data" array; flatten across all jobs.
+        var listings = new List<OpenFigiListing>();
+        foreach (var job in jobs)
+        {
+            if (job.Data is null)
+                continue;
+
+            foreach (var match in job.Data)
+            {
+                listings.Add(new OpenFigiListing(
+                    Isin: match.Isin,
+                    Ticker: match.Ticker ?? string.Empty,
+                    Name: match.Name ?? string.Empty,
+                    ExchCode: match.ExchCode ?? string.Empty,
+                    Currency: match.Currency));
+            }
+        }
+
+        if (listings.Count == 0)
+            logger.LogDebug("OpenFIGI returned no listings for {DebugLabel}", debugLabel);
+
+        return listings;
     }
+
+    // Strip CR/LF so attacker-influenced ticker/ISIN values cannot forge log entries (log injection).
+    private static string? Sanitize(string? value)
+        => value?.Replace("\r", string.Empty).Replace("\n", string.Empty);
 
     private sealed class OpenFigiMappingRequest
     {
@@ -136,6 +164,15 @@ internal sealed class OpenFigiClient(
     }
 
     private sealed class OpenFigiMappingResponse
+    {
+        [JsonPropertyName("data")]
+        public List<OpenFigiMatch>? Data { get; set; }
+
+        [JsonPropertyName("error")]
+        public string? Error { get; set; }
+    }
+
+    private sealed class OpenFigiMatch
     {
         [JsonPropertyName("figi")]
         public string? Figi { get; set; }

--- a/code/FinanceManager.Infrastructure/Services/Stocks/OpenFigiClient.cs
+++ b/code/FinanceManager.Infrastructure/Services/Stocks/OpenFigiClient.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Application.FinancialAccounts.Stock.Resolution;
 using FinanceManager.Application.Shared.ExternalServices;
 using FinanceManager.Domain.Services;
 using Microsoft.Extensions.Logging;
@@ -7,37 +8,80 @@ using System.Text.Json.Serialization;
 namespace FinanceManager.Infrastructure.Services.Stocks;
 
 /// <summary>
-/// OpenFIGI API client for resolving ticker symbols to ISINs.
+/// OpenFIGI API client for resolving ticker symbols to ISINs and listing metadata.
 /// See: https://www.openfigi.com/api
 /// </summary>
 internal sealed class OpenFigiClient(
     HttpClient httpClient,
     ILogger<OpenFigiClient> logger,
-    IExternalServiceConfigService configService) : IIsinResolver
+    IExternalServiceConfigService configService) : IOpenFigiClient, IIsinResolver
 {
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
         PropertyNameCaseInsensitive = true
     };
 
+    public async Task<IReadOnlyList<OpenFigiListing>> MapByTickerAsync(string baseTicker, string? exchCode = null, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(baseTicker))
+            return [];
+
+        var request = new OpenFigiMappingRequest
+        {
+            IdType = "TICKER",
+            IdValue = baseTicker,
+            ExchCode = exchCode ?? string.Empty
+        };
+
+        return await ExecuteMapping([request], $"ticker {baseTicker} / exchCode {exchCode ?? "(any)"}", ct);
+    }
+
+    public async Task<IReadOnlyList<OpenFigiListing>> MapByIsinAsync(string isin, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(isin))
+            return [];
+
+        var request = new OpenFigiMappingRequest
+        {
+            IdType = "ID_ISIN",
+            IdValue = isin,
+            ExchCode = string.Empty
+        };
+
+        return await ExecuteMapping([request], $"ISIN {isin}", ct);
+    }
+
     public async Task<string?> ResolveAsync(string ticker, string? region = null, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(ticker))
             return null;
 
-        var serviceConfig = await configService.GetServiceAsync("OpenFigi", ct);
-        var request = new OpenFigiMappingRequest
+        var results = await MapByTickerAsync(ticker, region, ct);
+        var first = results.FirstOrDefault();
+        if (first is null)
         {
-            IdType = "TICKER",
-            IdValue = ticker,
-            ExchCode = region ?? string.Empty
-        };
+            logger.LogDebug("OpenFIGI returned no results for ticker {Ticker}", ticker);
+            return null;
+        }
 
+        if (string.IsNullOrWhiteSpace(first.Isin))
+        {
+            logger.LogDebug("OpenFIGI returned no ISIN for ticker {Ticker}", ticker);
+            return null;
+        }
+
+        logger.LogDebug("Resolved ticker {Ticker} to ISIN {Isin}", ticker, first.Isin);
+        return first.Isin;
+    }
+
+    private async Task<IReadOnlyList<OpenFigiListing>> ExecuteMapping(List<OpenFigiMappingRequest> requests, string debugLabel, CancellationToken ct)
+    {
+        var serviceConfig = await configService.GetServiceAsync("OpenFigi", ct);
         var url = $"{serviceConfig.BaseUrl.TrimEnd('/')}/mapping";
 
         try
         {
-            var content = JsonSerializer.Serialize(new[] { request });
+            var content = JsonSerializer.Serialize(requests);
             var httpContent = new StringContent(content, System.Text.Encoding.UTF8, "application/json");
 
             if (!string.IsNullOrWhiteSpace(serviceConfig.ApiKey))
@@ -46,8 +90,8 @@ internal sealed class OpenFigiClient(
             var response = await httpClient.PostAsync(url, httpContent, ct);
             if (!response.IsSuccessStatusCode)
             {
-                logger.LogWarning("OpenFIGI mapping request failed with status {StatusCode} for ticker {Ticker}", response.StatusCode, ticker);
-                return null;
+                logger.LogWarning("OpenFIGI mapping request failed with status {StatusCode} for {DebugLabel}", response.StatusCode, debugLabel);
+                return [];
             }
 
             var responseContent = await response.Content.ReadAsStringAsync(ct);
@@ -55,24 +99,27 @@ internal sealed class OpenFigiClient(
 
             if (results is null || results.Count == 0)
             {
-                logger.LogDebug("OpenFIGI returned no results for ticker {Ticker}", ticker);
-                return null;
+                logger.LogDebug("OpenFIGI returned no results for {DebugLabel}", debugLabel);
+                return [];
             }
 
-            var isin = results[0].Isin;
-            if (string.IsNullOrWhiteSpace(isin))
+            var listings = new List<OpenFigiListing>(results.Count);
+            foreach (var result in results)
             {
-                logger.LogDebug("OpenFIGI returned no ISIN for ticker {Ticker}", ticker);
-                return null;
+                listings.Add(new OpenFigiListing(
+                    Isin: result.Isin,
+                    Ticker: result.Ticker ?? string.Empty,
+                    Name: result.Name ?? string.Empty,
+                    ExchCode: result.ExchCode ?? string.Empty,
+                    Currency: result.Currency));
             }
 
-            logger.LogDebug("Resolved ticker {Ticker} to ISIN {Isin}", ticker, isin);
-            return isin;
+            return listings;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "OpenFIGI mapping request failed for ticker {Ticker}", ticker);
-            return null;
+            logger.LogError(ex, "OpenFIGI mapping request failed for {DebugLabel}", debugLabel);
+            return [];
         }
     }
 
@@ -101,5 +148,14 @@ internal sealed class OpenFigiClient(
 
         [JsonPropertyName("compositeFigi")]
         public string? CompositeFigi { get; set; }
+
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("exchCode")]
+        public string? ExchCode { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string? Currency { get; set; }
     }
 }

--- a/code/FinanceManager.Infrastructure/Services/Stocks/OpenFigiClient.cs
+++ b/code/FinanceManager.Infrastructure/Services/Stocks/OpenFigiClient.cs
@@ -75,6 +75,10 @@ internal sealed class OpenFigiClient(
             logger.LogDebug("Resolved ticker {Ticker} to ISIN {Isin}", Sanitize(ticker), Sanitize(first.Isin));
             return first.Isin;
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             // Legacy IIsinResolver contract returns null on failure; the decorating
@@ -90,12 +94,12 @@ internal sealed class OpenFigiClient(
         var url = $"{serviceConfig.BaseUrl.TrimEnd('/')}/mapping";
 
         var content = JsonSerializer.Serialize(requests);
-        var httpContent = new StringContent(content, System.Text.Encoding.UTF8, "application/json");
+        using var httpContent = new StringContent(content, System.Text.Encoding.UTF8, "application/json");
 
         if (!string.IsNullOrWhiteSpace(serviceConfig.ApiKey))
             httpContent.Headers.Add("X-OPENFIGI-APIKEY", serviceConfig.ApiKey);
 
-        var response = await httpClient.PostAsync(url, httpContent, ct);
+        using var response = await httpClient.PostAsync(url, httpContent, ct);
         if (!response.IsSuccessStatusCode)
         {
             // Surface transport-level failures (rate limits, outages) so callers can back off /

--- a/code/FinanceManager.Tests.Unit/Application/Services/Stocks/InstrumentResolverTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Stocks/InstrumentResolverTests.cs
@@ -17,11 +17,24 @@ public class InstrumentResolverTests
     private readonly Mock<IOpenFigiClient> _openFigiClientMock = new();
     private readonly Mock<IAlphaVantageClient> _avClientMock = new();
     private readonly Mock<IStockDetailsRepository> _stockDetailsRepositoryMock = new();
+    private readonly Mock<IQuoteFactorResolver> _quoteFactorResolverMock = new();
     private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
     private readonly ILogger<InstrumentResolver> _logger = LoggerFactory.Create(_ => { }).CreateLogger<InstrumentResolver>();
 
-    private InstrumentResolver CreateResolver() =>
-        new(_openFigiClientMock.Object, _avClientMock.Object, _stockDetailsRepositoryMock.Object, _cache, _logger);
+    private InstrumentResolver CreateResolver()
+    {
+        _quoteFactorResolverMock
+            .Setup(x => x.ResolveAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1m);  // Default: no conversion
+
+        return new(
+            _openFigiClientMock.Object,
+            _avClientMock.Object,
+            _stockDetailsRepositoryMock.Object,
+            _quoteFactorResolverMock.Object,
+            _cache,
+            _logger);
+    }
 
     [Fact]
     public async Task ResolveAsync_WithNullOrWhitespaceTicker_ReturnsNoMatch()
@@ -259,6 +272,10 @@ public class InstrumentResolverTests
                     Currency: "GBP")
             });
 
+        _quoteFactorResolverMock
+            .Setup(x => x.ResolveAsync("GBX", "GBP", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(100m);  // GBX → GBP conversion factor
+
         _stockDetailsRepositoryMock
             .Setup(x => x.GetByTicker("VANGUARD", It.IsAny<CancellationToken>()))
             .ReturnsAsync((StockDetails?)null);
@@ -269,6 +286,9 @@ public class InstrumentResolverTests
         Assert.NotNull(result.Match);
         Assert.Equal("GBP", result.Match.Currency);
         Assert.Equal(100m, result.Match.QuoteFactor);
+        _quoteFactorResolverMock.Verify(
+            x => x.ResolveAsync("GBX", "GBP", It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Unit/Application/Services/Stocks/InstrumentResolverTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Stocks/InstrumentResolverTests.cs
@@ -1,0 +1,304 @@
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Application.FinancialAccounts.Stock.Resolution;
+using FinanceManager.Domain.Dtos;
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Entities.Stocks;
+using FinanceManager.Domain.Repositories;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services.Stocks;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class InstrumentResolverTests
+{
+    private readonly Mock<IOpenFigiClient> _openFigiClientMock = new();
+    private readonly Mock<IAlphaVantageClient> _avClientMock = new();
+    private readonly Mock<IStockDetailsRepository> _stockDetailsRepositoryMock = new();
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+    private readonly ILogger<InstrumentResolver> _logger = LoggerFactory.Create(_ => { }).CreateLogger<InstrumentResolver>();
+
+    private InstrumentResolver CreateResolver() =>
+        new(_openFigiClientMock.Object, _avClientMock.Object, _stockDetailsRepositoryMock.Object, _cache, _logger);
+
+    [Fact]
+    public async Task ResolveAsync_WithNullOrWhitespaceTicker_ReturnsNoMatch()
+    {
+        var resolver = CreateResolver();
+
+        var result = await resolver.ResolveAsync(null!, TestContext.Current.CancellationToken);
+
+        Assert.Equal(ResolutionKind.NoMatch, result.Kind);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithSingleUnambiguousMatch_ReturnsAutoResolved()
+    {
+        var resolver = CreateResolver();
+        _avClientMock
+            .Setup(x => x.SearchTicker("CSPX", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TickerSearchMatch>
+            {
+                new()
+                {
+                    Symbol = "CSPX.LON",
+                    Name = "iShares Core S&P 500 ETF",
+                    Type = "ETF",
+                    Region = "GB",
+                    Currency = "GBP",
+                    MatchScore = 1m
+                }
+            });
+
+        _openFigiClientMock
+            .Setup(x => x.MapByTickerAsync("CSPX", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OpenFigiListing>
+            {
+                new(
+                    Isin: "IE00B5BMR087",
+                    Ticker: "CSPX",
+                    Name: "iShares Core S&P 500 ETF",
+                    ExchCode: "LN",
+                    Currency: "GBP")
+            });
+
+        _stockDetailsRepositoryMock
+            .Setup(x => x.GetByTicker("CSPX", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockDetails?)null);
+
+        var result = await resolver.ResolveAsync("CSPX", TestContext.Current.CancellationToken);
+
+        Assert.Equal(ResolutionKind.AutoResolved, result.Kind);
+        Assert.NotNull(result.Match);
+        Assert.Equal("IE00B5BMR087", result.Match.Isin);
+        Assert.Equal("CSPX.LON", result.Match.AlphaVantageSymbol);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithMultipleExchanges_ReturnsCandidatesAmbiguous()
+    {
+        var resolver = CreateResolver();
+        _avClientMock
+            .Setup(x => x.SearchTicker("AAPL", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TickerSearchMatch>
+            {
+                new()
+                {
+                    Symbol = "AAPL",
+                    Name = "Apple Inc",
+                    Type = "Equity",
+                    Region = "US",
+                    Currency = "USD",
+                    MatchScore = 1m
+                },
+                new()
+                {
+                    Symbol = "AAPL.LSE",
+                    Name = "Apple Inc",
+                    Type = "Equity",
+                    Region = "GB",
+                    Currency = "GBP",
+                    MatchScore = 0.8m
+                }
+            });
+
+        _openFigiClientMock
+            .Setup(x => x.MapByTickerAsync("AAPL", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OpenFigiListing>
+            {
+                new(
+                    Isin: "US0378331005",
+                    Ticker: "AAPL",
+                    Name: "Apple Inc",
+                    ExchCode: "US",
+                    Currency: "USD"),
+                new(
+                    Isin: "US0378331005",
+                    Ticker: "AAPL",
+                    Name: "Apple Inc",
+                    ExchCode: "LN",
+                    Currency: "GBP")
+            });
+
+        _stockDetailsRepositoryMock
+            .Setup(x => x.GetByTicker("AAPL", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockDetails?)null);
+
+        var result = await resolver.ResolveAsync("AAPL", TestContext.Current.CancellationToken);
+
+        Assert.Equal(ResolutionKind.Ambiguous, result.Kind);
+        Assert.True(result.Candidates.Count >= 2);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithExchangeHintDisambiguates_ReturnsAutoResolved()
+    {
+        var resolver = CreateResolver();
+        _avClientMock
+            .Setup(x => x.SearchTicker("MSFT", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TickerSearchMatch>
+            {
+                new()
+                {
+                    Symbol = "MSFT",
+                    Name = "Microsoft Corp",
+                    Type = "Equity",
+                    Region = "US",
+                    Currency = "USD",
+                    MatchScore = 1m
+                }
+            });
+
+        _openFigiClientMock
+            .Setup(x => x.MapByTickerAsync("MSFT", "US", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OpenFigiListing>
+            {
+                new(
+                    Isin: "US5949181045",
+                    Ticker: "MSFT",
+                    Name: "Microsoft Corp",
+                    ExchCode: "US",
+                    Currency: "USD")
+            });
+
+        _stockDetailsRepositoryMock
+            .Setup(x => x.GetByTicker("MSFT", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockDetails?)null);
+
+        var result = await resolver.ResolveAsync("MSFT.US", TestContext.Current.CancellationToken);
+
+        Assert.Equal(ResolutionKind.AutoResolved, result.Kind);
+        Assert.NotNull(result.Match);
+        Assert.Equal("US5949181045", result.Match.Isin);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithNoMatch_ReturnsNoMatch()
+    {
+        var resolver = CreateResolver();
+        _avClientMock
+            .Setup(x => x.SearchTicker("INVALIDTICKER", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TickerSearchMatch>());
+
+        _openFigiClientMock
+            .Setup(x => x.MapByTickerAsync("INVALIDTICKER", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OpenFigiListing>());
+
+        _stockDetailsRepositoryMock
+            .Setup(x => x.GetByTicker("INVALIDTICKER", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockDetails?)null);
+
+        var result = await resolver.ResolveAsync("INVALIDTICKER", TestContext.Current.CancellationToken);
+
+        Assert.Equal(ResolutionKind.NoMatch, result.Kind);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithOpenFigiFailure_FallsBackToAvOnly()
+    {
+        var resolver = CreateResolver();
+        _avClientMock
+            .Setup(x => x.SearchTicker("CSPX", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TickerSearchMatch>
+            {
+                new()
+                {
+                    Symbol = "CSPX.LON",
+                    Name = "iShares Core S&P 500 ETF",
+                    Type = "ETF",
+                    Region = "GB",
+                    Currency = "GBP",
+                    MatchScore = 1m
+                }
+            });
+
+        _openFigiClientMock
+            .Setup(x => x.MapByTickerAsync("CSPX", null, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("OpenFIGI API unavailable"));
+
+        _stockDetailsRepositoryMock
+            .Setup(x => x.GetByTicker("CSPX", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockDetails?)null);
+
+        var result = await resolver.ResolveAsync("CSPX", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.True(result.Kind is ResolutionKind.Ambiguous or ResolutionKind.AutoResolved);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithGbxCurrency_HandlesQuoteFactor()
+    {
+        var resolver = CreateResolver();
+        _avClientMock
+            .Setup(x => x.SearchTicker("VANGUARD", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TickerSearchMatch>
+            {
+                new()
+                {
+                    Symbol = "VANGUARD.LSE",
+                    Name = "Vanguard FTSE All-Share ETF",
+                    Type = "ETF",
+                    Region = "GB",
+                    Currency = "GBX",
+                    MatchScore = 1m
+                }
+            });
+
+        _openFigiClientMock
+            .Setup(x => x.MapByTickerAsync("VANGUARD", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OpenFigiListing>
+            {
+                new(
+                    Isin: "IE00B4L5Y983",
+                    Ticker: "VANGUARD",
+                    Name: "Vanguard FTSE All-Share ETF",
+                    ExchCode: "LN",
+                    Currency: "GBP")
+            });
+
+        _stockDetailsRepositoryMock
+            .Setup(x => x.GetByTicker("VANGUARD", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockDetails?)null);
+
+        var result = await resolver.ResolveAsync("VANGUARD", TestContext.Current.CancellationToken);
+
+        Assert.Equal(ResolutionKind.AutoResolved, result.Kind);
+        Assert.NotNull(result.Match);
+        Assert.Equal("GBP", result.Match.Currency);
+        Assert.Equal(100m, result.Match.QuoteFactor);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WithCachedStockDetails_ReturnsCachedMatch()
+    {
+        var resolver = CreateResolver();
+        var gbp = new Currency { ShortName = "GBP", Symbol = "£" };
+        var existing = new StockDetails
+        {
+            Isin = "IE00B5BMR087",
+            Ticker = "CSPX",
+            AlphaVantageSymbol = "CSPX.LON",
+            Name = "iShares Core S&P 500 ETF",
+            Type = "ETF",
+            Region = "GB",
+            Currency = gbp
+        };
+
+        _stockDetailsRepositoryMock
+            .Setup(x => x.GetByTicker("CSPX", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var result = await resolver.ResolveAsync("CSPX", TestContext.Current.CancellationToken);
+
+        Assert.Equal(ResolutionKind.AutoResolved, result.Kind);
+        Assert.NotNull(result.Match);
+        Assert.Equal("IE00B5BMR087", result.Match.Isin);
+        Assert.Equal("CSPX.LON", result.Match.AlphaVantageSymbol);
+
+        _avClientMock.Verify(x => x.SearchTicker(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _openFigiClientMock.Verify(x => x.MapByTickerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/Stocks/InstrumentResolverTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Stocks/InstrumentResolverTests.cs
@@ -188,6 +188,66 @@ public class InstrumentResolverTests
     }
 
     [Fact]
+    public async Task ResolveAsync_SingleAvMatchButMultipleDistinctIsins_StaysAmbiguous()
+    {
+        // No exchange hint, one AV match, but OpenFIGI returns two DIFFERENT instruments
+        // sharing the ticker — the resolver must not auto-resolve an arbitrary one.
+        var resolver = CreateResolver();
+        _avClientMock
+            .Setup(x => x.SearchTicker("ABC", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TickerSearchMatch>
+            {
+                new() { Symbol = "ABC", Name = "Ambiguous Co", Type = "Equity", Region = "US", Currency = "USD", MatchScore = 1m }
+            });
+
+        _openFigiClientMock
+            .Setup(x => x.MapByTickerAsync("ABC", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OpenFigiListing>
+            {
+                new(Isin: "US1111111111", Ticker: "ABC", Name: "Ambiguous Co A", ExchCode: "US", Currency: "USD"),
+                new(Isin: "US2222222222", Ticker: "ABC", Name: "Ambiguous Co B", ExchCode: "UN", Currency: "USD")
+            });
+
+        _stockDetailsRepositoryMock
+            .Setup(x => x.GetByTicker("ABC", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockDetails?)null);
+
+        var result = await resolver.ResolveAsync("ABC", TestContext.Current.CancellationToken);
+
+        Assert.Equal(ResolutionKind.Ambiguous, result.Kind);
+        Assert.Equal(2, result.Candidates.Count);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_OpenFigiDown_KeepsAlphaVantageCurrency()
+    {
+        // During an OpenFIGI outage the AV-only candidate must retain the AV currency,
+        // not be forced to USD.
+        var resolver = CreateResolver();
+        _avClientMock
+            .Setup(x => x.SearchTicker("CSPX", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TickerSearchMatch>
+            {
+                new() { Symbol = "CSPX.LON", Name = "iShares Core S&P 500 ETF", Type = "ETF", Region = "GB", Currency = "GBP", MatchScore = 1m }
+            });
+
+        _openFigiClientMock
+            .Setup(x => x.MapByTickerAsync("CSPX", null, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("OpenFIGI unavailable"));
+
+        _stockDetailsRepositoryMock
+            .Setup(x => x.GetByTicker("CSPX", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockDetails?)null);
+
+        var result = await resolver.ResolveAsync("CSPX", TestContext.Current.CancellationToken);
+
+        var candidate = result.Match ?? Assert.Single(result.Candidates);
+        Assert.Equal("GBP", candidate.Currency);
+        Assert.Equal(1m, candidate.QuoteFactor);
+        Assert.Null(candidate.Isin);
+    }
+
+    [Fact]
     public async Task ResolveAsync_WithNoMatch_ReturnsNoMatch()
     {
         var resolver = CreateResolver();
@@ -272,9 +332,10 @@ public class InstrumentResolverTests
                     Currency: "GBP")
             });
 
+        // 1 GBX = 0.01 GBP (contract: multiply from-amount by factor to get to-amount)
         _quoteFactorResolverMock
             .Setup(x => x.ResolveAsync("GBX", "GBP", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(100m);  // GBX → GBP conversion factor
+            .ReturnsAsync(0.01m);
 
         _stockDetailsRepositoryMock
             .Setup(x => x.GetByTicker("VANGUARD", It.IsAny<CancellationToken>()))
@@ -285,7 +346,7 @@ public class InstrumentResolverTests
         Assert.Equal(ResolutionKind.AutoResolved, result.Kind);
         Assert.NotNull(result.Match);
         Assert.Equal("GBP", result.Match.Currency);
-        Assert.Equal(100m, result.Match.QuoteFactor);
+        Assert.Equal(0.01m, result.Match.QuoteFactor);
         _quoteFactorResolverMock.Verify(
             x => x.ResolveAsync("GBX", "GBP", It.IsAny<CancellationToken>()),
             Times.Once);

--- a/code/FinanceManager.Tests.Unit/Application/Services/Stocks/InstrumentResolverTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Stocks/InstrumentResolverTests.cs
@@ -17,6 +17,7 @@ public class InstrumentResolverTests
     private readonly Mock<IOpenFigiClient> _openFigiClientMock = new();
     private readonly Mock<IAlphaVantageClient> _avClientMock = new();
     private readonly Mock<IStockDetailsRepository> _stockDetailsRepositoryMock = new();
+    private readonly Mock<ICurrencyRepository> _currencyRepositoryMock = new();
     private readonly Mock<IQuoteFactorResolver> _quoteFactorResolverMock = new();
     private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
     private readonly ILogger<InstrumentResolver> _logger = LoggerFactory.Create(_ => { }).CreateLogger<InstrumentResolver>();
@@ -27,21 +28,34 @@ public class InstrumentResolverTests
             .Setup(x => x.ResolveAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(1m);  // Default: no conversion
 
+        _currencyRepositoryMock
+            .Setup(x => x.GetOrAdd(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string shortName, string? symbol, CancellationToken _) =>
+                new Currency { ShortName = shortName, Symbol = symbol ?? shortName });
+
+        _stockDetailsRepositoryMock
+            .Setup(x => x.Add(It.IsAny<StockDetails>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((StockDetails d, CancellationToken _) => d);
+
         return new(
             _openFigiClientMock.Object,
             _avClientMock.Object,
             _stockDetailsRepositoryMock.Object,
+            _currencyRepositoryMock.Object,
             _quoteFactorResolverMock.Object,
             _cache,
             _logger);
     }
 
-    [Fact]
-    public async Task ResolveAsync_WithNullOrWhitespaceTicker_ReturnsNoMatch()
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task ResolveAsync_WithNullOrWhitespaceTicker_ReturnsNoMatch(string? input)
     {
         var resolver = CreateResolver();
 
-        var result = await resolver.ResolveAsync(null!, TestContext.Current.CancellationToken);
+        var result = await resolver.ResolveAsync(input!, TestContext.Current.CancellationToken);
 
         Assert.Equal(ResolutionKind.NoMatch, result.Kind);
     }
@@ -87,6 +101,13 @@ public class InstrumentResolverTests
         Assert.NotNull(result.Match);
         Assert.Equal("IE00B5BMR087", result.Match.Isin);
         Assert.Equal("CSPX.LON", result.Match.AlphaVantageSymbol);
+
+        // Auto-resolved pair must be persisted so future lookups skip the providers.
+        _stockDetailsRepositoryMock.Verify(
+            x => x.Add(
+                It.Is<StockDetails>(d => d.Isin == "IE00B5BMR087" && d.AlphaVantageSymbol == "CSPX.LON"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Unit/Application/Services/Stocks/QuoteFactorResolverTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Stocks/QuoteFactorResolverTests.cs
@@ -1,0 +1,80 @@
+using FinanceManager.Application.FinancialAccounts.Stock.Resolution;
+using FinanceManager.Domain.Entities.Currencies;
+using FinanceManager.Domain.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services.Stocks;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class QuoteFactorResolverTests
+{
+    private readonly Mock<ICurrencyExchangeRateProvider> _exchangeRateProviderMock = new();
+    private readonly ILogger<QuoteFactorResolver> _logger = LoggerFactory.Create(_ => { }).CreateLogger<QuoteFactorResolver>();
+
+    private QuoteFactorResolver CreateResolver() => new(_exchangeRateProviderMock.Object, _logger);
+
+    [Fact]
+    public async Task ResolveAsync_GbxToGbp_Returns0point01()
+    {
+        var resolver = CreateResolver();
+
+        var factor = await resolver.ResolveAsync("GBX", "GBP", TestContext.Current.CancellationToken);
+
+        // 1 GBX (penny) = 0.01 GBP; contract is multiply from-amount by factor to get to-amount.
+        Assert.Equal(0.01m, factor);
+        _exchangeRateProviderMock.Verify(
+            x => x.GetExchangeRateAsync(It.IsAny<Currency>(), It.IsAny<Currency>(), It.IsAny<DateTime>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_GbpToGbx_Returns100()
+    {
+        var resolver = CreateResolver();
+
+        var factor = await resolver.ResolveAsync("GBP", "GBX", TestContext.Current.CancellationToken);
+
+        Assert.Equal(100m, factor);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SameCurrency_Returns1()
+    {
+        var resolver = CreateResolver();
+
+        var factor = await resolver.ResolveAsync("USD", "USD", TestContext.Current.CancellationToken);
+
+        Assert.Equal(1m, factor);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_UnknownPair_FallsBackToExchangeRateApi()
+    {
+        var resolver = CreateResolver();
+        _exchangeRateProviderMock
+            .Setup(x => x.GetExchangeRateAsync(
+                It.Is<Currency>(c => c.ShortName == "USD"),
+                It.Is<Currency>(c => c.ShortName == "EUR"),
+                It.IsAny<DateTime>()))
+            .ReturnsAsync(0.92m);
+
+        var factor = await resolver.ResolveAsync("USD", "EUR", TestContext.Current.CancellationToken);
+
+        Assert.Equal(0.92m, factor);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_WhenExchangeApiFails_Returns1()
+    {
+        var resolver = CreateResolver();
+        _exchangeRateProviderMock
+            .Setup(x => x.GetExchangeRateAsync(It.IsAny<Currency>(), It.IsAny<Currency>(), It.IsAny<DateTime>()))
+            .ThrowsAsync(new HttpRequestException("network down"));
+
+        var factor = await resolver.ResolveAsync("USD", "JPY", TestContext.Current.CancellationToken);
+
+        Assert.Equal(1m, factor);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Services/Stocks/OpenFigiClientTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Services/Stocks/OpenFigiClientTests.cs
@@ -184,6 +184,87 @@ public class OpenFigiClientTests
         Assert.Equal("US0378331005", result);
     }
 
+    [Fact]
+    public async Task MapByTickerAsync_WithValidTickerAndExchange_ReturnsListings()
+    {
+        // Arrange
+        var httpHandler = new MockHttpMessageHandler(response: """
+            [
+              {
+                "figi": "BBG000B9XRY4",
+                "ticker": "AAPL",
+                "isin": "US0378331005",
+                "compositeFigi": "BBG000HKWL63",
+                "name": "Apple Inc",
+                "exchCode": "US",
+                "currency": "USD"
+              }
+            ]
+            """);
+
+        var client = CreateClient(httpHandler);
+
+        // Act
+        var result = await client.MapByTickerAsync("AAPL", "US", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal("US0378331005", result[0].Isin);
+        Assert.Equal("AAPL", result[0].Ticker);
+        Assert.Equal("Apple Inc", result[0].Name);
+        Assert.Equal("US", result[0].ExchCode);
+        Assert.Equal("USD", result[0].Currency);
+    }
+
+    [Fact]
+    public async Task MapByIsinAsync_WithValidIsin_ReturnsAllVenues()
+    {
+        // Arrange
+        var httpHandler = new MockHttpMessageHandler(response: """
+            [
+              {
+                "isin": "IE00B5BMR087",
+                "ticker": "CSPX",
+                "name": "iShares Core S&P 500 ETF",
+                "exchCode": "LN",
+                "currency": "GBP"
+              },
+              {
+                "isin": "IE00B5BMR087",
+                "ticker": "CSPX",
+                "name": "iShares Core S&P 500 ETF",
+                "exchCode": "SX",
+                "currency": "EUR"
+              }
+            ]
+            """);
+
+        var client = CreateClient(httpHandler);
+
+        // Act
+        var result = await client.MapByIsinAsync("IE00B5BMR087", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.All(result, x => Assert.Equal("IE00B5BMR087", x.Isin));
+        Assert.Contains(result, x => x.ExchCode == "LN");
+        Assert.Contains(result, x => x.ExchCode == "SX");
+    }
+
+    [Fact]
+    public async Task MapByTickerAsync_WithEmptyTicker_ReturnsEmpty()
+    {
+        // Arrange
+        var httpHandler = new MockHttpMessageHandler(response: "[]");
+        var client = CreateClient(httpHandler);
+
+        // Act
+        var result = await client.MapByTickerAsync(string.Empty, ct: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
     private sealed class StubExternalServiceConfigService(ExternalServiceConfiguration config) : IExternalServiceConfigService
     {
         public ValueTask<ExternalServiceConfiguration> GetServiceAsync(string serviceName, CancellationToken ct = default) =>

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Services/Stocks/OpenFigiClientTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Services/Stocks/OpenFigiClientTests.cs
@@ -36,10 +36,14 @@ public class OpenFigiClientTests
         var httpHandler = new MockHttpMessageHandler(response: """
             [
               {
-                "figi": "BBG000B9XRY4",
-                "ticker": "AAPL",
-                "isin": "US0378331005",
-                "compositeFigi": "BBG000HKWL63"
+                "data": [
+                  {
+                    "figi": "BBG000B9XRY4",
+                    "ticker": "AAPL",
+                    "isin": "US0378331005",
+                    "compositeFigi": "BBG000HKWL63"
+                  }
+                ]
               }
             ]
             """);
@@ -102,9 +106,13 @@ public class OpenFigiClientTests
         var httpHandler = new MockHttpMessageHandler(response: """
             [
               {
-                "figi": "BBG000B9XRY4",
-                "ticker": "AAPL",
-                "compositeFigi": "BBG000HKWL63"
+                "data": [
+                  {
+                    "figi": "BBG000B9XRY4",
+                    "ticker": "AAPL",
+                    "compositeFigi": "BBG000HKWL63"
+                  }
+                ]
               }
             ]
             """);
@@ -142,10 +150,14 @@ public class OpenFigiClientTests
         var httpHandler = new MockHttpMessageHandler(response: """
             [
               {
-                "figi": "BBG000B9XRY4",
-                "ticker": "AAPL",
-                "isin": "US0378331005",
-                "compositeFigi": "BBG000HKWL63"
+                "data": [
+                  {
+                    "figi": "BBG000B9XRY4",
+                    "ticker": "AAPL",
+                    "isin": "US0378331005",
+                    "compositeFigi": "BBG000HKWL63"
+                  }
+                ]
               }
             ]
             """);
@@ -167,10 +179,14 @@ public class OpenFigiClientTests
         var httpHandler = new MockHttpMessageHandler(response: """
             [
               {
-                "figi": "BBG000B9XRY4",
-                "ticker": "AAPL",
-                "isin": "US0378331005",
-                "compositeFigi": "BBG000HKWL63"
+                "data": [
+                  {
+                    "figi": "BBG000B9XRY4",
+                    "ticker": "AAPL",
+                    "isin": "US0378331005",
+                    "compositeFigi": "BBG000HKWL63"
+                  }
+                ]
               }
             ]
             """);
@@ -187,17 +203,21 @@ public class OpenFigiClientTests
     [Fact]
     public async Task MapByTickerAsync_WithValidTickerAndExchange_ReturnsListings()
     {
-        // Arrange
+        // Arrange — OpenFIGI v3 wraps matches inside each job's "data" array.
         var httpHandler = new MockHttpMessageHandler(response: """
             [
               {
-                "figi": "BBG000B9XRY4",
-                "ticker": "AAPL",
-                "isin": "US0378331005",
-                "compositeFigi": "BBG000HKWL63",
-                "name": "Apple Inc",
-                "exchCode": "US",
-                "currency": "USD"
+                "data": [
+                  {
+                    "figi": "BBG000B9XRY4",
+                    "ticker": "AAPL",
+                    "isin": "US0378331005",
+                    "compositeFigi": "BBG000HKWL63",
+                    "name": "Apple Inc",
+                    "exchCode": "US",
+                    "currency": "USD"
+                  }
+                ]
               }
             ]
             """);
@@ -219,22 +239,26 @@ public class OpenFigiClientTests
     [Fact]
     public async Task MapByIsinAsync_WithValidIsin_ReturnsAllVenues()
     {
-        // Arrange
+        // Arrange — a single job whose "data" array lists every venue for the ISIN.
         var httpHandler = new MockHttpMessageHandler(response: """
             [
               {
-                "isin": "IE00B5BMR087",
-                "ticker": "CSPX",
-                "name": "iShares Core S&P 500 ETF",
-                "exchCode": "LN",
-                "currency": "GBP"
-              },
-              {
-                "isin": "IE00B5BMR087",
-                "ticker": "CSPX",
-                "name": "iShares Core S&P 500 ETF",
-                "exchCode": "SX",
-                "currency": "EUR"
+                "data": [
+                  {
+                    "isin": "IE00B5BMR087",
+                    "ticker": "CSPX",
+                    "name": "iShares Core S&P 500 ETF",
+                    "exchCode": "LN",
+                    "currency": "GBP"
+                  },
+                  {
+                    "isin": "IE00B5BMR087",
+                    "ticker": "CSPX",
+                    "name": "iShares Core S&P 500 ETF",
+                    "exchCode": "SX",
+                    "currency": "EUR"
+                  }
+                ]
               }
             ]
             """);
@@ -263,6 +287,21 @@ public class OpenFigiClientTests
 
         // Assert
         Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task MapByTickerAsync_WhenApiReturnsFailure_Throws()
+    {
+        // Arrange — transport failures must surface so callers can enter cooldown.
+        var httpHandler = new MockHttpMessageHandler(
+            statusCode: HttpStatusCode.TooManyRequests,
+            response: "Rate limited");
+
+        var client = CreateClient(httpHandler);
+
+        // Act / Assert
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.MapByTickerAsync("AAPL", "US", TestContext.Current.CancellationToken));
     }
 
     private sealed class StubExternalServiceConfigService(ExternalServiceConfiguration config) : IExternalServiceConfigService


### PR DESCRIPTION
## Summary

Implements `IInstrumentResolver` interface that reconciles Alpha Vantage and OpenFIGI data to auto-resolve unambiguous instruments or return candidates for user disambiguation. Normalizes broker tickers into base symbol + exchange hint. Includes 3-layer caching (memory → DB → API), OpenFIGI fallback/cooldown on failure, and GBX/GBP currency reconciliation with configurable quote factors.

## Key Components

- **InstrumentResolver** (Application): Orchestrates AV + OF data fanout, reconciles results, and decides auto-resolve vs. candidate return
- **IOpenFigiClient** (abstraction): Maps base-ticker+exchange or ISIN to listings; decouples HTTP layer from business logic
- **OpenFigiClient** (Infrastructure, rebuilt): Implements both new `IOpenFigiClient` and legacy `IIsinResolver` for backward compatibility
- **BrokerSymbol** (normalizer): Parses broker tickers (e.g., `CSPX.UK`) → base + exchange hint; lookup tables map suffixes to OF exchange codes and AV regions
- **InstrumentListing**, **InstrumentResolution**, **ResolutionKind**: Domain types for results

## Test Plan

- [x] Single unambiguous match → AutoResolved with persisted (ISIN, AvSymbol) pair
- [x] Multi-exchange candidates → Ambiguous with full list for user confirmation
- [x] Exchange hint disambiguates → AutoResolved despite multiple venues
- [x] No matches → NoMatch
- [x] OpenFIGI failure → AV-only candidates with cooldown backoff
- [x] GBX vs GBP reconciliation → 100× quote factor applied, currency normalized to GBP
- [x] Cached StockDetails → Short-circuit all API calls
- [x] All 491 unit tests passing, `dotnet build` clean, `dotnet format` applied

## Notes

- Legacy `IIsinResolver` path kept working for backward compatibility; #433 rekeys consumers to ISIN + new interface
- Cooldown timer is now instance-level (not static) to avoid cross-test pollution
- No UI changes — this is infrastructure for #433 (API endpoint) and #434 (UI rework)

Closes #432.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTxjxp3DqT1im7So51q9gh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added instrument resolution system to normalize and resolve broker ticker symbols into standardized financial instruments with support for exchange hints (e.g., MSFT.US)
  * Auto-resolves unambiguous matches; provides candidate listings for ambiguous tickers requiring user confirmation
  * Integrated currency conversion handling for stock quotes

* **Tests**
  * Added comprehensive test coverage for instrument resolution and currency conversion workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->