### PR TITLE
Cache dashboard overview in localStorage for instant re-navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ rules agents must follow when updating this file.
 
 ## [Unreleased]
 
+### Added
+- Dashboard data is now cached in the browser's local storage: navigating back to the dashboard after visiting another page renders the previous result instantly, then silently refreshes in the background when the server responds. #444
+
 ### Fixed
 - The custom date-range icon in the account-details range selector now works: clicking the calendar icon opens a date-range picker (previously it was embedded in a menu and never appeared), letting users pick an arbitrary start/end range for the account history and chart. #436
 - The next-younger boundary entry attached to a loaded account (used to extend balance series past the selected window) is now resolved from the end of the date range instead of the start, so it correctly points at the first entry *after* the window rather than the earliest in-range entry. Affects both single-account and whole-portfolio loads. #411

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
@@ -39,6 +39,7 @@ public partial class Dashboard : ComponentBase
 
     [Inject] public required IFinancialAccountService FinancialAccountService { get; set; }
     [Inject] public required DashboardHttpClient DashboardHttpClient { get; set; }
+    [Inject] public required DashboardOverviewCacheService DashboardOverviewCacheService { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
     [Inject] public required ILogger<Dashboard> Logger { get; set; }
@@ -78,40 +79,54 @@ public partial class Dashboard : ComponentBase
         var startDate = StartDate;
         var endDate = EndDate;
 
-        _isLoading = true;
         _hasError = false;
-        StateHasChanged();
 
+        var user = await LoginService.GetLoggedUser();
+        if (user is null)
+        {
+            if (requestVersion == _loadOverviewVersion)
+                _overview = null;
+            return;
+        }
+
+        var currency = SettingsService.GetCurrency();
+
+        // Render cached data immediately so the page feels instant on re-navigation.
+        // The API call below always runs and updates the view when fresh data arrives.
+        var cached = await DashboardOverviewCacheService.GetCachedAsync(user.UserId, currency.Id, startDate, endDate);
+        if (cached is not null && requestVersion == _loadOverviewVersion)
+        {
+            _overview = cached.ToDto();
+            _overviewStart = startDate;
+            _overviewEnd = endDate;
+            _isLoading = false;
+            StateHasChanged();
+        }
+        else if (requestVersion == _loadOverviewVersion)
+        {
+            _isLoading = true;
+            StateHasChanged();
+        }
+
+        DashboardOverviewDto? freshOverview = null;
         try
         {
-            var user = await LoginService.GetLoggedUser();
-            if (user is null)
-            {
-                if (requestVersion == _loadOverviewVersion)
-                {
-                    _overview = null;
-                }
-                return;
-            }
+            freshOverview = await DashboardHttpClient.GetOverview(user.UserId, currency.Id, startDate, endDate);
 
-            var currency = SettingsService.GetCurrency();
-
-            var overview = await DashboardHttpClient.GetOverview(user.UserId, currency.Id, startDate, endDate);
-
-            // Swap the held overview only after the call succeeds, and only if this is
-            // still the latest reload, so cards keep rendering the previous data (and
-            // never self-load) during a reload. The matching range is committed in the
-            // same step so the displayed dates and amounts always move together.
             if (requestVersion == _loadOverviewVersion)
             {
-                _overview = overview;
+                _overview = freshOverview;
                 _overviewStart = startDate;
                 _overviewEnd = endDate;
             }
+
+            if (freshOverview is not null)
+                await DashboardOverviewCacheService.SaveAsync(freshOverview);
         }
         catch (Exception ex)
         {
-            if (requestVersion == _loadOverviewVersion)
+            // If we already rendered cached data, keep it visible rather than blanking the screen.
+            if (requestVersion == _loadOverviewVersion && cached is null)
             {
                 _overview = null;
                 _hasError = true;

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
@@ -85,7 +85,11 @@ public partial class Dashboard : ComponentBase
         if (user is null)
         {
             if (requestVersion == _loadOverviewVersion)
+            {
                 _overview = null;
+                _isLoading = false;
+                StateHasChanged();
+            }
             return;
         }
 
@@ -119,9 +123,6 @@ public partial class Dashboard : ComponentBase
                 _overviewStart = startDate;
                 _overviewEnd = endDate;
             }
-
-            if (freshOverview is not null)
-                await DashboardOverviewCacheService.SaveAsync(freshOverview);
         }
         catch (Exception ex)
         {
@@ -139,6 +140,18 @@ public partial class Dashboard : ComponentBase
             {
                 _isLoading = false;
                 StateHasChanged();
+            }
+        }
+
+        if (freshOverview is not null)
+        {
+            try
+            {
+                await DashboardOverviewCacheService.SaveAsync(freshOverview);
+            }
+            catch (Exception cacheEx)
+            {
+                Logger.LogWarning(cacheEx, "Dashboard overview loaded but caching failed.");
             }
         }
     }

--- a/code/FinanceManager.Components/Models/DashboardOverviewCacheSnapshot.cs
+++ b/code/FinanceManager.Components/Models/DashboardOverviewCacheSnapshot.cs
@@ -1,0 +1,61 @@
+using FinanceManager.Domain.Dtos.Dashboard;
+using FinanceManager.Domain.Entities.MoneyFlowModels;
+
+namespace FinanceManager.Components.Models;
+
+public sealed class DashboardOverviewCacheSnapshot
+{
+    public const int CurrentSchemaVersion = 1;
+
+    public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+    public DateTime FetchedAtUtc { get; set; }
+    public int UserId { get; set; }
+    public int CurrencyId { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+
+    public List<TimeSeriesModel> NetWorthSeries { get; set; } = [];
+    public List<TimeSeriesModel> NetCashFlowSeries { get; set; } = [];
+    public List<TimeSeriesModel> ClosingBalanceSeries { get; set; } = [];
+    public List<NameValueResult> LiabilitiesPerType { get; set; } = [];
+    public List<NameValueResult> LiabilitiesPerAccount { get; set; } = [];
+    public List<NameValueResult> LabelsValue { get; set; } = [];
+    public List<NameValueResult> AssetsPerType { get; set; } = [];
+    public List<NameValueResult> AssetsPerAccount { get; set; } = [];
+    public List<NameValueResult> ExpenseDistribution { get; set; } = [];
+
+    public static DashboardOverviewCacheSnapshot FromDto(DashboardOverviewDto dto) => new()
+    {
+        FetchedAtUtc = DateTime.UtcNow,
+        UserId = dto.UserId,
+        CurrencyId = dto.CurrencyId,
+        StartDate = dto.StartDate,
+        EndDate = dto.EndDate,
+        NetWorthSeries = dto.NetWorthSeries,
+        NetCashFlowSeries = dto.NetCashFlowSeries,
+        ClosingBalanceSeries = dto.ClosingBalanceSeries,
+        LiabilitiesPerType = dto.LiabilitiesPerType,
+        LiabilitiesPerAccount = dto.LiabilitiesPerAccount,
+        LabelsValue = dto.LabelsValue,
+        AssetsPerType = dto.AssetsPerType,
+        AssetsPerAccount = dto.AssetsPerAccount,
+        ExpenseDistribution = dto.ExpenseDistribution,
+    };
+
+    public DashboardOverviewDto ToDto() => new()
+    {
+        UserId = UserId,
+        CurrencyId = CurrencyId,
+        StartDate = StartDate,
+        EndDate = EndDate,
+        NetWorthSeries = NetWorthSeries,
+        NetCashFlowSeries = NetCashFlowSeries,
+        ClosingBalanceSeries = ClosingBalanceSeries,
+        LiabilitiesPerType = LiabilitiesPerType,
+        LiabilitiesPerAccount = LiabilitiesPerAccount,
+        LabelsValue = LabelsValue,
+        AssetsPerType = AssetsPerType,
+        AssetsPerAccount = AssetsPerAccount,
+        ExpenseDistribution = ExpenseDistribution,
+    };
+}

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -51,6 +51,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<NavMenuStateCacheService>()
                 .AddScoped<DashboardHttpClient>()
                 .AddScoped<DashboardOverviewCardsCacheService>()
+                .AddScoped<DashboardOverviewCacheService>()
                 .AddScoped<AssetsPageCardsCacheService>()
                 .AddScoped<InvestmentPaycheckEstimateCacheService>()
                 .AddScoped<IUserService, UserService>()

--- a/code/FinanceManager.Components/Services/DashboardOverviewCacheService.cs
+++ b/code/FinanceManager.Components/Services/DashboardOverviewCacheService.cs
@@ -20,8 +20,12 @@ public class DashboardOverviewCacheService(
     {
         var key = BuildKey(userId, currencyId, start, end);
 
-        if (_memoryCache.TryGetValue(BuildMemoryKey(key), out DashboardOverviewCacheSnapshot? snapshot) && IsUsable(snapshot))
-            return snapshot;
+        if (_memoryCache.TryGetValue(BuildMemoryKey(key), out DashboardOverviewCacheSnapshot? snapshot))
+        {
+            if (IsUsable(snapshot))
+                return snapshot;
+            _memoryCache.Remove(BuildMemoryKey(key));
+        }
 
         try
         {
@@ -35,7 +39,11 @@ public class DashboardOverviewCacheService(
         }
 
         if (!IsUsable(snapshot))
+        {
+            _memoryCache.Remove(BuildMemoryKey(key));
+            await _localStorageService.RemoveItemAsync(BuildStorageKey(key));
             return null;
+        }
 
         _memoryCache.Set(BuildMemoryKey(key), snapshot, MemorySlidingExpiration);
         return snapshot;
@@ -55,7 +63,7 @@ public class DashboardOverviewCacheService(
            && DateTime.UtcNow - snapshot.FetchedAtUtc <= MaxStale;
 
     private static string BuildKey(int userId, int currencyId, DateTime start, DateTime end)
-        => $"{userId}:{currencyId}:{start.Date:O}:{end:O}";
+        => $"{userId}:{currencyId}:{start.Date:yyyy-MM-dd}:{end.Date:yyyy-MM-dd}";
 
     private static string BuildMemoryKey(string key) => $"{CacheKeyPrefix}:memory:{key}";
 

--- a/code/FinanceManager.Components/Services/DashboardOverviewCacheService.cs
+++ b/code/FinanceManager.Components/Services/DashboardOverviewCacheService.cs
@@ -8,9 +8,9 @@ using System.Text.Json;
 namespace FinanceManager.Components.Services;
 
 public class DashboardOverviewCacheService(
-    ILocalStorageService localStorageService,
-    IMemoryCache memoryCache,
-    ILogger<DashboardOverviewCacheService> logger)
+    ILocalStorageService _localStorageService,
+    IMemoryCache _memoryCache,
+    ILogger<DashboardOverviewCacheService> _logger)
 {
     private const string CacheKeyPrefix = "dashboard-overview-cache-v1";
     private static readonly TimeSpan MaxStale = TimeSpan.FromHours(24);
@@ -20,24 +20,24 @@ public class DashboardOverviewCacheService(
     {
         var key = BuildKey(userId, currencyId, start, end);
 
-        if (memoryCache.TryGetValue(BuildMemoryKey(key), out DashboardOverviewCacheSnapshot? snapshot) && IsUsable(snapshot))
+        if (_memoryCache.TryGetValue(BuildMemoryKey(key), out DashboardOverviewCacheSnapshot? snapshot) && IsUsable(snapshot))
             return snapshot;
 
         try
         {
-            snapshot = await localStorageService.GetItemAsync<DashboardOverviewCacheSnapshot>(BuildStorageKey(key));
+            snapshot = await _localStorageService.GetItemAsync<DashboardOverviewCacheSnapshot>(BuildStorageKey(key));
         }
         catch (JsonException ex)
         {
-            logger.LogWarning(ex, "Corrupt dashboard overview cache payload; evicting.");
-            await localStorageService.RemoveItemAsync(BuildStorageKey(key));
+            _logger.LogWarning(ex, "Corrupt dashboard overview cache payload; evicting.");
+            await _localStorageService.RemoveItemAsync(BuildStorageKey(key));
             return null;
         }
 
         if (!IsUsable(snapshot))
             return null;
 
-        memoryCache.Set(BuildMemoryKey(key), snapshot, MemorySlidingExpiration);
+        _memoryCache.Set(BuildMemoryKey(key), snapshot, MemorySlidingExpiration);
         return snapshot;
     }
 
@@ -45,8 +45,8 @@ public class DashboardOverviewCacheService(
     {
         var key = BuildKey(overview.UserId, overview.CurrencyId, overview.StartDate, overview.EndDate);
         var snapshot = DashboardOverviewCacheSnapshot.FromDto(overview);
-        memoryCache.Set(BuildMemoryKey(key), snapshot, MemorySlidingExpiration);
-        await localStorageService.SetItemAsync(BuildStorageKey(key), snapshot);
+        _memoryCache.Set(BuildMemoryKey(key), snapshot, MemorySlidingExpiration);
+        await _localStorageService.SetItemAsync(BuildStorageKey(key), snapshot);
     }
 
     private static bool IsUsable(DashboardOverviewCacheSnapshot? snapshot)

--- a/code/FinanceManager.Components/Services/DashboardOverviewCacheService.cs
+++ b/code/FinanceManager.Components/Services/DashboardOverviewCacheService.cs
@@ -12,9 +12,9 @@ public class DashboardOverviewCacheService(
     IMemoryCache _memoryCache,
     ILogger<DashboardOverviewCacheService> _logger)
 {
-    private const string CacheKeyPrefix = "dashboard-overview-cache-v1";
-    private static readonly TimeSpan MaxStale = TimeSpan.FromHours(24);
-    private static readonly TimeSpan MemorySlidingExpiration = TimeSpan.FromMinutes(30);
+    private const string _cacheKeyPrefix = "dashboard-overview-cache-v1";
+    private static readonly TimeSpan _maxStale = TimeSpan.FromHours(24);
+    private static readonly TimeSpan _memorySlidingExpiration = TimeSpan.FromMinutes(30);
 
     public async Task<DashboardOverviewCacheSnapshot?> GetCachedAsync(int userId, int currencyId, DateTime start, DateTime end)
     {
@@ -45,7 +45,7 @@ public class DashboardOverviewCacheService(
             return null;
         }
 
-        _memoryCache.Set(BuildMemoryKey(key), snapshot, MemorySlidingExpiration);
+        _memoryCache.Set(BuildMemoryKey(key), snapshot, _memorySlidingExpiration);
         return snapshot;
     }
 
@@ -53,19 +53,19 @@ public class DashboardOverviewCacheService(
     {
         var key = BuildKey(overview.UserId, overview.CurrencyId, overview.StartDate, overview.EndDate);
         var snapshot = DashboardOverviewCacheSnapshot.FromDto(overview);
-        _memoryCache.Set(BuildMemoryKey(key), snapshot, MemorySlidingExpiration);
+        _memoryCache.Set(BuildMemoryKey(key), snapshot, _memorySlidingExpiration);
         await _localStorageService.SetItemAsync(BuildStorageKey(key), snapshot);
     }
 
     private static bool IsUsable(DashboardOverviewCacheSnapshot? snapshot)
         => snapshot is not null
            && snapshot.SchemaVersion == DashboardOverviewCacheSnapshot.CurrentSchemaVersion
-           && DateTime.UtcNow - snapshot.FetchedAtUtc <= MaxStale;
+           && DateTime.UtcNow - snapshot.FetchedAtUtc <= _maxStale;
 
     private static string BuildKey(int userId, int currencyId, DateTime start, DateTime end)
         => $"{userId}:{currencyId}:{start.Date:yyyy-MM-dd}:{end.Date:yyyy-MM-dd}";
 
-    private static string BuildMemoryKey(string key) => $"{CacheKeyPrefix}:memory:{key}";
+    private static string BuildMemoryKey(string key) => $"{_cacheKeyPrefix}:memory:{key}";
 
-    private static string BuildStorageKey(string key) => $"{CacheKeyPrefix}:{key}";
+    private static string BuildStorageKey(string key) => $"{_cacheKeyPrefix}:{key}";
 }

--- a/code/FinanceManager.Components/Services/DashboardOverviewCacheService.cs
+++ b/code/FinanceManager.Components/Services/DashboardOverviewCacheService.cs
@@ -1,0 +1,63 @@
+using Blazored.LocalStorage;
+using FinanceManager.Components.Models;
+using FinanceManager.Domain.Dtos.Dashboard;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace FinanceManager.Components.Services;
+
+public class DashboardOverviewCacheService(
+    ILocalStorageService localStorageService,
+    IMemoryCache memoryCache,
+    ILogger<DashboardOverviewCacheService> logger)
+{
+    private const string CacheKeyPrefix = "dashboard-overview-cache-v1";
+    private static readonly TimeSpan MaxStale = TimeSpan.FromHours(24);
+    private static readonly TimeSpan MemorySlidingExpiration = TimeSpan.FromMinutes(30);
+
+    public async Task<DashboardOverviewCacheSnapshot?> GetCachedAsync(int userId, int currencyId, DateTime start, DateTime end)
+    {
+        var key = BuildKey(userId, currencyId, start, end);
+
+        if (memoryCache.TryGetValue(BuildMemoryKey(key), out DashboardOverviewCacheSnapshot? snapshot) && IsUsable(snapshot))
+            return snapshot;
+
+        try
+        {
+            snapshot = await localStorageService.GetItemAsync<DashboardOverviewCacheSnapshot>(BuildStorageKey(key));
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Corrupt dashboard overview cache payload; evicting.");
+            await localStorageService.RemoveItemAsync(BuildStorageKey(key));
+            return null;
+        }
+
+        if (!IsUsable(snapshot))
+            return null;
+
+        memoryCache.Set(BuildMemoryKey(key), snapshot, MemorySlidingExpiration);
+        return snapshot;
+    }
+
+    public async Task SaveAsync(DashboardOverviewDto overview)
+    {
+        var key = BuildKey(overview.UserId, overview.CurrencyId, overview.StartDate, overview.EndDate);
+        var snapshot = DashboardOverviewCacheSnapshot.FromDto(overview);
+        memoryCache.Set(BuildMemoryKey(key), snapshot, MemorySlidingExpiration);
+        await localStorageService.SetItemAsync(BuildStorageKey(key), snapshot);
+    }
+
+    private static bool IsUsable(DashboardOverviewCacheSnapshot? snapshot)
+        => snapshot is not null
+           && snapshot.SchemaVersion == DashboardOverviewCacheSnapshot.CurrentSchemaVersion
+           && DateTime.UtcNow - snapshot.FetchedAtUtc <= MaxStale;
+
+    private static string BuildKey(int userId, int currencyId, DateTime start, DateTime end)
+        => $"{userId}:{currencyId}:{start.Date:O}:{end:O}";
+
+    private static string BuildMemoryKey(string key) => $"{CacheKeyPrefix}:memory:{key}";
+
+    private static string BuildStorageKey(string key) => $"{CacheKeyPrefix}:{key}";
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `DashboardOverviewCacheSnapshot` model wrapping the full `DashboardOverviewDto` with schema version and fetch timestamp.
- Adds `DashboardOverviewCacheService` with a dual-layer memory + localStorage cache (24 h max-stale, since fresh data always revalidates in background).
- Updates `Dashboard.razor.cs` to use stale-while-revalidate: on load it immediately renders any cached snapshot then always fires the API call, updating the view when fresh data arrives. If the API fails but cached data was displayed, the error is suppressed.

## Behaviour change

- **First visit**: unchanged — skeleton while API loads (~11 s), result saved to cache.
- **Subsequent visits (same month)**: cached result renders instantly (<100 ms), API call runs in the background, UI silently updates when fresh data arrives.
- **Error with cache**: existing cached data stays on screen; no error banner.
- **Error without cache**: existing error state (banner + retry button) unchanged.

## Test plan

- [ ] First load: skeleton shows while API loads, data appears after response.
- [ ] Navigate away and back (same month): dashboard renders immediately from cache.
- [ ] Wait for API to return: if data changed, cards update without a full refresh.
- [ ] Change date range: cache miss → skeleton → API load as before.
- [ ] Unit tests: 502 passing, 0 failing.

closes #444

https://claude.ai/code/session_01NHifa6u2oH7Em36kifraR1
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHifa6u2oH7Em36kifraR1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard data is now cached, enabling instant display on page reload when previous data is available.
  * Dashboard cache persists across browser sessions with automatic refresh every 24 hours.

* **Bug Fixes**
  * Improved error handling during dashboard refresh to preserve cached data when network issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->