### PR TITLE
fix: resolve #434 - Rework AddStockEntry to minimal input with confirm-on-ambiguity picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Adding a stock holding now needs only a search term, units, and a date: the form resolves the instrument through the `search-instrument` endpoint and auto-fills name, type, currency, and price. Unambiguous matches resolve silently; when several listings match, an inline picker (name · exchange · currency · ISIN) lets you choose. The confirmed instrument's ISIN is stored as the entry key and the typed term is kept as the display ticker. Entries still save when a price can't be fetched, showing a subtle "price pending" indicator so a provider outage doesn't block the add. #434
 - Dashboard data is now cached in the browser's local storage: navigating back to the dashboard after visiting another page renders the previous result instantly, then silently refreshes in the background when the server responds. #444
 
 ### Fixed

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/AddStockEntry.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/AddStockEntry.razor
@@ -1,22 +1,15 @@
-﻿@using FinanceManager.Domain.Entities
-@using System.ComponentModel.DataAnnotations
-@using FinanceManager.Domain.Enums
-@using FinanceManager.Domain.Repositories
+@using FinanceManager.Application.FinancialAccounts.Stock.Resolution
 @using FinanceManager.Components.CustomValidationAttributes
-@using FinanceManager.Domain.Repositories.Account
-@using Microsoft.AspNetCore.Components.Forms
-@using MudBlazor.Utilities
-@using static MudBlazor.CategoryTypes
 
-<MudForm @ref="_form" @bind-IsValid="@_success" @bind-Errors="@_errors" FieldChanged=OnFieldChanged>
-    <MudContainer MaxWidth="MaxWidth.Medium" onchange="">
+<MudForm @ref="_form" @bind-IsValid="@_success" @bind-Errors="@_errors">
+    <MudContainer MaxWidth="MaxWidth.Medium">
 
         <MudGrid Justify="Justify.Center">
-            <MudItem xs="12" sm="12" md="12">
+            <MudItem xs="12">
                 <MudText Typo="Typo.h4">Add new entry</MudText>
-
                 <MudText Typo="Typo.subtitle1">@StockAccount.Name</MudText>
             </MudItem>
+
             <MudItem xs="12" sm="6">
                 <MudDatePicker Label="Posting date" @bind-Date="_postingDate"
                                Validation="@(new NotInFutureAttribute())" />
@@ -25,26 +18,88 @@
                 <MudTimePicker Label="Time" @bind-Time="_time"
                                Validation="@(new NotInFutureAttributeTime(_postingDate))" />
             </MudItem>
-            <MudItem xs="12" sm="6">
-                <MudAutocomplete T="string" Label="Ticker" @bind-Value="Ticker" SearchFunc="@SearchTicker"
-                                 ResetValueOnEmptyText=false CoerceText=false CoerceValue=false SelectValueOnTab=false />
+
+            <MudItem xs="12" sm="8">
+                <MudAutocomplete T="string" Label="Search instrument (ticker or name)" @bind-Value="_searchTerm"
+                                 SearchFunc="@SearchTicker" ResetValueOnEmptyText="false" CoerceText="false"
+                                 CoerceValue="true" SelectValueOnTab="false"
+                                 Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.Search"
+                                 OnAdornmentClick="ResolveInstrument" />
             </MudItem>
-            <MudItem xs="12" sm="6">
-                <MudNumericField ReadOnly HideSpinButtons="true" @bind-Value="PricePerUnit" Label="Price per unit"
-                                 Variant="Variant.Text" AdornmentText="@_currency.ShortName" Adornment="Adornment.End" />
-            </MudItem>
-            <MudItem xs="12" sm="6">
-                <MudNumericField Required="true" HideSpinButtons="true" @bind-Value="BalanceChange"
-                                 Label="Balance change" Variant="Variant.Text" Immediate />
-            </MudItem>
-            <MudItem xs="12" sm="6">
-                <MudAutocomplete @bind-Value="InvestmentTypeName" Label="Investment type" Variant="Variant.Text"
-                                 SearchFunc="Search" />
+            <MudItem xs="12" sm="4" Class="d-flex align-center">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false"
+                           OnClick="ResolveInstrument" Disabled="@_resolving" FullWidth="true">
+                    @if (_resolving)
+                    {
+                        <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
+                    }
+                    Search
+                </MudButton>
             </MudItem>
 
+            <MudItem xs="12" sm="6">
+                <MudNumericField Required="true" HideSpinButtons="true" @bind-Value="BalanceChange"
+                                 Label="Units (balance change)" Variant="Variant.Text" Immediate="true" />
+            </MudItem>
+            <MudItem xs="12" sm="6">
+                <MudNumericField T="decimal?" ReadOnly="true" HideSpinButtons="true" Value="PricePerUnit"
+                                 Label="Price per unit" Variant="Variant.Text"
+                                 AdornmentText="@_currency.ShortName" Adornment="Adornment.End" />
+            </MudItem>
+
+            @if (_resolveMessage is not null)
+            {
+                <MudItem xs="12">
+                    <MudAlert Severity="Severity.Warning" Dense="true">@_resolveMessage</MudAlert>
+                </MudItem>
+            }
+
+            @if (_resolution?.Kind == ResolutionKind.Ambiguous && _resolution.Candidates.Count > 0)
+            {
+                <MudItem xs="12">
+                    <MudText Typo="Typo.subtitle2" Class="mb-2">Multiple matches found — pick one:</MudText>
+                    <MudRadioGroup T="InstrumentListing" Value="_selectedListing" ValueChanged="SelectListing">
+                        @foreach (var candidate in _resolution.Candidates)
+                        {
+                            <MudRadio T="InstrumentListing" Value="candidate" Color="Color.Primary" Class="d-flex">
+                                <MudText Typo="Typo.body2">
+                                    <b>@candidate.Name</b> · @candidate.Exchange · @candidate.Currency
+                                    @if (!string.IsNullOrWhiteSpace(candidate.Isin))
+                                    {
+                                        <text> · @candidate.Isin</text>
+                                    }
+                                </MudText>
+                            </MudRadio>
+                        }
+                    </MudRadioGroup>
+                </MudItem>
+            }
+
+            @if (_selectedListing is not null)
+            {
+                <MudItem xs="12">
+                    <MudPaper Class="pa-3" Elevation="0" Outlined="true">
+                        <MudText Typo="Typo.subtitle2">@_selectedListing.Name</MudText>
+                        <MudStack Row AlignItems="AlignItems.Center" Spacing="2" Class="mt-1">
+                            <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">@InvestmentTypeName</MudChip>
+                            @if (!string.IsNullOrWhiteSpace(_selectedListing.Isin))
+                            {
+                                <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">@_selectedListing.Isin</MudChip>
+                            }
+                            <MudChip T="string" Size="Size.Small" Color="Color.Default" Variant="Variant.Outlined">@_selectedListing.Currency</MudChip>
+                            @if (_pricePending)
+                            {
+                                <MudChip T="string" Size="Size.Small" Color="Color.Warning" Variant="Variant.Filled"
+                                         Icon="@Icons.Material.Filled.HourglassEmpty">Price pending</MudChip>
+                            }
+                        </MudStack>
+                    </MudPaper>
+                </MudItem>
+            }
+
             <MudItem xs="12">
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick=Add>Add</MudButton>
-                <MudButton Variant="Variant.Outlined" Color="Color.Secondary" DropShadow="false" OnClick=Cancel
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" DropShadow="false" OnClick="Add">Add</MudButton>
+                <MudButton Variant="Variant.Outlined" Color="Color.Secondary" DropShadow="false" OnClick="Cancel"
                            Class="mx-2">Cancel</MudButton>
                 @if (CustomButton is not null)
                 {

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/AddStockEntry.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/AddStockEntry.razor.cs
@@ -1,4 +1,4 @@
-using FinanceManager.Application.Identity.Users;
+using FinanceManager.Application.FinancialAccounts.Stock.Resolution;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.Entities.Currencies;
@@ -8,32 +8,29 @@ using FinanceManager.Domain.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using MudBlazor;
-using MudBlazor.Utilities;
 
 namespace FinanceManager.Components.Components.Features.FinancialAccounts.StockAccountComponents.Crud;
 
 public partial class AddStockEntry
 {
-    private Task<IEnumerable<string>> SearchTicker(string value, CancellationToken token)
-    {
-        if (string.IsNullOrEmpty(value)) return Task.FromResult(Tickers.AsEnumerable());
-
-        return Task.FromResult(Tickers.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase)));
-    }
-
     private Currency _currency = DefaultCurrency.PLN;
     private bool _success;
     private string[] _errors = [];
     private MudForm? _form;
 
-    private List<string> _investmentTypes = Enum.GetValues(typeof(InvestmentType)).Cast<InvestmentType>().Select(x => x.ToString()).ToList();
-
     private DateTime? _postingDate = DateTime.Today;
     private TimeSpan? _time = new TimeSpan(01, 00, 00);
-    public string InvestmentTypeName { get; set; } = FinanceManager.Domain.Enums.InvestmentType.Stock.ToString();
-    public string Ticker { get; set; } = string.Empty;
+
+    private string _searchTerm = string.Empty;
+    private bool _resolving;
+    private string? _resolveMessage;
+    private InstrumentResolution? _resolution;
+    private InstrumentListing? _selectedListing;
+    private bool _pricePending;
+
     public decimal? BalanceChange;
-    public decimal? PricePerUnit { get; set; } = null;
+    public decimal? PricePerUnit { get; private set; }
+    public string InvestmentTypeName { get; private set; } = InvestmentType.Stock.ToString();
 
     [Parameter] public List<string> Tickers { get; set; } = [];
     [Parameter] public RenderFragment? CustomButton { get; set; }
@@ -45,31 +42,87 @@ public partial class AddStockEntry
     [Inject] public required StockPriceHttpClient StockPriceHttpClient { get; set; }
     [Inject] public required ILogger<AddStockEntry> Logger { get; set; }
 
-    protected async Task OnFieldChanged(FormFieldChangedEventArgs args)
-    {
-        if (string.IsNullOrEmpty(Ticker)) return;
-        if (!_postingDate.HasValue) return;
-        if (args.Field is MudTextField<decimal?> textField)
-        {
-            if (textField is null || textField.Label is null) return;
-            if (!textField.Label.ToLower().Contains("ticker")) return;
-        }
-
-        if (args.Field is MudNumericField<decimal?> numericField)
-        {
-            if (numericField is null || numericField.Label is null) return;
-            if (!numericField.Label.ToLower().Contains("change")) return;
-        }
-
-        var pricePerUnit = await StockPriceHttpClient.GetStockPrice(Ticker, DefaultCurrency.PLN.Id, _postingDate.Value);
-        if (pricePerUnit is null) return;
-
-        PricePerUnit = BalanceChange * pricePerUnit.PricePerUnit;
-    }
     protected override Task OnParametersSetAsync()
     {
         _currency = SettingsService.GetCurrency();
         return base.OnParametersSetAsync();
+    }
+
+    private Task<IEnumerable<string>> SearchTicker(string value, CancellationToken token)
+    {
+        if (string.IsNullOrEmpty(value)) return Task.FromResult(Tickers.AsEnumerable());
+
+        return Task.FromResult(Tickers.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase)));
+    }
+
+    /// <summary>
+    /// Resolves the entered search term against the instrument-resolution endpoint.
+    /// A single match auto-fills the form; ambiguous matches surface the candidate picker.
+    /// </summary>
+    public async Task ResolveInstrument()
+    {
+        if (string.IsNullOrWhiteSpace(_searchTerm)) return;
+
+        _resolving = true;
+        _resolveMessage = null;
+        _resolution = null;
+        _selectedListing = null;
+        PricePerUnit = null;
+        _pricePending = false;
+
+        try
+        {
+            _resolution = await StockPriceHttpClient.SearchInstrument(_searchTerm.Trim());
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error resolving instrument for '{SearchTerm}'.", _searchTerm);
+        }
+
+        if (_resolution is null || _resolution.Kind == ResolutionKind.NoMatch)
+        {
+            _resolveMessage = $"No instrument found for \"{_searchTerm}\".";
+        }
+        else if (_resolution.Kind == ResolutionKind.AutoResolved && _resolution.Match is not null)
+        {
+            await SelectListing(_resolution.Match);
+        }
+
+        _resolving = false;
+    }
+
+    /// <summary>Applies a confirmed listing: fills name/type/currency and fetches its price.</summary>
+    public async Task SelectListing(InstrumentListing listing)
+    {
+        _selectedListing = listing;
+        InvestmentTypeName = InstrumentTypeMapper.MapToInvestmentType(listing.Type).ToString();
+        await FetchPrice();
+    }
+
+    private async Task FetchPrice()
+    {
+        PricePerUnit = null;
+        _pricePending = false;
+
+        if (_selectedListing is null || string.IsNullOrWhiteSpace(_selectedListing.Isin) || !_postingDate.HasValue)
+        {
+            _pricePending = true;
+            return;
+        }
+
+        try
+        {
+            var price = await StockPriceHttpClient.GetStockPrice(_selectedListing.Isin, _currency.Id, _postingDate.Value);
+            if (price is null)
+                _pricePending = true;
+            else
+                PricePerUnit = price.PricePerUnit;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error fetching price for ISIN '{Isin}'.", _selectedListing.Isin);
+            _pricePending = true;
+        }
     }
 
     public async Task Add()
@@ -82,24 +135,30 @@ public partial class AddStockEntry
         if (!_postingDate.HasValue) return;
         if (!_time.HasValue) return;
 
-        DateTime date = new(_postingDate.Value.Year, _postingDate.Value.Month, _postingDate.Value.Day, _time.Value.Hours, _time.Value.Minutes, _time.Value.Seconds);
-        InvestmentType investmentType = Domain.Enums.InvestmentType.Stock;
+        if (_selectedListing is null)
+        {
+            _errors = ["Please search for and confirm an instrument first."];
+            return;
+        }
 
-        try
+        if (string.IsNullOrWhiteSpace(_selectedListing.Isin))
         {
-            investmentType = (InvestmentType)Enum.Parse(typeof(InvestmentType), InvestmentTypeName);
+            _errors = ["The selected instrument has no ISIN, which is required to save the entry."];
+            return;
         }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error parsing investment type '{InvestmentTypeName}'.", InvestmentTypeName);
-        }
+
+        DateTime date = new(_postingDate.Value.Year, _postingDate.Value.Month, _postingDate.Value.Day, _time.Value.Hours, _time.Value.Minutes, _time.Value.Seconds);
+        InvestmentType investmentType = InstrumentTypeMapper.MapToInvestmentType(_selectedListing.Type);
 
         var id = 0;
         var currentMaxId = StockAccount.GetMaxId();
         if (currentMaxId is not null)
             id += currentMaxId.Value + 1;
 
-        StockAccountEntry entry = new(StockAccount.AccountId, id, date.ToUniversalTime(), -1, BalanceChange.Value, Ticker, investmentType);
+        StockAccountEntry entry = new(StockAccount.AccountId, id, date.ToUniversalTime(), -1, BalanceChange.Value, _selectedListing.Isin, investmentType)
+        {
+            Ticker = _searchTerm.Trim()
+        };
 
         try
         {
@@ -109,6 +168,7 @@ public partial class AddStockEntry
         catch (Exception ex)
         {
             _errors = [ex.ToString()];
+            return;
         }
 
         await ActionCompleted.InvokeAsync();
@@ -118,14 +178,4 @@ public partial class AddStockEntry
     {
         await ActionCompleted.InvokeAsync();
     }
-
-    private async Task<IEnumerable<string>> Search(string value, CancellationToken token)
-    {
-        if (string.IsNullOrEmpty(value))
-            return _investmentTypes;
-
-        return await Task.FromResult(_investmentTypes.Where(x => x.Contains(value, StringComparison.InvariantCultureIgnoreCase)));
-    }
-
-
 }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/InstrumentTypeMapper.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/StockAccountComponents/Crud/InstrumentTypeMapper.cs
@@ -1,0 +1,34 @@
+using FinanceManager.Domain.Enums;
+
+namespace FinanceManager.Components.Components.Features.FinancialAccounts.StockAccountComponents.Crud;
+
+/// <summary>
+/// Maps the free-form instrument type string returned by instrument resolution
+/// (e.g. Alpha Vantage / OpenFIGI: "Equity", "ETF", "Bond") onto the app's <see cref="InvestmentType"/>.
+/// Defaults to <see cref="InvestmentType.Stock"/> because resolution is only used from stock accounts.
+/// </summary>
+public static class InstrumentTypeMapper
+{
+    public static InvestmentType MapToInvestmentType(string? type)
+    {
+        if (string.IsNullOrWhiteSpace(type)) return InvestmentType.Stock;
+
+        var normalized = type.Trim().ToLowerInvariant();
+
+        if (normalized.Contains("bond") || normalized.Contains("note") || normalized.Contains("bill") || normalized.Contains("treasury"))
+            return InvestmentType.Bond;
+        if (normalized.Contains("crypto"))
+            return InvestmentType.Crypto;
+        if (normalized.Contains("commodit"))
+            return InvestmentType.Commodities;
+        if (normalized.Contains("reit") || normalized.Contains("real estate") || normalized.Contains("property"))
+            return InvestmentType.Property;
+        if (normalized.Contains("cash") || normalized.Contains("currency"))
+            return InvestmentType.Cash;
+        if (normalized.Contains("equity") || normalized.Contains("stock") || normalized.Contains("share")
+            || normalized.Contains("etf") || normalized.Contains("fund"))
+            return InvestmentType.Stock;
+
+        return InvestmentType.Stock;
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/FinancialAccounts/InstrumentTypeMapperTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/FinancialAccounts/InstrumentTypeMapperTests.cs
@@ -1,0 +1,41 @@
+using FinanceManager.Components.Components.Features.FinancialAccounts.StockAccountComponents.Crud;
+using FinanceManager.Domain.Enums;
+
+namespace FinanceManager.Tests.Unit.Components.FinancialAccounts;
+
+[Trait("Category", "Unit")]
+public class InstrumentTypeMapperTests
+{
+    [Theory]
+    [InlineData("Equity", InvestmentType.Stock)]
+    [InlineData("Common Stock", InvestmentType.Stock)]
+    [InlineData("ETF", InvestmentType.Stock)]
+    [InlineData("Mutual Fund", InvestmentType.Stock)]
+    [InlineData("Bond", InvestmentType.Bond)]
+    [InlineData("Treasury Note", InvestmentType.Bond)]
+    [InlineData("Crypto", InvestmentType.Crypto)]
+    [InlineData("Commodity", InvestmentType.Commodities)]
+    [InlineData("REIT", InvestmentType.Property)]
+    [InlineData("Real Estate", InvestmentType.Property)]
+    [InlineData("Cash", InvestmentType.Cash)]
+    public void MapToInvestmentType_MapsKnownTypes(string type, InvestmentType expected)
+    {
+        Assert.Equal(expected, InstrumentTypeMapper.MapToInvestmentType(type));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("something-unknown")]
+    public void MapToInvestmentType_DefaultsToStock_WhenNullEmptyOrUnknown(string? type)
+    {
+        Assert.Equal(InvestmentType.Stock, InstrumentTypeMapper.MapToInvestmentType(type));
+    }
+
+    [Fact]
+    public void MapToInvestmentType_IsCaseInsensitive()
+    {
+        Assert.Equal(InvestmentType.Bond, InstrumentTypeMapper.MapToInvestmentType("CORPORATE BOND"));
+    }
+}


### PR DESCRIPTION
Closes #434

## What

Reworks `AddStockEntry.razor` (+ code-behind) into the minimal resolve-on-search flow described in the issue (part 4 of 4 of the stock-details resolution refactor).

- **Minimal input** — the form now needs only a **search term**, **units**, and a **date**. Name, type, currency, and price are auto-filled from the resolved match.
- **Resolution** — pressing search calls `StockPriceHttpClient.SearchInstrument`:
  - `AutoResolved` → fields fill silently and the price is fetched by ISIN.
  - `Ambiguous` → an inline `MudRadioGroup` picker lists candidates as **name · exchange · currency · ISIN**; selecting one fills the fields.
  - `NoMatch`/error → a subtle warning alert.
- **ISIN as key** — the confirmed instrument's **ISIN** is stored as the entry key and the typed term is kept as the display **ticker** alias. (This also fixes the pre-existing bug where the broker ticker was written into the ISIN field.)
- **Price-pending** — the entry still saves when price resolution fails, surfacing a subtle "price pending" chip so a provider outage doesn't block the add.

## New code

- `InstrumentTypeMapper` — pure static mapper from the resolved instrument-type string (e.g. "Equity", "ETF", "Bond") to `InvestmentType`, with unit tests.

## Validation

- `dotnet build` — clean (0 warnings, warnings-as-errors).
- `dotnet format` — clean.
- `dotnet test` (unit) — **518 passed**, including the new mapper tests.
- UI rendered on the guest/demo account and screenshotted on **mobile (430px)** and **desktop (1280px)**: the reworked form renders correctly and the resolve flow works end-to-end (the "no match" state was exercised live). Note: the external instrument-resolution providers (Alpha Vantage / OpenFIGI) are not reachable from the cloud sandbox, so live auto-resolve/ambiguous results can't be demonstrated there — the form, states, and the round-trip to the endpoint are verified.
- Changelog entry added under `[Unreleased] → Added`.

## Notes

- The existing caller (`StockAccountDetailsPageContent.razor`) is unchanged; the `Tickers` parameter is retained for autocomplete suggestions.

---
_Generated by [Claude Code](https://claude.ai/code/session_013M7pQytpK14Naz9ZW3kLA9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified instrument search replacing separate ticker and investment type fields
  * Search now resolves instrument details and displays candidates when results are ambiguous
  * Added instrument summary card showing name, currency, and ISIN
  * Loading spinner and status messaging during instrument resolution
  * Radio group selection for choosing among multiple matching instruments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->