### PR TITLE
Fix CodeQL security alerts: hardcoded credentials and exception exposure #450

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ rules agents must follow when updating this file.
 
 ## [Unreleased]
 
+### Security
+- The default admin and test-user accounts are no longer seeded with passwords hard-coded in source. Their passwords are now read from configuration (`Seeding:AdminPassword` / `Seeding:TestUserPassword`); when unset — as in production — the accounts are not created. The stock-price bulk-import endpoint now returns a generic error message and logs the exception server-side instead of echoing the raw exception text to the caller. #450
+
 ### Added
 - Adding a stock holding now needs only a search term, units, and a date: the form resolves the instrument through the `search-instrument` endpoint and auto-fills name, type, currency, and price. Unambiguous matches resolve silently; when several listings match, an inline picker (name · exchange · currency · ISIN) lets you choose. The confirmed instrument's ISIN is stored as the entry key and the typed term is kept as the display ticker. Entries still save when a price can't be fetched, showing a subtle "price pending" indicator so a provider outage doesn't block the add. #434
 - Dashboard data is now cached in the browser's local storage: navigating back to the dashboard after visiting another page renders the previous result instantly, then silently refreshes in the background when the server responds. #444

--- a/code/FinanceManager.Api/Controllers/StockPriceController.cs
+++ b/code/FinanceManager.Api/Controllers/StockPriceController.cs
@@ -15,6 +15,7 @@ using FinanceManager.Domain.Identity.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Logging;
 
 namespace FinanceManager.Api.Controllers;
 
@@ -23,7 +24,8 @@ namespace FinanceManager.Api.Controllers;
 [Tags("Stock Prices")]
 public partial class StockPriceController(IStockPriceRepository stockPriceRepository, ICurrencyExchangeService currencyExchangeService,
 ICurrencyRepository currencyRepository, IStockMarketService stockMarketService, IStockPriceProvider stockPriceProvider, IStockDetailsRepository stockDetailsRepository,
-IStockPriceBulkImportService stockPriceBulkImportService, IIsinResolver isinResolver, IInstrumentResolver instrumentResolver) : ControllerBase
+IStockPriceBulkImportService stockPriceBulkImportService, IIsinResolver isinResolver, IInstrumentResolver instrumentResolver,
+ILogger<StockPriceController> logger) : ControllerBase
 {
 
     [HttpGet("search-instrument")]
@@ -387,7 +389,8 @@ IStockPriceBulkImportService stockPriceBulkImportService, IIsinResolver isinReso
         }
         catch (InvalidOperationException ex)
         {
-            return BadRequest(ex.Message);
+            logger.LogError(ex, "Failed to process stock price bulk import request");
+            return BadRequest("An error occurred while processing the request.");
         }
 
         return Ok(result);

--- a/code/FinanceManager.Api/appsettings.Development.json
+++ b/code/FinanceManager.Api/appsettings.Development.json
@@ -17,6 +17,10 @@
     }
   },
   "UseInMemoryDatabase": "false",
+  "Seeding": {
+    "AdminPassword": "Admin1234",
+    "TestUserPassword": "testuser"
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Server=desktop-iinen1q\\mikidatabase;Database=FinanceManager;Trusted_Connection=True;TrustServerCertificate=True;"
   },

--- a/code/FinanceManager.Application/Identity/Seeders/AdminAccountSeeder.cs
+++ b/code/FinanceManager.Application/Identity/Seeders/AdminAccountSeeder.cs
@@ -21,7 +21,7 @@ public class AdminAccountSeeder(IUserRepository userRepository, IConfiguration c
         // so no credential is hard-coded. When it is not configured, skip seeding rather
         // than create an account with a predictable password.
         var password = configuration["Seeding:AdminPassword"];
-        if (string.IsNullOrEmpty(password))
+        if (string.IsNullOrWhiteSpace(password))
         {
             logger.LogWarning("Skipping admin account seeding: 'Seeding:AdminPassword' is not configured.");
             return;

--- a/code/FinanceManager.Application/Identity/Seeders/AdminAccountSeeder.cs
+++ b/code/FinanceManager.Application/Identity/Seeders/AdminAccountSeeder.cs
@@ -1,20 +1,33 @@
-﻿using FinanceManager.Application.Shared.Seeders;
+using FinanceManager.Application.Shared.Seeders;
 using FinanceManager.Domain.Identity.Entities;
 using FinanceManager.Domain.Identity.Repositories;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace FinanceManager.Application.Identity.Seeders;
 
-public class AdminAccountSeeder(IUserRepository userRepository) : ISeeder
+public class AdminAccountSeeder(IUserRepository userRepository, IConfiguration configuration,
+    ILogger<AdminAccountSeeder> logger) : ISeeder
 {
     private const string _defaultAdminUserName = "admin@localhost";
-    private const string _defaultAdminPassword = "Admin1234";
 
     public async Task Seed(CancellationToken cancellationToken = default)
     {
         var existingAdmin = await userRepository.GetUser(_defaultAdminUserName);
         if (existingAdmin is not null) return;
 
-        var encryptedPassword = PasswordEncryptionProvider.EncryptPassword(_defaultAdminPassword);
+        // The default admin password is supplied via configuration (Seeding:AdminPassword)
+        // — e.g. appsettings.Development.json, user secrets, or an environment variable —
+        // so no credential is hard-coded. When it is not configured, skip seeding rather
+        // than create an account with a predictable password.
+        var password = configuration["Seeding:AdminPassword"];
+        if (string.IsNullOrEmpty(password))
+        {
+            logger.LogWarning("Skipping admin account seeding: 'Seeding:AdminPassword' is not configured.");
+            return;
+        }
+
+        var encryptedPassword = PasswordEncryptionProvider.EncryptPassword(password);
         await userRepository.AddUser(_defaultAdminUserName, encryptedPassword, PricingLevel.Free, UserRole.Admin);
     }
 }

--- a/code/FinanceManager.Application/Identity/Seeders/TestUserAccountSeeder.cs
+++ b/code/FinanceManager.Application/Identity/Seeders/TestUserAccountSeeder.cs
@@ -1,20 +1,32 @@
 using FinanceManager.Application.Shared.Seeders;
 using FinanceManager.Domain.Identity.Entities;
 using FinanceManager.Domain.Identity.Repositories;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace FinanceManager.Application.Identity.Seeders;
 
-public class TestUserAccountSeeder(IUserRepository userRepository) : ISeeder
+public class TestUserAccountSeeder(IUserRepository userRepository, IConfiguration configuration,
+    ILogger<TestUserAccountSeeder> logger) : ISeeder
 {
     private const string _defaultTestUserName = "testuser";
-    private const string _defaultTestUserPassword = "testuser";
 
     public async Task Seed(CancellationToken cancellationToken = default)
     {
         var existingTestUser = await userRepository.GetUser(_defaultTestUserName);
         if (existingTestUser is not null) return;
 
-        var encryptedPassword = PasswordEncryptionProvider.EncryptPassword(_defaultTestUserPassword);
+        // Demo/test credentials belong in configuration (Seeding:TestUserPassword) — e.g.
+        // appsettings.Development.json or an environment variable — not in source code.
+        // When unset (such as in production) the test account is simply not created.
+        var password = configuration["Seeding:TestUserPassword"];
+        if (string.IsNullOrEmpty(password))
+        {
+            logger.LogWarning("Skipping test user account seeding: 'Seeding:TestUserPassword' is not configured.");
+            return;
+        }
+
+        var encryptedPassword = PasswordEncryptionProvider.EncryptPassword(password);
         await userRepository.AddUser(_defaultTestUserName, encryptedPassword, PricingLevel.Free, UserRole.User);
     }
 }

--- a/code/FinanceManager.Application/Identity/Seeders/TestUserAccountSeeder.cs
+++ b/code/FinanceManager.Application/Identity/Seeders/TestUserAccountSeeder.cs
@@ -20,7 +20,7 @@ public class TestUserAccountSeeder(IUserRepository userRepository, IConfiguratio
         // appsettings.Development.json or an environment variable — not in source code.
         // When unset (such as in production) the test account is simply not created.
         var password = configuration["Seeding:TestUserPassword"];
-        if (string.IsNullOrEmpty(password))
+        if (string.IsNullOrWhiteSpace(password))
         {
             logger.LogWarning("Skipping test user account seeding: 'Seeding:TestUserPassword' is not configured.");
             return;

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/StockPriceControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/StockPriceControllerTests.cs
@@ -15,6 +15,7 @@ using FinanceManager.Domain.FinancialAccounts.Stock.Services;
 using FinanceManager.Domain.Identity.Repositories;
 using FinanceManager.Domain.Identity.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Moq;
 using IIsinResolver = FinanceManager.Domain.FinancialAccounts.Stock.Services.IIsinResolver;
 
@@ -59,7 +60,8 @@ public class StockPriceControllerTests
             _stockDetailsRepository.Object,
             _stockPriceBulkImportService.Object,
             isinResolverMock.Object,
-            _instrumentResolverMock.Object);
+            _instrumentResolverMock.Object,
+            new Mock<ILogger<StockPriceController>>().Object);
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/StockPriceControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/StockPriceControllerTests.cs
@@ -14,6 +14,7 @@ using FinanceManager.Domain.FinancialAccounts.Stock.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Stock.Services;
 using FinanceManager.Domain.Identity.Repositories;
 using FinanceManager.Domain.Identity.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -33,6 +34,7 @@ public class StockPriceControllerTests
     private readonly Mock<IStockDetailsRepository> _stockDetailsRepository = new();
     private readonly Mock<IStockPriceBulkImportService> _stockPriceBulkImportService = new();
     private readonly Mock<IInstrumentResolver> _instrumentResolverMock = new();
+    private readonly Mock<ILogger<StockPriceController>> _logger = new();
     private readonly StockPriceController _controller;
 
     public StockPriceControllerTests()
@@ -61,7 +63,36 @@ public class StockPriceControllerTests
             _stockPriceBulkImportService.Object,
             isinResolverMock.Object,
             _instrumentResolverMock.Object,
-            new Mock<ILogger<StockPriceController>>().Object);
+            _logger.Object);
+    }
+
+    [Fact]
+    public async Task BulkImportClosePrices_ReturnsGenericBadRequest_WhenImportFails()
+    {
+        var file = new Mock<IFormFile>();
+        file.SetupGet(f => f.Length).Returns(1);
+        file.SetupGet(f => f.FileName).Returns("prices.csv");
+        file.Setup(f => f.OpenReadStream()).Returns(new MemoryStream([]));
+
+        _stockPriceBulkImportService
+            .Setup(service => service.ImportClosePrices(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("sensitive parser details"));
+
+        var result = await _controller.BulkImportClosePrices(file.Object, TestContext.Current.CancellationToken);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        var message = Assert.IsType<string>(badRequest.Value);
+        Assert.Equal("An error occurred while processing the request.", message);
+        Assert.DoesNotContain("sensitive parser details", message);
+
+        _logger.Verify(
+            logger => logger.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((_, _) => true),
+                It.IsAny<InvalidOperationException>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Resolves the three pre-existing CodeQL security alerts reported on `develop`.

- **HIGH / MEDIUM — Hardcoded credentials** (`AdminAccountSeeder`, `TestUserAccountSeeder`): the default admin and test-user passwords are no longer literals in source. They are read from configuration (`Seeding:AdminPassword` / `Seeding:TestUserPassword`). When the key is unset — as in production — the account is not seeded (logged as a warning) rather than created with a predictable password. Dev values live in `appsettings.Development.json`, so the local workflow (`admin@localhost` / `Admin1234`, `testuser` / `testuser`) is unchanged.
- **MEDIUM — Information exposure through exception message** (`StockPriceController` bulk import): the raw `ex.Message` is no longer returned to the caller. The exception is logged server-side via an injected `ILogger<StockPriceController>` and the client receives a generic `"An error occurred while processing the request."`.

## Acceptance criteria

- [x] `AdminAccountSeeder` reads the default password from `IConfiguration` (no hard-coded string)
- [x] `TestUserAccountSeeder` reads the default password from `IConfiguration` (no hard-coded string)
- [x] `StockPriceController` returns a generic error message; exception detail is logged, not returned to the caller
- [ ] CodeQL `security-scan` check passes on the branch (verified in CI)
- [x] Unit tests remain green (518 unit, 259 integration)

## Notes

Integration tests authenticate via directly-generated JWTs and do not run the seeders, so no tests depend on the seeded passwords. Build is clean (warnings-as-errors), `dotnet format` is clean.

closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011eMoeMGYtcKbWURDHw9pMR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Default admin and test user account passwords are now configurable via application settings (instead of hardcoded values).

* **Bug Fixes**
  * Improved bulk price import error handling to avoid exposing internal exception text; responses now use a generic bad request message.
  * The failure path now records an error log entry.

* **Tests**
  * Updated unit tests to account for injected logging and to verify the error is logged on import failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->