### PR TITLE
Harden dashboard snapshot load against storage failures and stale writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ rules agents must follow when updating this file.
 - Dashboard data is now cached in the browser's local storage: navigating back to the dashboard after visiting another page renders the previous result instantly, then silently refreshes in the background when the server responds. #444
 
 ### Fixed
+- The dashboard no longer blanks out if reading its saved snapshot fails: a local-storage or interop error on the snapshot read is now logged and the page falls through to a fresh server fetch instead of aborting the load. A slower, superseded reload also no longer overwrites the snapshot written by a newer one, preventing a stale first paint on the next visit. #463
 - The custom date-range icon in the account-details range selector now works: clicking the calendar icon opens a date-range picker (previously it was embedded in a menu and never appeared), letting users pick an arbitrary start/end range for the account history and chart. #436
 - The next-younger boundary entry attached to a loaded account (used to extend balance series past the selected window) is now resolved from the end of the date range instead of the start, so it correctly points at the first entry *after* the window rather than the earliest in-range entry. Affects both single-account and whole-portfolio loads. #411
 

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
@@ -102,7 +102,17 @@ public partial class Dashboard : ComponentBase
 
         // Paint the last-rendered snapshot immediately so the page feels instant on
         // re-navigation. The API call below always runs and reconciles the view.
-        var snapshot = await SnapshotService.GetAsync<DashboardOverviewSnapshot>(snapshotKey);
+        DashboardOverviewSnapshot? snapshot = null;
+        try
+        {
+            snapshot = await SnapshotService.GetAsync<DashboardOverviewSnapshot>(snapshotKey);
+        }
+        catch (Exception snapshotReadEx)
+        {
+            // A storage/interop failure on read must not abort the load — fall through to the fresh fetch.
+            Logger.LogWarning(snapshotReadEx, "Failed to read dashboard snapshot; continuing with fresh fetch.");
+        }
+
         if (snapshot is not null && requestVersion == _loadOverviewVersion)
         {
             _overview = snapshot.ToDto();
@@ -153,7 +163,9 @@ public partial class Dashboard : ComponentBase
             }
         }
 
-        if (freshOverview is not null && changed)
+        // Skip the write when a newer load has superseded this one, so a slower
+        // earlier request can't overwrite the latest request's snapshot.
+        if (requestVersion == _loadOverviewVersion && freshOverview is not null && changed)
         {
             try
             {


### PR DESCRIPTION
## What

Follow-up to #461 / #462 applying two robustness review comments that landed just before that PR merged.

closes #463

## Changes (`Dashboard.razor.cs`)

1. **Guard the snapshot read.** `SnapshotService.GetAsync` can throw beyond `JsonException` (local-storage / JS-interop failures). The read in `LoadOverview` is now wrapped in `try/catch`: on failure it logs and continues with `snapshot = null`, so the fresh API fetch still runs instead of the whole load aborting and leaving the dashboard blank.
2. **Version-guard the snapshot save.** The final `SnapshotService.SetAsync` now also checks `requestVersion == _loadOverviewVersion`, matching the version-guard pattern used elsewhere in the method, so a slower superseded reload can't overwrite the snapshot produced by a newer one (which would cause a stale first paint next visit).

## Verification

- `dotnet build` clean (warnings-as-errors) and `dotnet format` clean.
- Unit tests green: 560 passing.
- No visual change — these are defensive load-path guards only; the dashboard renders identically to #462 (already screenshotted there on guest mobile + desktop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrnLtPuWMUnAvufxNKZxgX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrnLtPuWMUnAvufxNKZxgX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Dashboard now loads successfully even when cached data retrieval encounters issues, falling back to fresh data fetching.
  * Prevents stale dashboard data from overwriting recent updates, ensuring consistency across concurrent load requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->