### PR TITLE
Add date time provider abstraction

### DIFF
--- a/code/FinanceManager.Application/Identity/Lockout/AccountLockoutService.cs
+++ b/code/FinanceManager.Application/Identity/Lockout/AccountLockoutService.cs
@@ -2,6 +2,7 @@ using FinanceManager.Application.Shared.Options;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
 using FinanceManager.Domain.Identity.Repositories;
 using FinanceManager.Domain.Identity.Services;
+using FinanceManager.Domain.Shared.Services;
 using Microsoft.Extensions.Options;
 
 namespace FinanceManager.Application.Identity.Lockout;
@@ -12,7 +13,7 @@ namespace FinanceManager.Application.Identity.Lockout;
 /// concurrent guesses can't lose updates; locking the account also resets the counter, so a lapsed lockout requires
 /// a fresh threshold of failures to lock again, and a successful login clears the state.
 /// </summary>
-public class AccountLockoutService(IUserRepository userRepository, IOptions<AccountLockoutOptions> options) : IAccountLockoutService
+public class AccountLockoutService(IUserRepository userRepository, IOptions<AccountLockoutOptions> options, IDateTimeProvider dateTimeProvider) : IAccountLockoutService
 {
     private readonly AccountLockoutOptions _options = options.Value;
 
@@ -21,7 +22,7 @@ public class AccountLockoutService(IUserRepository userRepository, IOptions<Acco
         if (!_options.Enabled) return false;
 
         var state = await userRepository.GetLoginThrottlingState(login);
-        return state?.LockoutEndUtc is DateTime lockoutEnd && lockoutEnd > DateTime.UtcNow;
+        return state?.LockoutEndUtc is DateTime lockoutEnd && lockoutEnd > dateTimeProvider.UtcNow;
     }
 
     public async Task RegisterFailedAttempt(string login, CancellationToken cancellationToken = default)
@@ -34,7 +35,7 @@ public class AccountLockoutService(IUserRepository userRepository, IOptions<Acco
         if (attempts is null) return;
 
         if (attempts >= _options.MaxFailedAttempts)
-            await userRepository.LockAccount(login, DateTime.UtcNow.Add(_options.LockoutDuration));
+            await userRepository.LockAccount(login, dateTimeProvider.UtcNow.Add(_options.LockoutDuration));
     }
 
     public async Task Reset(string login, CancellationToken cancellationToken = default)

--- a/code/FinanceManager.Application/Identity/PasswordReset/PasswordResetService.cs
+++ b/code/FinanceManager.Application/Identity/PasswordReset/PasswordResetService.cs
@@ -3,6 +3,7 @@ using FinanceManager.Domain.FinancialAccounts.Shared.Services;
 using FinanceManager.Domain.Identity.Entities;
 using FinanceManager.Domain.Identity.Repositories;
 using FinanceManager.Domain.Identity.Services;
+using FinanceManager.Domain.Shared.Services;
 using Microsoft.Extensions.Options;
 using System.Security.Cryptography;
 
@@ -11,7 +12,8 @@ namespace FinanceManager.Application.Identity.PasswordReset;
 public class PasswordResetService(
     IUserRepository userRepository,
     IPasswordResetTokenRepository tokenRepository,
-    IOptions<PasswordResetOptions> options) : IPasswordResetService
+    IOptions<PasswordResetOptions> options,
+    IDateTimeProvider dateTimeProvider) : IPasswordResetService
 {
     private const int _tokenByteLength = 32;
     private readonly PasswordResetOptions _options = options.Value;
@@ -32,7 +34,7 @@ public class PasswordResetService(
         var user = await userRepository.GetUser(normalizedLogin);
         if (user is null) return rawToken;
 
-        var now = DateTime.UtcNow;
+        var now = dateTimeProvider.UtcNow;
 
         // Requesting a new link supersedes any earlier one, so only the freshest token can be redeemed.
         await tokenRepository.InvalidateActiveTokensForUser(user.UserId, now);
@@ -60,14 +62,14 @@ public class PasswordResetService(
         if (existing.UsedAt is not null)
             return PasswordResetResult.Failure(PasswordResetStatus.AlreadyUsed);
 
-        if (DateTime.UtcNow >= existing.ExpiresAt)
+        if (dateTimeProvider.UtcNow >= existing.ExpiresAt)
             return PasswordResetResult.Failure(PasswordResetStatus.Expired);
 
         // Claim the token atomically *before* changing the password. The conditional consume succeeds for only the
         // single caller that flips UsedAt from null, so two concurrent redemptions of the same link can't both clear
         // the check above and reset the password twice — the loser is rejected here rather than overwriting the
         // winner's new password. (The checks above stay as a cheap fast-path for the common, uncontended case.)
-        if (!await tokenRepository.TryConsume(existing.TokenHash, DateTime.UtcNow))
+        if (!await tokenRepository.TryConsume(existing.TokenHash, dateTimeProvider.UtcNow))
             return PasswordResetResult.Failure(PasswordResetStatus.AlreadyUsed);
 
         var encryptedPassword = PasswordEncryptionProvider.EncryptPassword(newPassword);

--- a/code/FinanceManager.Application/Identity/RefreshTokens/RefreshTokenService.cs
+++ b/code/FinanceManager.Application/Identity/RefreshTokens/RefreshTokenService.cs
@@ -3,12 +3,13 @@ using FinanceManager.Domain.FinancialAccounts.Shared.Services;
 using FinanceManager.Domain.Identity.Entities;
 using FinanceManager.Domain.Identity.Repositories;
 using FinanceManager.Domain.Identity.Services;
+using FinanceManager.Domain.Shared.Services;
 using Microsoft.Extensions.Options;
 using System.Security.Cryptography;
 
 namespace FinanceManager.Application.Identity.RefreshTokens;
 
-public class RefreshTokenService(IRefreshTokenRepository repository, IOptions<RefreshTokenOptions> options) : IRefreshTokenService
+public class RefreshTokenService(IRefreshTokenRepository repository, IOptions<RefreshTokenOptions> options, IDateTimeProvider dateTimeProvider) : IRefreshTokenService
 {
     private const int _tokenByteLength = 32;
     private readonly RefreshTokenOptions _options = options.Value;
@@ -16,7 +17,7 @@ public class RefreshTokenService(IRefreshTokenRepository repository, IOptions<Re
     public async Task<string> Issue(int userId, CancellationToken cancellationToken = default)
     {
         var rawToken = GenerateRawToken();
-        var now = DateTime.UtcNow;
+        var now = dateTimeProvider.UtcNow;
 
         await repository.Add(new RefreshToken
         {
@@ -40,7 +41,7 @@ public class RefreshTokenService(IRefreshTokenRepository repository, IOptions<Re
         if (existing is null)
             return RefreshTokenRotationResult.Failure(RefreshTokenStatus.NotFound);
 
-        var now = DateTime.UtcNow;
+        var now = dateTimeProvider.UtcNow;
 
         // A token is only ever revoked once it has been rotated (or the family was nuked). Seeing it again means
         // someone is replaying a stolen, already-used token — revoke the whole family and force a fresh login.
@@ -80,7 +81,7 @@ public class RefreshTokenService(IRefreshTokenRepository repository, IOptions<Re
         var existing = await repository.GetByHash(Hash(rawToken));
         if (existing is null || existing.RevokedAt is not null) return;
 
-        existing.RevokedAt = DateTime.UtcNow;
+        existing.RevokedAt = dateTimeProvider.UtcNow;
         await repository.Update(existing);
     }
 

--- a/code/FinanceManager.Application/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Application/ServiceCollectionExtension.cs
@@ -6,8 +6,10 @@ using FinanceManager.Application.Identity.Users;
 using FinanceManager.Application.Insights;
 using FinanceManager.Application.Labels;
 using FinanceManager.Application.MoneyFlow;
+using FinanceManager.Application.Shared.Time;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
 using FinanceManager.Domain.Identity.Services;
+using FinanceManager.Domain.Shared.Services;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,7 +19,8 @@ public static class ServiceCollectionExtension
 {
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
-        services.AddScoped<ISettingsService, SettingsService>()
+        services.AddSingleton<IDateTimeProvider, DateTimeProvider>()
+                .AddScoped<ISettingsService, SettingsService>()
                 .AddScoped<PricingProvider>()
                 .AddScoped<AuthenticationStateProvider, CustomAuthenticationStateProvider>();
         return services;
@@ -28,6 +31,8 @@ public static class ServiceCollectionExtension
         // Identity must come before FinancialAccounts and Labels: seeders run in
         // ISeeder registration order (admin/test users, then financial-account
         // detail seeders, then labels).
+        services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
+
         services
             .AddIdentityApplication()
             .AddFinancialAccountsApplication()

--- a/code/FinanceManager.Application/Shared/Time/DateTimeProvider.cs
+++ b/code/FinanceManager.Application/Shared/Time/DateTimeProvider.cs
@@ -1,0 +1,8 @@
+using FinanceManager.Domain.Shared.Services;
+
+namespace FinanceManager.Application.Shared.Time;
+
+public sealed class DateTimeProvider : IDateTimeProvider
+{
+    public DateTime UtcNow => DateTime.UtcNow;
+}

--- a/code/FinanceManager.Domain/Shared/Services/IDateTimeProvider.cs
+++ b/code/FinanceManager.Domain/Shared/Services/IDateTimeProvider.cs
@@ -1,0 +1,8 @@
+namespace FinanceManager.Domain.Shared.Services;
+
+public interface IDateTimeProvider
+{
+    DateTime UtcNow { get; }
+
+    DateTime TodayUtc => UtcNow.Date;
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/AccountLockoutServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/AccountLockoutServiceTests.cs
@@ -3,6 +3,7 @@ using FinanceManager.Application.Shared.Options;
 using FinanceManager.Domain.Identity.Entities;
 using FinanceManager.Domain.Identity.Repositories;
 using Microsoft.Extensions.Options;
+using FinanceManager.Tests.Unit.Shared.Time;
 using Moq;
 
 namespace FinanceManager.Tests.Unit.Application.Services;
@@ -19,10 +20,11 @@ public class AccountLockoutServiceTests
         MaxFailedAttempts = 3,
         LockoutDuration = TimeSpan.FromMinutes(15),
     };
+    private readonly FakeDateTimeProvider _dateTimeProvider = new(DateTime.UtcNow);
     private readonly AccountLockoutService _service;
 
     public AccountLockoutServiceTests() =>
-        _service = new AccountLockoutService(_userRepository.Object, Options.Create(_options));
+        _service = new AccountLockoutService(_userRepository.Object, Options.Create(_options), _dateTimeProvider);
 
     private void SetupState(int failedAttempts, DateTime? lockoutEndUtc) =>
         _userRepository.Setup(r => r.GetLoginThrottlingState(_login))
@@ -46,7 +48,7 @@ public class AccountLockoutServiceTests
     public async Task RegisterFailedAttempt_ReachingThreshold_LocksForConfiguredWindow()
     {
         SetupIncrementReturns(3);
-        var before = DateTime.UtcNow;
+        var before = _dateTimeProvider.UtcNow;
 
         DateTime capturedLockoutEnd = default;
         _userRepository.Setup(r => r.LockAccount(_login, It.IsAny<DateTime>()))
@@ -59,7 +61,7 @@ public class AccountLockoutServiceTests
         // Lockout end is roughly now + the configured duration.
         Assert.InRange(capturedLockoutEnd,
             before.Add(_options.LockoutDuration),
-            DateTime.UtcNow.Add(_options.LockoutDuration).AddSeconds(1));
+            _dateTimeProvider.UtcNow.Add(_options.LockoutDuration).AddSeconds(1));
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Unit/Application/Services/PasswordResetServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/PasswordResetServiceTests.cs
@@ -6,6 +6,7 @@ using FinanceManager.Domain.Identity.Entities;
 using FinanceManager.Domain.Identity.Repositories;
 using FinanceManager.Domain.Identity.Services;
 using Microsoft.Extensions.Options;
+using FinanceManager.Tests.Unit.Shared.Time;
 using Moq;
 using System.Security.Cryptography;
 using System.Text;
@@ -18,10 +19,11 @@ public class PasswordResetServiceTests
     private readonly Mock<IUserRepository> _userRepository = new();
     private readonly Mock<IPasswordResetTokenRepository> _tokenRepository = new();
     private readonly PasswordResetOptions _options = new() { TokenValidityMinutes = 60 };
+    private readonly FakeDateTimeProvider _dateTimeProvider = new(DateTime.UtcNow);
     private readonly PasswordResetService _service;
 
     public PasswordResetServiceTests() =>
-        _service = new PasswordResetService(_userRepository.Object, _tokenRepository.Object, Options.Create(_options));
+        _service = new PasswordResetService(_userRepository.Object, _tokenRepository.Object, Options.Create(_options), _dateTimeProvider);
 
     private static string Hash(string raw) => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(raw)));
 

--- a/code/FinanceManager.Tests.Unit/Application/Services/RefreshTokenServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/RefreshTokenServiceTests.cs
@@ -5,6 +5,7 @@ using FinanceManager.Domain.Identity.Entities;
 using FinanceManager.Domain.Identity.Repositories;
 using FinanceManager.Domain.Identity.Services;
 using Microsoft.Extensions.Options;
+using FinanceManager.Tests.Unit.Shared.Time;
 using Moq;
 using System.Security.Cryptography;
 using System.Text;
@@ -16,10 +17,11 @@ public class RefreshTokenServiceTests
 {
     private readonly Mock<IRefreshTokenRepository> _repository = new();
     private readonly RefreshTokenOptions _options = new() { SlidingValidityDays = 14, AbsoluteValidityDays = 30 };
+    private readonly FakeDateTimeProvider _dateTimeProvider = new(DateTime.UtcNow);
     private readonly RefreshTokenService _service;
 
     public RefreshTokenServiceTests() =>
-        _service = new RefreshTokenService(_repository.Object, Options.Create(_options));
+        _service = new RefreshTokenService(_repository.Object, Options.Create(_options), _dateTimeProvider);
 
     private static string Hash(string raw) => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(raw)));
 

--- a/code/FinanceManager.Tests.Unit/Shared/Time/FakeDateTimeProvider.cs
+++ b/code/FinanceManager.Tests.Unit/Shared/Time/FakeDateTimeProvider.cs
@@ -1,0 +1,12 @@
+using FinanceManager.Domain.Shared.Services;
+
+namespace FinanceManager.Tests.Unit.Shared.Time;
+
+internal sealed class FakeDateTimeProvider(DateTime utcNow) : IDateTimeProvider
+{
+    public DateTime UtcNow { get; private set; } = DateTime.SpecifyKind(utcNow, DateTimeKind.Utc);
+
+    public void SetUtcNow(DateTime utcNow) => UtcNow = DateTime.SpecifyKind(utcNow, DateTimeKind.Utc);
+
+    public void Advance(TimeSpan timeSpan) => UtcNow = UtcNow.Add(timeSpan);
+}


### PR DESCRIPTION
### Motivation
- Make time access testable by removing direct `DateTime.UtcNow` usages and introducing a time abstraction that can be replaced in tests.

### Description
- Add `IDateTimeProvider` interface with `UtcNow`/`TodayUtc` and a production `DateTimeProvider` implementation that delegates to `DateTime.UtcNow` (`code/FinanceManager.Domain/Shared/Services/IDateTimeProvider.cs`, `code/FinanceManager.Application/Shared/Time/DateTimeProvider.cs`).
- Register the provider in DI via `AddSingleton<IDateTimeProvider, DateTimeProvider>` in application registration paths (`code/FinanceManager.Application/ServiceCollectionExtension.cs`).
- Update time-sensitive identity services to accept `IDateTimeProvider` and use `dateTimeProvider.UtcNow` instead of `DateTime.UtcNow` (RefreshTokenService, PasswordResetService, AccountLockoutService).
- Add `FakeDateTimeProvider` for unit tests and wire affected unit tests to use it so tests can control time (`code/FinanceManager.Tests.Unit/Shared/Time/FakeDateTimeProvider.cs` and updated test files).

### Testing
- Ran `dotnet build code/FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --no-restore`, which succeeded.
- Ran the unit test suite with the project runner using `dotnet run --project code/FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj`, and the tests completed successfully (unit tests passed).
- Attempted `dotnet test code/FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --no-restore` but it was blocked by the .NET 10 / Microsoft.Testing.Platform VSTest incompatibility, so the project runner was used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36fadbd6c48320a74161e9d3716fe2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated account lockout, password reset, and refresh token services to use dependency-injected time provider instead of direct system clock.
  * Registered time provider as a singleton in the dependency injection container.

* **Tests**
  * Added fake datetime provider for unit tests enabling deterministic time control.
  * Updated service tests to use injectable time provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->