### PR TITLE
Fix admin asset symbol create Location header

### DIFF
--- a/code/FinanceManager.Api/Controllers/Admin/AssetController.cs
+++ b/code/FinanceManager.Api/Controllers/Admin/AssetController.cs
@@ -126,11 +126,12 @@ public class AssetController(
     {
         if (string.IsNullOrWhiteSpace(dto.Symbol))
             return BadRequest("Symbol is required.");
-        if (await listingRepository.Get(listingId, cancellationToken) is null)
+        var listing = await listingRepository.Get(listingId, cancellationToken);
+        if (listing is null)
             return NotFound("Listing not found.");
 
         var created = await symbolRepository.Add(dto.ToNewEntity(listingId), cancellationToken);
-        return CreatedAtAction(nameof(GetAsset), new { id = 0L }, created.ToDto());
+        return CreatedAtAction(nameof(GetAsset), new { id = listing.AssetId }, created.ToDto());
     }
 
     [HttpPut("symbols/{id:long}")]

--- a/code/FinanceManager.Tests.Integration/Controllers/AssetControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/AssetControllerTests.cs
@@ -91,6 +91,7 @@ public class AssetControllerTests(OptionsProvider optionsProvider) : ControllerT
             new MarketDataSymbolDto { Provider = MarketDataProvider.AlphaVantage, Symbol = "SXR8.DE", IsPrimary = true },
             TestContext.Current.CancellationToken);
         symbolResponse.EnsureSuccessStatusCode();
+        Assert.Equal($"http://localhost/api/admin/assets/{asset.Id}", symbolResponse.Headers.Location?.ToString());
 
         var fetched = await Client.GetFromJsonAsync<AssetDto>($"api/admin/assets/{asset.Id}", TestContext.Current.CancellationToken);
         Assert.NotNull(fetched);


### PR DESCRIPTION
### Motivation
- Ensure the API returns a correct `Location` header that points to the owning asset after creating a market-data symbol, so clients receive a meaningful link to the updated asset tree.

### Description
- Load the `listing` before creating a `MarketDataSymbol` and return `CreatedAtAction` with `id = listing.AssetId` instead of a placeholder `0L` in `AssetController.CreateSymbol`.
- Add an integration assertion verifying the create response `Location` header equals `http://localhost/api/admin/assets/{asset.Id}` in `AssetControllerTests`.

### Testing
- Ran `dotnet build code/FinanceManager.slnx` which succeeded. 
- Ran `dotnet test` from the `code/` directory which passed all tests (866 total, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37a6b75604832089973f7b4cb0e05f)