### PR TITLE
Add InvestmentPriceProvider on the new asset model #481

### DIFF
--- a/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
+++ b/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
@@ -46,11 +46,12 @@ public class InvestmentPriceProvider(
     {
         if (assetListingId <= 0) return 0m;
 
-        var listing = await listingRepository.Get(assetListingId, ct);
-        if (listing is null) return 0m;
-
+        // Cache-first: a hit must not depend on any repository I/O.
         var cacheKey = $"INVEST_PRICE_{targetCurrency.ShortName}_{asOf:yyyyMMdd}_{assetListingId}";
         if (cache.TryGetValue(cacheKey, out decimal cached)) return cached;
+
+        var listing = await listingRepository.Get(assetListingId, ct);
+        if (listing is null) return 0m;
 
         var quote = await priceQuoteRepository.GetLatestOnOrBefore(assetListingId, DayEnd(asOf), cancellationToken: ct);
         if (quote is null)
@@ -63,7 +64,7 @@ public class InvestmentPriceProvider(
 
         var price = await ConvertAsync(quote.Price, quote.Currency, targetCurrency, asOf, ct);
         if (price > 0)
-            cache.Set(cacheKey, price, new MemoryCacheEntryOptions { SlidingExpiration = _cacheTtl });
+            cache.Set(cacheKey, price, new MemoryCacheEntryOptions { AbsoluteExpirationRelativeToNow = _cacheTtl });
 
         return price;
     }
@@ -180,7 +181,10 @@ public class InvestmentPriceProvider(
             return;
         }
 
-        var fetchKey = $"INVEST_FETCH_{listing.Id}_{symbol.Id}_{start.Date:yyyyMMdd}_{end.Date:yyyyMMdd}";
+        // Key the lock by listing+symbol only: _fetchLocks is static and never evicts, so per-range
+        // keys would leak a SemaphoreSlim per requested window. Sharing one lock per symbol also
+        // serialises overlapping range fetches, which is what we want.
+        var fetchKey = $"INVEST_FETCH_{listing.Id}_{symbol.Id}";
         var fetchLock = _fetchLocks.GetOrAdd(fetchKey, _ => new SemaphoreSlim(1, 1));
         await fetchLock.WaitAsync(ct);
         try
@@ -211,7 +215,7 @@ public class InvestmentPriceProvider(
                 return;
             }
 
-            var normalizedCurrencyName = NormalizedCurrencyName(listing);
+            var normalizedCurrencyName = NormalizedCurrencyName(rawCurrencyName, listing.PriceMultiplier);
             foreach (var price in prices)
             {
                 if (price.PricePerUnit <= 0) continue;
@@ -239,14 +243,16 @@ public class InvestmentPriceProvider(
         }
     }
 
-    private static string NormalizedCurrencyName(AssetListing listing)
+    // Normalise from the currency the prices were actually fetched in (symbol currency, falling
+    // back to the listing's trading currency), so PriceQuote.Currency matches RawCurrency.
+    private static string NormalizedCurrencyName(string rawCurrencyName, decimal priceMultiplier)
     {
-        if (listing.PriceMultiplier == 1m)
-            return listing.TradingCurrency;
+        if (priceMultiplier == 1m)
+            return rawCurrencyName;
 
-        return _minorToMajorCurrency.TryGetValue(listing.TradingCurrency, out var major)
+        return _minorToMajorCurrency.TryGetValue(rawCurrencyName, out var major)
             ? major
-            : listing.TradingCurrency;
+            : rawCurrencyName;
     }
 
     private static bool NeedsFetch(IReadOnlyList<PriceQuote> existing, DateTime start, DateTime end)

--- a/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
+++ b/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
@@ -1,0 +1,269 @@
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.Assets.Services;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
+
+namespace FinanceManager.Application.Assets.Pricing;
+
+/// <summary>
+/// Prices an <see cref="AssetListing"/> on the new asset model. Serves cached
+/// <see cref="PriceQuote"/> rows first, fetches from the listing's primary enabled
+/// <see cref="MarketDataSymbol"/> through the existing <see cref="IStockPriceSource"/> fallback
+/// chain when data is missing, normalises the raw quote with the listing's
+/// <see cref="AssetListing.PriceMultiplier"/> (e.g. GBX → GBP) and converts to the target currency.
+/// </summary>
+public class InvestmentPriceProvider(
+    IAssetListingRepository listingRepository,
+    IMarketDataSymbolRepository symbolRepository,
+    IPriceQuoteRepository priceQuoteRepository,
+    IStockPriceSource priceSource,
+    ICurrencyRepository currencyRepository,
+    ICurrencyExchangeService currencyExchangeService,
+    IMemoryCache cache,
+    ILogger<InvestmentPriceProvider> logger) : IInvestmentPriceProvider
+{
+    private const int _fetchLookbackDays = 7;
+    private static readonly TimeSpan _cacheTtl = TimeSpan.FromMinutes(60);
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> _fetchLocks = new();
+
+    // Minor "pence"-style quote units collapse to their major currency once PriceMultiplier is
+    // applied (1 GBX = 0.01 GBP), so FX conversion can use a currency the rate provider knows.
+    private static readonly Dictionary<string, string> _minorToMajorCurrency = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["GBX"] = "GBP",
+        ["GBP."] = "GBP",
+        ["ZAC"] = "ZAR",
+        ["ILA"] = "ILS",
+    };
+
+    public async Task<decimal> GetPricePerUnitAsync(long assetListingId, Currency targetCurrency, DateTime asOf, CancellationToken ct = default)
+    {
+        if (assetListingId <= 0) return 0m;
+
+        var listing = await listingRepository.Get(assetListingId, ct);
+        if (listing is null) return 0m;
+
+        var cacheKey = $"INVEST_PRICE_{targetCurrency.ShortName}_{asOf:yyyyMMdd}_{assetListingId}";
+        if (cache.TryGetValue(cacheKey, out decimal cached)) return cached;
+
+        var quote = await priceQuoteRepository.GetLatestOnOrBefore(assetListingId, DayEnd(asOf), cancellationToken: ct);
+        if (quote is null)
+        {
+            await TryFetchAndStoreAsync(listing, asOf.AddDays(-_fetchLookbackDays), asOf, ct);
+            quote = await priceQuoteRepository.GetLatestOnOrBefore(assetListingId, DayEnd(asOf), cancellationToken: ct);
+        }
+
+        if (quote is null) return 0m;
+
+        var price = await ConvertAsync(quote.Price, quote.Currency, targetCurrency, asOf, ct);
+        if (price > 0)
+            cache.Set(cacheKey, price, new MemoryCacheEntryOptions { SlidingExpiration = _cacheTtl });
+
+        return price;
+    }
+
+    public async Task<IReadOnlyDictionary<DateTime, decimal>> GetPricePerUnitSeriesAsync(
+        long assetListingId,
+        Currency targetCurrency,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        if (assetListingId <= 0 || start == default || end == default || end < start)
+            return new Dictionary<DateTime, decimal>();
+
+        var listing = await listingRepository.Get(assetListingId, ct);
+        if (listing is null) return new Dictionary<DateTime, decimal>();
+
+        var startDate = start.Date;
+        var endDate = end.Date;
+
+        var existing = await priceQuoteRepository.GetRange(assetListingId, DayStart(startDate), DayEnd(endDate), ct);
+        if (NeedsFetch(existing, startDate, endDate))
+        {
+            await TryFetchAndStoreAsync(listing, startDate, endDate, ct);
+            existing = await priceQuoteRepository.GetRange(assetListingId, DayStart(startDate), DayEnd(endDate), ct);
+        }
+
+        var latestByDate = existing
+            .GroupBy(x => x.PriceTime.Date)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(p => p.PriceTime).First());
+
+        var seed = await priceQuoteRepository.GetLatestOnOrBefore(assetListingId, DayStart(startDate), cancellationToken: ct);
+
+        // Prefetch FX rates once per distinct source currency over the whole range instead of
+        // issuing one (uncached) conversion per day inside the loop.
+        var ratesByCurrency = new Dictionary<string, Dictionary<DateTime, decimal>>(StringComparer.OrdinalIgnoreCase);
+        var sourceCurrencyNames = latestByDate.Values
+            .Select(q => q.Currency)
+            .Concat(seed is not null ? [seed.Currency] : [])
+            .Where(name => !string.Equals(name, targetCurrency.ShortName, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        foreach (var name in sourceCurrencyNames)
+        {
+            var fromCurrency = await currencyRepository.GetOrAdd(name, name, ct);
+            var rates = await currencyExchangeService.GetExchangeRateAsync(fromCurrency, targetCurrency, startDate, endDate);
+            var rateMap = new Dictionary<DateTime, decimal>(rates.Count);
+            foreach (var (rateDate, value) in rates)
+            {
+                if (value is not null)
+                    rateMap[rateDate.Date] = value.Value;
+            }
+
+            ratesByCurrency[name] = rateMap;
+        }
+
+        var series = new Dictionary<DateTime, decimal>((endDate - startDate).Days + 1);
+        var latestKnown = seed;
+
+        for (var date = startDate; date <= endDate; date = date.AddDays(1))
+        {
+            if (latestByDate.TryGetValue(date, out var todayQuote))
+                latestKnown = todayQuote;
+
+            if (latestKnown is null) continue;
+
+            decimal converted;
+            if (string.Equals(latestKnown.Currency, targetCurrency.ShortName, StringComparison.OrdinalIgnoreCase))
+            {
+                converted = latestKnown.Price;
+            }
+            else if (ratesByCurrency.TryGetValue(latestKnown.Currency, out var rateMap) && rateMap.TryGetValue(date, out var rate))
+            {
+                converted = latestKnown.Price * rate;
+            }
+            else
+            {
+                // Dates outside the prefetched range or with a missing rate fall back to the
+                // per-call path so the result matches the point lookup.
+                converted = await ConvertAsync(latestKnown.Price, latestKnown.Currency, targetCurrency, date, ct);
+            }
+
+            if (converted > 0)
+                series[date] = converted;
+        }
+
+        return series;
+    }
+
+    private async Task<decimal> ConvertAsync(decimal price, string sourceCurrencyName, Currency targetCurrency, DateTime date, CancellationToken ct)
+    {
+        if (price <= 0) return 0m;
+        if (string.Equals(sourceCurrencyName, targetCurrency.ShortName, StringComparison.OrdinalIgnoreCase))
+            return price;
+
+        if (date > DateTime.UtcNow) date = DateTime.UtcNow;
+        var sourceCurrency = await currencyRepository.GetOrAdd(sourceCurrencyName, sourceCurrencyName, ct);
+        var rate = await currencyExchangeService.GetExchangeRateAsync(sourceCurrency, targetCurrency, date.Date);
+        return rate is decimal value ? price * value : 0m;
+    }
+
+    private async Task TryFetchAndStoreAsync(AssetListing listing, DateTime start, DateTime end, CancellationToken ct)
+    {
+        var symbol = listing.MarketDataSymbols
+            .Where(s => s.IsEnabled)
+            .OrderByDescending(s => s.IsPrimary)
+            .ThenBy(s => s.Id)
+            .FirstOrDefault();
+
+        if (symbol is null)
+        {
+            logger.LogDebug("Listing {ListingId} has no enabled market-data symbol; cannot fetch prices", listing.Id);
+            return;
+        }
+
+        var fetchKey = $"INVEST_FETCH_{listing.Id}_{symbol.Id}_{start.Date:yyyyMMdd}_{end.Date:yyyyMMdd}";
+        var fetchLock = _fetchLocks.GetOrAdd(fetchKey, _ => new SemaphoreSlim(1, 1));
+        await fetchLock.WaitAsync(ct);
+        try
+        {
+            // Re-check after acquiring the lock so a concurrent fetch isn't repeated.
+            var existing = await priceQuoteRepository.GetRange(listing.Id, DayStart(start), DayEnd(end), ct);
+            if (!NeedsFetch(existing, start.Date, end.Date))
+                return;
+
+            var rawCurrencyName = string.IsNullOrWhiteSpace(symbol.Currency) ? listing.TradingCurrency : symbol.Currency;
+            var rawCurrency = await currencyRepository.GetOrAdd(rawCurrencyName, rawCurrencyName, ct);
+
+            IReadOnlyList<Domain.FinancialAccounts.Stock.Entities.StockPrice> prices;
+            try
+            {
+                prices = await priceSource.GetDailySeries(symbol.Symbol, string.Empty, start, end, rawCurrency, ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Price fetch failed for listing {ListingId} symbol {Symbol}", listing.Id, symbol.Symbol);
+                await symbolRepository.RecordFetchResult(symbol.Id, null, ex.Message, ct);
+                return;
+            }
+
+            if (prices.Count == 0)
+            {
+                await symbolRepository.RecordFetchResult(symbol.Id, null, "No price data returned", ct);
+                return;
+            }
+
+            var normalizedCurrencyName = NormalizedCurrencyName(listing);
+            foreach (var price in prices)
+            {
+                if (price.PricePerUnit <= 0) continue;
+
+                await priceQuoteRepository.Upsert(new PriceQuote
+                {
+                    AssetListingId = listing.Id,
+                    MarketDataSymbolId = symbol.Id,
+                    Provider = symbol.Provider,
+                    Price = price.PricePerUnit * listing.PriceMultiplier,
+                    Currency = normalizedCurrencyName,
+                    PriceTime = DayStart(price.Date),
+                    QuoteType = PriceQuoteType.EndOfDay,
+                    RawPrice = price.PricePerUnit,
+                    RawCurrency = rawCurrencyName,
+                    FetchedAt = DateTimeOffset.UtcNow
+                }, ct);
+            }
+
+            await symbolRepository.RecordFetchResult(symbol.Id, DateTimeOffset.UtcNow, null, ct);
+        }
+        finally
+        {
+            fetchLock.Release();
+        }
+    }
+
+    private static string NormalizedCurrencyName(AssetListing listing)
+    {
+        if (listing.PriceMultiplier == 1m)
+            return listing.TradingCurrency;
+
+        return _minorToMajorCurrency.TryGetValue(listing.TradingCurrency, out var major)
+            ? major
+            : listing.TradingCurrency;
+    }
+
+    private static bool NeedsFetch(IReadOnlyList<PriceQuote> existing, DateTime start, DateTime end)
+    {
+        if (existing is null || existing.Count == 0) return true;
+
+        var existingDates = existing.Select(x => x.PriceTime.Date).ToHashSet();
+        for (var date = start.Date; date <= end.Date; date = date.AddDays(1))
+        {
+            if (date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday) continue;
+            if (!existingDates.Contains(date)) return true;
+        }
+
+        return false;
+    }
+
+    private static DateTimeOffset DayStart(DateTime date) => new(date.Date, TimeSpan.Zero);
+
+    private static DateTimeOffset DayEnd(DateTime date) => new DateTimeOffset(date.Date, TimeSpan.Zero).AddDays(1).AddTicks(-1);
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Registration.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Registration.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Application.Assets.Pricing;
 using FinanceManager.Application.FinancialAccounts.Bond;
 using FinanceManager.Application.FinancialAccounts.Bond.Assets;
 using FinanceManager.Application.FinancialAccounts.Bond.Balance;
@@ -24,6 +25,7 @@ using FinanceManager.Application.FinancialAccounts.Stock.Market;
 using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
 using FinanceManager.Application.FinancialAccounts.Stock.Seeders;
 using FinanceManager.Application.Shared.Seeders;
+using FinanceManager.Domain.Assets.Services;
 using FinanceManager.Domain.FinancialAccounts.Bond.Exports;
 using FinanceManager.Domain.FinancialAccounts.Bond.Services;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Exports;
@@ -74,6 +76,7 @@ internal static class Registration
                 .AddScoped<IBondAccountExportService, BondAccountExportService>()
                 .AddScoped<IAccountCsvExportService<BondAccountExportDto>, BondAccountCsvExportService>()
                 .AddScoped<IStockPriceProvider, StockPriceProvider>()
+                .AddScoped<IInvestmentPriceProvider, InvestmentPriceProvider>()
                 .AddScoped<IStockPriceBulkImportService, StockPriceBulkImportService>()
                 .AddScoped<IStockUnrealizedGainLossCalculator, StockUnrealizedGainLossCalculator>()
                 .AddScoped<IBondUnrealizedGainLossCalculator, BondUnrealizedGainLossCalculator>()

--- a/code/FinanceManager.Domain/Assets/Services/IInvestmentPriceProvider.cs
+++ b/code/FinanceManager.Domain/Assets/Services/IInvestmentPriceProvider.cs
@@ -1,0 +1,34 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+
+namespace FinanceManager.Domain.Assets.Services;
+
+/// <summary>
+/// Reads prices for an <see cref="Entities.AssetListing"/> with automatic provider fallback:
+/// serves cached <see cref="Entities.PriceQuote"/> rows first, fetches from the listing's
+/// configured <see cref="Entities.MarketDataSymbol"/> when data is missing, normalises the raw
+/// quote with <see cref="Entities.AssetListing.PriceMultiplier"/> (e.g. GBX → GBP) and converts
+/// to the requested currency. Keyed on the listing rather than a globally-unique ticker, so the
+/// same instrument trading on several exchanges is priced independently.
+/// </summary>
+public interface IInvestmentPriceProvider
+{
+    /// <summary>
+    /// Get the normalised price per unit for <paramref name="assetListingId"/> converted to
+    /// <paramref name="targetCurrency"/> as of <paramref name="asOf"/>. Uses the most recent quote
+    /// on or before that date, fetching from the provider when the cache has nothing.
+    /// Returns 0 when no price can be determined.
+    /// </summary>
+    Task<decimal> GetPricePerUnitAsync(long assetListingId, Currency targetCurrency, DateTime asOf, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get the per-day price per unit for <paramref name="assetListingId"/> converted to
+    /// <paramref name="targetCurrency"/> over [<paramref name="start"/>, <paramref name="end"/>].
+    /// Days without a quote carry the latest known older price forward.
+    /// </summary>
+    Task<IReadOnlyDictionary<DateTime, decimal>> GetPricePerUnitSeriesAsync(
+        long assetListingId,
+        Currency targetCurrency,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default);
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceProviderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceProviderTests.cs
@@ -1,0 +1,235 @@
+using FinanceManager.Application.Assets.Pricing;
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+using FinanceManager.Domain.FinancialAccounts.Stock.Entities;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services.Assets;
+
+[Trait("Category", "Unit")]
+public class InvestmentPriceProviderTests
+{
+    private static readonly Currency _usd = new(1, "USD", "$");
+
+    private readonly Mock<IAssetListingRepository> _listingRepository = new();
+    private readonly Mock<IMarketDataSymbolRepository> _symbolRepository = new();
+    private readonly InMemoryPriceQuoteRepository _priceQuoteRepository = new();
+    private readonly Mock<IStockPriceSource> _priceSource = new();
+    private readonly Mock<ICurrencyRepository> _currencyRepository = new();
+    private readonly Mock<ICurrencyExchangeService> _currencyExchangeService = new();
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+
+    public InvestmentPriceProviderTests()
+    {
+        _symbolRepository
+            .Setup(x => x.RecordFetchResult(It.IsAny<long>(), It.IsAny<DateTimeOffset?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // GetOrAdd echoes back a currency with the requested short name.
+        _currencyRepository
+            .Setup(x => x.GetOrAdd(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string shortName, string? symbol, CancellationToken _) => new Currency(0, shortName, symbol ?? shortName));
+    }
+
+    private InvestmentPriceProvider CreateSut() => new(
+        _listingRepository.Object,
+        _symbolRepository.Object,
+        _priceQuoteRepository,
+        _priceSource.Object,
+        _currencyRepository.Object,
+        _currencyExchangeService.Object,
+        _cache,
+        LoggerFactory.Create(_ => { }).CreateLogger<InvestmentPriceProvider>());
+
+    private static AssetListing Listing(string tradingCurrency = "USD", decimal multiplier = 1m) => new()
+    {
+        Id = 10,
+        AssetId = 1,
+        Ticker = "CSPX",
+        ExchangeMic = "XLON",
+        ExchangeName = "London Stock Exchange",
+        TradingCurrency = tradingCurrency,
+        PriceMultiplier = multiplier,
+        IsActive = true,
+        MarketDataSymbols =
+        [
+            new MarketDataSymbol
+            {
+                Id = 100,
+                AssetListingId = 10,
+                Provider = MarketDataProvider.AlphaVantage,
+                Symbol = "CSPX.LON",
+                IsPrimary = true,
+                IsEnabled = true
+            }
+        ]
+    };
+
+    private static StockPrice Price(decimal value, DateTime date) =>
+        new() { Isin = string.Empty, PricePerUnit = value, Currency = _usd, Date = date };
+
+    [Fact]
+    public async Task GetPricePerUnit_ServesCachedQuote_WithoutFetching()
+    {
+        var asOf = new DateTime(2024, 6, 3);
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing());
+        _priceQuoteRepository.Seed(new PriceQuote
+        {
+            AssetListingId = 10,
+            Provider = MarketDataProvider.AlphaVantage,
+            Price = 123m,
+            Currency = "USD",
+            PriceTime = new DateTimeOffset(asOf, TimeSpan.Zero),
+            QuoteType = PriceQuoteType.EndOfDay
+        });
+
+        var result = await CreateSut().GetPricePerUnitAsync(10, _usd, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(123m, result);
+        _priceSource.Verify(
+            x => x.GetDailySeries(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPricePerUnit_FetchesPersistsAndReturns_WhenNoQuoteCached()
+    {
+        var asOf = new DateTime(2024, 6, 3);
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing());
+        _priceSource
+            .Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Price(200m, asOf)]);
+
+        var result = await CreateSut().GetPricePerUnitAsync(10, _usd, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(200m, result);
+        var stored = Assert.Single(_priceQuoteRepository.All);
+        Assert.Equal(200m, stored.Price);
+        Assert.Equal("USD", stored.Currency);
+        Assert.Equal(MarketDataProvider.AlphaVantage, stored.Provider);
+        Assert.Equal(100, stored.MarketDataSymbolId);
+    }
+
+    [Fact]
+    public async Task GetPricePerUnit_NormalisesGbxWithMultiplier_AndConvertsToTarget()
+    {
+        var asOf = new DateTime(2024, 6, 3);
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing("GBX", 0.01m));
+        _priceSource
+            .Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Price(500m, asOf)]); // 500 GBX
+        // Normalised 5 GBP → USD at 1.25 = 6.25
+        _currencyExchangeService
+            .Setup(x => x.GetExchangeRateAsync(It.Is<Currency>(c => c.ShortName == "GBP"), It.Is<Currency>(c => c.ShortName == "USD"), It.IsAny<DateTime>()))
+            .ReturnsAsync(1.25m);
+
+        var result = await CreateSut().GetPricePerUnitAsync(10, _usd, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(6.25m, result);
+        var stored = Assert.Single(_priceQuoteRepository.All);
+        Assert.Equal(5m, stored.Price);
+        Assert.Equal("GBP", stored.Currency);
+        Assert.Equal(500m, stored.RawPrice);
+        Assert.Equal("GBX", stored.RawCurrency);
+    }
+
+    [Fact]
+    public async Task GetPricePerUnit_ReturnsZero_WhenNoSymbolConfigured()
+    {
+        var asOf = new DateTime(2024, 6, 3);
+        var listing = Listing();
+        listing.MarketDataSymbols.Clear();
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(listing);
+
+        var result = await CreateSut().GetPricePerUnitAsync(10, _usd, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(0m, result);
+        Assert.Empty(_priceQuoteRepository.All);
+    }
+
+    [Fact]
+    public async Task GetPricePerUnitSeries_CarriesLastKnownPriceForward_OnDaysWithoutQuote()
+    {
+        var mon = new DateTime(2024, 1, 1); // Monday
+        var wed = new DateTime(2024, 1, 3);
+        var fri = new DateTime(2024, 1, 5);
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing());
+        _priceSource
+            .Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Price(100m, mon), Price(110m, wed)]);
+
+        var series = await CreateSut().GetPricePerUnitSeriesAsync(10, _usd, mon, fri, TestContext.Current.CancellationToken);
+
+        Assert.Equal(100m, series[mon]);
+        Assert.Equal(100m, series[new DateTime(2024, 1, 2)]); // Tue carries Monday forward
+        Assert.Equal(110m, series[wed]);
+        Assert.Equal(110m, series[new DateTime(2024, 1, 4)]); // Thu carries Wednesday forward
+        Assert.Equal(110m, series[fri]);
+    }
+
+    /// <summary>Minimal in-memory <see cref="IPriceQuoteRepository"/> so fetch→store→read flows are exercised end-to-end.</summary>
+    private sealed class InMemoryPriceQuoteRepository : IPriceQuoteRepository
+    {
+        private readonly List<PriceQuote> _quotes = [];
+        private long _nextId = 1;
+
+        public IReadOnlyList<PriceQuote> All => _quotes;
+
+        public void Seed(PriceQuote quote) => _quotes.Add(quote);
+
+        public Task<PriceQuote?> Get(long id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_quotes.FirstOrDefault(x => x.Id == id));
+
+        public Task<PriceQuote?> GetLatestOnOrBefore(long assetListingId, DateTimeOffset asOf, MarketDataProvider? provider = null, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_quotes
+                .Where(x => x.AssetListingId == assetListingId && x.PriceTime <= asOf && (provider is null || x.Provider == provider))
+                .OrderByDescending(x => x.PriceTime)
+                .FirstOrDefault());
+
+        public Task<IReadOnlyList<PriceQuote>> GetRange(long assetListingId, DateTimeOffset start, DateTimeOffset end, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<PriceQuote>>(_quotes
+                .Where(x => x.AssetListingId == assetListingId && x.PriceTime >= start && x.PriceTime <= end)
+                .OrderBy(x => x.PriceTime)
+                .ToList());
+
+        public Task<PriceQuote> Add(PriceQuote quote, CancellationToken cancellationToken = default)
+        {
+            quote.Id = _nextId++;
+            _quotes.Add(quote);
+            return Task.FromResult(quote);
+        }
+
+        public Task<PriceQuote> Upsert(PriceQuote quote, CancellationToken cancellationToken = default)
+        {
+            var existing = _quotes.FirstOrDefault(x =>
+                x.AssetListingId == quote.AssetListingId
+                && x.Provider == quote.Provider
+                && x.PriceTime == quote.PriceTime
+                && x.QuoteType == quote.QuoteType);
+
+            if (existing is not null)
+            {
+                existing.Price = quote.Price;
+                existing.Currency = quote.Currency;
+                existing.RawPrice = quote.RawPrice;
+                existing.RawCurrency = quote.RawCurrency;
+                existing.MarketDataSymbolId = quote.MarketDataSymbolId;
+                return Task.FromResult(existing);
+            }
+
+            return Add(quote, cancellationToken);
+        }
+
+        public Task<bool> Delete(long id, CancellationToken cancellationToken = default)
+        {
+            var removed = _quotes.RemoveAll(x => x.Id == id);
+            return Task.FromResult(removed > 0);
+        }
+    }
+}


### PR DESCRIPTION
## What

Next stage of the stock → investment cutover (after #474 model and #477 admin UI): wire **pricing** onto the new asset model so valuation can read prices keyed on an `AssetListing` instead of the legacy ISIN-centric `StockDetails`/`StockPrice` path.

This is **additive** — the legacy `StockPriceProvider` stays in place and keeps serving current consumers. The new provider is registered in DI alongside it, ready for the investment-account vertical slice to consume in a later stage.

## Changes

- **`IInvestmentPriceProvider`** (Domain `Assets/Services`) — point + series price lookups keyed on `assetListingId`, returning prices in a requested `Currency`.
- **`InvestmentPriceProvider`** (Application `Assets/Pricing`):
  - Serves cached `PriceQuote` rows first (repository + `IMemoryCache`); fetches from the listing's primary enabled `MarketDataSymbol` through the existing `IStockPriceSource` fallback chain (Alpha Vantage → EODHD) when data is missing.
  - Persists fetched quotes (raw + normalised) via `IPriceQuoteRepository`, and records fetch outcome on the symbol.
  - **GBX normalisation**: stores `RawPrice` in the listing's trading currency and `Price = RawPrice × AssetListing.PriceMultiplier` in the normalised currency (GBX → GBP), so FX conversion uses a currency the rate provider knows.
  - Converts the normalised price to the target currency, reusing the per-currency FX-prefetch approach from `StockPriceProvider` for the series path (carry-forward on no-quote days).
- Registered in `FinancialAccounts/Registration.cs`.

## Tests

`InvestmentPriceProviderTests` (5 cases): repository cache hit (no fetch), provider fetch + persist, GBX `PriceMultiplier` normalisation + FX conversion, missing-symbol → 0, and series carry-forward on days without a quote. Uses a small in-memory `IPriceQuoteRepository` fake so the fetch → store → read flow is exercised end-to-end.

- ✅ Unit: 596 passed
- ✅ Integration: 266 passed
- ✅ Architecture: 9 passed (Domain stays EF-free)
- ✅ `dotnet format --verify-no-changes` clean

## Notes

- No changelog entry: this stage is internal plumbing with no user-visible effect yet (no consumer until the investment-account slice). Per CLAUDE.md's changelog exception for non-user-visible changes.
- No UI change → no screenshots.
- **Out of scope** (next stage): repointing `InstrumentResolver` to persist `Asset`/`AssetListing`/`MarketDataSymbol`/`AssetIdentifier`, and consuming this provider from the investment-account UI / net-worth.

closes #481

---
_Generated by [Claude Code](https://claude.ai/code/session_011bbrbkPuVwjtUDqg8Kg8x4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added investment price lookup functionality supporting single-point and time-series price queries.
  * Implemented automatic currency conversion for asset prices.
  * Added intelligent price data backfilling to ensure historical pricing availability.
  * Integrated in-memory caching for improved performance.

* **Tests**
  * Added comprehensive unit test coverage for price functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->