### PR TITLE
Add investment account valuation service (holdings-on-read + pricing) #485

### DIFF
--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
@@ -1,0 +1,103 @@
+using FinanceManager.Domain.Assets.Services;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Services;
+
+namespace FinanceManager.Application.FinancialAccounts.Investments.Valuation;
+
+/// <summary>
+/// Values an investment account by computing holdings on read from its
+/// <see cref="Domain.FinancialAccounts.Investments.Entities.InvestmentTransaction"/> rows and
+/// pricing each listing through <see cref="IInvestmentPriceProvider"/>.
+/// </summary>
+internal class InvestmentValuationService(
+    IInvestmentTransactionRepository transactionRepository,
+    IInvestmentPriceProvider priceProvider) : IInvestmentValuationService
+{
+    public async Task<IReadOnlyDictionary<long, decimal>> GetHoldingsAsOfAsync(int accountId, DateOnly asOf, CancellationToken ct = default)
+    {
+        var holdings = await transactionRepository.GetHoldingsAsOf([accountId], asOf, ct);
+        return holdings
+            .Where(kvp => kvp.Value != 0m)
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+    }
+
+    public async Task<decimal> GetAccountValueAsync(int accountId, Currency targetCurrency, DateTime asOf, CancellationToken ct = default)
+    {
+        var holdings = await GetHoldingsAsOfAsync(accountId, DateOnly.FromDateTime(asOf), ct);
+        if (holdings.Count == 0) return 0m;
+
+        decimal total = 0m;
+        foreach (var (listingId, holding) in holdings)
+        {
+            var price = await priceProvider.GetPricePerUnitAsync(listingId, targetCurrency, asOf, ct);
+            if (price > 0) total += holding * price;
+        }
+
+        return total;
+    }
+
+    public async Task<IReadOnlyDictionary<DateTime, decimal>> GetAccountValueSeriesAsync(
+        int accountId,
+        Currency targetCurrency,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        var result = new Dictionary<DateTime, decimal>();
+        if (start == default || end == default || end < start) return result;
+
+        var transactions = await transactionRepository.GetByAccount(accountId, ct);
+        if (transactions.Count == 0) return result;
+
+        var startDate = start.Date;
+        var endDate = end.Date;
+        var startDateOnly = DateOnly.FromDateTime(startDate);
+        var endDateOnly = DateOnly.FromDateTime(endDate);
+
+        var byListing = transactions
+            .Where(t => t.TradeDate <= endDateOnly)
+            .GroupBy(t => t.AssetListingId)
+            .ToList();
+        if (byListing.Count == 0) return result;
+
+        // For each listing: the running holding carried into the window (everything before start),
+        // the per-day signed-quantity deltas inside the window, and the price-per-unit series
+        // (already in the target currency). One price-series fetch per distinct listing.
+        var holdings = new Dictionary<long, decimal>();
+        var dailyDeltas = new Dictionary<long, Dictionary<DateTime, decimal>>();
+        var priceSeries = new Dictionary<long, IReadOnlyDictionary<DateTime, decimal>>();
+
+        foreach (var group in byListing)
+        {
+            var listingId = group.Key;
+            holdings[listingId] = group.Where(t => t.TradeDate < startDateOnly).Sum(t => t.SignedQuantity);
+            dailyDeltas[listingId] = group
+                .Where(t => t.TradeDate >= startDateOnly)
+                .GroupBy(t => t.TradeDate.ToDateTime(TimeOnly.MinValue))
+                .ToDictionary(g => g.Key, g => g.Sum(t => t.SignedQuantity));
+            priceSeries[listingId] = await priceProvider.GetPricePerUnitSeriesAsync(listingId, targetCurrency, start, end, ct);
+        }
+
+        for (var date = startDate; date <= endDate; date = date.AddDays(1))
+        {
+            decimal dayValue = 0m;
+            foreach (var group in byListing)
+            {
+                var listingId = group.Key;
+                if (dailyDeltas[listingId].TryGetValue(date, out var delta))
+                    holdings[listingId] += delta;
+
+                var holding = holdings[listingId];
+                if (holding == 0m) continue;
+
+                if (priceSeries[listingId].TryGetValue(date, out var price) && price > 0)
+                    dayValue += holding * price;
+            }
+
+            if (dayValue != 0m) result[date] = dayValue;
+        }
+
+        return result;
+    }
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Registration.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Registration.cs
@@ -13,6 +13,7 @@ using FinanceManager.Application.FinancialAccounts.Currencies.ExchangeRates;
 using FinanceManager.Application.FinancialAccounts.Currencies.Export;
 using FinanceManager.Application.FinancialAccounts.Currencies.Import;
 using FinanceManager.Application.FinancialAccounts.Currencies.Seeders;
+using FinanceManager.Application.FinancialAccounts.Investments.Valuation;
 using FinanceManager.Application.FinancialAccounts.Shared.Csv;
 using FinanceManager.Application.FinancialAccounts.Shared.Exports;
 using FinanceManager.Application.FinancialAccounts.Shared.Imports;
@@ -30,6 +31,7 @@ using FinanceManager.Domain.FinancialAccounts.Bond.Exports;
 using FinanceManager.Domain.FinancialAccounts.Bond.Services;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Exports;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+using FinanceManager.Domain.FinancialAccounts.Investments.Services;
 using FinanceManager.Domain.FinancialAccounts.Shared.Exports;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
 using FinanceManager.Domain.FinancialAccounts.Stock.Exports;
@@ -77,6 +79,7 @@ internal static class Registration
                 .AddScoped<IAccountCsvExportService<BondAccountExportDto>, BondAccountCsvExportService>()
                 .AddScoped<IStockPriceProvider, StockPriceProvider>()
                 .AddScoped<IInvestmentPriceProvider, InvestmentPriceProvider>()
+                .AddScoped<IInvestmentValuationService, InvestmentValuationService>()
                 .AddScoped<IStockPriceBulkImportService, StockPriceBulkImportService>()
                 .AddScoped<IStockUnrealizedGainLossCalculator, StockUnrealizedGainLossCalculator>()
                 .AddScoped<IBondUnrealizedGainLossCalculator, BondUnrealizedGainLossCalculator>()

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Services/IInvestmentValuationService.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Services/IInvestmentValuationService.cs
@@ -1,0 +1,42 @@
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+
+namespace FinanceManager.Domain.FinancialAccounts.Investments.Services;
+
+/// <summary>
+/// Values an investment account on the new asset model. Holdings are computed on read from the
+/// account's <see cref="Entities.InvestmentTransaction"/> rows (signed Buy/Sell quantities per
+/// <see cref="AssetListing"/>) rather than from a stored running balance, and valued through
+/// <see cref="Services.IInvestmentPriceProvider"/> (which already normalises GBX-style quotes and
+/// converts to the requested currency).
+/// </summary>
+public interface IInvestmentValuationService
+{
+    /// <summary>
+    /// Net holdings per <see cref="AssetListing"/> for an account as of <paramref name="asOf"/>:
+    /// the signed sum of Buy (+) and Sell (−) quantities for transactions on or before that date.
+    /// Listings whose net holding is zero are omitted. Returns an empty map for an account with no
+    /// transactions.
+    /// </summary>
+    Task<IReadOnlyDictionary<long, decimal>> GetHoldingsAsOfAsync(int accountId, DateOnly asOf, CancellationToken ct = default);
+
+    /// <summary>
+    /// Total value of an account's holdings converted to <paramref name="targetCurrency"/> as of
+    /// <paramref name="asOf"/>. Each listing's holding is valued at its price per unit on that date.
+    /// Returns 0 when the account holds nothing or no prices can be determined.
+    /// </summary>
+    Task<decimal> GetAccountValueAsync(int accountId, Currency targetCurrency, DateTime asOf, CancellationToken ct = default);
+
+    /// <summary>
+    /// Daily account value in <paramref name="targetCurrency"/> over [<paramref name="start"/>,
+    /// <paramref name="end"/>]. Holdings are carried forward on days without a transaction and each
+    /// listing is priced from its own per-day series, so a day's value reflects the holdings held
+    /// that day at that day's price. Days that value to zero are omitted.
+    /// </summary>
+    Task<IReadOnlyDictionary<DateTime, decimal>> GetAccountValueSeriesAsync(
+        int accountId,
+        Currency targetCurrency,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default);
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
@@ -1,0 +1,165 @@
+using FinanceManager.Application.FinancialAccounts.Investments.Valuation;
+using FinanceManager.Domain.Assets.Services;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services.Investments;
+
+[Trait("Category", "Unit")]
+public class InvestmentValuationServiceTests
+{
+    private static readonly Currency _usd = new(1, "USD", "$");
+    private const int _accountId = 7;
+
+    private readonly Mock<IInvestmentTransactionRepository> _transactionRepository = new();
+    private readonly Mock<IInvestmentPriceProvider> _priceProvider = new();
+
+    private InvestmentValuationService CreateSut() => new(_transactionRepository.Object, _priceProvider.Object);
+
+    private static InvestmentTransaction Tx(long listingId, InvestmentTransactionType type, decimal qty, DateOnly tradeDate) =>
+        new()
+        {
+            AccountId = _accountId,
+            AssetListingId = listingId,
+            Type = type,
+            Quantity = qty,
+            UnitPrice = 1m,
+            Currency = "USD",
+            TradeDate = tradeDate
+        };
+
+    [Fact]
+    public async Task GetHoldingsAsOf_OmitsZeroNetHoldings()
+    {
+        var asOf = new DateOnly(2024, 6, 30);
+        _transactionRepository
+            .Setup(x => x.GetHoldingsAsOf(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), asOf, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<long, decimal> { [10] = 5m, [20] = 0m });
+
+        var holdings = await CreateSut().GetHoldingsAsOfAsync(_accountId, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(5m, Assert.Contains(10L, holdings));
+        Assert.DoesNotContain(20L, holdings);
+    }
+
+    [Fact]
+    public async Task GetAccountValue_SumsHoldingsTimesPrice_AcrossListings()
+    {
+        var asOf = new DateTime(2024, 6, 30);
+        _transactionRepository
+            .Setup(x => x.GetHoldingsAsOf(It.IsAny<IReadOnlyCollection<int>>(), DateOnly.FromDateTime(asOf), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<long, decimal> { [10] = 3m, [20] = 2m });
+        _priceProvider.Setup(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(100m);
+        _priceProvider.Setup(x => x.GetPricePerUnitAsync(20, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(50m);
+
+        var value = await CreateSut().GetAccountValueAsync(_accountId, _usd, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(3m * 100m + 2m * 50m, value); // 400
+    }
+
+    [Fact]
+    public async Task GetAccountValue_ReturnsZero_WhenAccountHoldsNothing()
+    {
+        var asOf = new DateTime(2024, 6, 30);
+        _transactionRepository
+            .Setup(x => x.GetHoldingsAsOf(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<long, decimal>());
+
+        var value = await CreateSut().GetAccountValueAsync(_accountId, _usd, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(0m, value);
+        _priceProvider.Verify(
+            x => x.GetPricePerUnitAsync(It.IsAny<long>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAccountValue_NetsBuyAndSell()
+    {
+        var asOf = new DateTime(2024, 6, 30);
+        _transactionRepository
+            .Setup(x => x.GetHoldingsAsOf(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<long, decimal> { [10] = 4m }); // e.g. bought 6, sold 2
+        _priceProvider.Setup(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(25m);
+
+        var value = await CreateSut().GetAccountValueAsync(_accountId, _usd, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(100m, value);
+    }
+
+    [Fact]
+    public async Task GetAccountValueSeries_CarriesHoldingsForward_AndPricesPerDay()
+    {
+        var start = new DateTime(2024, 1, 1); // Monday
+        var end = new DateTime(2024, 1, 4);
+
+        // Buy 2 on Jan 1, buy 1 more on Jan 3 → holding is 2 on Jan 1-2, then 3 on Jan 3-4.
+        _transactionRepository
+            .Setup(x => x.GetByAccount(_accountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                Tx(10, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 1)),
+                Tx(10, InvestmentTransactionType.Buy, 1m, new DateOnly(2024, 1, 3))
+            });
+
+        // Flat price of 10 every day in the window.
+        _priceProvider
+            .Setup(x => x.GetPricePerUnitSeriesAsync(10, _usd, start, end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, decimal>
+            {
+                [new DateTime(2024, 1, 1)] = 10m,
+                [new DateTime(2024, 1, 2)] = 10m,
+                [new DateTime(2024, 1, 3)] = 10m,
+                [new DateTime(2024, 1, 4)] = 10m
+            });
+
+        var series = await CreateSut().GetAccountValueSeriesAsync(_accountId, _usd, start, end, TestContext.Current.CancellationToken);
+
+        Assert.Equal(20m, series[new DateTime(2024, 1, 1)]); // 2 * 10
+        Assert.Equal(20m, series[new DateTime(2024, 1, 2)]); // holding carried forward
+        Assert.Equal(30m, series[new DateTime(2024, 1, 3)]); // 3 * 10
+        Assert.Equal(30m, series[new DateTime(2024, 1, 4)]);
+    }
+
+    [Fact]
+    public async Task GetAccountValueSeries_SeedsHoldingsFromBeforeWindow()
+    {
+        var start = new DateTime(2024, 2, 1);
+        var end = new DateTime(2024, 2, 2);
+
+        // The only purchase happened before the window; the holding must be carried into it.
+        _transactionRepository
+            .Setup(x => x.GetByAccount(_accountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 15))
+            });
+        _priceProvider
+            .Setup(x => x.GetPricePerUnitSeriesAsync(10, _usd, start, end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, decimal>
+            {
+                [new DateTime(2024, 2, 1)] = 8m,
+                [new DateTime(2024, 2, 2)] = 9m
+            });
+
+        var series = await CreateSut().GetAccountValueSeriesAsync(_accountId, _usd, start, end, TestContext.Current.CancellationToken);
+
+        Assert.Equal(40m, series[new DateTime(2024, 2, 1)]); // 5 * 8
+        Assert.Equal(45m, series[new DateTime(2024, 2, 2)]); // 5 * 9
+    }
+
+    [Fact]
+    public async Task GetAccountValueSeries_ReturnsEmpty_WhenNoTransactions()
+    {
+        _transactionRepository
+            .Setup(x => x.GetByAccount(_accountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>());
+
+        var series = await CreateSut().GetAccountValueSeriesAsync(
+            _accountId, _usd, new DateTime(2024, 1, 1), new DateTime(2024, 1, 31), TestContext.Current.CancellationToken);
+
+        Assert.Empty(series);
+    }
+}


### PR DESCRIPTION
## What

First layer of the **investment-account vertical slice** (lineage of #474): an Application-layer `IInvestmentValuationService` that values an investment account on the new asset model, with **holdings computed on read** (no stored running balance).

The whole slice is XL, so it's split along layer boundaries. This PR is the additive backend foundation that the API, Blazor UI, and net-worth/diversification migration will build on. Legacy stock services are untouched.

## API

`IInvestmentValuationService` (Domain `FinancialAccounts/Investments/Services`):

- `GetHoldingsAsOfAsync(accountId, asOf)` — net signed Buy(+)/Sell(−) quantity per `AssetListing` for `TradeDate ≤ asOf` (via `IInvestmentTransactionRepository.GetHoldingsAsOf`), zero net holdings omitted.
- `GetAccountValueAsync(accountId, targetCurrency, asOf)` — total value, each listing's holding priced through `IInvestmentPriceProvider` (already GBX-normalised + FX-converted).
- `GetAccountValueSeriesAsync(accountId, targetCurrency, start, end)` — daily value series; carries holdings forward on no-transaction days, seeds the pre-window holding, and prices each listing from its own per-day series (one price-series fetch per distinct listing).

## Validation

- Build clean (warnings-as-errors), `dotnet format` clean.
- Unit tests: 605 passed — covers zero-holding omission, multi-listing value, Buy+Sell netting, empty account, series carry-forward, pre-window seed, empty series.
- Architecture tests: 9 passed (Domain stays EF-free; Application → Domain only).

No UI change and no user-visible behaviour yet (no consumer wired), so no screenshot and no changelog entry — consistent with #481/#483.

## Next in the slice

1. ✅ Valuation service (this PR)
2. API controllers + typed HTTP clients
3. Blazor investment-account components (with screenshots)
4. Net-worth / diversification migration onto this service

closes #485

---
_Generated by [Claude Code](https://claude.ai/code/session_011bbrbkPuVwjtUDqg8Kg8x4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added investment account valuation capabilities, including computing net holdings as of a specific date, calculating total account value in a target currency, and generating day-by-day valuation trends over a specified period.

* **Tests**
  * Added comprehensive unit tests validating holdings computation, account valuation calculations, and time-series value tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->