### PR TITLE
Add investment transaction + valuation API and typed HTTP clients #487

### DIFF
--- a/code/FinanceManager.Api/Controllers/Accounts/InvestmentTransactionController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/InvestmentTransactionController.cs
@@ -40,6 +40,7 @@ public class InvestmentTransactionController(
     {
         var transaction = await transactionRepository.Get(id, cancellationToken);
         if (transaction is null) return NotFound();
+        if (transaction.UserId is < int.MinValue or > int.MaxValue) return Forbid();
         if (!ApiAuthenticationHelper.IsAccountOwner(User, (int)transaction.UserId)) return Forbid();
 
         return Ok(transaction.ToDto());
@@ -48,6 +49,7 @@ public class InvestmentTransactionController(
     [HttpPost("Add")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InvestmentTransactionDto))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Add(AddInvestmentTransactionRequest request, CancellationToken cancellationToken = default)
     {
@@ -55,7 +57,8 @@ public class InvestmentTransactionController(
             return BadRequest("Invalid input parameters.");
 
         var account = await accountRepository.Get(request.AccountId);
-        if (account is null || !ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
 
         var result = await transactionRepository.Add(request.ToEntity(account.UserId), cancellationToken);
         await dashboardCacheInvalidator.InvalidateUser(account.UserId);
@@ -73,7 +76,8 @@ public class InvestmentTransactionController(
             return BadRequest("Invalid input parameters.");
 
         var account = await accountRepository.Get(request.AccountId);
-        if (account is null || !ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
 
         var existing = await transactionRepository.Get(request.Id, cancellationToken);
         if (existing is null || existing.AccountId != request.AccountId) return NotFound();
@@ -90,7 +94,8 @@ public class InvestmentTransactionController(
     public async Task<IActionResult> Delete(int accountId, long id, CancellationToken cancellationToken = default)
     {
         var account = await accountRepository.Get(accountId);
-        if (account is null || !ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
 
         var existing = await transactionRepository.Get(id, cancellationToken);
         if (existing is null || existing.AccountId != accountId) return NotFound();

--- a/code/FinanceManager.Api/Controllers/Accounts/InvestmentTransactionController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/InvestmentTransactionController.cs
@@ -1,0 +1,105 @@
+using FinanceManager.Api.Helpers;
+using FinanceManager.Domain.Dashboard.Services;
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Stock.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinanceManager.Api.Controllers.Accounts;
+
+[Authorize]
+[Route("api/[controller]")]
+[ApiController]
+[Tags("Investment Transactions")]
+public class InvestmentTransactionController(
+    IAccountRepository<StockAccount> accountRepository,
+    IInvestmentTransactionRepository transactionRepository,
+    ICacheInvalidator dashboardCacheInvalidator) : ControllerBase
+{
+    [HttpGet("GetByAccount/{accountId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<InvestmentTransactionDto>))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetByAccount(int accountId, CancellationToken cancellationToken = default)
+    {
+        var account = await accountRepository.Get(accountId);
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+
+        var transactions = await transactionRepository.GetByAccount(accountId, cancellationToken);
+        return Ok(transactions.Select(x => x.ToDto()).ToList());
+    }
+
+    [HttpGet("Get/{id:long}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InvestmentTransactionDto))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Get(long id, CancellationToken cancellationToken = default)
+    {
+        var transaction = await transactionRepository.Get(id, cancellationToken);
+        if (transaction is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, (int)transaction.UserId)) return Forbid();
+
+        return Ok(transaction.ToDto());
+    }
+
+    [HttpPost("Add")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InvestmentTransactionDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Add(AddInvestmentTransactionRequest request, CancellationToken cancellationToken = default)
+    {
+        if (!IsValid(request.AssetListingId, request.Quantity, request.UnitPrice, request.Currency, request.TradeDate))
+            return BadRequest("Invalid input parameters.");
+
+        var account = await accountRepository.Get(request.AccountId);
+        if (account is null || !ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+
+        var result = await transactionRepository.Add(request.ToEntity(account.UserId), cancellationToken);
+        await dashboardCacheInvalidator.InvalidateUser(account.UserId);
+        return Ok(result.ToDto());
+    }
+
+    [HttpPut("Update")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(bool))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Update(UpdateInvestmentTransactionRequest request, CancellationToken cancellationToken = default)
+    {
+        if (!IsValid(request.AssetListingId, request.Quantity, request.UnitPrice, request.Currency, request.TradeDate))
+            return BadRequest("Invalid input parameters.");
+
+        var account = await accountRepository.Get(request.AccountId);
+        if (account is null || !ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+
+        var existing = await transactionRepository.Get(request.Id, cancellationToken);
+        if (existing is null || existing.AccountId != request.AccountId) return NotFound();
+
+        var result = await transactionRepository.Update(request.ToEntity(), cancellationToken);
+        await dashboardCacheInvalidator.InvalidateUser(account.UserId);
+        return Ok(result);
+    }
+
+    [HttpDelete("Delete/{accountId:int}/{id:long}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(bool))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Delete(int accountId, long id, CancellationToken cancellationToken = default)
+    {
+        var account = await accountRepository.Get(accountId);
+        if (account is null || !ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+
+        var existing = await transactionRepository.Get(id, cancellationToken);
+        if (existing is null || existing.AccountId != accountId) return NotFound();
+
+        var result = await transactionRepository.Delete(id, cancellationToken);
+        await dashboardCacheInvalidator.InvalidateUser(account.UserId);
+        return Ok(result);
+    }
+
+    private static bool IsValid(long assetListingId, decimal quantity, decimal unitPrice, string? currency, DateOnly tradeDate) =>
+        assetListingId > 0 && quantity > 0 && unitPrice >= 0 && !string.IsNullOrWhiteSpace(currency) && tradeDate != default;
+}

--- a/code/FinanceManager.Api/Controllers/Accounts/InvestmentValuationController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/InvestmentValuationController.cs
@@ -1,0 +1,70 @@
+using FinanceManager.Api.Helpers;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Services;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Stock.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinanceManager.Api.Controllers.Accounts;
+
+[Authorize]
+[Route("api/[controller]")]
+[ApiController]
+[Tags("Investment Valuation")]
+public class InvestmentValuationController(
+    IAccountRepository<StockAccount> accountRepository,
+    IInvestmentValuationService valuationService,
+    ICurrencyRepository currencyRepository) : ControllerBase
+{
+    [HttpGet("Holdings/{accountId:int}/{date:DateTime}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IReadOnlyDictionary<long, decimal>))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetHoldings(int accountId, DateTime date, CancellationToken cancellationToken = default)
+    {
+        var account = await accountRepository.Get(accountId);
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+
+        var holdings = await valuationService.GetHoldingsAsOfAsync(accountId, DateOnly.FromDateTime(date), cancellationToken);
+        return Ok(holdings);
+    }
+
+    [HttpGet("Value/{accountId:int}/{currencyId:int}/{date:DateTime}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(decimal))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetValue(int accountId, int currencyId, DateTime date, CancellationToken cancellationToken = default)
+    {
+        var account = await accountRepository.Get(accountId);
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+
+        var currency = await currencyRepository.GetCurrency(currencyId, cancellationToken);
+        if (currency is null) return NotFound("Currency not found.");
+
+        var value = await valuationService.GetAccountValueAsync(accountId, currency, date, cancellationToken);
+        return Ok(value);
+    }
+
+    [HttpGet("ValueSeries/{accountId:int}/{currencyId:int}/{startDate:DateTime}/{endDate:DateTime}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IReadOnlyDictionary<DateTime, decimal>))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetValueSeries(int accountId, int currencyId, DateTime startDate, DateTime endDate, CancellationToken cancellationToken = default)
+    {
+        if (endDate < startDate) return BadRequest("End date must be on or after start date.");
+
+        var account = await accountRepository.Get(accountId);
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+
+        var currency = await currencyRepository.GetCurrency(currencyId, cancellationToken);
+        if (currency is null) return NotFound("Currency not found.");
+
+        var series = await valuationService.GetAccountValueSeriesAsync(accountId, currency, startDate, endDate, cancellationToken);
+        return Ok(series);
+    }
+}

--- a/code/FinanceManager.Components/HttpClients/InvestmentTransactionHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/InvestmentTransactionHttpClient.cs
@@ -1,0 +1,42 @@
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+using System.Net;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Components.HttpClients;
+
+public class InvestmentTransactionHttpClient(HttpClient httpClient)
+{
+    public async Task<IReadOnlyList<InvestmentTransactionDto>> GetByAccountAsync(int accountId)
+    {
+        var response = await httpClient.GetAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/GetByAccount/{accountId}");
+        if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.NoContent) return [];
+        if (!response.IsSuccessStatusCode) return [];
+        return await response.Content.ReadFromJsonAsync<List<InvestmentTransactionDto>>() ?? [];
+    }
+
+    public async Task<InvestmentTransactionDto?> GetAsync(long id)
+    {
+        var response = await httpClient.GetAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Get/{id}");
+        if (!response.IsSuccessStatusCode) return null;
+        return await response.Content.ReadFromJsonAsync<InvestmentTransactionDto>();
+    }
+
+    public async Task<InvestmentTransactionDto?> AddAsync(AddInvestmentTransactionRequest request)
+    {
+        var response = await httpClient.PostAsJsonAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Add", request);
+        if (!response.IsSuccessStatusCode) return null;
+        return await response.Content.ReadFromJsonAsync<InvestmentTransactionDto>();
+    }
+
+    public async Task<bool> UpdateAsync(UpdateInvestmentTransactionRequest request)
+    {
+        var response = await httpClient.PutAsJsonAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Update", request);
+        return response.IsSuccessStatusCode;
+    }
+
+    public async Task<bool> DeleteAsync(int accountId, long id)
+    {
+        var response = await httpClient.DeleteAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Delete/{accountId}/{id}");
+        return response.IsSuccessStatusCode;
+    }
+}

--- a/code/FinanceManager.Components/HttpClients/InvestmentTransactionHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/InvestmentTransactionHttpClient.cs
@@ -8,7 +8,7 @@ public class InvestmentTransactionHttpClient(HttpClient httpClient)
 {
     public async Task<IReadOnlyList<InvestmentTransactionDto>> GetByAccountAsync(int accountId)
     {
-        var response = await httpClient.GetAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/GetByAccount/{accountId}");
+        using var response = await httpClient.GetAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/GetByAccount/{accountId}");
         if (response.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.NoContent) return [];
         if (!response.IsSuccessStatusCode) return [];
         return await response.Content.ReadFromJsonAsync<List<InvestmentTransactionDto>>() ?? [];
@@ -16,27 +16,27 @@ public class InvestmentTransactionHttpClient(HttpClient httpClient)
 
     public async Task<InvestmentTransactionDto?> GetAsync(long id)
     {
-        var response = await httpClient.GetAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Get/{id}");
+        using var response = await httpClient.GetAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Get/{id}");
         if (!response.IsSuccessStatusCode) return null;
         return await response.Content.ReadFromJsonAsync<InvestmentTransactionDto>();
     }
 
     public async Task<InvestmentTransactionDto?> AddAsync(AddInvestmentTransactionRequest request)
     {
-        var response = await httpClient.PostAsJsonAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Add", request);
+        using var response = await httpClient.PostAsJsonAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Add", request);
         if (!response.IsSuccessStatusCode) return null;
         return await response.Content.ReadFromJsonAsync<InvestmentTransactionDto>();
     }
 
     public async Task<bool> UpdateAsync(UpdateInvestmentTransactionRequest request)
     {
-        var response = await httpClient.PutAsJsonAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Update", request);
+        using var response = await httpClient.PutAsJsonAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Update", request);
         return response.IsSuccessStatusCode;
     }
 
     public async Task<bool> DeleteAsync(int accountId, long id)
     {
-        var response = await httpClient.DeleteAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Delete/{accountId}/{id}");
+        using var response = await httpClient.DeleteAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Delete/{accountId}/{id}");
         return response.IsSuccessStatusCode;
     }
 }

--- a/code/FinanceManager.Components/HttpClients/InvestmentValuationHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/InvestmentValuationHttpClient.cs
@@ -7,7 +7,7 @@ public class InvestmentValuationHttpClient(HttpClient httpClient)
 {
     public async Task<IReadOnlyDictionary<long, decimal>> GetHoldingsAsync(int accountId, DateTime date)
     {
-        var response = await httpClient.GetAsync(
+        using var response = await httpClient.GetAsync(
             $"{httpClient.BaseAddress}api/InvestmentValuation/Holdings/{accountId}/{Iso(date)}");
         if (!response.IsSuccessStatusCode) return new Dictionary<long, decimal>();
         return await response.Content.ReadFromJsonAsync<Dictionary<long, decimal>>() ?? [];
@@ -15,7 +15,7 @@ public class InvestmentValuationHttpClient(HttpClient httpClient)
 
     public async Task<decimal> GetValueAsync(int accountId, int currencyId, DateTime date)
     {
-        var response = await httpClient.GetAsync(
+        using var response = await httpClient.GetAsync(
             $"{httpClient.BaseAddress}api/InvestmentValuation/Value/{accountId}/{currencyId}/{Iso(date)}");
         if (!response.IsSuccessStatusCode) return 0m;
         return await response.Content.ReadFromJsonAsync<decimal>();
@@ -23,7 +23,7 @@ public class InvestmentValuationHttpClient(HttpClient httpClient)
 
     public async Task<IReadOnlyDictionary<DateTime, decimal>> GetValueSeriesAsync(int accountId, int currencyId, DateTime start, DateTime end)
     {
-        var response = await httpClient.GetAsync(
+        using var response = await httpClient.GetAsync(
             $"{httpClient.BaseAddress}api/InvestmentValuation/ValueSeries/{accountId}/{currencyId}/{Iso(start)}/{Iso(end)}");
         if (!response.IsSuccessStatusCode) return new Dictionary<DateTime, decimal>();
         return await response.Content.ReadFromJsonAsync<Dictionary<DateTime, decimal>>() ?? [];

--- a/code/FinanceManager.Components/HttpClients/InvestmentValuationHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/InvestmentValuationHttpClient.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Components.HttpClients;
+
+public class InvestmentValuationHttpClient(HttpClient httpClient)
+{
+    public async Task<IReadOnlyDictionary<long, decimal>> GetHoldingsAsync(int accountId, DateTime date)
+    {
+        var response = await httpClient.GetAsync(
+            $"{httpClient.BaseAddress}api/InvestmentValuation/Holdings/{accountId}/{Iso(date)}");
+        if (!response.IsSuccessStatusCode) return new Dictionary<long, decimal>();
+        return await response.Content.ReadFromJsonAsync<Dictionary<long, decimal>>() ?? [];
+    }
+
+    public async Task<decimal> GetValueAsync(int accountId, int currencyId, DateTime date)
+    {
+        var response = await httpClient.GetAsync(
+            $"{httpClient.BaseAddress}api/InvestmentValuation/Value/{accountId}/{currencyId}/{Iso(date)}");
+        if (!response.IsSuccessStatusCode) return 0m;
+        return await response.Content.ReadFromJsonAsync<decimal>();
+    }
+
+    public async Task<IReadOnlyDictionary<DateTime, decimal>> GetValueSeriesAsync(int accountId, int currencyId, DateTime start, DateTime end)
+    {
+        var response = await httpClient.GetAsync(
+            $"{httpClient.BaseAddress}api/InvestmentValuation/ValueSeries/{accountId}/{currencyId}/{Iso(start)}/{Iso(end)}");
+        if (!response.IsSuccessStatusCode) return new Dictionary<DateTime, decimal>();
+        return await response.Content.ReadFromJsonAsync<Dictionary<DateTime, decimal>>() ?? [];
+    }
+
+    // Date-only ISO form so the value binds cleanly to the route's DateTime constraint.
+    private static string Iso(DateTime date) => date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+}

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -24,6 +24,9 @@ public static class ServiceCollectionExtension
                 .AddScoped<StockAccountImportHttpClient>()
                 .AddScoped<AssetHttpClient>()
 
+                .AddScoped<InvestmentTransactionHttpClient>()
+                .AddScoped<InvestmentValuationHttpClient>()
+
                 .AddScoped<CurrencyAccountHttpClient>()
                 .AddScoped<CurrencyAccountImportHttpClient>()
                 .AddScoped<CurrencyEntryHttpClient>()

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionDtos.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionDtos.cs
@@ -1,0 +1,42 @@
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+
+namespace FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+
+/// <summary>Read model for an <see cref="InvestmentTransaction"/> returned over the API.</summary>
+public record InvestmentTransactionDto(
+    long Id,
+    long UserId,
+    int AccountId,
+    long AssetListingId,
+    InvestmentTransactionType Type,
+    decimal Quantity,
+    decimal UnitPrice,
+    string Currency,
+    DateOnly TradeDate,
+    decimal? Fee,
+    string? Notes);
+
+/// <summary>Request to add a new investment transaction. The owning user is derived from the account, not this payload.</summary>
+public record AddInvestmentTransactionRequest(
+    int AccountId,
+    long AssetListingId,
+    InvestmentTransactionType Type,
+    decimal Quantity,
+    decimal UnitPrice,
+    string Currency,
+    DateOnly TradeDate,
+    decimal? Fee = null,
+    string? Notes = null);
+
+/// <summary>Request to update an existing investment transaction. Account and owner are not reassigned.</summary>
+public record UpdateInvestmentTransactionRequest(
+    long Id,
+    int AccountId,
+    long AssetListingId,
+    InvestmentTransactionType Type,
+    decimal Quantity,
+    decimal UnitPrice,
+    string Currency,
+    DateOnly TradeDate,
+    decimal? Fee = null,
+    string? Notes = null);

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionMappingExtensions.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionMappingExtensions.cs
@@ -1,0 +1,49 @@
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+
+namespace FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+
+public static class InvestmentTransactionMappingExtensions
+{
+    public static InvestmentTransactionDto ToDto(this InvestmentTransaction transaction) => new(
+        transaction.Id,
+        transaction.UserId,
+        transaction.AccountId,
+        transaction.AssetListingId,
+        transaction.Type,
+        transaction.Quantity,
+        transaction.UnitPrice,
+        transaction.Currency,
+        transaction.TradeDate,
+        transaction.Fee,
+        transaction.Notes);
+
+    /// <summary>Build a new entity from an add request, stamping the owning user resolved from the account.</summary>
+    public static InvestmentTransaction ToEntity(this AddInvestmentTransactionRequest request, long userId) => new()
+    {
+        UserId = userId,
+        AccountId = request.AccountId,
+        AssetListingId = request.AssetListingId,
+        Type = request.Type,
+        Quantity = request.Quantity,
+        UnitPrice = request.UnitPrice,
+        Currency = request.Currency,
+        TradeDate = request.TradeDate,
+        Fee = request.Fee,
+        Notes = request.Notes
+    };
+
+    /// <summary>Map an update request onto the editable fields the repository copies by id.</summary>
+    public static InvestmentTransaction ToEntity(this UpdateInvestmentTransactionRequest request) => new()
+    {
+        Id = request.Id,
+        AccountId = request.AccountId,
+        AssetListingId = request.AssetListingId,
+        Type = request.Type,
+        Quantity = request.Quantity,
+        UnitPrice = request.UnitPrice,
+        Currency = request.Currency,
+        TradeDate = request.TradeDate,
+        Fee = request.Fee,
+        Notes = request.Notes
+    };
+}

--- a/code/FinanceManager.Tests.Integration/Controllers/InvestmentTransactionControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/InvestmentTransactionControllerTests.cs
@@ -133,6 +133,46 @@ public class InvestmentTransactionControllerTests(OptionsProvider optionsProvide
     }
 
     [Fact]
+    public async Task Get_ReturnsTransaction()
+    {
+        var id = await SeedTransaction(InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10));
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentTransactionHttpClient(Client);
+
+        var result = await client.GetAsync(id);
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result!.Id);
+        Assert.Equal(_testAccountId, result.AccountId);
+    }
+
+    [Fact]
+    public async Task Update_ForUnknownTransaction_ReturnsFalse()
+    {
+        await SeedAccount();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentTransactionHttpClient(Client);
+        var update = new UpdateInvestmentTransactionRequest(
+            long.MaxValue, _testAccountId, _listingId, InvestmentTransactionType.Buy, 8m, 130m, "USD", new DateOnly(2024, 1, 10));
+
+        var result = await client.UpdateAsync(update);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task Delete_ForUnknownTransaction_ReturnsFalse()
+    {
+        await SeedAccount();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentTransactionHttpClient(Client);
+
+        var result = await client.DeleteAsync(_testAccountId, long.MaxValue);
+
+        Assert.False(result);
+    }
+
+    [Fact]
     public async Task Update_ModifiesTransaction()
     {
         var id = await SeedTransaction(InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10));

--- a/code/FinanceManager.Tests.Integration/Controllers/InvestmentTransactionControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/InvestmentTransactionControllerTests.cs
@@ -1,0 +1,175 @@
+using FinanceManager.Application.Identity.Users;
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Dtos;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Infrastructure.Contexts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public class InvestmentTransactionControllerTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider), IDisposable
+{
+    private const int _testUserId = 91;
+    private const int _testAccountId = 791;
+    private const long _listingId = 5001;
+    private TestDatabase? _testDatabase;
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+        if (descriptor != null)
+            services.Remove(descriptor);
+
+        _testDatabase = new TestDatabase();
+        services.AddSingleton(_testDatabase.Context);
+
+        var planVerifierMock = new Mock<IUserPlanVerifier>();
+        planVerifierMock.Setup(x => x.CanAddMoreAccounts(_testUserId)).ReturnsAsync(true);
+        planVerifierMock.Setup(x => x.CanAddMoreEntries(_testUserId, It.IsAny<int>())).ReturnsAsync(true);
+        services.AddSingleton(planVerifierMock.Object);
+    }
+
+    private async Task SeedAccount()
+    {
+        if (_testDatabase is null) return;
+        if (await _testDatabase.Context.Accounts.AnyAsync(a => a.AccountId == _testAccountId, TestContext.Current.CancellationToken)) return;
+        _testDatabase.Context.Accounts.Add(new FinancialAccountBaseDto
+        {
+            AccountId = _testAccountId,
+            UserId = _testUserId,
+            Name = "Test Investment Account",
+            AccountLabel = AccountLabel.Stock,
+            AccountType = AccountType.Stock
+        });
+        await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private async Task<long> SeedTransaction(InvestmentTransactionType type, decimal quantity, DateOnly tradeDate)
+    {
+        await SeedAccount();
+        var transaction = new InvestmentTransaction
+        {
+            UserId = _testUserId,
+            AccountId = _testAccountId,
+            AssetListingId = _listingId,
+            Type = type,
+            Quantity = quantity,
+            UnitPrice = 100m,
+            Currency = "USD",
+            TradeDate = tradeDate
+        };
+        _testDatabase!.Context.InvestmentTransactions.Add(transaction);
+        await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        return transaction.Id;
+    }
+
+    private static AddInvestmentTransactionRequest AddRequest(int accountId) => new(
+        accountId, _listingId, InvestmentTransactionType.Buy, 3m, 120m, "USD", new DateOnly(2024, 6, 1));
+
+    [Fact]
+    public async Task Add_CreatesTransaction()
+    {
+        await SeedAccount();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentTransactionHttpClient(Client);
+
+        var result = await client.AddAsync(AddRequest(_testAccountId));
+
+        Assert.NotNull(result);
+        Assert.Equal(_testUserId, result!.UserId);
+        Assert.Equal(3m, result.Quantity);
+
+        var inDb = await _testDatabase!.Context.InvestmentTransactions
+            .FirstOrDefaultAsync(x => x.AccountId == _testAccountId, TestContext.Current.CancellationToken);
+        Assert.NotNull(inDb);
+        Assert.Equal(120m, inDb!.UnitPrice);
+        Assert.Equal(_testUserId, inDb.UserId);
+    }
+
+    [Fact]
+    public async Task Add_ForOtherUsersAccount_ReturnsForbidden()
+    {
+        await SeedAccount();
+        Authorize("otheruser", _testUserId + 1, UserRole.User);
+
+        var response = await Client.PostAsJsonAsync("api/InvestmentTransaction/Add", AddRequest(_testAccountId), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Add_WithInvalidQuantity_ReturnsBadRequest()
+    {
+        await SeedAccount();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var invalid = AddRequest(_testAccountId) with { Quantity = 0m };
+
+        var response = await Client.PostAsJsonAsync("api/InvestmentTransaction/Add", invalid, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetByAccount_ReturnsTransactions()
+    {
+        await SeedTransaction(InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10));
+        await SeedTransaction(InvestmentTransactionType.Sell, 2m, new DateOnly(2024, 2, 10));
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentTransactionHttpClient(Client);
+
+        var transactions = await client.GetByAccountAsync(_testAccountId);
+
+        Assert.Equal(2, transactions.Count);
+    }
+
+    [Fact]
+    public async Task Update_ModifiesTransaction()
+    {
+        var id = await SeedTransaction(InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10));
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentTransactionHttpClient(Client);
+        var update = new UpdateInvestmentTransactionRequest(
+            id, _testAccountId, _listingId, InvestmentTransactionType.Buy, 8m, 130m, "USD", new DateOnly(2024, 1, 10));
+
+        var result = await client.UpdateAsync(update);
+
+        Assert.True(result);
+        var inDb = await _testDatabase!.Context.InvestmentTransactions
+            .FirstOrDefaultAsync(x => x.Id == id, TestContext.Current.CancellationToken);
+        Assert.Equal(8m, inDb!.Quantity);
+        Assert.Equal(130m, inDb.UnitPrice);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesTransaction()
+    {
+        var id = await SeedTransaction(InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10));
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentTransactionHttpClient(Client);
+
+        var result = await client.DeleteAsync(_testAccountId, id);
+
+        Assert.True(result);
+        var inDb = await _testDatabase!.Context.InvestmentTransactions
+            .FirstOrDefaultAsync(x => x.Id == id, TestContext.Current.CancellationToken);
+        Assert.Null(inDb);
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _testDatabase?.Dispose();
+        _testDatabase = null;
+        GC.SuppressFinalize(this);
+    }
+}

--- a/code/FinanceManager.Tests.Integration/Controllers/InvestmentValuationControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/InvestmentValuationControllerTests.cs
@@ -116,6 +116,32 @@ public class InvestmentValuationControllerTests(OptionsProvider optionsProvider)
     }
 
     [Fact]
+    public async Task GetValueSeries_ReturnsDailyValues()
+    {
+        await SeedHoldingsWithPrice();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentValuationHttpClient(Client);
+
+        var series = await client.GetValueSeriesAsync(_testAccountId, _usdCurrencyId, _asOf.AddDays(-3), _asOf);
+
+        Assert.NotEmpty(series);
+        Assert.Equal(300m, series[_asOf]); // 3 units * 100 USD on the priced day
+    }
+
+    [Fact]
+    public async Task GetValueSeries_WithInvalidDateRange_ReturnsBadRequest()
+    {
+        await SeedHoldingsWithPrice();
+        Authorize("testuser", _testUserId, UserRole.User);
+
+        var response = await Client.GetAsync(
+            $"api/InvestmentValuation/ValueSeries/{_testAccountId}/{_usdCurrencyId}/{_asOf:yyyy-MM-dd}/{_asOf.AddDays(-1):yyyy-MM-dd}",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
     public async Task GetValue_ForOtherUsersAccount_ReturnsForbidden()
     {
         await SeedHoldingsWithPrice();

--- a/code/FinanceManager.Tests.Integration/Controllers/InvestmentValuationControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/InvestmentValuationControllerTests.cs
@@ -1,0 +1,149 @@
+using FinanceManager.Application.Identity.Users;
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Dtos;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Infrastructure.Contexts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Net;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public class InvestmentValuationControllerTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider), IDisposable
+{
+    private const int _testUserId = 92;
+    private const int _testAccountId = 792;
+    private const long _listingId = 5002;
+    private const int _usdCurrencyId = 840;
+    private static readonly DateTime _asOf = new(2024, 6, 10);
+    private TestDatabase? _testDatabase;
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+        if (descriptor != null)
+            services.Remove(descriptor);
+
+        _testDatabase = new TestDatabase();
+        services.AddSingleton(_testDatabase.Context);
+
+        var planVerifierMock = new Mock<IUserPlanVerifier>();
+        planVerifierMock.Setup(x => x.CanAddMoreAccounts(_testUserId)).ReturnsAsync(true);
+        planVerifierMock.Setup(x => x.CanAddMoreEntries(_testUserId, It.IsAny<int>())).ReturnsAsync(true);
+        services.AddSingleton(planVerifierMock.Object);
+    }
+
+    private async Task SeedAccount()
+    {
+        if (_testDatabase is null) return;
+        if (await _testDatabase.Context.Accounts.AnyAsync(a => a.AccountId == _testAccountId, TestContext.Current.CancellationToken)) return;
+        _testDatabase.Context.Accounts.Add(new FinancialAccountBaseDto
+        {
+            AccountId = _testAccountId,
+            UserId = _testUserId,
+            Name = "Test Valuation Account",
+            AccountLabel = AccountLabel.Stock,
+            AccountType = AccountType.Stock
+        });
+        await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    // Net holding 3 (buy 5, sell 2) on a USD listing priced at 100 USD, so account value is 300 USD.
+    private async Task SeedHoldingsWithPrice()
+    {
+        await SeedAccount();
+        var context = _testDatabase!.Context;
+
+        context.Currencies.Add(new Currency(_usdCurrencyId, "USD", "$"));
+        context.AssetListings.Add(new AssetListing
+        {
+            Id = _listingId,
+            AssetId = 1,
+            Ticker = "CSPX",
+            ExchangeMic = "XNAS",
+            ExchangeName = "United States",
+            TradingCurrency = "USD",
+            PriceMultiplier = 1m,
+            IsActive = true
+        });
+        context.PriceQuotes.Add(new PriceQuote
+        {
+            AssetListingId = _listingId,
+            Provider = MarketDataProvider.AlphaVantage,
+            Price = 100m,
+            Currency = "USD",
+            PriceTime = new DateTimeOffset(_asOf, TimeSpan.Zero),
+            QuoteType = PriceQuoteType.EndOfDay,
+            FetchedAt = DateTimeOffset.UtcNow
+        });
+        context.InvestmentTransactions.AddRange(
+            new InvestmentTransaction { UserId = _testUserId, AccountId = _testAccountId, AssetListingId = _listingId, Type = InvestmentTransactionType.Buy, Quantity = 5m, UnitPrice = 90m, Currency = "USD", TradeDate = new DateOnly(2024, 6, 1) },
+            new InvestmentTransaction { UserId = _testUserId, AccountId = _testAccountId, AssetListingId = _listingId, Type = InvestmentTransactionType.Sell, Quantity = 2m, UnitPrice = 95m, Currency = "USD", TradeDate = new DateOnly(2024, 6, 5) });
+
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task GetHoldings_ReturnsNetHoldingPerListing()
+    {
+        await SeedHoldingsWithPrice();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentValuationHttpClient(Client);
+
+        var holdings = await client.GetHoldingsAsync(_testAccountId, _asOf);
+
+        Assert.Equal(3m, Assert.Contains(_listingId, holdings));
+    }
+
+    [Fact]
+    public async Task GetValue_ValuesHoldingsAtQuotePrice()
+    {
+        await SeedHoldingsWithPrice();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentValuationHttpClient(Client);
+
+        var value = await client.GetValueAsync(_testAccountId, _usdCurrencyId, _asOf);
+
+        Assert.Equal(300m, value); // 3 units * 100 USD
+    }
+
+    [Fact]
+    public async Task GetValue_ForOtherUsersAccount_ReturnsForbidden()
+    {
+        await SeedHoldingsWithPrice();
+        Authorize("otheruser", _testUserId + 1, UserRole.User);
+
+        var response = await Client.GetAsync(
+            $"api/InvestmentValuation/Value/{_testAccountId}/{_usdCurrencyId}/{_asOf:yyyy-MM-dd}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetHoldings_ForUnknownAccount_ReturnsNotFound()
+    {
+        await SeedAccount();
+        Authorize("testuser", _testUserId, UserRole.User);
+
+        var response = await Client.GetAsync(
+            $"api/InvestmentValuation/Holdings/999999/{_asOf:yyyy-MM-dd}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _testDatabase?.Dispose();
+        _testDatabase = null;
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## What

Step 2 of the **investment-account vertical slice** (lineage of #474): the HTTP surface over the new asset model, built on the valuation service from #486. Mirrors the existing `StockEntryController`/`StockAccountController` patterns. Additive — legacy stock controllers/clients untouched, no Blazor UI yet (step 3).

## Changes

**API**
- **`InvestmentTransactionController`** — `GetByAccount`, `Get`, `Add`, `Update`, `Delete` over `InvestmentTransaction`, keyed by account. JWT auth + `ApiAuthenticationHelper.IsAccountOwner` checks and dashboard cache invalidation, exactly like the stock controllers. The transaction's `UserId` is taken from the owning account, **never trusted from the request body**; basic input validation (positive quantity, non-negative price, currency, listing, date) returns 400.
- **`InvestmentValuationController`** — `Holdings`, `Value`, `ValueSeries` over `IInvestmentValuationService`, resolving the target currency via `ICurrencyRepository`.

**DTOs** — `InvestmentTransactionDto`, `AddInvestmentTransactionRequest`, `UpdateInvestmentTransactionRequest` + mapping extensions under `FinancialAccounts/Investments/Dtos`.

**Components** — `InvestmentTransactionHttpClient` and `InvestmentValuationHttpClient`, registered in `AddUIComponents`.

**Tests** — integration test classes for both controllers (required by `ControllerCoverageTests`): CRUD, ownership (403), invalid input (400), unknown account (404), holdings netting (buy 5 / sell 2 → 3), and an end-to-end value path against a seeded `PriceQuote` (3 units × 100 USD → 300).

## Validation

- Build clean (warnings-as-errors), `dotnet format --verify-no-changes` clean.
- Unit: 605 passed · Architecture: 9 passed (incl. controller-coverage) · Integration: 276 passed.

No Blazor/user-visible change yet (clients not consumed by a page), so no screenshot and no changelog — consistent with the earlier slice PRs.

## Slice roadmap
1. ✅ Valuation service (#486)
2. ✅ Transaction + valuation API & HTTP clients (this PR)
3. ⬜ Blazor investment-account components (with screenshots)
4. ⬜ Net-worth / diversification migration

closes #487

---
_Generated by [Claude Code](https://claude.ai/code/session_011bbrbkPuVwjtUDqg8Kg8x4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Full investment transaction management: add, update, delete, and view transactions for stock accounts
  * Investment valuation capabilities: view portfolio holdings, calculate account value in any currency, and track valuation trends across custom date ranges

<!-- end of auto-generated comment: release notes by coderabbit.ai -->