### PR TITLE
Disable Claude co-author attribution in commits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "includeCoAuthoredBy": false,
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
## Summary

Adds `"includeCoAuthoredBy": false` to the project-level `.claude/settings.json` so commits made by Claude Code no longer include the `Co-Authored-By: Claude ...` trailer.

## Details

- Merged the new key alongside the existing `hooks` configuration — no other settings changed.
- Config-only change with no user-visible application behaviour, so no changelog entry or issue reference is required (non-user-visible chore exemption per `CLAUDE.md`).
- The `Claude-Session:` trailer is controlled separately (`attribution.sessionUrl`) and is intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RU8JrXGhhWnXkW9fWLtfqb)_