### PR TITLE
Update NuGet dependencies to latest stable versions

### DIFF
--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -47,17 +47,17 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MudBlazor" Version="9.5.0" />
+    <PackageVersion Include="MudBlazor" Version="9.6.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.4" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.6" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />


### PR DESCRIPTION
## Summary

Updated 5 NuGet packages to their latest stable versions. All unit, integration, and architecture tests pass successfully.

## Package Updates

**Patch Updates (Minor version bumps):**
- Microsoft.NET.Test.Sdk: 18.6.0 → 18.7.0
- Scalar.AspNetCore: 2.16.4 → 2.16.6
- MudBlazor: 9.5.0 → 9.6.0
- OpenTelemetry.Instrumentation.AspNetCore: 1.15.2 → 1.16.0
- OpenTelemetry.Instrumentation.Http: 1.15.1 → 1.16.0

**Packages Not Updated:**
- GitHub.Copilot.SDK: Kept at 1.0.0-beta.4 (stable 1.0.4 has breaking API changes that would require code migration)
- Blazored.LocalStorage & Blazored.SessionStorage: Not found in package sources (may require maintenance review)

## Testing

✅ Build: Succeeded
✅ Unit Tests: 494 tests passed
✅ Integration Tests: 252 tests passed
✅ Architecture Tests: 9 tests passed

## Breaking Changes

No breaking changes to application code. The GitHub.Copilot.SDK stable release has incompatible APIs with the beta version but was not updated due to the required code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DchnjVRwX2BUDQx8EmiSGA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several bundled dependencies to newer versions, including testing, UI, API documentation, and telemetry components.
  * These updates may improve stability, compatibility, and overall app performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->