### PR TITLE
Update Scalar.AspNetCore to 2.16.10

### DIFF
--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -60,7 +60,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.6" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.10" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />


### PR DESCRIPTION
## Summary
Updated Scalar.AspNetCore from 2.16.6 to 2.16.10 (patch version with bug fixes and improvements).

## Changes
- Scalar.AspNetCore: 2.16.6 → 2.16.10 (patch update - backwards-compatible)

## Dependency Updates Attempted & Reverted
- Microsoft.OpenApi: 2.7.5 → 3.8.0 (major version with breaking changes in IOpenApiMediaType.Example property - incompatible with current source generators)
- GitHub.Copilot.SDK: 1.0.0-beta.4 → 1.0.6-preview.1 (breaking namespace changes - reverted)

These updates were reverted to avoid build failures and maintain stability.

## Testing
- ✅ Build: Successful
- ✅ Unit tests: 497 passed
- ✅ Integration tests: 252 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7vjvbaUCzVvHcD4aGVsMx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled third-party component to a newer version, which may include stability improvements and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->