### PR TITLE
Complete investment instrument import flow #510

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 Instructions for AI agents working on FinanceManager.
 
+- **Local development workflows**: use [$mikis-teamwork](C:\\Users\\Miki\\.codex\\skills\\mikis-teamwork\\SKILL.md) for each development workflow on the local machine.
 - **Project conventions** (build, tests, architecture, branching, changelog): read [`CLAUDE.md`](./CLAUDE.md).
 - **Using the running app** — above all the **develop-only auto test login** (`/DevelopLogin/{login}/{page}`)
   that signs you in as `guest` or `testuser` without the landing page or login form: read

--- a/code/FinanceManager.Api/Controllers/Accounts/InvestmentInstrumentDiscoveryController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/InvestmentInstrumentDiscoveryController.cs
@@ -7,8 +7,7 @@ namespace FinanceManager.Api.Controllers.Accounts;
 
 /// <summary>
 /// User-facing instrument discovery over external providers (OpenFIGI + Alpha Vantage), kept
-/// separate from the admin asset CRUD API. Currently exposes search; import-preview and import
-/// arrive in a later slice.
+/// separate from the admin asset CRUD API.
 /// </summary>
 [Authorize]
 [ApiController]
@@ -25,5 +24,24 @@ public class InvestmentInstrumentDiscoveryController(IInvestmentInstrumentDiscov
 
         var results = await discoveryService.SearchAsync(query, cancellationToken);
         return Ok(results);
+    }
+
+    [HttpPost("import-preview")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InstrumentImportPreviewDto))]
+    public async Task<IActionResult> ImportPreview([FromBody] InstrumentDiscoveryResultDto instrument, CancellationToken cancellationToken) =>
+        Ok(await discoveryService.GetImportPreviewAsync(instrument, cancellationToken));
+
+    [HttpPost("import")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ImportedInstrumentDto))]
+    public async Task<IActionResult> Import([FromBody] ImportInstrumentCommand command, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return Ok(await discoveryService.ImportAsync(command, cancellationToken));
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 }

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInvestmentInstrumentDiscoveryService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInvestmentInstrumentDiscoveryService.cs
@@ -20,4 +20,6 @@ public interface IInvestmentInstrumentDiscoveryService
     /// Alpha Vantage for the provider price symbol.
     /// </summary>
     Task<IReadOnlyList<InstrumentDiscoveryResultDto>> SearchAsync(string query, CancellationToken ct = default);
+    Task<InstrumentImportPreviewDto> GetImportPreviewAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default);
+    Task<ImportedInstrumentDto> ImportAsync(ImportInstrumentCommand command, CancellationToken ct = default);
 }

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InvestmentInstrumentDiscoveryService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InvestmentInstrumentDiscoveryService.cs
@@ -1,6 +1,9 @@
 using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
 using FinanceManager.Application.FinancialAccounts.Stock.Resolution;
 using FinanceManager.Domain.Assets.Discovery;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -16,6 +19,9 @@ namespace FinanceManager.Application.FinancialAccounts.Investments.Discovery;
 public sealed partial class InvestmentInstrumentDiscoveryService(
     IOpenFigiClient openFigiClient,
     IAlphaVantageClient alphaVantageClient,
+    IAssetRepository assetRepository,
+    IAssetListingRepository listingRepository,
+    IMarketDataSymbolRepository symbolRepository,
     IMemoryCache cache,
     ILogger<InvestmentInstrumentDiscoveryService> logger) : IInvestmentInstrumentDiscoveryService
 {
@@ -232,6 +238,170 @@ public sealed partial class InvestmentInstrumentDiscoveryService(
             ? (mapping.Mic, mapping.ExchangeName, token)
             : (null, token, token);
     }
+
+    public async Task<InstrumentImportPreviewDto> GetImportPreviewAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default)
+    {
+        var (asset, listing, symbol) = await FindExistingAsync(instrument, ct);
+        return new InstrumentImportPreviewDto
+        {
+            Instrument = instrument,
+            AssetAlreadyExists = asset is not null,
+            ListingAlreadyExists = listing is not null,
+            MarketDataSymbolAlreadyExists = symbol is not null,
+            CanImport = HasRequiredImportData(instrument),
+            Warnings = ImportWarnings(instrument)
+        };
+    }
+
+    public async Task<ImportedInstrumentDto> ImportAsync(ImportInstrumentCommand command, CancellationToken ct = default)
+    {
+        var instrument = command.Instrument;
+        ValidateImport(instrument);
+        var warnings = ImportWarnings(instrument).ToList();
+        var (asset, listing, symbol) = await FindExistingAsync(instrument, ct);
+        var createdAsset = asset is null;
+        asset ??= await assetRepository.Add(new Asset
+        {
+            Name = instrument.DisplayName,
+            Type = ParseAssetType(instrument.SecurityType),
+            Isin = instrument.Isin,
+            ShareClassFigi = instrument.ShareClassFigi,
+            CompositeFigi = instrument.CompositeFigi,
+            BaseCurrency = instrument.TradingCurrency
+        }, ct);
+
+        var createdListing = listing is null;
+        listing ??= await listingRepository.Add(new AssetListing
+        {
+            AssetId = asset.Id,
+            Ticker = instrument.Ticker.Trim().ToUpperInvariant(),
+            ExchangeMic = instrument.ExchangeMic!,
+            ExchangeName = instrument.ExchangeName ?? instrument.ExchangeMic!,
+            TradingCurrency = instrument.TradingCurrency!.ToUpperInvariant(),
+            ListingFigi = instrument.ListingFigi,
+            PriceMultiplier = _minorCurrencyUnits.Contains(instrument.TradingCurrency) ? 0.01m : 1m
+        }, ct);
+
+        var createdSymbol = symbol is null && !string.IsNullOrWhiteSpace(instrument.ProviderSymbol);
+        if (createdSymbol)
+        {
+            var error = await ValidateSymbolAsync(instrument, ct);
+            if (error is not null) warnings.Add(error);
+            symbol = await symbolRepository.Add(new MarketDataSymbol
+            {
+                AssetListingId = listing.Id,
+                Provider = MarketDataProvider.AlphaVantage,
+                Symbol = instrument.ProviderSymbol!,
+                ProviderExchangeCode = instrument.ExchangeCode,
+                Currency = instrument.TradingCurrency,
+                IsPrimary = true,
+                IsEnabled = error is null,
+                LastValidatedAt = error is null ? DateTimeOffset.UtcNow : null,
+                LastError = error
+            }, ct);
+        }
+
+        return new ImportedInstrumentDto
+        {
+            AssetId = asset.Id,
+            AssetListingId = listing.Id,
+            MarketDataSymbolId = symbol?.Id,
+            Ticker = listing.Ticker,
+            ExchangeName = listing.ExchangeName,
+            TradingCurrency = listing.TradingCurrency,
+            CreatedAsset = createdAsset,
+            CreatedListing = createdListing,
+            CreatedMarketDataSymbol = createdSymbol,
+            Warnings = warnings
+        };
+    }
+
+    private async Task<(Asset? Asset, AssetListing? Listing, MarketDataSymbol? Symbol)> FindExistingAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(instrument.ProviderSymbol))
+        {
+            var providerSymbol = await symbolRepository.Get(MarketDataProvider.AlphaVantage, instrument.ProviderSymbol, ct);
+            if (providerSymbol is not null)
+            {
+                var providerListing = await listingRepository.Get(providerSymbol.AssetListingId, ct);
+                if (providerListing is not null)
+                    return (await assetRepository.Get(providerListing.AssetId, ct), providerListing, providerSymbol);
+            }
+        }
+
+        Asset? asset = null;
+        if (!string.IsNullOrWhiteSpace(instrument.ShareClassFigi))
+            asset = await assetRepository.GetByShareClassFigi(instrument.ShareClassFigi, ct);
+        if (asset is null && !string.IsNullOrWhiteSpace(instrument.CompositeFigi))
+            asset = (await assetRepository.GetAll(ct)).FirstOrDefault(x => x.CompositeFigi == instrument.CompositeFigi);
+        if (asset is null && !string.IsNullOrWhiteSpace(instrument.Isin))
+            asset = await assetRepository.GetByIsin(instrument.Isin, ct);
+        if (asset is null)
+            asset = (await assetRepository.GetAll(ct)).FirstOrDefault(x =>
+                x.Type == ParseAssetType(instrument.SecurityType) && string.Equals(x.Name.Trim(), instrument.DisplayName.Trim(), StringComparison.OrdinalIgnoreCase));
+
+        AssetListing? listing = null;
+        if (!string.IsNullOrWhiteSpace(instrument.ExchangeMic) && !string.IsNullOrWhiteSpace(instrument.TradingCurrency))
+        {
+            listing = await listingRepository.Get(instrument.Ticker, instrument.ExchangeMic, instrument.TradingCurrency, ct);
+            if (listing is not null)
+                asset = await assetRepository.Get(listing.AssetId, ct);
+        }
+        if (asset is not null)
+        {
+            var listings = await listingRepository.GetByAsset(asset.Id, ct);
+            if (!string.IsNullOrWhiteSpace(instrument.ListingFigi))
+                listing = listings.FirstOrDefault(x => x.ListingFigi == instrument.ListingFigi);
+            listing ??= listings.FirstOrDefault(x =>
+                x.Ticker.Equals(instrument.Ticker, StringComparison.OrdinalIgnoreCase)
+                && x.ExchangeMic.Equals(instrument.ExchangeMic, StringComparison.OrdinalIgnoreCase)
+                && x.TradingCurrency.Equals(instrument.TradingCurrency, StringComparison.OrdinalIgnoreCase));
+        }
+
+        MarketDataSymbol? symbol = null;
+        if (listing is not null && !string.IsNullOrWhiteSpace(instrument.ProviderSymbol))
+            symbol = (await symbolRepository.GetByListing(listing.Id, ct)).FirstOrDefault(x =>
+                x.Provider == MarketDataProvider.AlphaVantage && x.Symbol.Equals(instrument.ProviderSymbol, StringComparison.OrdinalIgnoreCase));
+        return (asset, listing, symbol);
+    }
+
+    private async Task<string?> ValidateSymbolAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct)
+    {
+        try
+        {
+            var prices = await alphaVantageClient.GetDailySeries(instrument.ProviderSymbol!, DateTime.UtcNow.AddDays(-10), DateTime.UtcNow,
+                new Currency { ShortName = instrument.TradingCurrency! }, ct);
+            return prices.Any(x => x.PricePerUnit > 0) ? null : "Alpha Vantage returned no positive recent price; the symbol was saved disabled.";
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "Alpha Vantage validation failed for {Symbol}", instrument.ProviderSymbol);
+            return "Alpha Vantage validation failed; the symbol was saved disabled.";
+        }
+    }
+
+    private static IReadOnlyList<string> ImportWarnings(InstrumentDiscoveryResultDto instrument) =>
+        [.. instrument.Warnings,
+            .. (HasRequiredImportData(instrument) ? [] : new[] { "Name, ticker, exchange MIC, and trading currency must be confirmed before import." }),
+            .. (_minorCurrencyUnits.Contains(instrument.TradingCurrency ?? string.Empty)
+                ? new[] { "Minor-unit currency detected; price multiplier will be set to 0.01." } : [])];
+
+    private static void ValidateImport(InstrumentDiscoveryResultDto instrument)
+    {
+        if (!HasRequiredImportData(instrument))
+            throw new ArgumentException("Name, ticker, exchange MIC, and trading currency must be confirmed before import.");
+        if (ParseAssetType(instrument.SecurityType) is not (AssetType.Stock or AssetType.ETF))
+            throw new ArgumentException("Only stocks and ETFs can be imported.");
+    }
+
+    private static bool HasRequiredImportData(InstrumentDiscoveryResultDto instrument) =>
+        !string.IsNullOrWhiteSpace(instrument.DisplayName) && !string.IsNullOrWhiteSpace(instrument.Ticker)
+        && !string.IsNullOrWhiteSpace(instrument.ExchangeMic) && !string.IsNullOrWhiteSpace(instrument.TradingCurrency);
+
+    private static AssetType ParseAssetType(string? securityType) =>
+        securityType?.Contains("ETF", StringComparison.OrdinalIgnoreCase) == true ? AssetType.ETF
+        : securityType?.Contains("Equity", StringComparison.OrdinalIgnoreCase) == true || securityType?.Contains("Stock", StringComparison.OrdinalIgnoreCase) == true ? AssetType.Stock
+        : AssetType.Other;
 
     // Identity-first dedupe: prefer FIGI, then ISIN+currency, then ticker+exchange+currency.
     private static string DedupeKey(InstrumentDiscoveryResultDto dto)

--- a/code/FinanceManager.Application/Identity/Seeders/TestUserAccountSeeder.cs
+++ b/code/FinanceManager.Application/Identity/Seeders/TestUserAccountSeeder.cs
@@ -9,7 +9,7 @@ namespace FinanceManager.Application.Identity.Seeders;
 public class TestUserAccountSeeder(IUserRepository userRepository, IConfiguration configuration,
     ILogger<TestUserAccountSeeder> logger) : ISeeder
 {
-    private const string _defaultTestUserName = "testuser@localhost";
+    private const string _defaultTestUserName = "testuser";
 
     public async Task Seed(CancellationToken cancellationToken = default)
     {

--- a/code/FinanceManager.Components/Components/Features/Admin/AdminAssets.razor
+++ b/code/FinanceManager.Components/Components/Features/Admin/AdminAssets.razor
@@ -21,6 +21,7 @@
                       Class="flex-grow-1" />
         <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="Admin/AddAsset"
                    StartIcon="@Icons.Material.Filled.Add">Add asset</MudButton>
+        <FinanceManager.Components.Components.Features.FinancialAccounts.InvestmentAccountComponents.InstrumentImport Imported="@(_ => ReloadAssetsAsync())" />
     </MudStack>
 
     @if (_pagedElements.Any())

--- a/code/FinanceManager.Components/Components/Features/Admin/AdminAssets.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Admin/AdminAssets.razor.cs
@@ -41,6 +41,12 @@ public partial class AdminAssets : ComponentBase
         _isLoading = false;
     }
 
+    private async Task ReloadAssetsAsync()
+    {
+        _allElements = await AssetHttpClient.GetAssets();
+        ApplyFilter();
+    }
+
     private void PageChanged(int i)
     {
         SelectedPage = i;

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InstrumentImport.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InstrumentImport.razor
@@ -1,0 +1,81 @@
+@using FinanceManager.Components.HttpClients
+@using FinanceManager.Domain.Assets.Discovery
+@using Microsoft.AspNetCore.Components
+
+<MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.CloudDownload" OnClick="@(() => _open = true)" aria-label="@ButtonText">@ButtonText</MudButton>
+
+<MudOverlay Visible="@_open" DarkBackground="true" ZIndex="1400">
+    <MudPaper Class="pa-5" Style="width: min(620px, 94vw);">
+        <MudText Typo="Typo.h6" Class="mb-3">Import instrument</MudText>
+        <MudAutocomplete T="InstrumentDiscoveryResultDto" Label="Ticker, name, or ISIN"
+                         Value="_selected" ValueChanged="SelectAsync" SearchFunc="SearchAsync"
+                         ToStringFunc="@(x => x is null ? string.Empty : $"{x.Ticker} · {x.ExchangeName ?? x.ExchangeMic} · {x.TradingCurrency} — {x.DisplayName}")"
+                         MinCharacters="2" DebounceInterval="400" Dense="true" />
+        @if (_error is not null)
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Class="mt-3">@_error</MudAlert>
+        }
+        @if (_preview is not null)
+        {
+            <MudAlert Severity="Severity.Info" Dense="true" Class="mt-3">
+                Asset: @(_preview.AssetAlreadyExists ? "reuse" : "create") · Listing: @(_preview.ListingAlreadyExists ? "reuse" : "create") · Symbol: @(_preview.MarketDataSymbolAlreadyExists ? "reuse" : "create")
+            </MudAlert>
+            @foreach (var warning in _preview.Warnings)
+            {
+                <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">@warning</MudAlert>
+            }
+        }
+        <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="2" Class="mt-4">
+            <MudButton Variant="Variant.Text" OnClick="Close" Disabled="@_busy">Cancel</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ImportAsync" Disabled="@(_busy || _preview?.CanImport != true)">Import</MudButton>
+        </MudStack>
+    </MudPaper>
+</MudOverlay>
+
+@code {
+    [Inject] public required InvestmentInstrumentDiscoveryHttpClient Client { get; set; }
+    [Parameter] public string ButtonText { get; set; } = "Import instrument";
+    [Parameter] public EventCallback<ImportedInstrumentDto> Imported { get; set; }
+
+    private bool _open;
+    private bool _busy;
+    private InstrumentDiscoveryResultDto? _selected;
+    private InstrumentImportPreviewDto? _preview;
+    private string? _error;
+
+    private async Task<IEnumerable<InstrumentDiscoveryResultDto>> SearchAsync(string value, CancellationToken ct) =>
+        string.IsNullOrWhiteSpace(value) ? [] : await Client.SearchAsync(value, ct);
+
+    private async Task SelectAsync(InstrumentDiscoveryResultDto? value)
+    {
+        _selected = value;
+        _error = null;
+        try { _preview = value is null ? null : await Client.PreviewAsync(value); }
+        catch { _preview = null; _error = "Could not prepare the import preview."; }
+    }
+
+    private async Task ImportAsync()
+    {
+        if (_selected is null) return;
+        _busy = true;
+        try
+        {
+            var result = await Client.ImportAsync(_selected);
+            if (result is not null)
+            {
+                Close();
+                await Imported.InvokeAsync(result);
+            }
+        }
+        catch { _error = "Could not import the instrument."; }
+        finally { _busy = false; }
+    }
+
+    private void Close()
+    {
+        _open = false;
+        _selected = null;
+        _preview = null;
+        _error = null;
+    }
+}

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
@@ -114,6 +114,10 @@ else
                              ResetValueOnEmptyText="true"
                              CoerceText="false"
                              Dense="true" />
+            @if (_editingId is null)
+            {
+                <InstrumentImport ButtonText="Can't find it? Import instrument" Imported="OnInstrumentImportedAsync" />
+            }
             <MudSelect T="InvestmentTransactionType" Label="Type" @bind-Value="_formType" Dense="true">
                 <MudSelectItem T="InvestmentTransactionType" Value="InvestmentTransactionType.Buy">Buy</MudSelectItem>
                 <MudSelectItem T="InvestmentTransactionType" Value="InvestmentTransactionType.Sell">Sell</MudSelectItem>

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -1,6 +1,7 @@
 using FinanceManager.Components.Components.Features.FinancialAccounts.Shared;
 using FinanceManager.Components.Helpers;
 using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.Assets.Discovery;
 using FinanceManager.Domain.Assets.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
@@ -418,6 +419,13 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
             Logger.LogError(ex, "Failed to search instrument listings for '{Query}'", value);
             return [];
         }
+    }
+
+    private async Task OnInstrumentImportedAsync(ImportedInstrumentDto imported)
+    {
+        await OnInstrumentSelectedAsync(new InstrumentSearchResultDto(
+            imported.AssetListingId, imported.Ticker, imported.ExchangeName, imported.TradingCurrency));
+        Snackbar.Add(imported.Warnings.Count == 0 ? "Instrument imported." : $"Instrument imported with {imported.Warnings.Count} warning(s).", Severity.Success);
     }
 
     private async Task SaveAsync()

--- a/code/FinanceManager.Components/HttpClients/InvestmentInstrumentDiscoveryHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/InvestmentInstrumentDiscoveryHttpClient.cs
@@ -1,0 +1,26 @@
+using FinanceManager.Domain.Assets.Discovery;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Components.HttpClients;
+
+public class InvestmentInstrumentDiscoveryHttpClient(HttpClient httpClient)
+{
+    private const string _base = "api/investments/instruments";
+
+    public async Task<IReadOnlyList<InstrumentDiscoveryResultDto>> SearchAsync(string query, CancellationToken ct = default) =>
+        await httpClient.GetFromJsonAsync<List<InstrumentDiscoveryResultDto>>($"{_base}/search?query={Uri.EscapeDataString(query)}", ct) ?? [];
+
+    public async Task<InstrumentImportPreviewDto?> PreviewAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default)
+    {
+        using var response = await httpClient.PostAsJsonAsync($"{_base}/import-preview", instrument, ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<InstrumentImportPreviewDto>(cancellationToken: ct);
+    }
+
+    public async Task<ImportedInstrumentDto?> ImportAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default)
+    {
+        using var response = await httpClient.PostAsJsonAsync($"{_base}/import", new ImportInstrumentCommand(instrument), ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<ImportedInstrumentDto>(cancellationToken: ct);
+    }
+}

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -22,6 +22,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<AssetHttpClient>()
 
                 .AddScoped<InvestmentTransactionHttpClient>()
+                .AddScoped<InvestmentInstrumentDiscoveryHttpClient>()
                 .AddScoped<InvestmentValuationHttpClient>()
 
                 .AddScoped<CurrencyAccountHttpClient>()

--- a/code/FinanceManager.Domain/Assets/Discovery/InstrumentImportDtos.cs
+++ b/code/FinanceManager.Domain/Assets/Discovery/InstrumentImportDtos.cs
@@ -1,0 +1,29 @@
+using FinanceManager.Domain.Assets.Entities;
+
+namespace FinanceManager.Domain.Assets.Discovery;
+
+public sealed class InstrumentImportPreviewDto
+{
+    public required InstrumentDiscoveryResultDto Instrument { get; init; }
+    public bool AssetAlreadyExists { get; init; }
+    public bool ListingAlreadyExists { get; init; }
+    public bool MarketDataSymbolAlreadyExists { get; init; }
+    public bool CanImport { get; init; }
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+}
+
+public sealed record ImportInstrumentCommand(InstrumentDiscoveryResultDto Instrument);
+
+public sealed class ImportedInstrumentDto
+{
+    public long AssetId { get; init; }
+    public long AssetListingId { get; init; }
+    public long? MarketDataSymbolId { get; init; }
+    public string Ticker { get; init; } = string.Empty;
+    public string ExchangeName { get; init; } = string.Empty;
+    public string TradingCurrency { get; init; } = string.Empty;
+    public bool CreatedAsset { get; init; }
+    public bool CreatedListing { get; init; }
+    public bool CreatedMarketDataSymbol { get; init; }
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+}

--- a/code/FinanceManager.Domain/Assets/Repositories/IMarketDataSymbolRepository.cs
+++ b/code/FinanceManager.Domain/Assets/Repositories/IMarketDataSymbolRepository.cs
@@ -13,6 +13,9 @@ public interface IMarketDataSymbolRepository
     /// <summary>The preferred enabled symbol for a listing and provider (IsPrimary first, then any enabled).</summary>
     Task<MarketDataSymbol?> GetPrimary(long assetListingId, MarketDataProvider provider, CancellationToken cancellationToken = default);
 
+    /// <summary>Get the globally unique provider symbol mapping, or <c>null</c>.</summary>
+    Task<MarketDataSymbol?> Get(MarketDataProvider provider, string symbol, CancellationToken cancellationToken = default);
+
     /// <summary>Insert a new provider symbol and return the persisted entity (with its generated id).</summary>
     Task<MarketDataSymbol> Add(MarketDataSymbol symbol, CancellationToken cancellationToken = default);
 

--- a/code/FinanceManager.Infrastructure/Repositories/Assets/MarketDataSymbolRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Assets/MarketDataSymbolRepository.cs
@@ -22,6 +22,10 @@ public class MarketDataSymbolRepository(AppDbContext context) : IMarketDataSymbo
             .ThenBy(x => x.Id)
             .FirstOrDefaultAsync(cancellationToken);
 
+    public Task<MarketDataSymbol?> Get(MarketDataProvider provider, string symbol, CancellationToken cancellationToken = default) =>
+        context.MarketDataSymbols.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Provider == provider && x.Symbol == symbol, cancellationToken);
+
     public async Task<MarketDataSymbol> Add(MarketDataSymbol symbol, CancellationToken cancellationToken = default)
     {
         var now = DateTimeOffset.UtcNow;

--- a/code/FinanceManager.Tests.Unit/Application/Services/Discovery/InvestmentInstrumentDiscoveryServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Discovery/InvestmentInstrumentDiscoveryServiceTests.cs
@@ -1,6 +1,9 @@
 using FinanceManager.Application.FinancialAccounts.Investments.Discovery;
 using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
 using FinanceManager.Application.FinancialAccounts.Stock.Resolution;
+using FinanceManager.Domain.Assets.Discovery;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -14,12 +17,29 @@ public class InvestmentInstrumentDiscoveryServiceTests
 {
     private readonly Mock<IOpenFigiClient> _openFigiClientMock = new();
     private readonly Mock<IAlphaVantageClient> _avClientMock = new();
+    private readonly Mock<IAssetRepository> _assetRepositoryMock = new();
+    private readonly Mock<IAssetListingRepository> _listingRepositoryMock = new();
+    private readonly Mock<IMarketDataSymbolRepository> _symbolRepositoryMock = new();
     private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
     private readonly ILogger<InvestmentInstrumentDiscoveryService> _logger =
         LoggerFactory.Create(_ => { }).CreateLogger<InvestmentInstrumentDiscoveryService>();
 
     private InvestmentInstrumentDiscoveryService CreateService() =>
-        new(_openFigiClientMock.Object, _avClientMock.Object, _cache, _logger);
+        new(_openFigiClientMock.Object, _avClientMock.Object, _assetRepositoryMock.Object,
+            _listingRepositoryMock.Object, _symbolRepositoryMock.Object, _cache, _logger);
+
+    private static InstrumentDiscoveryResultDto Instrument() => new()
+    {
+        DisplayName = "iShares Core S&P 500 UCITS ETF",
+        Ticker = "CSPX",
+        ExchangeMic = "XLON",
+        ExchangeCode = "LN",
+        TradingCurrency = "USD",
+        SecurityType = "ETF",
+        ShareClassFigi = "BBGSC",
+        ListingFigi = "BBG001",
+        ProviderSymbol = "CSPX.LON"
+    };
 
     [Theory]
     [InlineData(null)]
@@ -238,5 +258,71 @@ public class InvestmentInstrumentDiscoveryServiceTests
         await service.SearchAsync("cspx", TestContext.Current.CancellationToken);
 
         _openFigiClientMock.Verify(x => x.MapByTickerAsync("CSPX", It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PreviewAndImport_WhenInstrumentExists_ReusesAllRecords()
+    {
+        var asset = new Asset { Id = 1, Name = "iShares Core S&P 500 UCITS ETF", ShareClassFigi = "BBGSC" };
+        var listing = new AssetListing { Id = 2, AssetId = 1, Ticker = "CSPX", ExchangeMic = "XLON", TradingCurrency = "USD", ListingFigi = "BBG001" };
+        var symbol = new MarketDataSymbol { Id = 3, AssetListingId = 2, Provider = MarketDataProvider.AlphaVantage, Symbol = "CSPX.LON" };
+        _assetRepositoryMock.Setup(x => x.GetByShareClassFigi("BBGSC", It.IsAny<CancellationToken>())).ReturnsAsync(asset);
+        _listingRepositoryMock.Setup(x => x.GetByAsset(1, It.IsAny<CancellationToken>())).ReturnsAsync([listing]);
+        _symbolRepositoryMock.Setup(x => x.GetByListing(2, It.IsAny<CancellationToken>())).ReturnsAsync([symbol]);
+
+        var preview = await CreateService().GetImportPreviewAsync(Instrument(), TestContext.Current.CancellationToken);
+        var result = await CreateService().ImportAsync(new ImportInstrumentCommand(Instrument()), TestContext.Current.CancellationToken);
+
+        Assert.True(preview.AssetAlreadyExists);
+        Assert.True(preview.ListingAlreadyExists);
+        Assert.True(preview.MarketDataSymbolAlreadyExists);
+        Assert.False(result.CreatedAsset);
+        Assert.False(result.CreatedListing);
+        Assert.False(result.CreatedMarketDataSymbol);
+        _assetRepositoryMock.Verify(x => x.Add(It.IsAny<Asset>(), It.IsAny<CancellationToken>()), Times.Never);
+        _listingRepositoryMock.Verify(x => x.Add(It.IsAny<AssetListing>(), It.IsAny<CancellationToken>()), Times.Never);
+        _symbolRepositoryMock.Verify(x => x.Add(It.IsAny<MarketDataSymbol>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ImportAsync_WhenValidationReturnsNoPrices_SavesDisabledSymbol()
+    {
+        _assetRepositoryMock.Setup(x => x.GetAll(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _assetRepositoryMock.Setup(x => x.Add(It.IsAny<Asset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Asset asset, CancellationToken _) => { asset.Id = 1; return asset; });
+        _listingRepositoryMock.Setup(x => x.Add(It.IsAny<AssetListing>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AssetListing listing, CancellationToken _) => { listing.Id = 2; return listing; });
+        _symbolRepositoryMock.Setup(x => x.Add(It.IsAny<MarketDataSymbol>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MarketDataSymbol symbol, CancellationToken _) => { symbol.Id = 3; return symbol; });
+        _avClientMock.Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+            It.IsAny<FinanceManager.Domain.FinancialAccounts.Currencies.Entities.Currency>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var result = await CreateService().ImportAsync(new ImportInstrumentCommand(Instrument()), TestContext.Current.CancellationToken);
+
+        Assert.True(result.CreatedMarketDataSymbol);
+        Assert.Contains(result.Warnings, warning => warning.Contains("saved disabled", StringComparison.OrdinalIgnoreCase));
+        _symbolRepositoryMock.Verify(x => x.Add(It.Is<MarketDataSymbol>(symbol => !symbol.IsEnabled && symbol.LastError != null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportAsync_WhenProviderSymbolExists_ReusesItsListingAndAsset()
+    {
+        var asset = new Asset { Id = 1, Name = "Existing ETF" };
+        var listing = new AssetListing { Id = 2, AssetId = 1, Ticker = "CSPX", ExchangeMic = "XLON", TradingCurrency = "USD", ExchangeName = "London Stock Exchange" };
+        var symbol = new MarketDataSymbol { Id = 3, AssetListingId = 2, Provider = MarketDataProvider.AlphaVantage, Symbol = "CSPX.LON" };
+        _symbolRepositoryMock.Setup(x => x.Get(MarketDataProvider.AlphaVantage, "CSPX.LON", It.IsAny<CancellationToken>())).ReturnsAsync(symbol);
+        _listingRepositoryMock.Setup(x => x.Get(2, It.IsAny<CancellationToken>())).ReturnsAsync(listing);
+        _assetRepositoryMock.Setup(x => x.Get(1, It.IsAny<CancellationToken>())).ReturnsAsync(asset);
+
+        var result = await CreateService().ImportAsync(new ImportInstrumentCommand(Instrument()), TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, result.AssetId);
+        Assert.Equal(2, result.AssetListingId);
+        Assert.Equal(3, result.MarketDataSymbolId);
+        Assert.False(result.CreatedAsset);
+        Assert.False(result.CreatedListing);
+        Assert.False(result.CreatedMarketDataSymbol);
     }
 }


### PR DESCRIPTION
## What changed

- added import preview and confirmed import endpoints for discovered instruments
- reused or created assets, listings, and Alpha Vantage symbols with identity-first deduplication
- validated provider symbols before enabling them and handled ambiguous exchange data safely
- added a shared search/import dialog to investment transaction entry and the admin assets page
- aligned the seeded development login with `/DevelopLogin/testuser`
- added regression coverage for reuse, failed validation, and globally unique provider symbols

## Why

Issue #510 already had provider-backed search, but users could not turn a discovery result into master data or continue transaction entry. Live PostgreSQL testing also exposed a duplicate provider-symbol failure and a testuser seeding mismatch; both are fixed here.

## Validation

- `dotnet build ./code/FinanceManager.slnx --no-restore`
- 14 focused `InvestmentInstrumentDiscoveryServiceTests`
- 6 relevant integration tests for discovery and develop login
- live browser flow against PostgreSQL using `/DevelopLogin/testuser`
- live CSPX search, preview, reuse import (HTTP 200), price loading, and ambiguous-MIC rejection

Closes #510