### PR TITLE
Currency management overhaul: preferred user currency, DB-backed exchange rates, predefined currency inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ rules agents must follow when updating this file.
 
 ## [Unreleased]
 
+### Added
+- Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
+
+### Changed
+- Currency fields are no longer free-text anywhere in the app: the admin asset editor (base and trading currency) and the bond-details form now offer a dropdown of predefined currencies (plus pence-style quote units like GBX for listings), and the API rejects currency codes outside that list. The predefined list now ships with the major world currencies (EUR, GBP, CHF, JPY, CZK, SEK, NOK, DKK, HUF, CAD, AUD) besides PLN and USD.
+- Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
+
 ### Security
 - The default admin and test-user accounts are no longer seeded with passwords hard-coded in source. Their passwords are now read from configuration (`Seeding:AdminPassword` / `Seeding:TestUserPassword`); when unset — as in production — the accounts are not created. The stock-price bulk-import endpoint now returns a generic error message and logs the exception server-side instead of echoing the raw exception text to the caller. #450
 

--- a/code/FinanceManager.Api/Controllers/Admin/AssetController.cs
+++ b/code/FinanceManager.Api/Controllers/Admin/AssetController.cs
@@ -1,5 +1,7 @@
 using FinanceManager.Domain.Assets.Dtos;
 using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -16,7 +18,8 @@ namespace FinanceManager.Api.Controllers.Admin;
 public class AssetController(
     IAssetRepository assetRepository,
     IAssetListingRepository listingRepository,
-    IMarketDataSymbolRepository symbolRepository) : ControllerBase
+    IMarketDataSymbolRepository symbolRepository,
+    ICurrencyRepository currencyRepository) : ControllerBase
 {
     // ----- Assets -----
 
@@ -44,6 +47,8 @@ public class AssetController(
     {
         if (string.IsNullOrWhiteSpace(dto.Name))
             return BadRequest("Asset name is required.");
+        if (!await IsKnownCurrency(dto.BaseCurrency, cancellationToken))
+            return BadRequest("Base currency must be one of the predefined currencies.");
 
         var created = await assetRepository.Add(dto.ToNewEntity(), cancellationToken);
         return CreatedAtAction(nameof(GetAsset), new { id = created.Id }, created.ToDto());
@@ -57,6 +62,8 @@ public class AssetController(
     {
         if (string.IsNullOrWhiteSpace(dto.Name))
             return BadRequest("Asset name is required.");
+        if (!await IsKnownCurrency(dto.BaseCurrency, cancellationToken))
+            return BadRequest("Base currency must be one of the predefined currencies.");
 
         var entity = dto.ToNewEntity();
         entity.Id = id;
@@ -83,6 +90,8 @@ public class AssetController(
     {
         if (ValidateListing(dto) is string error)
             return BadRequest(error);
+        if (!await IsKnownTradingCurrency(dto.TradingCurrency, cancellationToken))
+            return BadRequest("Trading currency must be one of the predefined currencies.");
         if (await assetRepository.Get(assetId, cancellationToken) is null)
             return NotFound("Asset not found.");
 
@@ -98,6 +107,8 @@ public class AssetController(
     {
         if (ValidateListing(dto) is string error)
             return BadRequest(error);
+        if (!await IsKnownTradingCurrency(dto.TradingCurrency, cancellationToken))
+            return BadRequest("Trading currency must be one of the predefined currencies.");
 
         var existing = await listingRepository.Get(id, cancellationToken);
         if (existing is null) return NotFound();
@@ -158,6 +169,24 @@ public class AssetController(
     {
         var deleted = await symbolRepository.Delete(id, cancellationToken);
         return deleted ? NoContent() : NotFound();
+    }
+
+    // Currency codes must come from the predefined list; free-typed codes are rejected. An empty
+    // base currency is allowed because it is optional on an asset.
+    private async Task<bool> IsKnownCurrency(string? currency, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(currency)) return true;
+        return await currencyRepository.GetByCode(currency, cancellationToken) is not null;
+    }
+
+    // Listings additionally accept minor "pence"-style quote units (e.g. GBX) that exchanges use
+    // as trading currencies but that are not standalone currencies.
+    private async Task<bool> IsKnownTradingCurrency(string? currency, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(currency) && DefaultCurrency.MinorQuoteUnits.ContainsKey(currency.Trim()))
+            return true;
+
+        return await IsKnownCurrency(currency, cancellationToken);
     }
 
     private static string? ValidateListing(AssetListingDto dto)

--- a/code/FinanceManager.Api/Controllers/CurrencyController.cs
+++ b/code/FinanceManager.Api/Controllers/CurrencyController.cs
@@ -1,0 +1,18 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinanceManager.Api.Controllers;
+
+[Route("api/[controller]")]
+[Authorize]
+[ApiController]
+[Tags("Currencies")]
+public class CurrencyController(ICurrencyRepository currencyRepository) : ControllerBase
+{
+    [HttpGet("GetAll")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<Currency>))]
+    public async Task<IActionResult> GetAll(CancellationToken cancellationToken = default) =>
+        Ok(await currencyRepository.GetCurrencies(cancellationToken).OrderBy(x => x.ShortName).ToListAsync(cancellationToken));
+}

--- a/code/FinanceManager.Api/Controllers/UserController.cs
+++ b/code/FinanceManager.Api/Controllers/UserController.cs
@@ -1,6 +1,7 @@
 using FinanceManager.Api.Helpers;
 using FinanceManager.Application.Identity;
 using FinanceManager.Application.Identity.Users;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
 using FinanceManager.Domain.Identity.Commands;
 using FinanceManager.Domain.Identity.Dtos;
 using FinanceManager.Domain.Identity.Entities;
@@ -14,7 +15,7 @@ namespace FinanceManager.Api.Controllers;
 [Route("api/[controller]")]
 [ApiController]
 [Tags("Users")]
-public class UserController(IUserRepository userRepository, UsersService usersService, IUserPlanVerifier userPlanVerifier) : ControllerBase
+public class UserController(IUserRepository userRepository, UsersService usersService, IUserPlanVerifier userPlanVerifier, ICurrencyRepository currencyRepository) : ControllerBase
 {
 
     [AllowAnonymous]
@@ -123,6 +124,26 @@ public class UserController(IUserRepository userRepository, UsersService usersSe
 
         var encryptedPassword = PasswordEncryptionProvider.EncryptPassword(updatePassword.Password);
         var result = await userRepository.UpdatePassword(updatePassword.UserId, encryptedPassword);
+        return result ? Ok(result) : BadRequest();
+    }
+
+    [Authorize(Roles = "Admin, User")]
+    [HttpPut]
+    [Route("UpdatePreferredCurrency")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(bool))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> UpdatePreferredCurrency(UpdatePreferredCurrency updatePreferredCurrency, CancellationToken cancellationToken = default)
+    {
+        // A "User"-role caller may only change their own preferred currency; Admins may change anyone's.
+        if (!ApiAuthenticationHelper.IsAdminOrAuthenticatedUser(User, updatePreferredCurrency.UserId))
+            return Forbid();
+
+        // Only currencies from the predefined list are accepted — the id must exist.
+        if (await currencyRepository.GetCurrency(updatePreferredCurrency.CurrencyId, cancellationToken) is null)
+            return BadRequest("Unknown currency.");
+
+        var result = await userRepository.UpdatePreferredCurrency(updatePreferredCurrency.UserId, updatePreferredCurrency.CurrencyId);
         return result ? Ok(result) : BadRequest();
     }
 

--- a/code/FinanceManager.Api/Migrations/20260712121810_AddExchangeRatesAndUserPreferredCurrency.Designer.cs
+++ b/code/FinanceManager.Api/Migrations/20260712121810_AddExchangeRatesAndUserPreferredCurrency.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceManager.Infrastructure.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceManager.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712121810_AddExchangeRatesAndUserPreferredCurrency")]
+    partial class AddExchangeRatesAndUserPreferredCurrency
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/code/FinanceManager.Api/Migrations/20260712121810_AddExchangeRatesAndUserPreferredCurrency.cs
+++ b/code/FinanceManager.Api/Migrations/20260712121810_AddExchangeRatesAndUserPreferredCurrency.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using System;
+
+#nullable disable
+
+namespace FinanceManager.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExchangeRatesAndUserPreferredCurrency : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PreferredCurrencyId",
+                table: "Users",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "ExchangeRates",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    FromCurrency = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
+                    ToCurrency = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
+                    Date = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Rate = table.Column<decimal>(type: "numeric(18,8)", precision: 18, scale: 8, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExchangeRates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExchangeRates_FromCurrency_ToCurrency_Date",
+                table: "ExchangeRates",
+                columns: new[] { "FromCurrency", "ToCurrency", "Date" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExchangeRates");
+
+            migrationBuilder.DropColumn(
+                name: "PreferredCurrencyId",
+                table: "Users");
+        }
+    }
+}

--- a/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
+++ b/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
@@ -34,13 +34,7 @@ public class InvestmentPriceProvider(
 
     // Minor "pence"-style quote units collapse to their major currency once PriceMultiplier is
     // applied (1 GBX = 0.01 GBP), so FX conversion can use a currency the rate provider knows.
-    private static readonly Dictionary<string, string> _minorToMajorCurrency = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["GBX"] = "GBP",
-        ["GBP."] = "GBP",
-        ["ZAC"] = "ZAR",
-        ["ILA"] = "ILS",
-    };
+    private static readonly IReadOnlyDictionary<string, string> _minorToMajorCurrency = DefaultCurrency.MinorQuoteUnits;
 
     public async Task<decimal> GetPricePerUnitAsync(long assetListingId, Currency targetCurrency, DateTime asOf, CancellationToken ct = default)
     {
@@ -164,7 +158,17 @@ public class InvestmentPriceProvider(
         if (date > DateTime.UtcNow) date = DateTime.UtcNow;
         var sourceCurrency = await currencyRepository.GetOrAdd(sourceCurrencyName, sourceCurrencyName, ct);
         var rate = await currencyExchangeService.GetExchangeRateAsync(sourceCurrency, targetCurrency, date.Date);
-        return rate is decimal value ? price * value : 0m;
+        if (rate is decimal value) return price * value;
+
+        // The preferred currency could not be reached; fall back to USD so the position keeps a
+        // value instead of collapsing to zero.
+        logger.LogWarning("No exchange rate {From}→{To} on {Date}; falling back to USD", sourceCurrency.ShortName, targetCurrency.ShortName, date.Date);
+
+        if (string.Equals(sourceCurrencyName, DefaultCurrency.USD.ShortName, StringComparison.OrdinalIgnoreCase))
+            return price;
+
+        var usdRate = await currencyExchangeService.GetExchangeRateAsync(sourceCurrency, DefaultCurrency.USD, date.Date);
+        return usdRate is decimal toUsd ? price * toUsd : 0m;
     }
 
     private async Task TryFetchAndStoreAsync(AssetListing listing, DateTime start, DateTime end, CancellationToken ct)

--- a/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
+++ b/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
@@ -56,8 +56,11 @@ public class InvestmentPriceProvider(
 
         if (quote is null) return 0m;
 
-        var price = await ConvertAsync(quote.Price, quote.Currency, targetCurrency, asOf, ct);
-        if (price > 0)
+        var (price, direct) = await ConvertAsync(quote.Price, quote.Currency, targetCurrency, asOf, ct);
+
+        // A USD-fallback value is not denominated in the target currency, so caching it under the
+        // target-currency key would serve mislabelled amounts for the whole TTL.
+        if (price > 0 && direct)
             cache.Set(cacheKey, price, new MemoryCacheEntryOptions { AbsoluteExpirationRelativeToNow = _cacheTtl });
 
         return price;
@@ -139,7 +142,7 @@ public class InvestmentPriceProvider(
             {
                 // Dates outside the prefetched range or with a missing rate fall back to the
                 // per-call path so the result matches the point lookup.
-                converted = await ConvertAsync(latestKnown.Price, latestKnown.Currency, targetCurrency, date, ct);
+                (converted, _) = await ConvertAsync(latestKnown.Price, latestKnown.Currency, targetCurrency, date, ct);
             }
 
             if (converted > 0)
@@ -149,26 +152,28 @@ public class InvestmentPriceProvider(
         return series;
     }
 
-    private async Task<decimal> ConvertAsync(decimal price, string sourceCurrencyName, Currency targetCurrency, DateTime date, CancellationToken ct)
+    // Direct is false when the returned value is the USD fallback (i.e. not denominated in
+    // targetCurrency); such values must not be cached under the target currency.
+    private async Task<(decimal Price, bool Direct)> ConvertAsync(decimal price, string sourceCurrencyName, Currency targetCurrency, DateTime date, CancellationToken ct)
     {
-        if (price <= 0) return 0m;
+        if (price <= 0) return (0m, true);
         if (string.Equals(sourceCurrencyName, targetCurrency.ShortName, StringComparison.OrdinalIgnoreCase))
-            return price;
+            return (price, true);
 
         if (date > DateTime.UtcNow) date = DateTime.UtcNow;
         var sourceCurrency = await currencyRepository.GetOrAdd(sourceCurrencyName, sourceCurrencyName, ct);
         var rate = await currencyExchangeService.GetExchangeRateAsync(sourceCurrency, targetCurrency, date.Date);
-        if (rate is decimal value) return price * value;
+        if (rate is decimal value) return (price * value, true);
 
         // The preferred currency could not be reached; fall back to USD so the position keeps a
         // value instead of collapsing to zero.
         logger.LogWarning("No exchange rate {From}→{To} on {Date}; falling back to USD", sourceCurrency.ShortName, targetCurrency.ShortName, date.Date);
 
         if (string.Equals(sourceCurrencyName, DefaultCurrency.USD.ShortName, StringComparison.OrdinalIgnoreCase))
-            return price;
+            return (price, false);
 
         var usdRate = await currencyExchangeService.GetExchangeRateAsync(sourceCurrency, DefaultCurrency.USD, date.Date);
-        return usdRate is decimal toUsd ? price * toUsd : 0m;
+        return usdRate is decimal toUsd ? (price * toUsd, false) : (0m, false);
     }
 
     private async Task TryFetchAndStoreAsync(AssetListing listing, DateTime start, DateTime end, CancellationToken ct)

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
@@ -1,12 +1,11 @@
-﻿using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
-using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
-using FinanceManager.Domain.FinancialAccounts.Shared.Services;
-using FinanceManager.Domain.Identity.Services;
 
 namespace FinanceManager.Application.FinancialAccounts.Currencies.ExchangeRates;
 
 internal class CurrencyExchangeService(
+    IExchangeRateRepository exchangeRateRepository,
     IEnumerable<ICurrencyExchangeRateProvider> providers) : ICurrencyExchangeService
 {
     public async Task<List<(DateTime Date, decimal? Value)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd)
@@ -60,12 +59,52 @@ internal class CurrencyExchangeService(
 
     public async Task<decimal?> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
     {
+        var rate = await ResolveDirectAsync(fromCurrency, toCurrency, date);
+        if (rate is not null) return rate;
+
+        return await ResolveViaUsdAsync(fromCurrency, toCurrency, date);
+    }
+
+    // Cheapest sources first: the application's own database, then the configured providers
+    // (local CSV files, then external APIs). External hits are persisted so the same pair and
+    // date never leave the app twice.
+    private async Task<decimal?> ResolveDirectAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
+    {
+        var stored = await exchangeRateRepository.Get(fromCurrency.ShortName, toCurrency.ShortName, date);
+        if (stored is not null) return stored;
+
+        var storedInverse = await exchangeRateRepository.Get(toCurrency.ShortName, fromCurrency.ShortName, date);
+        if (storedInverse is decimal inverse && inverse != 0) return 1m / inverse;
+
         foreach (var provider in providers)
         {
             var rate = await provider.GetExchangeRateAsync(fromCurrency, toCurrency, date);
-            if (rate is not null) return rate;
+            if (rate is not null)
+            {
+                await exchangeRateRepository.Add(fromCurrency.ShortName, toCurrency.ShortName, date, rate.Value);
+                return rate;
+            }
         }
 
         return null;
     }
+
+    // When no source knows the pair directly, cross through USD (from → USD → to) so values can
+    // still be expressed in the requested currency.
+    private async Task<decimal?> ResolveViaUsdAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
+    {
+        var usd = DefaultCurrency.USD;
+        if (IsUsd(fromCurrency) || IsUsd(toCurrency)) return null;
+
+        var fromToUsd = await ResolveDirectAsync(fromCurrency, usd, date);
+        if (fromToUsd is null) return null;
+
+        var usdToTarget = await ResolveDirectAsync(usd, toCurrency, date);
+        if (usdToTarget is null) return null;
+
+        return fromToUsd * usdToTarget;
+    }
+
+    private static bool IsUsd(Currency currency) =>
+        string.Equals(currency.ShortName, DefaultCurrency.USD.ShortName, StringComparison.OrdinalIgnoreCase);
 }

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/QuoteFactorResolver.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Resolution/QuoteFactorResolver.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 namespace FinanceManager.Application.FinancialAccounts.Stock.Resolution;
 
 public sealed class QuoteFactorResolver(
-    ICurrencyExchangeRateProvider exchangeRateProvider,
+    ICurrencyExchangeService currencyExchangeService,
     ILogger<QuoteFactorResolver> logger) : IQuoteFactorResolver
 {
     // Conversion factors for currency pairs that share a base unit but differ in scale (not FX rates).
@@ -40,7 +40,7 @@ public sealed class QuoteFactorResolver(
         {
             var fromCurr = new Currency { ShortName = from, Symbol = from };
             var toCurr = new Currency { ShortName = to, Symbol = to };
-            var rate = await exchangeRateProvider.GetExchangeRateAsync(fromCurr, toCurr, DateTime.UtcNow);
+            var rate = await currencyExchangeService.GetExchangeRateAsync(fromCurr, toCurr, DateTime.UtcNow);
 
             if (rate.HasValue && rate.Value > 0)
             {

--- a/code/FinanceManager.Application/Identity/Users/SettingsService.cs
+++ b/code/FinanceManager.Application/Identity/Users/SettingsService.cs
@@ -1,5 +1,4 @@
-﻿using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
-using FinanceManager.Domain.FinancialAccounts.Shared.Services;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.Identity.Services;
 
 namespace FinanceManager.Application.Identity.Users;
@@ -7,4 +6,5 @@ namespace FinanceManager.Application.Identity.Users;
 public class SettingsService : ISettingsService
 {
     public Currency GetCurrency() => DefaultCurrency.PLN;
+    public Task<Currency> GetCurrencyAsync() => Task.FromResult(DefaultCurrency.PLN);
 }

--- a/code/FinanceManager.Components/Components/Features/Admin/AdminAddBondDetails.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Admin/AdminAddBondDetails.razor.cs
@@ -34,11 +34,12 @@ public partial class AdminAddBondDetails : ComponentBase
 
     private readonly List<BondCalculationMethod> _calculationMethods = [];
     private readonly IReadOnlyList<BondType> _bondTypes = Enum.GetValues<BondType>();
-    private readonly IReadOnlyList<Currency> _currencies = [DefaultCurrency.PLN, DefaultCurrency.USD];
+    private IReadOnlyList<Currency> _currencies = [DefaultCurrency.PLN, DefaultCurrency.USD];
     private readonly IReadOnlyList<Capitalization> _capitalizations = Enum.GetValues<Capitalization>();
     private readonly IReadOnlyList<DateOperator> _dateOperators = Enum.GetValues<DateOperator>();
 
     [Inject] public required BondDetailsHttpClient BondDetailsHttpClient { get; set; }
+    [Inject] public required CurrencyHttpClient CurrencyHttpClient { get; set; }
     [Inject] public required NavigationManager NavigationManager { get; set; }
 
     protected override async Task OnInitializedAsync()
@@ -46,6 +47,13 @@ public partial class AdminAddBondDetails : ComponentBase
         try
         {
             _issuers = await BondDetailsHttpClient.GetIssuers();
+
+            var currencies = await CurrencyHttpClient.GetAll();
+            if (currencies.Count > 0)
+            {
+                _currencies = currencies;
+                _selectedCurrency = currencies.FirstOrDefault(x => x.ShortName == DefaultCurrency.PLN.ShortName) ?? currencies[0];
+            }
         }
         catch (Exception ex)
         {

--- a/code/FinanceManager.Components/Components/Features/Admin/AdminEditAsset.razor
+++ b/code/FinanceManager.Components/Components/Features/Admin/AdminEditAsset.razor
@@ -56,7 +56,13 @@ else
             <MudTextField T="string" @bind-Value="_asset.Domicile" Label="Domicile" Variant="Variant.Outlined" Margin="Margin.Dense" />
         </MudItem>
         <MudItem xs="12" sm="6">
-            <MudTextField T="string" @bind-Value="_asset.BaseCurrency" Label="Base currency" Variant="Variant.Outlined" Margin="Margin.Dense" />
+            <MudSelect T="string" @bind-Value="_asset.BaseCurrency" Label="Base currency" Clearable
+                       Variant="Variant.Outlined" Margin="Margin.Dense">
+                @foreach (var currency in _currencyOptions)
+                {
+                    <MudSelectItem T="string" Value="@currency">@currency</MudSelectItem>
+                }
+            </MudSelect>
         </MudItem>
         <MudItem xs="12" sm="6">
             <MudSelect T="DistributionPolicy?" @bind-Value="_asset.DistributionPolicy" Label="Distribution policy" Clearable
@@ -212,7 +218,13 @@ else
             <MudTextField T="string" @bind-Value="l.ExchangeName" Label="Exchange name" Variant="Variant.Outlined" Margin="Margin.Dense" />
         </MudItem>
         <MudItem xs="12" sm="4">
-            <MudTextField T="string" @bind-Value="l.TradingCurrency" Label="Trading currency" Variant="Variant.Outlined" Margin="Margin.Dense" />
+            <MudSelect T="string" @bind-Value="l.TradingCurrency" Label="Trading currency"
+                       Variant="Variant.Outlined" Margin="Margin.Dense">
+                @foreach (var currency in TradingCurrencyOptions)
+                {
+                    <MudSelectItem T="string" Value="@currency">@currency</MudSelectItem>
+                }
+            </MudSelect>
         </MudItem>
         <MudItem xs="12" sm="4">
             <MudNumericField T="decimal" @bind-Value="l.PriceMultiplier" Label="Price multiplier" Step="0.01m" Min="0.0000001m"

--- a/code/FinanceManager.Components/Components/Features/Admin/AdminEditAsset.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Admin/AdminEditAsset.razor.cs
@@ -1,6 +1,7 @@
 using FinanceManager.Components.Components.Shared.Dialogs;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Domain.Assets.Dtos;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
 
@@ -11,6 +12,7 @@ public partial class AdminEditAsset : ComponentBase
     [Parameter] public long? Id { get; set; }
 
     [Inject] public required AssetHttpClient AssetHttpClient { get; set; }
+    [Inject] public required CurrencyHttpClient CurrencyHttpClient { get; set; }
     [Inject] public required IDialogService DialogService { get; set; }
 
     private bool _isLoading = true;
@@ -21,6 +23,13 @@ public partial class AdminEditAsset : ComponentBase
     private readonly Dictionary<long, MarketDataSymbolDto> _newSymbols = [];
     private readonly List<string> _errors = [];
     private readonly List<string> _info = [];
+    private List<string> _currencyOptions = [];
+
+    // Listings can also trade in minor "pence"-style quote units (e.g. GBX) that are not
+    // standalone currencies.
+    private IEnumerable<string> TradingCurrencyOptions =>
+        _currencyOptions.Concat(DefaultCurrency.MinorQuoteUnits.Keys
+            .Where(x => !_currencyOptions.Contains(x, StringComparer.OrdinalIgnoreCase)));
 
     private DateTime? InceptionDateTime
     {
@@ -30,6 +39,8 @@ public partial class AdminEditAsset : ComponentBase
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadCurrencyOptions();
+
         if (Id is null or 0)
         {
             _isNew = true;
@@ -39,7 +50,34 @@ public partial class AdminEditAsset : ComponentBase
         }
 
         _asset = await AssetHttpClient.GetAsset(Id.Value);
+        IncludeExistingCurrencies();
         _isLoading = false;
+    }
+
+    private async Task LoadCurrencyOptions()
+    {
+        try
+        {
+            _currencyOptions = [.. (await CurrencyHttpClient.GetAll()).Select(x => x.ShortName)];
+        }
+        catch (Exception ex)
+        {
+            _errors.Insert(0, $"Failed to load currencies: {ex.Message}");
+        }
+    }
+
+    // Older assets can carry a currency that predates the predefined list; keep it selectable so
+    // opening the editor doesn't silently blank the stored value.
+    private void IncludeExistingCurrencies()
+    {
+        if (_asset is null) return;
+
+        List<string?> existing = [_asset.BaseCurrency, .. _asset.Listings.Select(x => x.TradingCurrency)];
+        foreach (var currency in existing)
+        {
+            if (!string.IsNullOrWhiteSpace(currency) && !_currencyOptions.Contains(currency, StringComparer.OrdinalIgnoreCase))
+                _currencyOptions.Add(currency);
+        }
     }
 
     private MarketDataSymbolDto NewSymbol(long listingId)

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/AssetsDistributionOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/AssetsDistributionOverviewCard.razor.cs
@@ -31,9 +31,9 @@ public partial class AssetsDistributionOverviewCard
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        _currency = SettingsService.GetCurrency();
+        _currency = await SettingsService.GetCurrencyAsync();
     }
 
     protected override async Task OnParametersSetAsync()

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentPaycheckEstimatorCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentPaycheckEstimatorCard.razor.cs
@@ -51,10 +51,9 @@ public partial class InvestmentPaycheckEstimatorCard
         }
     }
 
-    protected override Task OnInitializedAsync()
+    protected override async Task OnInitializedAsync()
     {
-        _currency = SettingsService.GetCurrency();
-        return Task.CompletedTask;
+        _currency = await SettingsService.GetCurrencyAsync();
     }
 
     protected override async Task OnParametersSetAsync()

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
@@ -45,9 +45,9 @@ public partial class InvestmentRateCard
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        _currency = SettingsService.GetCurrency();
+        _currency = await SettingsService.GetCurrencyAsync();
     }
 
     protected override async Task OnParametersSetAsync()

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/ClosingBalanceOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/ClosingBalanceOverviewCard.razor.cs
@@ -34,7 +34,7 @@ public partial class ClosingBalanceOverviewCard
 
     private async Task Reload()
     {
-        var currency = SettingsService.GetCurrency();
+        var currency = await SettingsService.GetCurrencyAsync();
         _currency = currency.ShortName;
 
         if (Model is not null)

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/ExpenseDistributionOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/ExpenseDistributionOverviewCard.razor.cs
@@ -31,9 +31,9 @@ public partial class ExpenseDistributionOverviewCard
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        _currency = SettingsService.GetCurrency();
+        _currency = await SettingsService.GetCurrencyAsync();
     }
 
     protected override async Task OnParametersSetAsync()

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/FinancialLabelsListCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/FinancialLabelsListCard.razor.cs
@@ -36,7 +36,7 @@ public partial class FinancialLabelsListCard
     {
         _isLoading = true;
         _hasError = false;
-        _currency = SettingsService.GetCurrency();
+        _currency = await SettingsService.GetCurrencyAsync();
 
         if (Model is not null)
         {

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Liabilities/LiabilitiesDistributionOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Liabilities/LiabilitiesDistributionOverviewCard.razor.cs
@@ -30,9 +30,9 @@ public partial class LiabilitiesDistributionOverviewCard
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
-        _currency = SettingsService.GetCurrency();
+        _currency = await SettingsService.GetCurrencyAsync();
     }
 
     protected override async Task OnParametersSetAsync()

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Liabilities/LiabilitiesTimeSeriesCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Liabilities/LiabilitiesTimeSeriesCard.razor.cs
@@ -36,7 +36,7 @@ public partial class LiabilitiesTimeSeriesCard
         StateHasChanged();
         try
         {
-            _currency = SettingsService.GetCurrency().ShortName;
+            _currency = (await SettingsService.GetCurrencyAsync()).ShortName;
 
             ChartData.Clear();
             var data = await LiabilitiesHttpClient.GetLiabilitiesTimeSeries(user.UserId, StartDateTime, EndDateTime).ToListAsync();

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/NetCashFlowOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/NetCashFlowOverviewCard.razor.cs
@@ -52,7 +52,7 @@ public partial class NetCashFlowOverviewCard
 
     private async Task Reload()
     {
-        var currency = SettingsService.GetCurrency();
+        var currency = await SettingsService.GetCurrencyAsync();
         _currency = currency.ShortName;
         _totalNetCashFlow = null;
 

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/TimeSeries/AssetsTimeSeriesCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/TimeSeries/AssetsTimeSeriesCard.razor.cs
@@ -41,7 +41,7 @@ public partial class AssetsTimeSeriesCard
         StateHasChanged();
         try
         {
-            var currency = SettingsService.GetCurrency();
+            var currency = await SettingsService.GetCurrencyAsync();
             _currency = currency.ShortName;
 
             ChartData.Clear();

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/TimeSeries/NetWorthTimeSeriesCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/TimeSeries/NetWorthTimeSeriesCard.razor.cs
@@ -35,7 +35,7 @@ public partial class NetWorthTimeSeriesCard
     {
         if (Model is not null)
         {
-            _currency = SettingsService.GetCurrency().ShortName;
+            _currency = (await SettingsService.GetCurrencyAsync()).ShortName;
             _series = [.. Model.Series.OrderBy(x => x.DateTime).Select(x => new TimeSeriesModel(x.DateTime, x.Value))];
             _hasError = false;
             _isLoading = false;
@@ -54,7 +54,7 @@ public partial class NetWorthTimeSeriesCard
         StateHasChanged();
         try
         {
-            var currency = SettingsService.GetCurrency();
+            var currency = await SettingsService.GetCurrencyAsync();
             _currency = currency.ShortName;
 
             var netWorth = await MoneyFlowHttpClient.GetNetWorth(user.UserId, currency, StartDateTime, EndDateTime);

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
@@ -97,7 +97,7 @@ public partial class Dashboard : ComponentBase
             return;
         }
 
-        var currency = SettingsService.GetCurrency();
+        var currency = await SettingsService.GetCurrencyAsync();
         var snapshotKey = BuildSnapshotKey(user.UserId);
 
         // Paint the last-rendered snapshot immediately so the page feels instant on

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
@@ -98,7 +98,7 @@ public partial class Dashboard : ComponentBase
         }
 
         var currency = await SettingsService.GetCurrencyAsync();
-        var snapshotKey = BuildSnapshotKey(user.UserId);
+        var snapshotKey = BuildSnapshotKey(user.UserId, currency.Id);
 
         // Paint the last-rendered snapshot immediately so the page feels instant on
         // re-navigation. The API call below always runs and reconciles the view.
@@ -179,7 +179,9 @@ public partial class Dashboard : ComponentBase
     }
 
     // Per-user key with no date component, so a single snapshot per user is overwritten each save.
-    private static string BuildSnapshotKey(int userId) => $"dashboard-overview:{userId}";
+    // The key is currency-scoped so a snapshot saved before a preferred-currency change is never
+    // painted with the new currency's labels.
+    private static string BuildSnapshotKey(int userId, int currencyId) => $"dashboard-overview:{userId}:{currencyId}";
 
     private static bool IsSameAsSnapshot(DashboardOverviewDto overview, DashboardOverviewSnapshot? snapshot)
     {

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
@@ -116,7 +116,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     {
         if (Account is null || Account.Entries is null) return;
 
-        _currency = SettingsService.GetCurrency();
+        _currency = await SettingsService.GetCurrencyAsync();
 
         if (Account.Entries.Count == 0)
         {
@@ -276,7 +276,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     {
         if (Account is null || _user is null) return;
 
-        _currency = SettingsService.GetCurrency();
+        _currency = await SettingsService.GetCurrencyAsync();
         var chartData = await MoneyFlowHttpClient.GetClosingBalance(_user.UserId, _currency, _dateStart, _dateEnd, [AccountId]);
         if (refreshVersion != _chartRefreshVersion) return;
 

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor.cs
@@ -285,7 +285,7 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
     {
         if (Account is null || _user is null) return;
 
-        _currency = SettingsService.GetCurrency();
+        _currency = await SettingsService.GetCurrencyAsync();
         var chartData = await MoneyFlowHttpClient.GetClosingBalance(_user.UserId, _currency, _dateStart, _dateEnd, [AccountId]);
         if (refreshVersion != _chartRefreshVersion) return;
 

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -111,7 +111,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
     private async Task LoadAsync(bool initialLoad = false)
     {
         _isLoading = true;
-        _currency = SettingsService.GetCurrency();
+        _currency = await SettingsService.GetCurrencyAsync();
         try
         {
             _accountName = (await InvestmentAccountHttpClient.GetAccountAsync(AccountId))?.Name ?? "Investments";

--- a/code/FinanceManager.Components/Components/Features/User/UserSettingsPage.razor
+++ b/code/FinanceManager.Components/Components/Features/User/UserSettingsPage.razor
@@ -14,6 +14,7 @@
                              @bind-SelectedValue="_selectedSection"
                              @bind-SelectedValue:after="OnSectionSelectedAfter">
                         <MudListItem T="string" Value="@("profile")" Text="Profile" />
+                        <MudListItem T="string" Value="@("preferences")" Text="Preferences" />
                         <MudListItem T="string" Value="@("password")" Text="Password" />
                         <MudListItem T="string" Value="@("subscription")" Text="Subscription" />
                         <MudListItem T="string" Value="@("danger")" Text="Danger zone" />
@@ -65,6 +66,31 @@
                                           Margin="Margin.Dense"
                                           Value="@_email"
                                           Disabled="true" />
+                        </MudItem>
+                    </MudGrid>
+                </section>
+
+                <MudDivider Class="my-6" />
+
+                <section id="preferences">
+                    <MudText Typo="Typo.h6">Preferences</MudText>
+                    <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
+                        All balances and asset values are recalculated to your preferred currency.
+                    </MudText>
+
+                    <MudGrid>
+                        <MudItem xs="12" md="6">
+                            <MudSelect T="int"
+                                       Label="Preferred currency"
+                                       Variant="Variant.Outlined"
+                                       Margin="Margin.Dense"
+                                       Value="@_selectedCurrencyId"
+                                       ValueChanged="@(v => { _selectedCurrencyId = v; MarkDirty(); })">
+                                @foreach (var currency in _currencies)
+                                {
+                                    <MudSelectItem T="int" Value="@currency.Id">@($"{currency.ShortName} ({currency.Symbol})")</MudSelectItem>
+                                }
+                            </MudSelect>
                         </MudItem>
                     </MudGrid>
                 </section>

--- a/code/FinanceManager.Components/Components/Features/User/UserSettingsPage.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/User/UserSettingsPage.razor.cs
@@ -1,4 +1,7 @@
 using FinanceManager.Application.Identity.Users;
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Components.Services;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
 using FinanceManager.Domain.Identity.Entities;
 using FinanceManager.Domain.Identity.Services;
@@ -36,6 +39,9 @@ public partial class UserSettingsPage : ComponentBase
 
     private string _selectedPlan = $"{PricingLevel.Free}";
     private string _initialPlan = $"{PricingLevel.Free}";
+    private List<Currency> _currencies = [];
+    private int _selectedCurrencyId = DefaultCurrency.PLN.Id;
+    private int _initialCurrencyId = DefaultCurrency.PLN.Id;
     private string? _selectedSection = "profile";
     private string? _deleteConfirmation;
 
@@ -48,6 +54,8 @@ public partial class UserSettingsPage : ComponentBase
 
     [Inject] public required IUserService UserService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
+    [Inject] public required CurrencyHttpClient CurrencyHttpClient { get; set; }
+    [Inject] public required UserSettingsService UserSettingsService { get; set; }
     [Inject] public required NavigationManager NavigationManager { get; set; }
     [Inject] public required IJSRuntime JSRuntime { get; set; }
 
@@ -76,6 +84,20 @@ public partial class UserSettingsPage : ComponentBase
 
         try
         {
+            _currencies = await CurrencyHttpClient.GetAll();
+        }
+        catch (Exception ex)
+        {
+            _errors.Insert(0, ex.Message);
+        }
+
+        _selectedCurrencyId = _currencies.Any(x => x.Id == _userData.PreferredCurrencyId)
+            ? _userData.PreferredCurrencyId
+            : DefaultCurrency.PLN.Id;
+        _initialCurrencyId = _selectedCurrencyId;
+
+        try
+        {
             _recordCapacity = await UserService.GetRecordCapacity(_loggedUser.UserId);
         }
         catch (Exception ex)
@@ -91,6 +113,7 @@ public partial class UserSettingsPage : ComponentBase
     {
         if (_displayName != _initialDisplayName) return true;
         if (_selectedPlan != _initialPlan) return true;
+        if (_selectedCurrencyId != _initialCurrencyId) return true;
         if (!string.IsNullOrEmpty(_currentPassword)) return true;
         if (!string.IsNullOrEmpty(_newPassword)) return true;
         if (!string.IsNullOrEmpty(_confirmPassword)) return true;
@@ -128,6 +151,11 @@ public partial class UserSettingsPage : ComponentBase
             await UpgradePricingPlan();
         }
 
+        if (_selectedCurrencyId != _initialCurrencyId)
+        {
+            await UpdatePreferredCurrency();
+        }
+
         _initialDisplayName = _displayName;
         _isDirty = HasChanges();
     }
@@ -136,6 +164,7 @@ public partial class UserSettingsPage : ComponentBase
     {
         _displayName = _initialDisplayName;
         _selectedPlan = _initialPlan;
+        _selectedCurrencyId = _initialCurrencyId;
         _currentPassword = null;
         _newPassword = null;
         _confirmPassword = null;
@@ -200,6 +229,26 @@ public partial class UserSettingsPage : ComponentBase
         catch (Exception ex)
         {
             _errors.Insert(0, ex.Message);
+        }
+    }
+
+    private async Task UpdatePreferredCurrency()
+    {
+        if (_loggedUser is null) return;
+
+        var result = await UserService.UpdatePreferredCurrency(_loggedUser.UserId, _selectedCurrencyId);
+        if (!result)
+        {
+            _errors.Insert(0, "Failed to change preferred currency.");
+            return;
+        }
+
+        _initialCurrencyId = _selectedCurrencyId;
+        var selectedCurrency = _currencies.FirstOrDefault(x => x.Id == _selectedCurrencyId);
+        if (selectedCurrency is not null)
+        {
+            UserSettingsService.SetCurrency(selectedCurrency);
+            _info.Insert(0, $"Preferred currency changed to {selectedCurrency.ShortName}.");
         }
     }
 

--- a/code/FinanceManager.Components/Components/Layout/MainLayout.razor
+++ b/code/FinanceManager.Components/Components/Layout/MainLayout.razor
@@ -48,6 +48,7 @@
     [Inject] public ILoginService LoginService { get; set; } = default!;
     [Inject] public IUserService UserService { get; set; } = default!;
     [Inject] public IBrowserViewportService BrowserViewportService { get; set; } = default!;
+    [Inject] public ISettingsService SettingsService { get; set; } = default!;
 
     private readonly Guid _viewportSubscriptionId = Guid.NewGuid();
     private string? _greeting;
@@ -62,6 +63,10 @@
     {
         var loggedUser = await LoginService.GetLoggedUser();
         if (loggedUser is null) return;
+
+        // Warm the preferred-currency cache before pages render, so components that read the
+        // display currency synchronously already see the user's preference.
+        await SettingsService.GetCurrencyAsync();
 
         var user = await UserService.GetUser(loggedUser.UserId);
         var firstName = user?.FirstName;

--- a/code/FinanceManager.Components/HttpClients/CurrencyHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/CurrencyHttpClient.cs
@@ -1,0 +1,10 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Components.HttpClients;
+
+public class CurrencyHttpClient(HttpClient httpClient)
+{
+    public async Task<List<Currency>> GetAll() =>
+        await httpClient.GetFromJsonAsync<List<Currency>>($"{httpClient.BaseAddress}api/Currency/GetAll") ?? [];
+}

--- a/code/FinanceManager.Components/HttpClients/UserHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/UserHttpClient.cs
@@ -34,6 +34,12 @@ public class UserHttpClient(HttpClient httpClient)
         return response.IsSuccessStatusCode;
     }
 
+    public async Task<bool> UpdatePreferredCurrency(UpdatePreferredCurrency updatePreferredCurrency)
+    {
+        var response = await httpClient.PutAsJsonAsync($"{httpClient.BaseAddress}api/User/UpdatePreferredCurrency/", updatePreferredCurrency);
+        return response.IsSuccessStatusCode;
+    }
+
     public async Task<bool> UpdateRole(UpdateUserRole updateUserRole)
     {
         var response = await httpClient.PutAsJsonAsync($"{httpClient.BaseAddress}api/User/UpdateUserRole/", updateUserRole);

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -58,8 +58,11 @@ public static class ServiceCollectionExtension
                 .AddScoped<ISnapshotService, LocalStorageSnapshotService>()
                 .AddScoped<AssetsPageCardsCacheService>()
                 .AddScoped<InvestmentPaycheckEstimateCacheService>()
+                .AddScoped<CurrencyHttpClient>()
                 .AddScoped<IUserService, UserService>()
                 .AddScoped<IFinancialAccountService, FinancialAccountService>()
+                .AddScoped<UserSettingsService>()
+                .AddScoped<ISettingsService>(sp => sp.GetRequiredService<UserSettingsService>())
                 .AddScoped<IUserRepository, UserLocalStorageRepository>();
         ;
 

--- a/code/FinanceManager.Components/Services/AssetsPageCardsCacheService.cs
+++ b/code/FinanceManager.Components/Services/AssetsPageCardsCacheService.cs
@@ -34,9 +34,11 @@ public class AssetsPageCardsCacheService(
         var startDate = refreshContext.StartDateTime.Date;
         var endDate = refreshContext.EndDateTime;
 
-        var assetsTimeSeriesTask = assetsHttpClient.GetAssetsTimeSeries(refreshContext.UserId, DefaultCurrency.PLN, startDate, endDate);
-        var assetsPerTypeTask = assetsHttpClient.GetEndAssetsPerType(refreshContext.UserId, DefaultCurrency.PLN, endDate);
-        var assetsPerAccountTask = assetsHttpClient.GetEndAssetsPerAccount(refreshContext.UserId, DefaultCurrency.PLN, endDate);
+        // Only the id crosses the wire, so the requested currency can be rebuilt from the context.
+        var currency = new Currency { Id = refreshContext.CurrencyId };
+        var assetsTimeSeriesTask = assetsHttpClient.GetAssetsTimeSeries(refreshContext.UserId, currency, startDate, endDate);
+        var assetsPerTypeTask = assetsHttpClient.GetEndAssetsPerType(refreshContext.UserId, currency, endDate);
+        var assetsPerAccountTask = assetsHttpClient.GetEndAssetsPerAccount(refreshContext.UserId, currency, endDate);
         var investmentRateTask = moneyFlowHttpClient.GetInvestmentRate(refreshContext.UserId, startDate, endDate).ToListAsync().AsTask();
         var monthlyInvestmentRatesTask = GetMonthlyInvestmentRatesAsync(refreshContext.UserId, endDate);
 

--- a/code/FinanceManager.Components/Services/DashboardOverviewCardsCacheService.cs
+++ b/code/FinanceManager.Components/Services/DashboardOverviewCardsCacheService.cs
@@ -32,8 +32,10 @@ public class DashboardOverviewCardsCacheService(
         var startDate = refreshContext.StartDateTime.Date;
         var endDate = refreshContext.EndDateTime;
 
-        var netCashFlowTask = moneyFlowHttpClient.GetNetCashFlow(refreshContext.UserId, DefaultCurrency.PLN, startDate, endDate);
-        var closingBalanceTask = moneyFlowHttpClient.GetClosingBalance(refreshContext.UserId, DefaultCurrency.PLN, startDate, endDate);
+        // Only the id crosses the wire, so the requested currency can be rebuilt from the context.
+        var currency = new Currency { Id = refreshContext.CurrencyId };
+        var netCashFlowTask = moneyFlowHttpClient.GetNetCashFlow(refreshContext.UserId, currency, startDate, endDate);
+        var closingBalanceTask = moneyFlowHttpClient.GetClosingBalance(refreshContext.UserId, currency, startDate, endDate);
 
         await Task.WhenAll(netCashFlowTask, closingBalanceTask);
 

--- a/code/FinanceManager.Components/Services/UserLocalStorageRepository.cs
+++ b/code/FinanceManager.Components/Services/UserLocalStorageRepository.cs
@@ -162,6 +162,7 @@ public class UserLocalStorageRepository(ILocalStorageService localStorageService
 
     public Task<bool> UpdatePassword(int userId, string password) => throw new NotImplementedException();
     public Task<bool> UpdatePricingPlan(int userId, PricingLevel pricingLevel) => throw new NotImplementedException();
+    public Task<bool> UpdatePreferredCurrency(int userId, int currencyId) => throw new NotImplementedException();
     public Task<User?> GetUser(string login) => throw new NotImplementedException();
     public Task<int> GetUsersCount() => throw new NotImplementedException();
     public IAsyncEnumerable<User> GetUsers(DateTime startDate, DateTime endDate) => throw new NotImplementedException();

--- a/code/FinanceManager.Components/Services/UserService.cs
+++ b/code/FinanceManager.Components/Services/UserService.cs
@@ -108,6 +108,26 @@ public class UserService(UserHttpClient httpClient, ILogger<UserService> logger)
         return false;
     }
 
+    public async Task<bool> UpdatePreferredCurrency(int userId, int currencyId)
+    {
+        try
+        {
+            var existingUser = await GetUser(userId);
+            if (existingUser is null) return false;
+            if (await httpClient.UpdatePreferredCurrency(new(userId, currencyId)))
+            {
+                OnUserChangeEvent?.Invoke(existingUser);
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error updating preferred currency for user {UserId}", userId);
+        }
+
+        return false;
+    }
+
     public async Task<bool> UpdateRole(int userId, UserRole userRole)
     {
         try

--- a/code/FinanceManager.Components/Services/UserSettingsService.cs
+++ b/code/FinanceManager.Components/Services/UserSettingsService.cs
@@ -1,0 +1,48 @@
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.Identity.Services;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Components.Services;
+
+/// <summary>
+/// Resolves the logged-in user's preferred currency once per app lifetime and hands it to every
+/// component that presents money, so all assets are recalculated to that currency.
+/// </summary>
+public class UserSettingsService(
+    ILoginService loginService,
+    IUserService userService,
+    CurrencyHttpClient currencyHttpClient,
+    ILogger<UserSettingsService> logger) : ISettingsService
+{
+    private Currency? _cachedCurrency;
+
+    public Currency GetCurrency() => _cachedCurrency ?? DefaultCurrency.PLN;
+
+    public async Task<Currency> GetCurrencyAsync()
+    {
+        if (_cachedCurrency is not null) return _cachedCurrency;
+
+        try
+        {
+            var loggedUser = await loginService.GetLoggedUser();
+            if (loggedUser is null) return DefaultCurrency.PLN;
+
+            var user = await userService.GetUser(loggedUser.UserId);
+            if (user is null) return DefaultCurrency.PLN;
+
+            var currencies = await currencyHttpClient.GetAll();
+            _cachedCurrency = currencies.FirstOrDefault(x => x.Id == user.PreferredCurrencyId) ?? DefaultCurrency.PLN;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to resolve the user's preferred currency; falling back to {Currency}", DefaultCurrency.PLN.ShortName);
+            return DefaultCurrency.PLN;
+        }
+
+        return _cachedCurrency;
+    }
+
+    /// <summary>Refreshes the cached currency after the user changed the preference in settings.</summary>
+    public void SetCurrency(Currency currency) => _cachedCurrency = currency;
+}

--- a/code/FinanceManager.Domain/FinancialAccounts/Currencies/Entities/DefaultCurrency.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Currencies/Entities/DefaultCurrency.cs
@@ -1,7 +1,39 @@
-﻿namespace FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+namespace FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 
 public static class DefaultCurrency
 {
     public static Currency PLN => new(0, "PLN", "zł");
     public static Currency USD => new(1, "USD", "$");
+
+    /// <summary>
+    /// Codes and symbols seeded into the predefined currency list (besides <see cref="PLN"/> and
+    /// <see cref="USD"/>). Ids are assigned at insert time so they never clash with currencies
+    /// already added by imports.
+    /// </summary>
+    public static IReadOnlyList<(string ShortName, string Symbol)> CommonCurrencies =>
+    [
+        ("EUR", "€"),
+        ("GBP", "£"),
+        ("CHF", "CHF"),
+        ("JPY", "¥"),
+        ("CZK", "Kč"),
+        ("SEK", "kr"),
+        ("NOK", "kr"),
+        ("DKK", "kr"),
+        ("HUF", "Ft"),
+        ("CAD", "C$"),
+        ("AUD", "A$"),
+    ];
+
+    /// <summary>
+    /// Minor "pence"-style quote units that legitimately appear as listing trading currencies and
+    /// collapse to their major currency once a price multiplier is applied (1 GBX = 0.01 GBP).
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, string> MinorQuoteUnits = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["GBX"] = "GBP",
+        ["GBP."] = "GBP",
+        ["ZAC"] = "ZAR",
+        ["ILA"] = "ILS",
+    };
 }

--- a/code/FinanceManager.Domain/FinancialAccounts/Currencies/Entities/ExchangeRate.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Currencies/Entities/ExchangeRate.cs
@@ -1,0 +1,10 @@
+namespace FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+
+public class ExchangeRate
+{
+    public long Id { get; set; }
+    public required string FromCurrency { get; set; }
+    public required string ToCurrency { get; set; }
+    public DateTime Date { get; set; }
+    public decimal Rate { get; set; }
+}

--- a/code/FinanceManager.Domain/FinancialAccounts/Currencies/Repositories/IExchangeRateRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Currencies/Repositories/IExchangeRateRepository.cs
@@ -1,0 +1,7 @@
+namespace FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+
+public interface IExchangeRateRepository
+{
+    public Task<decimal?> Get(string fromCurrency, string toCurrency, DateTime date, CancellationToken ct = default);
+    public Task Add(string fromCurrency, string toCurrency, DateTime date, decimal rate, CancellationToken ct = default);
+}

--- a/code/FinanceManager.Domain/Identity/Commands/UpdatePreferredCurrency.cs
+++ b/code/FinanceManager.Domain/Identity/Commands/UpdatePreferredCurrency.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace FinanceManager.Domain.Identity.Commands;
+
+// No range on UserId: guest sandbox accounts use negative ids, and the endpoint already restricts
+// callers to their own account (or an admin).
+public record UpdatePreferredCurrency(
+    int UserId,
+    [Range(0, int.MaxValue)] int CurrencyId);

--- a/code/FinanceManager.Domain/Identity/Dtos/UserDto.cs
+++ b/code/FinanceManager.Domain/Identity/Dtos/UserDto.cs
@@ -19,6 +19,8 @@ public class UserDto
     /// <summary>When set and still in the future, logins for this account are refused until this UTC instant.</summary>
     public DateTime? LockoutEndUtc { get; set; }
 
+    /// <summary>Currency all asset values are presented in for this user. Defaults to PLN.</summary>
+    public int PreferredCurrencyId { get; set; }
 
     public User ToUser() => new()
     {
@@ -28,7 +30,8 @@ public class UserDto
         LastName = LastName,
         PricingLevel = PricingLevel,
         UserRole = UserRole,
-        CreationDate = CreationDate
+        CreationDate = CreationDate,
+        PreferredCurrencyId = PreferredCurrencyId
     };
 
 }

--- a/code/FinanceManager.Domain/Identity/Dtos/UserDto.cs
+++ b/code/FinanceManager.Domain/Identity/Dtos/UserDto.cs
@@ -1,4 +1,5 @@
-﻿using FinanceManager.Domain.Identity.Entities;
+﻿using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.Identity.Entities;
 
 namespace FinanceManager.Domain.Identity.Dtos;
 
@@ -20,7 +21,7 @@ public class UserDto
     public DateTime? LockoutEndUtc { get; set; }
 
     /// <summary>Currency all asset values are presented in for this user. Defaults to PLN.</summary>
-    public int PreferredCurrencyId { get; set; }
+    public int PreferredCurrencyId { get; set; } = DefaultCurrency.PLN.Id;
 
     public User ToUser() => new()
     {

--- a/code/FinanceManager.Domain/Identity/Entities/User.cs
+++ b/code/FinanceManager.Domain/Identity/Entities/User.cs
@@ -11,4 +11,7 @@ public class User
     public PricingLevel PricingLevel { get; set; } = PricingLevel.Free;
     public UserRole UserRole { get; set; } = UserRole.User;
     public required DateTime CreationDate { get; set; }
+
+    /// <summary>Currency all asset values are presented in for this user. Defaults to PLN.</summary>
+    public int PreferredCurrencyId { get; set; }
 }

--- a/code/FinanceManager.Domain/Identity/Repositories/IUserRepository.cs
+++ b/code/FinanceManager.Domain/Identity/Repositories/IUserRepository.cs
@@ -13,6 +13,7 @@ public interface IUserRepository
     IAsyncEnumerable<int> GetUsersIds(int recordIndex, int recordsCount);
     Task<bool> UpdatePassword(int userId, string password);
     Task<bool> UpdatePricingPlan(int userId, PricingLevel pricingLevel);
+    Task<bool> UpdatePreferredCurrency(int userId, int currencyId);
     Task<bool> AddUser(string login, string password, PricingLevel pricingLevel, UserRole userRole, string? firstName = null, string? lastName = null);
 
     /// <summary>

--- a/code/FinanceManager.Domain/Identity/Services/ISettingsService.cs
+++ b/code/FinanceManager.Domain/Identity/Services/ISettingsService.cs
@@ -1,8 +1,12 @@
-﻿using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 
 namespace FinanceManager.Domain.Identity.Services;
 
 public interface ISettingsService
 {
+    /// <summary>Last resolved display currency; falls back to the app default until <see cref="GetCurrencyAsync"/> ran.</summary>
     Currency GetCurrency();
+
+    /// <summary>Resolves the logged-in user's preferred currency, falling back to the app default.</summary>
+    Task<Currency> GetCurrencyAsync();
 }

--- a/code/FinanceManager.Domain/Identity/Services/IUserService.cs
+++ b/code/FinanceManager.Domain/Identity/Services/IUserService.cs
@@ -12,6 +12,7 @@ public interface IUserService
     Task<bool> Delete(int userId);
     Task<bool> UpdatePassword(int userId, string newPassword, string? currentPassword = null);
     Task<bool> UpdatePricingPlan(int userId, PricingLevel newPricingLevel);
+    Task<bool> UpdatePreferredCurrency(int userId, int currencyId);
     Task<bool> UpdateRole(int userId, UserRole userRole);
 
 }

--- a/code/FinanceManager.Infrastructure/Contexts/AppDbContext.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/AppDbContext.cs
@@ -24,6 +24,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<RefreshToken> RefreshTokens { get; set; } = default!;
     public DbSet<PasswordResetToken> PasswordResetTokens { get; set; } = default!;
     public DbSet<Currency> Currencies { get; set; } = default!;
+    public DbSet<ExchangeRate> ExchangeRates { get; set; } = default!;
     public DbSet<FinancialAccountBaseDto> Accounts { get; set; } = default!;
     public DbSet<CurrencyAccountEntry> CurrencyEntries { get; set; } = default!;
     public DbSet<BondAccountEntry> BondEntries { get; set; } = default!;
@@ -51,6 +52,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.ApplyConfiguration(new FinancialAccountBaseDtoConfiguration());
         modelBuilder.ApplyConfiguration(new CurrencyAccountEntryConfiguration());
         modelBuilder.ApplyConfiguration(new CurrencyConfiguration());
+        modelBuilder.ApplyConfiguration(new ExchangeRateConfiguration());
         modelBuilder.ApplyConfiguration(new BondAccountEntryConfiguration());
         modelBuilder.ApplyConfiguration(new NewVisitsConfiguration());
         modelBuilder.ApplyConfiguration(new FinancialInsightConfiguration());

--- a/code/FinanceManager.Infrastructure/Contexts/Configurations/ExchangeRateConfiguration.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/Configurations/ExchangeRateConfiguration.cs
@@ -1,0 +1,18 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FinanceManager.Infrastructure.Contexts.Configurations;
+
+public class ExchangeRateConfiguration : IEntityTypeConfiguration<ExchangeRate>
+{
+    public void Configure(EntityTypeBuilder<ExchangeRate> builder)
+    {
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedOnAdd();
+        builder.Property(x => x.FromCurrency).HasMaxLength(8).IsRequired();
+        builder.Property(x => x.ToCurrency).HasMaxLength(8).IsRequired();
+        builder.Property(x => x.Rate).HasPrecision(18, 8);
+        builder.HasIndex(x => new { x.FromCurrency, x.ToCurrency, x.Date }).IsUnique();
+    }
+}

--- a/code/FinanceManager.Infrastructure/Repositories/CurrencyRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/CurrencyRepository.cs
@@ -63,9 +63,20 @@ public class CurrencyRepository(AppDbContext context) : ICurrencyRepository
             .Where(x => !existingCodes.Contains(x.ShortName, StringComparer.OrdinalIgnoreCase))
             .ToList();
 
-        if (missingDefaults.Count == 0) return;
+        var missingCommon = DefaultCurrency.CommonCurrencies
+            .Where(x => !existingCodes.Contains(x.ShortName, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+
+        if (missingDefaults.Count == 0 && missingCommon.Count == 0) return;
 
         context.Currencies.AddRange(missingDefaults);
+
+        // Common currencies get ids after every already-stored currency, so they never collide
+        // with ids handed out earlier by GetOrAdd.
+        var nextId = Math.Max(await context.Currencies.MaxAsync(x => (int?)x.Id, ct) ?? 1, 1) + 1;
+        foreach (var (shortName, symbol) in missingCommon)
+            context.Currencies.Add(new Currency(nextId++, shortName, symbol));
+
         await context.SaveChangesAsync(ct);
     }
 

--- a/code/FinanceManager.Infrastructure/Repositories/ExchangeRateRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/ExchangeRateRepository.cs
@@ -1,0 +1,85 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Infrastructure.Contexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Infrastructure.Repositories;
+
+public class ExchangeRateRepository(AppDbContext context) : IExchangeRateRepository
+{
+    // Exchange-rate lookups are fanned out in parallel batches (one task per date), but they all
+    // share this scoped repository and its DbContext, which is not thread-safe. Serialise the
+    // context access here so callers may keep their parallelism for the provider HTTP calls.
+    private readonly SemaphoreSlim _contextLock = new(1, 1);
+
+    public async Task<decimal?> Get(string fromCurrency, string toCurrency, DateTime date, CancellationToken ct = default)
+    {
+        var from = Normalize(fromCurrency);
+        var to = Normalize(toCurrency);
+        var day = NormalizeDate(date);
+
+        await _contextLock.WaitAsync(ct);
+        try
+        {
+            var rate = await context.ExchangeRates
+                .AsNoTracking()
+                .FirstOrDefaultAsync(x => x.FromCurrency == from && x.ToCurrency == to && x.Date == day, ct);
+
+            return rate?.Rate;
+        }
+        finally
+        {
+            _contextLock.Release();
+        }
+    }
+
+    public async Task Add(string fromCurrency, string toCurrency, DateTime date, decimal rate, CancellationToken ct = default)
+    {
+        var from = Normalize(fromCurrency);
+        var to = Normalize(toCurrency);
+        var day = NormalizeDate(date);
+
+        await _contextLock.WaitAsync(ct);
+        try
+        {
+            var existing = await context.ExchangeRates
+                .FirstOrDefaultAsync(x => x.FromCurrency == from && x.ToCurrency == to && x.Date == day, ct);
+
+            if (existing is not null)
+            {
+                existing.Rate = rate;
+            }
+            else
+            {
+                context.ExchangeRates.Add(new ExchangeRate
+                {
+                    FromCurrency = from,
+                    ToCurrency = to,
+                    Date = day,
+                    Rate = rate
+                });
+            }
+
+            try
+            {
+                await context.SaveChangesAsync(ct);
+            }
+            catch (DbUpdateException)
+            {
+                // A concurrent request persisted the same (from, to, date) row between the lookup
+                // above and this insert; the unique index rejected the duplicate. The rate is
+                // already stored.
+                context.ChangeTracker.Clear();
+            }
+        }
+        finally
+        {
+            _contextLock.Release();
+        }
+    }
+
+    private static string Normalize(string currency) => currency.Trim().ToUpperInvariant();
+
+    // Rates are daily; store the UTC day start so lookups are exact and PostgreSQL accepts the value.
+    private static DateTime NormalizeDate(DateTime date) => DateTime.SpecifyKind(date.Date, DateTimeKind.Utc);
+}

--- a/code/FinanceManager.Infrastructure/Repositories/ExchangeRateRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/ExchangeRateRepository.cs
@@ -66,10 +66,13 @@ public class ExchangeRateRepository(AppDbContext context) : IExchangeRateReposit
             }
             catch (DbUpdateException)
             {
-                // A concurrent request persisted the same (from, to, date) row between the lookup
-                // above and this insert; the unique index rejected the duplicate. The rate is
-                // already stored.
+                // The unique (from, to, date) index rejected the insert. If the row now exists, a
+                // concurrent request stored the rate between the lookup above and this insert and
+                // nothing is lost; any other write failure must surface unchanged.
                 context.ChangeTracker.Clear();
+                if (!await context.ExchangeRates.AsNoTracking()
+                        .AnyAsync(x => x.FromCurrency == from && x.ToCurrency == to && x.Date == day, ct))
+                    throw;
             }
         }
         finally

--- a/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
@@ -207,8 +207,8 @@ public class UserRepository(AppDbContext context) : IUserRepository
         var user = await context.Users.FirstOrDefaultAsync(x => x.Id == userId);
         if (user is null) return false;
 
+        // The entity is already tracked; change tracking persists just this property.
         user.PreferredCurrencyId = currencyId;
-        context.Update(user);
         await context.SaveChangesAsync();
 
         return true;

--- a/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
@@ -202,6 +202,17 @@ public class UserRepository(AppDbContext context) : IUserRepository
 
         return await Task.FromResult(true);
     }
+    public async Task<bool> UpdatePreferredCurrency(int userId, int currencyId)
+    {
+        var user = await context.Users.FirstOrDefaultAsync(x => x.Id == userId);
+        if (user is null) return false;
+
+        user.PreferredCurrencyId = currencyId;
+        context.Update(user);
+        await context.SaveChangesAsync();
+
+        return true;
+    }
     public async Task<bool> UpdatePricingPlan(int userId, PricingLevel pricingLevel)
     {
         var user = await context.Users.FirstOrDefaultAsync(x => x.Id == userId);

--- a/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
@@ -68,7 +68,7 @@ public static class ServiceCollectionExtension
         services.AddScoped<IOpenFigiClient>(sp => sp.GetRequiredService<OpenFigiClient>());
         services.AddScoped<IQuoteFactorResolver>(sp =>
             new QuoteFactorResolver(
-                sp.GetRequiredService<ICurrencyExchangeRateProvider>(),
+                sp.GetRequiredService<ICurrencyExchangeService>(),
                 sp.GetRequiredService<ILogger<QuoteFactorResolver>>()));
         services.AddScoped<IInstrumentResolver>(sp =>
             new InstrumentResolver(
@@ -102,6 +102,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<IFinancialInsightsRepository, FinancialInsightsRepository>()
                 .AddScoped<IFinancialLabelsRepository, FinancialLabelsRepository>()
                 .AddScoped<ICurrencyRepository, CurrencyRepository>()
+                .AddScoped<IExchangeRateRepository, ExchangeRateRepository>()
                 .AddScoped<IBondDetailsRepository, BondDetailsRepository>()
                 .AddScoped<ICsvHeaderMappingRepository, CsvHeaderMappingRepository>()
                 .AddScoped<IInflationDataProvider, InMemoryInflationDataProvider>()

--- a/code/FinanceManager.Tests.Integration/Controllers/CurrencyControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/CurrencyControllerTests.cs
@@ -1,0 +1,61 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Infrastructure.Contexts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public class CurrencyControllerTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider), IDisposable
+{
+    private TestDatabase? _testDatabase;
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        _testDatabase = new TestDatabase();
+
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+        if (descriptor != null)
+            services.Remove(descriptor);
+
+        services.AddSingleton(_testDatabase!.Context);
+    }
+
+    [Fact]
+    public async Task GetAll_Anonymous_IsUnauthorized()
+    {
+        ClearAuthorization();
+
+        var response = await Client.GetAsync("api/Currency/GetAll", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsPredefinedCurrenciesSortedByCode()
+    {
+        Authorize("TestUser", 1, UserRole.User);
+
+        var currencies = await Client.GetFromJsonAsync<List<Currency>>("api/Currency/GetAll", TestContext.Current.CancellationToken);
+
+        Assert.NotNull(currencies);
+        Assert.Contains(currencies, x => x.ShortName == DefaultCurrency.PLN.ShortName);
+        Assert.Contains(currencies, x => x.ShortName == DefaultCurrency.USD.ShortName);
+        foreach (var (shortName, _) in DefaultCurrency.CommonCurrencies)
+            Assert.Contains(currencies, x => x.ShortName == shortName);
+
+        Assert.Equal(currencies.OrderBy(x => x.ShortName, StringComparer.Ordinal).Select(x => x.ShortName), currencies.Select(x => x.ShortName));
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+        _testDatabase?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
@@ -1,5 +1,6 @@
 using FinanceManager.Application.FinancialAccounts.Currencies.ExchangeRates;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
@@ -20,6 +21,7 @@ public class CurrencyExchangeServiceTests : IDisposable
 {
     private readonly ILogger<FawazAhmedCurrencyApiClient> _loggerMock = LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<FawazAhmedCurrencyApiClient>();
     private readonly Mock<HttpMessageHandler> _httpMessageHandlerMock = new();
+    private readonly Mock<IExchangeRateRepository> _exchangeRateRepositoryMock = new();
     private readonly HttpClient _httpClient;
 
     public CurrencyExchangeServiceTests()
@@ -237,10 +239,110 @@ public class CurrencyExchangeServiceTests : IDisposable
         Assert.Equal(expectedRate, result.Value);
     }
 
+    [Fact]
+    public async Task GetExchangeRateAsync_RateStoredInDatabase_DoesNotCallExternalProvider()
+    {
+        // Arrange
+        var fromCurrency = new Currency(1, "USD", "$");
+        var toCurrency = new Currency(2, "EUR", "€");
+        var date = new DateTime(2024, 1, 15);
+
+        _exchangeRateRepositoryMock
+            .Setup(x => x.Get("USD", "EUR", date, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0.92m);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, date);
+
+        // Assert
+        Assert.Equal(0.92m, result);
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetExchangeRateAsync_InverseRateStoredInDatabase_ReturnsInvertedRateWithoutExternalCall()
+    {
+        // Arrange
+        var fromCurrency = new Currency(1, "USD", "$");
+        var toCurrency = new Currency(2, "EUR", "€");
+        var date = new DateTime(2024, 1, 15);
+
+        _exchangeRateRepositoryMock
+            .Setup(x => x.Get("EUR", "USD", date, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2m);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, date);
+
+        // Assert
+        Assert.Equal(0.5m, result);
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetExchangeRateAsync_ExternalProviderHit_PersistsRateToDatabase()
+    {
+        // Arrange
+        var fromCurrency = new Currency(1, "USD", "$");
+        var toCurrency = new Currency(2, "EUR", "€");
+        var date = new DateTime(2024, 1, 15);
+
+        var jsonResponse = @"{""usd"": {""eur"": 0.92}}";
+        SetupHttpResponse(HttpStatusCode.OK, jsonResponse);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, date);
+
+        // Assert
+        Assert.Equal(0.92m, result);
+        _exchangeRateRepositoryMock.Verify(x => x.Add("USD", "EUR", date, 0.92m, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetExchangeRateAsync_DirectPairUnavailable_FallsBackToUsdCrossRate()
+    {
+        // Arrange
+        var fromCurrency = new Currency(1, "GBP", "£");
+        var toCurrency = new Currency(2, "PLN", "zł");
+        var date = new DateTime(2024, 1, 15);
+
+        _exchangeRateRepositoryMock
+            .Setup(x => x.Get("GBP", "USD", date, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1.25m);
+        _exchangeRateRepositoryMock
+            .Setup(x => x.Get("USD", "PLN", date, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(4m);
+
+        // The direct GBP→PLN lookup misses everywhere, including the external provider.
+        SetupHttpResponse(HttpStatusCode.NotFound, "Not found");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, date);
+
+        // Assert
+        Assert.Equal(5m, result);
+    }
+
     private CurrencyExchangeService CreateService()
     {
         ICurrencyExchangeRateProvider[] providers = [new FawazAhmedCurrencyApiClient(_httpClient, _loggerMock)];
-        return new CurrencyExchangeService(providers);
+        return new CurrencyExchangeService(_exchangeRateRepositoryMock.Object, providers);
     }
     public void Dispose() => _httpClient?.Dispose();
     private void SetupHttpResponse(HttpStatusCode statusCode, string content)

--- a/code/FinanceManager.Tests.Unit/Application/Services/Stocks/QuoteFactorResolverTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Stocks/QuoteFactorResolverTests.cs
@@ -12,10 +12,10 @@ namespace FinanceManager.Tests.Unit.Application.Services.Stocks;
 [Trait("Category", "Unit")]
 public class QuoteFactorResolverTests
 {
-    private readonly Mock<ICurrencyExchangeService> _exchangeRateProviderMock = new();
+    private readonly Mock<ICurrencyExchangeService> _currencyExchangeServiceMock = new();
     private readonly ILogger<QuoteFactorResolver> _logger = LoggerFactory.Create(_ => { }).CreateLogger<QuoteFactorResolver>();
 
-    private QuoteFactorResolver CreateResolver() => new(_exchangeRateProviderMock.Object, _logger);
+    private QuoteFactorResolver CreateResolver() => new(_currencyExchangeServiceMock.Object, _logger);
 
     [Fact]
     public async Task ResolveAsync_GbxToGbp_Returns0point01()
@@ -26,7 +26,7 @@ public class QuoteFactorResolverTests
 
         // 1 GBX (penny) = 0.01 GBP; contract is multiply from-amount by factor to get to-amount.
         Assert.Equal(0.01m, factor);
-        _exchangeRateProviderMock.Verify(
+        _currencyExchangeServiceMock.Verify(
             x => x.GetExchangeRateAsync(It.IsAny<Currency>(), It.IsAny<Currency>(), It.IsAny<DateTime>()),
             Times.Never);
     }
@@ -55,7 +55,7 @@ public class QuoteFactorResolverTests
     public async Task ResolveAsync_UnknownPair_FallsBackToExchangeRateApi()
     {
         var resolver = CreateResolver();
-        _exchangeRateProviderMock
+        _currencyExchangeServiceMock
             .Setup(x => x.GetExchangeRateAsync(
                 It.Is<Currency>(c => c.ShortName == "USD"),
                 It.Is<Currency>(c => c.ShortName == "EUR"),
@@ -71,7 +71,7 @@ public class QuoteFactorResolverTests
     public async Task ResolveAsync_WhenExchangeApiFails_Returns1()
     {
         var resolver = CreateResolver();
-        _exchangeRateProviderMock
+        _currencyExchangeServiceMock
             .Setup(x => x.GetExchangeRateAsync(It.IsAny<Currency>(), It.IsAny<Currency>(), It.IsAny<DateTime>()))
             .ThrowsAsync(new HttpRequestException("network down"));
 

--- a/code/FinanceManager.Tests.Unit/Application/Services/Stocks/QuoteFactorResolverTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Stocks/QuoteFactorResolverTests.cs
@@ -12,7 +12,7 @@ namespace FinanceManager.Tests.Unit.Application.Services.Stocks;
 [Trait("Category", "Unit")]
 public class QuoteFactorResolverTests
 {
-    private readonly Mock<ICurrencyExchangeRateProvider> _exchangeRateProviderMock = new();
+    private readonly Mock<ICurrencyExchangeService> _exchangeRateProviderMock = new();
     private readonly ILogger<QuoteFactorResolver> _logger = LoggerFactory.Create(_ => { }).CreateLogger<QuoteFactorResolver>();
 
     private QuoteFactorResolver CreateResolver() => new(_exchangeRateProviderMock.Object, _logger);


### PR DESCRIPTION
# Summary

This PR delivers the currency-management overhaul in three parts:

## 1. No more free-typed currencies
- **Admin → Edit asset**: *Base currency* and *Trading currency* were free-text `MudTextField`s — they are now dropdowns fed from the currency list. Trading currency additionally offers pence-style quote units (GBX, GBP., ZAC, ILA), which now live in `DefaultCurrency.MinorQuoteUnits` (shared with `InvestmentPriceProvider`).
- **Admin → Add bond details**: the hardcoded `[PLN, USD]` list is replaced by the fetched currency list.
- **Server-side enforcement**: the asset admin API rejects currency codes outside the predefined list, and `UpdatePreferredCurrency` validates the currency id exists.
- New `GET api/Currency/GetAll` endpoint + `CurrencyHttpClient`; the seeded currency list now includes EUR, GBP, CHF, JPY, CZK, SEK, NOK, DKK, HUF, CAD, AUD besides PLN and USD (ids assigned after existing rows so they never collide with `GetOrAdd`-created currencies).

## 2. Preferred user currency
- `User`/`UserDto` gain `PreferredCurrencyId` (default PLN) with an EF migration, repository method, `PUT api/User/UpdatePreferredCurrency` (self-or-admin), and a **Settings → Preferences** currency picker.
- A new client-side `UserSettingsService` (implements `ISettingsService`) resolves the logged-in user's preferred currency once per app lifetime; `ISettingsService` gains `GetCurrencyAsync()` and the dashboard cards, account detail pages, and entry dialogs now use it (the cache is warmed in `MainLayout` for the remaining sync call sites). All valuations flow through the existing `currencyId` route parameters, so the whole app recalculates to the preference.
- **USD fallback**: when a stock's price cannot be converted to the preferred currency, `InvestmentPriceProvider` falls back to valuing the position in USD instead of dropping it to zero — e.g. a $100 stock with an unreachable USD→PLN rate stays $100 rather than disappearing.

## 3. Exchange rates: cache and app DB first, external only on miss
- New `ExchangeRates` table (`From`, `To`, `Date`, `Rate`, unique index) with `IExchangeRateRepository`/`ExchangeRateRepository`.
- `CurrencyExchangeService` resolution order is now: memory cache (existing `CachedCurrencyExchangeService` decorator) → database (direct **and inverse** pair) → CSV provider → external Fawaz Ahmed API — and every external hit is persisted, so a pair/date never leaves the app twice.
- Unknown pairs additionally resolve through a USD cross-rate (from→USD × USD→to).
- `QuoteFactorResolver` now goes through `ICurrencyExchangeService` instead of hitting the external provider directly, so it benefits from the cache and DB too.
- The repository serialises access to the scoped `DbContext` internally, since rate lookups fan out in parallel batches.

# Testing
- `dotnet build` clean (warnings-as-errors), `dotnet format` clean.
- Unit tests: 513/513 pass (new tests: DB-hit skips external provider, inverse-pair hit, external hit persisted, USD cross-rate fallback).
- Integration tests: 257/257 pass.
- Verified in the running app on the guest account: Settings → Preferences shows the predefined dropdown, switching PLN→USD saves and the dashboard (net worth, cash flow, distributions, money-by-label) recalculates everything to USD. Screenshots taken on mobile (430px) and desktop (1280px) viewports.

https://claude.ai/code/session_01JQH9W1FoWUzUZkFnHgFz7V

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQH9W1FoWUzUZkFnHgFz7V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added currency listings with common currency options.
  - Added preferred-currency selection in user settings.
  - Added exchange-rate storage and USD-based conversion fallback.
  - Added currency validation for assets and listings.
  - Added currency dropdowns to asset and listing forms.

- **Bug Fixes**
  - Improved handling of missing exchange rates and minor quote currencies.
  - Preserved existing currency values when editing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->