### PR TITLE
Shrink Azure publish package to fit free-tier disk quota

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,16 @@ jobs:
           path: '${{ github.workspace }}/TestResults/**/architecture-test-results.trx'
           reporter: dotnet-trx
 
+  # Deploy note: the target Azure Web Apps run on the free (F1) tier with a 1 GB disk quota.
+  # To avoid the "restart the app to make the deploy pass" problem (the deploy needs the old and
+  # new site on disk at once, and locked files block the swap), set the app setting
+  #   WEBSITE_RUN_FROM_PACKAGE=1
+  # on both FinanceManagerApi and FinanceManagerApi-dev so the site runs directly from the mounted
+  # deployment zip instead of being extracted into wwwroot.
+  #
+  # RID-scoping (optional, further shrinks foreign-RID native libs): once the App Service OS is
+  # confirmed, add "-r <rid> --self-contained false" (e.g. linux-x64 or win-x64) to the Publish API
+  # step below. Do NOT guess the RID — publishing the wrong one yields an app that will not start.
   publish:
     runs-on: ubuntu-latest
     needs: [build, unit-tests, integration-tests, architecture-tests, code-quality, security-scan]

--- a/code/Directory.Build.props
+++ b/code/Directory.Build.props
@@ -9,6 +9,15 @@
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
 		<CopilotCliDownloadTimeout>600000</CopilotCliDownloadTimeout>
+		<!-- Do not bundle the ~120 MB GitHub Copilot CLI binary into build/publish output.
+		     GitHub.Copilot.SDK downloads it at build time (runtimes/<rid>/native/copilot[.exe]),
+		     which alone is ~half the Azure publish package and blows past the free-tier disk quota.
+		     Production uses the OpenRouter provider (see appsettings.Production.json), so the
+		     Copilot provider is never invoked; install the CLI separately if a host needs it. -->
+		<CopilotSkipCliDownload>true</CopilotSkipCliDownload>
+		<!-- Ship only English satellite resource assemblies; drops ~11 MB of localized
+		     framework/library resources (ru, ja, pl, ko, ...) that the app does not use. -->
+		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
 	</PropertyGroup>
 
 	<!-- CalVer (YY.MM.DD) stamped automatically at build time. See issue #183. -->

--- a/code/FinanceManager.Api/FinanceManager.Api.csproj
+++ b/code/FinanceManager.Api/FinanceManager.Api.csproj
@@ -31,4 +31,10 @@
 	  <Folder Include="Migrations\" />
 	</ItemGroup>
 
+	<!-- The Blazor debug proxy (~12 MB) is only used when debugging a WASM client; it has no
+	     purpose in a Release deployment and needlessly inflates the Azure publish package. -->
+	<Target Name="RemoveBlazorDebugProxyFromPublish" AfterTargets="Publish">
+		<RemoveDir Directories="$(PublishDir)BlazorDebugProxy" />
+	</Target>
+
 </Project>


### PR DESCRIPTION
## Problem

The Release publish of `FinanceManager.Api` was **~248 MB**, which pushed the free (F1) tier's **1 GB disk quota** during deploys. Deploys only passed after a **manual app restart**.

## Root cause

Measured from a real Release publish, `runtimes/` alone was **127 MB** — dominated by a single **~120 MB `copilot` CLI binary** that `GitHub.Copilot.SDK` downloads at build time. Production uses the OpenRouter provider (see `appsettings.Production.json`), so the Copilot provider is never invoked.

## Changes

- **`CopilotSkipCliDownload=true`** (`Directory.Build.props`) — stop bundling the ~120 MB Copilot CLI binary.
- **`SatelliteResourceLanguages=en`** (`Directory.Build.props`) — drop ~11 MB of unused localized resource assemblies.
- **`RemoveBlazorDebugProxyFromPublish` target** (`FinanceManager.Api.csproj`) — strip the ~12 MB Blazor debug proxy, which is debug-only.
- **CI note** (`ci.yml`) — document `WEBSITE_RUN_FROM_PACKAGE=1` and the optional RID-scope publish lever.

## Result

**248 MB → 106 MB (−57%).** `runtimes/` 127 MB → 5.7 MB. All 513 unit tests pass.

## Follow-ups (operational, not code)

- Set **`WEBSITE_RUN_FROM_PACKAGE=1`** on `FinanceManagerApi` and `FinanceManagerApi-dev` — this is what actually eliminates the manual-restart-on-deploy step.
- Optionally add `-r <rid> --self-contained false` to the Publish API step once the App Service OS is confirmed, for a further few MB.

## Notes

- No user-visible runtime behavior change (CI/build chore), so no changelog entry.
- `CopilotSkipCliDownload` is global, so the Copilot provider won't run in any build unless the CLI is installed separately — fine for prod (OpenRouter), and `CopilotChatClient` already catches failures.
