### PR TITLE
Split investment discovery from import orchestration

### DIFF
--- a/code/FinanceManager.Api/Controllers/Accounts/InvestmentInstrumentDiscoveryController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/InvestmentInstrumentDiscoveryController.cs
@@ -13,7 +13,9 @@ namespace FinanceManager.Api.Controllers.Accounts;
 [ApiController]
 [Route("api/investments/instruments")]
 [Tags("Investment Instruments")]
-public class InvestmentInstrumentDiscoveryController(IInvestmentInstrumentDiscoveryService discoveryService) : ControllerBase
+public class InvestmentInstrumentDiscoveryController(
+    IInvestmentInstrumentDiscoveryService discoveryService,
+    IInstrumentImportService importService) : ControllerBase
 {
     [HttpGet("search")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<InstrumentDiscoveryResultDto>))]
@@ -29,7 +31,7 @@ public class InvestmentInstrumentDiscoveryController(IInvestmentInstrumentDiscov
     [HttpPost("import-preview")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(InstrumentImportPreviewDto))]
     public async Task<IActionResult> ImportPreview([FromBody] InstrumentDiscoveryResultDto instrument, CancellationToken cancellationToken) =>
-        Ok(await discoveryService.GetImportPreviewAsync(instrument, cancellationToken));
+        Ok(await importService.GetImportPreviewAsync(instrument, cancellationToken));
 
     [HttpPost("import")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ImportedInstrumentDto))]
@@ -37,7 +39,7 @@ public class InvestmentInstrumentDiscoveryController(IInvestmentInstrumentDiscov
     {
         try
         {
-            return Ok(await discoveryService.ImportAsync(command, cancellationToken));
+            return Ok(await importService.ImportAsync(command, cancellationToken));
         }
         catch (ArgumentException ex)
         {

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInstrumentImportService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInstrumentImportService.cs
@@ -1,0 +1,9 @@
+using FinanceManager.Domain.Assets.Discovery;
+
+namespace FinanceManager.Application.FinancialAccounts.Investments.Discovery;
+
+public interface IInstrumentImportService
+{
+    Task<InstrumentImportPreviewDto> GetImportPreviewAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default);
+    Task<ImportedInstrumentDto> ImportAsync(ImportInstrumentCommand command, CancellationToken ct = default);
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInvestmentInstrumentDiscoveryService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInvestmentInstrumentDiscoveryService.cs
@@ -7,11 +7,6 @@ namespace FinanceManager.Application.FinancialAccounts.Investments.Discovery;
 /// Alpha Vantage). Normalizes and merges provider responses into listing-level results that the
 /// investment transaction form and the admin asset page can present.
 /// </summary>
-/// <remarks>
-/// This is the first increment of the discovery feature (search only). Import-preview and import
-/// (creating/reusing <c>Asset</c>/<c>AssetListing</c>/<c>MarketDataSymbol</c> with provider symbol
-/// validation) are intentionally added in a later slice.
-/// </remarks>
 public interface IInvestmentInstrumentDiscoveryService
 {
     /// <summary>
@@ -20,6 +15,4 @@ public interface IInvestmentInstrumentDiscoveryService
     /// Alpha Vantage for the provider price symbol.
     /// </summary>
     Task<IReadOnlyList<InstrumentDiscoveryResultDto>> SearchAsync(string query, CancellationToken ct = default);
-    Task<InstrumentImportPreviewDto> GetImportPreviewAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default);
-    Task<ImportedInstrumentDto> ImportAsync(ImportInstrumentCommand command, CancellationToken ct = default);
 }

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InstrumentImportService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InstrumentImportService.cs
@@ -1,0 +1,188 @@
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Domain.Assets.Discovery;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Application.FinancialAccounts.Investments.Discovery;
+
+public sealed class InstrumentImportService(
+    IAlphaVantageClient alphaVantageClient,
+    IAssetRepository assetRepository,
+    IAssetListingRepository listingRepository,
+    IMarketDataSymbolRepository symbolRepository,
+    ILogger<InstrumentImportService> logger) : IInstrumentImportService
+{
+    public async Task<InstrumentImportPreviewDto> GetImportPreviewAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default)
+    {
+        var (asset, listing, symbol) = await FindExistingAsync(instrument, ct);
+        return new InstrumentImportPreviewDto
+        {
+            Instrument = instrument,
+            AssetAlreadyExists = asset is not null,
+            ListingAlreadyExists = listing is not null,
+            MarketDataSymbolAlreadyExists = symbol is not null,
+            CanImport = HasRequiredImportData(instrument),
+            Warnings = ImportWarnings(instrument)
+        };
+    }
+
+    public async Task<ImportedInstrumentDto> ImportAsync(ImportInstrumentCommand command, CancellationToken ct = default)
+    {
+        var instrument = command.Instrument;
+        ValidateImport(instrument);
+        var warnings = ImportWarnings(instrument).ToList();
+        var (asset, listing, symbol) = await FindExistingAsync(instrument, ct);
+        var createdAsset = asset is null;
+        asset ??= await assetRepository.Add(new Asset
+        {
+            Name = instrument.DisplayName,
+            Type = ParseAssetType(instrument.SecurityType),
+            Isin = instrument.Isin,
+            ShareClassFigi = instrument.ShareClassFigi,
+            CompositeFigi = instrument.CompositeFigi,
+            BaseCurrency = instrument.TradingCurrency
+        }, ct);
+
+        var createdListing = listing is null;
+        listing ??= await listingRepository.Add(new AssetListing
+        {
+            AssetId = asset.Id,
+            Ticker = instrument.Ticker.Trim().ToUpperInvariant(),
+            ExchangeMic = instrument.ExchangeMic!,
+            ExchangeName = instrument.ExchangeName ?? instrument.ExchangeMic!,
+            TradingCurrency = instrument.TradingCurrency!.ToUpperInvariant(),
+            ListingFigi = instrument.ListingFigi,
+            PriceMultiplier = InstrumentCurrencyUnits.IsMinor(instrument.TradingCurrency) ? 0.01m : 1m
+        }, ct);
+
+        var createdSymbol = symbol is null && !string.IsNullOrWhiteSpace(instrument.ProviderSymbol);
+        if (createdSymbol)
+        {
+            var error = await ValidateSymbolAsync(instrument, ct);
+            if (error is not null) warnings.Add(error);
+            symbol = await symbolRepository.Add(new MarketDataSymbol
+            {
+                AssetListingId = listing.Id,
+                Provider = MarketDataProvider.AlphaVantage,
+                Symbol = instrument.ProviderSymbol!,
+                ProviderExchangeCode = instrument.ExchangeCode,
+                Currency = instrument.TradingCurrency,
+                IsPrimary = true,
+                IsEnabled = error is null,
+                LastValidatedAt = error is null ? DateTimeOffset.UtcNow : null,
+                LastError = error
+            }, ct);
+        }
+
+        return new ImportedInstrumentDto
+        {
+            AssetId = asset.Id,
+            AssetListingId = listing.Id,
+            MarketDataSymbolId = symbol?.Id,
+            Ticker = listing.Ticker,
+            ExchangeName = listing.ExchangeName,
+            TradingCurrency = listing.TradingCurrency,
+            CreatedAsset = createdAsset,
+            CreatedListing = createdListing,
+            CreatedMarketDataSymbol = createdSymbol,
+            Warnings = warnings
+        };
+    }
+
+    private async Task<(Asset? Asset, AssetListing? Listing, MarketDataSymbol? Symbol)> FindExistingAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(instrument.ProviderSymbol))
+        {
+            var providerSymbol = await symbolRepository.Get(MarketDataProvider.AlphaVantage, instrument.ProviderSymbol, ct);
+            if (providerSymbol is not null)
+            {
+                var providerListing = await listingRepository.Get(providerSymbol.AssetListingId, ct);
+                if (providerListing is not null)
+                    return (await assetRepository.Get(providerListing.AssetId, ct), providerListing, providerSymbol);
+            }
+        }
+
+        Asset? asset = null;
+        if (!string.IsNullOrWhiteSpace(instrument.ShareClassFigi))
+            asset = await assetRepository.GetByShareClassFigi(instrument.ShareClassFigi, ct);
+        if (asset is null && !string.IsNullOrWhiteSpace(instrument.CompositeFigi))
+            asset = (await assetRepository.GetAll(ct)).FirstOrDefault(x => x.CompositeFigi == instrument.CompositeFigi);
+        if (asset is null && !string.IsNullOrWhiteSpace(instrument.Isin))
+            asset = await assetRepository.GetByIsin(instrument.Isin, ct);
+        if (asset is null)
+            asset = (await assetRepository.GetAll(ct)).FirstOrDefault(x =>
+                x.Type == ParseAssetType(instrument.SecurityType) && string.Equals(x.Name.Trim(), instrument.DisplayName.Trim(), StringComparison.OrdinalIgnoreCase));
+
+        AssetListing? listing = null;
+        if (!string.IsNullOrWhiteSpace(instrument.ExchangeMic) && !string.IsNullOrWhiteSpace(instrument.TradingCurrency))
+        {
+            listing = await listingRepository.Get(instrument.Ticker, instrument.ExchangeMic, instrument.TradingCurrency, ct);
+            if (listing is not null)
+                asset = await assetRepository.Get(listing.AssetId, ct);
+        }
+        if (asset is not null)
+        {
+            var listings = await listingRepository.GetByAsset(asset.Id, ct);
+            if (!string.IsNullOrWhiteSpace(instrument.ListingFigi))
+                listing = listings.FirstOrDefault(x => x.ListingFigi == instrument.ListingFigi);
+            listing ??= listings.FirstOrDefault(x =>
+                x.Ticker.Equals(instrument.Ticker, StringComparison.OrdinalIgnoreCase)
+                && x.ExchangeMic.Equals(instrument.ExchangeMic, StringComparison.OrdinalIgnoreCase)
+                && x.TradingCurrency.Equals(instrument.TradingCurrency, StringComparison.OrdinalIgnoreCase));
+        }
+
+        MarketDataSymbol? symbol = null;
+        if (listing is not null && !string.IsNullOrWhiteSpace(instrument.ProviderSymbol))
+            symbol = (await symbolRepository.GetByListing(listing.Id, ct)).FirstOrDefault(x =>
+                x.Provider == MarketDataProvider.AlphaVantage && x.Symbol.Equals(instrument.ProviderSymbol, StringComparison.OrdinalIgnoreCase));
+        return (asset, listing, symbol);
+    }
+
+    private async Task<string?> ValidateSymbolAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct)
+    {
+        try
+        {
+            var prices = await alphaVantageClient.GetDailySeries(instrument.ProviderSymbol!, DateTime.UtcNow.AddDays(-10), DateTime.UtcNow,
+                new Currency { ShortName = instrument.TradingCurrency! }, ct);
+            return prices.Any(x => x.PricePerUnit > 0) ? null : "Alpha Vantage returned no positive recent price; the symbol was saved disabled.";
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "Alpha Vantage validation failed for {Symbol}", instrument.ProviderSymbol);
+            return "Alpha Vantage validation failed; the symbol was saved disabled.";
+        }
+    }
+
+    private static IReadOnlyList<string> ImportWarnings(InstrumentDiscoveryResultDto instrument) =>
+        [.. instrument.Warnings,
+            .. (HasRequiredImportData(instrument) ? [] : new[] { "Name, ticker, exchange MIC, and trading currency must be confirmed before import." }),
+            .. (InstrumentCurrencyUnits.IsMinor(instrument.TradingCurrency)
+                ? new[] { "Minor-unit currency detected; price multiplier will be set to 0.01." } : [])];
+
+    private static void ValidateImport(InstrumentDiscoveryResultDto instrument)
+    {
+        if (!HasRequiredImportData(instrument))
+            throw new ArgumentException("Name, ticker, exchange MIC, and trading currency must be confirmed before import.");
+        if (ParseAssetType(instrument.SecurityType) is not (AssetType.Stock or AssetType.ETF))
+            throw new ArgumentException("Only stocks and ETFs can be imported.");
+    }
+
+    private static bool HasRequiredImportData(InstrumentDiscoveryResultDto instrument) =>
+        !string.IsNullOrWhiteSpace(instrument.DisplayName) && !string.IsNullOrWhiteSpace(instrument.Ticker)
+        && !string.IsNullOrWhiteSpace(instrument.ExchangeMic) && !string.IsNullOrWhiteSpace(instrument.TradingCurrency);
+
+    private static AssetType ParseAssetType(string? securityType) =>
+        securityType?.Contains("ETF", StringComparison.OrdinalIgnoreCase) == true ? AssetType.ETF
+        : securityType?.Contains("Equity", StringComparison.OrdinalIgnoreCase) == true || securityType?.Contains("Stock", StringComparison.OrdinalIgnoreCase) == true ? AssetType.Stock
+        : AssetType.Other;
+}
+
+internal static class InstrumentCurrencyUnits
+{
+    private static readonly HashSet<string> _minor = new(StringComparer.OrdinalIgnoreCase) { "GBX", "GBP.", "ZAC", "ILA" };
+
+    public static bool IsMinor(string? currency) => currency is not null && _minor.Contains(currency);
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InstrumentImportService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InstrumentImportService.cs
@@ -24,7 +24,8 @@ public sealed class InstrumentImportService(
             AssetAlreadyExists = asset is not null,
             ListingAlreadyExists = listing is not null,
             MarketDataSymbolAlreadyExists = symbol is not null,
-            CanImport = HasRequiredImportData(instrument),
+            CanImport = HasRequiredImportData(instrument)
+                && ParseAssetType(instrument.SecurityType) is AssetType.Stock or AssetType.ETF,
             Warnings = ImportWarnings(instrument)
         };
     }
@@ -43,7 +44,7 @@ public sealed class InstrumentImportService(
             Isin = instrument.Isin,
             ShareClassFigi = instrument.ShareClassFigi,
             CompositeFigi = instrument.CompositeFigi,
-            BaseCurrency = instrument.TradingCurrency
+            BaseCurrency = instrument.TradingCurrency!.ToUpperInvariant()
         }, ct);
 
         var createdListing = listing is null;
@@ -151,7 +152,8 @@ public sealed class InstrumentImportService(
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            logger.LogWarning(ex, "Alpha Vantage validation failed for {Symbol}", instrument.ProviderSymbol);
+            var sanitizedSymbol = instrument.ProviderSymbol?.Replace("\r", string.Empty).Replace("\n", string.Empty);
+            logger.LogWarning(ex, "Alpha Vantage validation failed for {Symbol}", sanitizedSymbol);
             return "Alpha Vantage validation failed; the symbol was saved disabled.";
         }
     }

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InvestmentInstrumentDiscoveryService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InvestmentInstrumentDiscoveryService.cs
@@ -1,9 +1,6 @@
 using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
 using FinanceManager.Application.FinancialAccounts.Stock.Resolution;
 using FinanceManager.Domain.Assets.Discovery;
-using FinanceManager.Domain.Assets.Entities;
-using FinanceManager.Domain.Assets.Repositories;
-using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -19,20 +16,12 @@ namespace FinanceManager.Application.FinancialAccounts.Investments.Discovery;
 public sealed partial class InvestmentInstrumentDiscoveryService(
     IOpenFigiClient openFigiClient,
     IAlphaVantageClient alphaVantageClient,
-    IAssetRepository assetRepository,
-    IAssetListingRepository listingRepository,
-    IMarketDataSymbolRepository symbolRepository,
     IMemoryCache cache,
     ILogger<InvestmentInstrumentDiscoveryService> logger) : IInvestmentInstrumentDiscoveryService
 {
     private static readonly TimeSpan _cacheTtl = TimeSpan.FromMinutes(15);
 
     // Pence-style minor currency units that normalise to a major unit via a 0.01 price multiplier.
-    private static readonly HashSet<string> _minorCurrencyUnits = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "GBX", "GBP.", "ZAC", "ILA",
-    };
-
     // ISIN: 2-letter country code + 9 alphanumerics + 1 check digit.
     [GeneratedRegex("^[A-Za-z]{2}[A-Za-z0-9]{9}[0-9]$")]
     private static partial Regex IsinRegex();
@@ -168,14 +157,14 @@ public sealed partial class InvestmentInstrumentDiscoveryService(
         if (mic is null)
             warnings.Add($"Exchange mapping for code '{exchangeCode}' is ambiguous or unknown; confirm the market (MIC) before importing.");
 
-        if (!string.IsNullOrWhiteSpace(currency) && _minorCurrencyUnits.Contains(currency))
+        if (InstrumentCurrencyUnits.IsMinor(currency))
             warnings.Add($"Listing is quoted in minor units ({currency}); a price multiplier of 0.01 will be applied to convert to the major unit.");
 
         if (providerSymbol is null)
             warnings.Add("No Alpha Vantage price symbol was found for this listing; automatic price updates may be unavailable.");
         else if (!string.IsNullOrWhiteSpace(avQuoteCurrency) && !string.IsNullOrWhiteSpace(currency)
                  && !string.Equals(avQuoteCurrency, currency, StringComparison.OrdinalIgnoreCase)
-                 && !_minorCurrencyUnits.Contains(currency))
+                 && !InstrumentCurrencyUnits.IsMinor(currency))
             warnings.Add($"Alpha Vantage quote currency ({avQuoteCurrency}) differs from the listing trading currency ({currency}); confirm before importing.");
 
         var source = providerSymbol is null ? "OpenFIGI" : "Combined";
@@ -238,170 +227,6 @@ public sealed partial class InvestmentInstrumentDiscoveryService(
             ? (mapping.Mic, mapping.ExchangeName, token)
             : (null, token, token);
     }
-
-    public async Task<InstrumentImportPreviewDto> GetImportPreviewAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default)
-    {
-        var (asset, listing, symbol) = await FindExistingAsync(instrument, ct);
-        return new InstrumentImportPreviewDto
-        {
-            Instrument = instrument,
-            AssetAlreadyExists = asset is not null,
-            ListingAlreadyExists = listing is not null,
-            MarketDataSymbolAlreadyExists = symbol is not null,
-            CanImport = HasRequiredImportData(instrument),
-            Warnings = ImportWarnings(instrument)
-        };
-    }
-
-    public async Task<ImportedInstrumentDto> ImportAsync(ImportInstrumentCommand command, CancellationToken ct = default)
-    {
-        var instrument = command.Instrument;
-        ValidateImport(instrument);
-        var warnings = ImportWarnings(instrument).ToList();
-        var (asset, listing, symbol) = await FindExistingAsync(instrument, ct);
-        var createdAsset = asset is null;
-        asset ??= await assetRepository.Add(new Asset
-        {
-            Name = instrument.DisplayName,
-            Type = ParseAssetType(instrument.SecurityType),
-            Isin = instrument.Isin,
-            ShareClassFigi = instrument.ShareClassFigi,
-            CompositeFigi = instrument.CompositeFigi,
-            BaseCurrency = instrument.TradingCurrency
-        }, ct);
-
-        var createdListing = listing is null;
-        listing ??= await listingRepository.Add(new AssetListing
-        {
-            AssetId = asset.Id,
-            Ticker = instrument.Ticker.Trim().ToUpperInvariant(),
-            ExchangeMic = instrument.ExchangeMic!,
-            ExchangeName = instrument.ExchangeName ?? instrument.ExchangeMic!,
-            TradingCurrency = instrument.TradingCurrency!.ToUpperInvariant(),
-            ListingFigi = instrument.ListingFigi,
-            PriceMultiplier = _minorCurrencyUnits.Contains(instrument.TradingCurrency) ? 0.01m : 1m
-        }, ct);
-
-        var createdSymbol = symbol is null && !string.IsNullOrWhiteSpace(instrument.ProviderSymbol);
-        if (createdSymbol)
-        {
-            var error = await ValidateSymbolAsync(instrument, ct);
-            if (error is not null) warnings.Add(error);
-            symbol = await symbolRepository.Add(new MarketDataSymbol
-            {
-                AssetListingId = listing.Id,
-                Provider = MarketDataProvider.AlphaVantage,
-                Symbol = instrument.ProviderSymbol!,
-                ProviderExchangeCode = instrument.ExchangeCode,
-                Currency = instrument.TradingCurrency,
-                IsPrimary = true,
-                IsEnabled = error is null,
-                LastValidatedAt = error is null ? DateTimeOffset.UtcNow : null,
-                LastError = error
-            }, ct);
-        }
-
-        return new ImportedInstrumentDto
-        {
-            AssetId = asset.Id,
-            AssetListingId = listing.Id,
-            MarketDataSymbolId = symbol?.Id,
-            Ticker = listing.Ticker,
-            ExchangeName = listing.ExchangeName,
-            TradingCurrency = listing.TradingCurrency,
-            CreatedAsset = createdAsset,
-            CreatedListing = createdListing,
-            CreatedMarketDataSymbol = createdSymbol,
-            Warnings = warnings
-        };
-    }
-
-    private async Task<(Asset? Asset, AssetListing? Listing, MarketDataSymbol? Symbol)> FindExistingAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct)
-    {
-        if (!string.IsNullOrWhiteSpace(instrument.ProviderSymbol))
-        {
-            var providerSymbol = await symbolRepository.Get(MarketDataProvider.AlphaVantage, instrument.ProviderSymbol, ct);
-            if (providerSymbol is not null)
-            {
-                var providerListing = await listingRepository.Get(providerSymbol.AssetListingId, ct);
-                if (providerListing is not null)
-                    return (await assetRepository.Get(providerListing.AssetId, ct), providerListing, providerSymbol);
-            }
-        }
-
-        Asset? asset = null;
-        if (!string.IsNullOrWhiteSpace(instrument.ShareClassFigi))
-            asset = await assetRepository.GetByShareClassFigi(instrument.ShareClassFigi, ct);
-        if (asset is null && !string.IsNullOrWhiteSpace(instrument.CompositeFigi))
-            asset = (await assetRepository.GetAll(ct)).FirstOrDefault(x => x.CompositeFigi == instrument.CompositeFigi);
-        if (asset is null && !string.IsNullOrWhiteSpace(instrument.Isin))
-            asset = await assetRepository.GetByIsin(instrument.Isin, ct);
-        if (asset is null)
-            asset = (await assetRepository.GetAll(ct)).FirstOrDefault(x =>
-                x.Type == ParseAssetType(instrument.SecurityType) && string.Equals(x.Name.Trim(), instrument.DisplayName.Trim(), StringComparison.OrdinalIgnoreCase));
-
-        AssetListing? listing = null;
-        if (!string.IsNullOrWhiteSpace(instrument.ExchangeMic) && !string.IsNullOrWhiteSpace(instrument.TradingCurrency))
-        {
-            listing = await listingRepository.Get(instrument.Ticker, instrument.ExchangeMic, instrument.TradingCurrency, ct);
-            if (listing is not null)
-                asset = await assetRepository.Get(listing.AssetId, ct);
-        }
-        if (asset is not null)
-        {
-            var listings = await listingRepository.GetByAsset(asset.Id, ct);
-            if (!string.IsNullOrWhiteSpace(instrument.ListingFigi))
-                listing = listings.FirstOrDefault(x => x.ListingFigi == instrument.ListingFigi);
-            listing ??= listings.FirstOrDefault(x =>
-                x.Ticker.Equals(instrument.Ticker, StringComparison.OrdinalIgnoreCase)
-                && x.ExchangeMic.Equals(instrument.ExchangeMic, StringComparison.OrdinalIgnoreCase)
-                && x.TradingCurrency.Equals(instrument.TradingCurrency, StringComparison.OrdinalIgnoreCase));
-        }
-
-        MarketDataSymbol? symbol = null;
-        if (listing is not null && !string.IsNullOrWhiteSpace(instrument.ProviderSymbol))
-            symbol = (await symbolRepository.GetByListing(listing.Id, ct)).FirstOrDefault(x =>
-                x.Provider == MarketDataProvider.AlphaVantage && x.Symbol.Equals(instrument.ProviderSymbol, StringComparison.OrdinalIgnoreCase));
-        return (asset, listing, symbol);
-    }
-
-    private async Task<string?> ValidateSymbolAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct)
-    {
-        try
-        {
-            var prices = await alphaVantageClient.GetDailySeries(instrument.ProviderSymbol!, DateTime.UtcNow.AddDays(-10), DateTime.UtcNow,
-                new Currency { ShortName = instrument.TradingCurrency! }, ct);
-            return prices.Any(x => x.PricePerUnit > 0) ? null : "Alpha Vantage returned no positive recent price; the symbol was saved disabled.";
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            logger.LogWarning(ex, "Alpha Vantage validation failed for {Symbol}", instrument.ProviderSymbol);
-            return "Alpha Vantage validation failed; the symbol was saved disabled.";
-        }
-    }
-
-    private static IReadOnlyList<string> ImportWarnings(InstrumentDiscoveryResultDto instrument) =>
-        [.. instrument.Warnings,
-            .. (HasRequiredImportData(instrument) ? [] : new[] { "Name, ticker, exchange MIC, and trading currency must be confirmed before import." }),
-            .. (_minorCurrencyUnits.Contains(instrument.TradingCurrency ?? string.Empty)
-                ? new[] { "Minor-unit currency detected; price multiplier will be set to 0.01." } : [])];
-
-    private static void ValidateImport(InstrumentDiscoveryResultDto instrument)
-    {
-        if (!HasRequiredImportData(instrument))
-            throw new ArgumentException("Name, ticker, exchange MIC, and trading currency must be confirmed before import.");
-        if (ParseAssetType(instrument.SecurityType) is not (AssetType.Stock or AssetType.ETF))
-            throw new ArgumentException("Only stocks and ETFs can be imported.");
-    }
-
-    private static bool HasRequiredImportData(InstrumentDiscoveryResultDto instrument) =>
-        !string.IsNullOrWhiteSpace(instrument.DisplayName) && !string.IsNullOrWhiteSpace(instrument.Ticker)
-        && !string.IsNullOrWhiteSpace(instrument.ExchangeMic) && !string.IsNullOrWhiteSpace(instrument.TradingCurrency);
-
-    private static AssetType ParseAssetType(string? securityType) =>
-        securityType?.Contains("ETF", StringComparison.OrdinalIgnoreCase) == true ? AssetType.ETF
-        : securityType?.Contains("Equity", StringComparison.OrdinalIgnoreCase) == true || securityType?.Contains("Stock", StringComparison.OrdinalIgnoreCase) == true ? AssetType.Stock
-        : AssetType.Other;
 
     // Identity-first dedupe: prefer FIGI, then ISIN+currency, then ticker+exchange+currency.
     private static string DedupeKey(InstrumentDiscoveryResultDto dto)

--- a/code/FinanceManager.Application/FinancialAccounts/Registration.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Registration.cs
@@ -70,6 +70,7 @@ internal static class Registration
                 .AddScoped<IInvestmentPriceProvider, InvestmentPriceProvider>()
                 .AddScoped<IInvestmentValuationService, InvestmentValuationService>()
                 .AddScoped<IInvestmentInstrumentDiscoveryService, InvestmentInstrumentDiscoveryService>()
+                .AddScoped<IInstrumentImportService, InstrumentImportService>()
                 .AddScoped<IBondUnrealizedGainLossCalculator, BondUnrealizedGainLossCalculator>()
                 .AddScoped<IBondService, BondService>();
 

--- a/code/FinanceManager.Tests.Unit/Application/Services/Discovery/InstrumentImportServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Discovery/InstrumentImportServiceTests.cs
@@ -1,0 +1,104 @@
+using FinanceManager.Application.FinancialAccounts.Investments.Discovery;
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Domain.Assets.Discovery;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services.Discovery;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class InstrumentImportServiceTests
+{
+    private readonly Mock<IAlphaVantageClient> _avClientMock = new();
+    private readonly Mock<IAssetRepository> _assetRepositoryMock = new();
+    private readonly Mock<IAssetListingRepository> _listingRepositoryMock = new();
+    private readonly Mock<IMarketDataSymbolRepository> _symbolRepositoryMock = new();
+    private readonly ILogger<InstrumentImportService> _logger =
+        LoggerFactory.Create(_ => { }).CreateLogger<InstrumentImportService>();
+
+    private InstrumentImportService CreateService() =>
+        new(_avClientMock.Object, _assetRepositoryMock.Object, _listingRepositoryMock.Object,
+            _symbolRepositoryMock.Object, _logger);
+
+    private static InstrumentDiscoveryResultDto Instrument() => new()
+    {
+        DisplayName = "iShares Core S&P 500 UCITS ETF",
+        Ticker = "CSPX",
+        ExchangeMic = "XLON",
+        ExchangeCode = "LN",
+        TradingCurrency = "USD",
+        SecurityType = "ETF",
+        ShareClassFigi = "BBGSC",
+        ListingFigi = "BBG001",
+        ProviderSymbol = "CSPX.LON"
+    };
+
+    [Fact]
+    public async Task PreviewAndImport_WhenInstrumentExists_ReusesAllRecords()
+    {
+        var asset = new Asset { Id = 1, Name = "iShares Core S&P 500 UCITS ETF", ShareClassFigi = "BBGSC" };
+        var listing = new AssetListing { Id = 2, AssetId = 1, Ticker = "CSPX", ExchangeMic = "XLON", TradingCurrency = "USD", ListingFigi = "BBG001" };
+        var symbol = new MarketDataSymbol { Id = 3, AssetListingId = 2, Provider = MarketDataProvider.AlphaVantage, Symbol = "CSPX.LON" };
+        _assetRepositoryMock.Setup(x => x.GetByShareClassFigi("BBGSC", It.IsAny<CancellationToken>())).ReturnsAsync(asset);
+        _listingRepositoryMock.Setup(x => x.GetByAsset(1, It.IsAny<CancellationToken>())).ReturnsAsync([listing]);
+        _symbolRepositoryMock.Setup(x => x.GetByListing(2, It.IsAny<CancellationToken>())).ReturnsAsync([symbol]);
+
+        var preview = await CreateService().GetImportPreviewAsync(Instrument(), TestContext.Current.CancellationToken);
+        var result = await CreateService().ImportAsync(new ImportInstrumentCommand(Instrument()), TestContext.Current.CancellationToken);
+
+        Assert.True(preview.AssetAlreadyExists);
+        Assert.True(preview.ListingAlreadyExists);
+        Assert.True(preview.MarketDataSymbolAlreadyExists);
+        Assert.False(result.CreatedAsset);
+        Assert.False(result.CreatedListing);
+        Assert.False(result.CreatedMarketDataSymbol);
+        _assetRepositoryMock.Verify(x => x.Add(It.IsAny<Asset>(), It.IsAny<CancellationToken>()), Times.Never);
+        _listingRepositoryMock.Verify(x => x.Add(It.IsAny<AssetListing>(), It.IsAny<CancellationToken>()), Times.Never);
+        _symbolRepositoryMock.Verify(x => x.Add(It.IsAny<MarketDataSymbol>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ImportAsync_WhenValidationReturnsNoPrices_SavesDisabledSymbol()
+    {
+        _assetRepositoryMock.Setup(x => x.GetAll(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _assetRepositoryMock.Setup(x => x.Add(It.IsAny<Asset>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Asset asset, CancellationToken _) => { asset.Id = 1; return asset; });
+        _listingRepositoryMock.Setup(x => x.Add(It.IsAny<AssetListing>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AssetListing listing, CancellationToken _) => { listing.Id = 2; return listing; });
+        _symbolRepositoryMock.Setup(x => x.Add(It.IsAny<MarketDataSymbol>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((MarketDataSymbol symbol, CancellationToken _) => { symbol.Id = 3; return symbol; });
+        _avClientMock.Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+            It.IsAny<FinanceManager.Domain.FinancialAccounts.Currencies.Entities.Currency>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var result = await CreateService().ImportAsync(new ImportInstrumentCommand(Instrument()), TestContext.Current.CancellationToken);
+
+        Assert.True(result.CreatedMarketDataSymbol);
+        Assert.Contains(result.Warnings, warning => warning.Contains("saved disabled", StringComparison.OrdinalIgnoreCase));
+        _symbolRepositoryMock.Verify(x => x.Add(It.Is<MarketDataSymbol>(symbol => !symbol.IsEnabled && symbol.LastError != null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportAsync_WhenProviderSymbolExists_ReusesItsListingAndAsset()
+    {
+        var asset = new Asset { Id = 1, Name = "Existing ETF" };
+        var listing = new AssetListing { Id = 2, AssetId = 1, Ticker = "CSPX", ExchangeMic = "XLON", TradingCurrency = "USD", ExchangeName = "London Stock Exchange" };
+        var symbol = new MarketDataSymbol { Id = 3, AssetListingId = 2, Provider = MarketDataProvider.AlphaVantage, Symbol = "CSPX.LON" };
+        _symbolRepositoryMock.Setup(x => x.Get(MarketDataProvider.AlphaVantage, "CSPX.LON", It.IsAny<CancellationToken>())).ReturnsAsync(symbol);
+        _listingRepositoryMock.Setup(x => x.Get(2, It.IsAny<CancellationToken>())).ReturnsAsync(listing);
+        _assetRepositoryMock.Setup(x => x.Get(1, It.IsAny<CancellationToken>())).ReturnsAsync(asset);
+
+        var result = await CreateService().ImportAsync(new ImportInstrumentCommand(Instrument()), TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, result.AssetId);
+        Assert.Equal(2, result.AssetListingId);
+        Assert.Equal(3, result.MarketDataSymbolId);
+        Assert.False(result.CreatedAsset);
+        Assert.False(result.CreatedListing);
+        Assert.False(result.CreatedMarketDataSymbol);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/Discovery/InvestmentInstrumentDiscoveryServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Discovery/InvestmentInstrumentDiscoveryServiceTests.cs
@@ -2,8 +2,6 @@ using FinanceManager.Application.FinancialAccounts.Investments.Discovery;
 using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
 using FinanceManager.Application.FinancialAccounts.Stock.Resolution;
 using FinanceManager.Domain.Assets.Discovery;
-using FinanceManager.Domain.Assets.Entities;
-using FinanceManager.Domain.Assets.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -17,29 +15,11 @@ public class InvestmentInstrumentDiscoveryServiceTests
 {
     private readonly Mock<IOpenFigiClient> _openFigiClientMock = new();
     private readonly Mock<IAlphaVantageClient> _avClientMock = new();
-    private readonly Mock<IAssetRepository> _assetRepositoryMock = new();
-    private readonly Mock<IAssetListingRepository> _listingRepositoryMock = new();
-    private readonly Mock<IMarketDataSymbolRepository> _symbolRepositoryMock = new();
     private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
     private readonly ILogger<InvestmentInstrumentDiscoveryService> _logger =
         LoggerFactory.Create(_ => { }).CreateLogger<InvestmentInstrumentDiscoveryService>();
-
     private InvestmentInstrumentDiscoveryService CreateService() =>
-        new(_openFigiClientMock.Object, _avClientMock.Object, _assetRepositoryMock.Object,
-            _listingRepositoryMock.Object, _symbolRepositoryMock.Object, _cache, _logger);
-
-    private static InstrumentDiscoveryResultDto Instrument() => new()
-    {
-        DisplayName = "iShares Core S&P 500 UCITS ETF",
-        Ticker = "CSPX",
-        ExchangeMic = "XLON",
-        ExchangeCode = "LN",
-        TradingCurrency = "USD",
-        SecurityType = "ETF",
-        ShareClassFigi = "BBGSC",
-        ListingFigi = "BBG001",
-        ProviderSymbol = "CSPX.LON"
-    };
+        new(_openFigiClientMock.Object, _avClientMock.Object, _cache, _logger);
 
     [Theory]
     [InlineData(null)]
@@ -260,69 +240,4 @@ public class InvestmentInstrumentDiscoveryServiceTests
         _openFigiClientMock.Verify(x => x.MapByTickerAsync("CSPX", It.IsAny<string?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    [Fact]
-    public async Task PreviewAndImport_WhenInstrumentExists_ReusesAllRecords()
-    {
-        var asset = new Asset { Id = 1, Name = "iShares Core S&P 500 UCITS ETF", ShareClassFigi = "BBGSC" };
-        var listing = new AssetListing { Id = 2, AssetId = 1, Ticker = "CSPX", ExchangeMic = "XLON", TradingCurrency = "USD", ListingFigi = "BBG001" };
-        var symbol = new MarketDataSymbol { Id = 3, AssetListingId = 2, Provider = MarketDataProvider.AlphaVantage, Symbol = "CSPX.LON" };
-        _assetRepositoryMock.Setup(x => x.GetByShareClassFigi("BBGSC", It.IsAny<CancellationToken>())).ReturnsAsync(asset);
-        _listingRepositoryMock.Setup(x => x.GetByAsset(1, It.IsAny<CancellationToken>())).ReturnsAsync([listing]);
-        _symbolRepositoryMock.Setup(x => x.GetByListing(2, It.IsAny<CancellationToken>())).ReturnsAsync([symbol]);
-
-        var preview = await CreateService().GetImportPreviewAsync(Instrument(), TestContext.Current.CancellationToken);
-        var result = await CreateService().ImportAsync(new ImportInstrumentCommand(Instrument()), TestContext.Current.CancellationToken);
-
-        Assert.True(preview.AssetAlreadyExists);
-        Assert.True(preview.ListingAlreadyExists);
-        Assert.True(preview.MarketDataSymbolAlreadyExists);
-        Assert.False(result.CreatedAsset);
-        Assert.False(result.CreatedListing);
-        Assert.False(result.CreatedMarketDataSymbol);
-        _assetRepositoryMock.Verify(x => x.Add(It.IsAny<Asset>(), It.IsAny<CancellationToken>()), Times.Never);
-        _listingRepositoryMock.Verify(x => x.Add(It.IsAny<AssetListing>(), It.IsAny<CancellationToken>()), Times.Never);
-        _symbolRepositoryMock.Verify(x => x.Add(It.IsAny<MarketDataSymbol>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task ImportAsync_WhenValidationReturnsNoPrices_SavesDisabledSymbol()
-    {
-        _assetRepositoryMock.Setup(x => x.GetAll(It.IsAny<CancellationToken>())).ReturnsAsync([]);
-        _assetRepositoryMock.Setup(x => x.Add(It.IsAny<Asset>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Asset asset, CancellationToken _) => { asset.Id = 1; return asset; });
-        _listingRepositoryMock.Setup(x => x.Add(It.IsAny<AssetListing>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((AssetListing listing, CancellationToken _) => { listing.Id = 2; return listing; });
-        _symbolRepositoryMock.Setup(x => x.Add(It.IsAny<MarketDataSymbol>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((MarketDataSymbol symbol, CancellationToken _) => { symbol.Id = 3; return symbol; });
-        _avClientMock.Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<DateTime>(), It.IsAny<DateTime>(),
-            It.IsAny<FinanceManager.Domain.FinancialAccounts.Currencies.Entities.Currency>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync([]);
-
-        var result = await CreateService().ImportAsync(new ImportInstrumentCommand(Instrument()), TestContext.Current.CancellationToken);
-
-        Assert.True(result.CreatedMarketDataSymbol);
-        Assert.Contains(result.Warnings, warning => warning.Contains("saved disabled", StringComparison.OrdinalIgnoreCase));
-        _symbolRepositoryMock.Verify(x => x.Add(It.Is<MarketDataSymbol>(symbol => !symbol.IsEnabled && symbol.LastError != null),
-            It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task ImportAsync_WhenProviderSymbolExists_ReusesItsListingAndAsset()
-    {
-        var asset = new Asset { Id = 1, Name = "Existing ETF" };
-        var listing = new AssetListing { Id = 2, AssetId = 1, Ticker = "CSPX", ExchangeMic = "XLON", TradingCurrency = "USD", ExchangeName = "London Stock Exchange" };
-        var symbol = new MarketDataSymbol { Id = 3, AssetListingId = 2, Provider = MarketDataProvider.AlphaVantage, Symbol = "CSPX.LON" };
-        _symbolRepositoryMock.Setup(x => x.Get(MarketDataProvider.AlphaVantage, "CSPX.LON", It.IsAny<CancellationToken>())).ReturnsAsync(symbol);
-        _listingRepositoryMock.Setup(x => x.Get(2, It.IsAny<CancellationToken>())).ReturnsAsync(listing);
-        _assetRepositoryMock.Setup(x => x.Get(1, It.IsAny<CancellationToken>())).ReturnsAsync(asset);
-
-        var result = await CreateService().ImportAsync(new ImportInstrumentCommand(Instrument()), TestContext.Current.CancellationToken);
-
-        Assert.Equal(1, result.AssetId);
-        Assert.Equal(2, result.AssetListingId);
-        Assert.Equal(3, result.MarketDataSymbolId);
-        Assert.False(result.CreatedAsset);
-        Assert.False(result.CreatedListing);
-        Assert.False(result.CreatedMarketDataSymbol);
-    }
 }


### PR DESCRIPTION
## What changed

- separated provider discovery/search from instrument import and persistence
- added a focused import service and interface
- updated the controller and DI registration
- split discovery and import unit tests

## Why

The previous service combined provider search, normalization, caching, validation, preview, and persistence. Separating the two use cases gives each class one reason to change without altering behavior.

## Validation

- `dotnet build ./code/FinanceManager.slnx`
- 513 unit tests passed

Closes #530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added instrument import preview and import capabilities.
  * Imports can create or reuse assets, listings, and market-data symbols.
  * Added validation, warnings, duplicate detection, and support for disabled symbols when market-data validation fails.
  * Improved handling of minor-unit currencies during instrument discovery.

* **Bug Fixes**
  * Prevented duplicate records when importing instruments that already exist.

* **Tests**
  * Added coverage for reuse, validation failures, and disabled market-data symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->