### PR TITLE
Separate account repository responsibilities

### DIFF
--- a/code/FinanceManager.Domain/FinancialAccounts/Shared/Repositories/IFinancalAccountRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Shared/Repositories/IFinancalAccountRepository.cs
@@ -5,23 +5,11 @@ namespace FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
 public interface IFinancialAccountRepository
 {
     public Task<Dictionary<int, Type>> GetAvailableAccounts(int userId);
-    public Task<int> GetLastAccountId();
     public Task<int> GetAccountsCount();
-    public Task<DateTime?> GetStartDate(int id);
-    public Task<DateTime?> GetEndDate(int id);
-
-    public Task<bool> AccountExists(int id);
     public Task<T?> GetAccount<T>(int userId, int id, DateTime dateStart, DateTime dateEnd) where T : BasicAccountInformation;
     public IAsyncEnumerable<T> GetAccounts<T>(int userId, DateTime dateStart, DateTime dateEnd) where T : BasicAccountInformation;
 
     public Task<int?> AddAccount<T>(T account) where T : BasicAccountInformation;
-    public Task AddAccount<AccountType, EntryType>(string accountName, List<EntryType> data) where AccountType : BasicAccountInformation where EntryType : FinancialEntryBase;
     public Task UpdateAccount<T>(T account) where T : BasicAccountInformation;
     public Task RemoveAccount(Type accountType, int id);
-
-    public Task<T?> GetNextYounger<T>(int accountId, DateTime date) where T : FinancialEntryBase;
-    public Task AddEntry<T>(T accountEntry, int id) where T : FinancialEntryBase;
-    Task<bool> AddLabel<T>(T accountEntry, int labelId) where T : FinancialEntryBase;
-    public Task UpdateEntry<T>(T accountEntry, int id) where T : FinancialEntryBase;
-    public Task RemoveEntry(int accountEntryId, int id);
 }

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
@@ -9,6 +9,7 @@ namespace FinanceManager.Infrastructure.Repositories.Account.Entry;
 
 public class BondEntryRepository(AppDbContext context) : IBondAccountEntryRepository<BondAccountEntry>
 {
+    private readonly BondEntryValueCalculator _valueCalculator = new(context);
     public async Task<bool> Add(BondAccountEntry entry, bool recalculate)
     {
         // Don't use entry.Value as it may be a placeholder (-1)
@@ -342,105 +343,7 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
     }
 
     private async Task RecalculateValues(int accountId, DateTime startDate)
-    {
-        if (!context.Database.IsRelational())
-        {
-            await RecalculateValuesInMemory(accountId, startDate);
-            return;
-        }
-
-        if (context.Database.ProviderName?.StartsWith("Npgsql") == true)
-        {
-            // DISTINCT ON picks the most-recent entry per BondDetailsId before startDate as the anchor.
-            await context.Database.ExecuteSqlAsync($"""
-                WITH anchors AS (
-                    SELECT DISTINCT ON ("BondDetailsId") "BondDetailsId", "Value" AS "AnchorValue"
-                    FROM "BondEntries"
-                    WHERE "AccountId" = {accountId} AND "PostingDate" < {startDate}
-                    ORDER BY "BondDetailsId", "PostingDate" DESC, "EntryId" DESC
-                ),
-                running AS (
-                    SELECT e."EntryId",
-                           COALESCE(a."AnchorValue", 0) + SUM(e."ValueChange") OVER (
-                               PARTITION BY e."BondDetailsId"
-                               ORDER BY e."PostingDate", e."EntryId"
-                               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-                           ) AS "NewValue"
-                    FROM "BondEntries" e
-                    LEFT JOIN anchors a ON a."BondDetailsId" = e."BondDetailsId"
-                    WHERE e."AccountId" = {accountId} AND e."PostingDate" >= {startDate}
-                )
-                UPDATE "BondEntries" AS e
-                SET "Value" = r."NewValue"
-                FROM running AS r
-                WHERE e."EntryId" = r."EntryId"
-                """);
-        }
-        else
-        {
-            await context.Database.ExecuteSqlAsync($"""
-                WITH anchors_raw AS (
-                    SELECT BondDetailsId, Value AS AnchorValue,
-                           ROW_NUMBER() OVER (PARTITION BY BondDetailsId ORDER BY PostingDate DESC, EntryId DESC) AS rn
-                    FROM BondEntries
-                    WHERE AccountId = {accountId} AND PostingDate < {startDate}
-                ),
-                anchors AS (
-                    SELECT BondDetailsId, AnchorValue FROM anchors_raw WHERE rn = 1
-                ),
-                running AS (
-                    SELECT e.EntryId,
-                           COALESCE(a.AnchorValue, 0) + SUM(e.ValueChange) OVER (
-                               PARTITION BY e.BondDetailsId
-                               ORDER BY e.PostingDate, e.EntryId
-                               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-                           ) AS NewValue
-                    FROM BondEntries e
-                    LEFT JOIN anchors a ON a.BondDetailsId = e.BondDetailsId
-                    WHERE e.AccountId = {accountId} AND e.PostingDate >= {startDate}
-                )
-                UPDATE e
-                SET Value = r.NewValue
-                FROM BondEntries e
-                INNER JOIN running r ON e.EntryId = r.EntryId
-                """);
-        }
-    }
-
-    private async Task RecalculateValuesInMemory(int accountId, DateTime startDate)
-    {
-        var entries = await context.BondEntries
-            .Where(e => e.AccountId == accountId && e.PostingDate >= startDate)
-            .OrderBy(e => e.PostingDate)
-            .ThenBy(e => e.EntryId)
-            .ToListAsync();
-
-        if (entries.Count == 0) return;
-
-        var bondIds = entries.Select(e => e.BondDetailsId).Distinct().ToList();
-
-        // Single query for all bond anchors instead of one per BondDetailsId group.
-        var anchors = (await context.BondEntries
-                .AsNoTracking()
-                .Where(e => e.AccountId == accountId && bondIds.Contains(e.BondDetailsId) && e.PostingDate < startDate)
-                .OrderByDescending(e => e.PostingDate)
-                .ThenByDescending(e => e.EntryId)
-                .ToListAsync())
-            .GroupBy(e => e.BondDetailsId)
-            .ToDictionary(g => g.Key, g => g.First().Value);
-
-        foreach (var bondGroup in entries.GroupBy(e => e.BondDetailsId))
-        {
-            decimal running = anchors.TryGetValue(bondGroup.Key, out var anchor) ? anchor : 0m;
-            foreach (var e in bondGroup.OrderBy(e => e.PostingDate).ThenBy(e => e.EntryId))
-            {
-                running += e.ValueChange;
-                e.Value = running;
-            }
-        }
-
-        await context.SaveChangesAsync();
-    }
+        => await _valueCalculator.Recalculate(accountId, startDate);
 
     public async Task<bool> AddLabel(int entryId, int labelId)
     {

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryValueCalculator.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryValueCalculator.cs
@@ -1,0 +1,105 @@
+using FinanceManager.Infrastructure.Contexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Infrastructure.Repositories.Account.Entry;
+
+internal sealed class BondEntryValueCalculator(AppDbContext context)
+{
+    public async Task Recalculate(int accountId, DateTime startDate)
+    {
+        if (!context.Database.IsRelational())
+        {
+            await RecalculateInMemory(accountId, startDate);
+            return;
+        }
+
+        if (context.Database.ProviderName?.StartsWith("Npgsql") == true)
+        {
+            await context.Database.ExecuteSqlAsync($"""
+                WITH anchors AS (
+                    SELECT DISTINCT ON ("BondDetailsId") "BondDetailsId", "Value" AS "AnchorValue"
+                    FROM "BondEntries"
+                    WHERE "AccountId" = {accountId} AND "PostingDate" < {startDate}
+                    ORDER BY "BondDetailsId", "PostingDate" DESC, "EntryId" DESC
+                ),
+                running AS (
+                    SELECT e."EntryId",
+                           COALESCE(a."AnchorValue", 0) + SUM(e."ValueChange") OVER (
+                               PARTITION BY e."BondDetailsId"
+                               ORDER BY e."PostingDate", e."EntryId"
+                               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                           ) AS "NewValue"
+                    FROM "BondEntries" e
+                    LEFT JOIN anchors a ON a."BondDetailsId" = e."BondDetailsId"
+                    WHERE e."AccountId" = {accountId} AND e."PostingDate" >= {startDate}
+                )
+                UPDATE "BondEntries" AS e
+                SET "Value" = r."NewValue"
+                FROM running AS r
+                WHERE e."EntryId" = r."EntryId"
+                """);
+        }
+        else
+        {
+            await context.Database.ExecuteSqlAsync($"""
+                WITH anchors_raw AS (
+                    SELECT BondDetailsId, Value AS AnchorValue,
+                           ROW_NUMBER() OVER (PARTITION BY BondDetailsId ORDER BY PostingDate DESC, EntryId DESC) AS rn
+                    FROM BondEntries
+                    WHERE AccountId = {accountId} AND PostingDate < {startDate}
+                ),
+                anchors AS (
+                    SELECT BondDetailsId, AnchorValue FROM anchors_raw WHERE rn = 1
+                ),
+                running AS (
+                    SELECT e.EntryId,
+                           COALESCE(a.AnchorValue, 0) + SUM(e.ValueChange) OVER (
+                               PARTITION BY e.BondDetailsId
+                               ORDER BY e.PostingDate, e.EntryId
+                               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                           ) AS NewValue
+                    FROM BondEntries e
+                    LEFT JOIN anchors a ON a.BondDetailsId = e.BondDetailsId
+                    WHERE e.AccountId = {accountId} AND e.PostingDate >= {startDate}
+                )
+                UPDATE e
+                SET Value = r.NewValue
+                FROM BondEntries e
+                INNER JOIN running r ON e.EntryId = r.EntryId
+                """);
+        }
+    }
+
+    private async Task RecalculateInMemory(int accountId, DateTime startDate)
+    {
+        var entries = await context.BondEntries
+            .Where(e => e.AccountId == accountId && e.PostingDate >= startDate)
+            .OrderBy(e => e.PostingDate)
+            .ThenBy(e => e.EntryId)
+            .ToListAsync();
+
+        if (entries.Count == 0) return;
+
+        var bondIds = entries.Select(e => e.BondDetailsId).Distinct().ToList();
+        var anchors = (await context.BondEntries
+                .AsNoTracking()
+                .Where(e => e.AccountId == accountId && bondIds.Contains(e.BondDetailsId) && e.PostingDate < startDate)
+                .OrderByDescending(e => e.PostingDate)
+                .ThenByDescending(e => e.EntryId)
+                .ToListAsync())
+            .GroupBy(e => e.BondDetailsId)
+            .ToDictionary(g => g.Key, g => g.First().Value);
+
+        foreach (var bondGroup in entries.GroupBy(e => e.BondDetailsId))
+        {
+            decimal running = anchors.TryGetValue(bondGroup.Key, out var anchor) ? anchor : 0m;
+            foreach (var entry in bondGroup.OrderBy(e => e.PostingDate).ThenBy(e => e.EntryId))
+            {
+                running += entry.ValueChange;
+                entry.Value = running;
+            }
+        }
+
+        await context.SaveChangesAsync();
+    }
+}

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryRepository.cs
@@ -8,6 +8,7 @@ namespace FinanceManager.Infrastructure.Repositories.Account.Entry;
 
 public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryRepository<CurrencyAccountEntry>
 {
+    private readonly CurrencyEntryValueCalculator _valueCalculator = new(context);
     public async Task<bool> Add(CurrencyAccountEntry entry, bool recalculate)
     {
         CurrencyAccountEntry newAccountEntry = new(entry.AccountId, 0, entry.PostingDate, entry.Value, entry.ValueChange)
@@ -384,77 +385,7 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
     }
 
     private async Task RecalculateValues(int accountId, DateTime startDate)
-    {
-        var anchor = await context.CurrencyEntries
-            .AsNoTracking()
-            .Where(e => e.AccountId == accountId && e.PostingDate < startDate)
-            .OrderByDescending(e => e.PostingDate)
-            .ThenByDescending(e => e.EntryId)
-            .Select(e => (decimal?)e.Value)
-            .FirstOrDefaultAsync();
-
-        if (!context.Database.IsRelational())
-        {
-            await RecalculateValuesInMemory(accountId, startDate, anchor);
-            return;
-        }
-
-        if (context.Database.ProviderName?.StartsWith("Npgsql") == true)
-        {
-            await context.Database.ExecuteSqlAsync($"""
-                WITH running AS (
-                    SELECT "EntryId",
-                           {anchor ?? 0m} + SUM("ValueChange") OVER (
-                               ORDER BY "PostingDate", "EntryId"
-                               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-                           ) AS "NewValue"
-                    FROM "CurrencyEntries"
-                    WHERE "AccountId" = {accountId}
-                      AND "PostingDate" >= {startDate}
-                )
-                UPDATE "CurrencyEntries" AS e
-                SET "Value" = r."NewValue"
-                FROM running AS r
-                WHERE e."EntryId" = r."EntryId"
-                """);
-        }
-        else
-        {
-            await context.Database.ExecuteSqlAsync($"""
-                WITH running AS (
-                    SELECT EntryId,
-                           {anchor ?? 0m} + SUM(ValueChange) OVER (
-                               ORDER BY PostingDate, EntryId
-                               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-                           ) AS NewValue
-                    FROM CurrencyEntries
-                    WHERE AccountId = {accountId}
-                      AND PostingDate >= {startDate}
-                )
-                UPDATE e
-                SET Value = r.NewValue
-                FROM CurrencyEntries AS e
-                INNER JOIN running AS r ON e.EntryId = r.EntryId
-                """);
-        }
-    }
-
-    private async Task RecalculateValuesInMemory(int accountId, DateTime startDate, decimal? anchor)
-    {
-        var entries = await context.CurrencyEntries
-            .Where(e => e.AccountId == accountId && e.PostingDate >= startDate)
-            .OrderBy(e => e.PostingDate)
-            .ThenBy(e => e.EntryId)
-            .ToListAsync();
-
-        decimal running = anchor ?? 0m;
-        foreach (var e in entries)
-        {
-            running += e.ValueChange;
-            e.Value = running;
-        }
-        await context.SaveChangesAsync();
-    }
+        => await _valueCalculator.Recalculate(accountId, startDate);
 
     public async Task<IReadOnlyList<CurrencyAccountEntry>> GetByIds(IReadOnlyCollection<int> entryIds, CancellationToken cancellationToken = default)
     {

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryValueCalculator.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryValueCalculator.cs
@@ -1,0 +1,76 @@
+using FinanceManager.Infrastructure.Contexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Infrastructure.Repositories.Account.Entry;
+
+internal sealed class CurrencyEntryValueCalculator(AppDbContext context)
+{
+    public async Task Recalculate(int accountId, DateTime startDate)
+    {
+        var anchor = await context.CurrencyEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == accountId && e.PostingDate < startDate)
+            .OrderByDescending(e => e.PostingDate)
+            .ThenByDescending(e => e.EntryId)
+            .Select(e => (decimal?)e.Value)
+            .FirstOrDefaultAsync();
+
+        if (!context.Database.IsRelational())
+        {
+            var entries = await context.CurrencyEntries
+                .Where(e => e.AccountId == accountId && e.PostingDate >= startDate)
+                .OrderBy(e => e.PostingDate)
+                .ThenBy(e => e.EntryId)
+                .ToListAsync();
+
+            decimal running = anchor ?? 0m;
+            foreach (var entry in entries)
+            {
+                running += entry.ValueChange;
+                entry.Value = running;
+            }
+
+            await context.SaveChangesAsync();
+            return;
+        }
+
+        if (context.Database.ProviderName?.StartsWith("Npgsql") == true)
+        {
+            await context.Database.ExecuteSqlAsync($"""
+                WITH running AS (
+                    SELECT "EntryId",
+                           {anchor ?? 0m} + SUM("ValueChange") OVER (
+                               ORDER BY "PostingDate", "EntryId"
+                               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                           ) AS "NewValue"
+                    FROM "CurrencyEntries"
+                    WHERE "AccountId" = {accountId}
+                      AND "PostingDate" >= {startDate}
+                )
+                UPDATE "CurrencyEntries" AS e
+                SET "Value" = r."NewValue"
+                FROM running AS r
+                WHERE e."EntryId" = r."EntryId"
+                """);
+        }
+        else
+        {
+            await context.Database.ExecuteSqlAsync($"""
+                WITH running AS (
+                    SELECT EntryId,
+                           {anchor ?? 0m} + SUM(ValueChange) OVER (
+                               ORDER BY PostingDate, EntryId
+                               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                           ) AS NewValue
+                    FROM CurrencyEntries
+                    WHERE AccountId = {accountId}
+                      AND PostingDate >= {startDate}
+                )
+                UPDATE e
+                SET Value = r.NewValue
+                FROM CurrencyEntries AS e
+                INNER JOIN running AS r ON e.EntryId = r.EntryId
+                """);
+        }
+    }
+}

--- a/code/FinanceManager.Infrastructure/Repositories/AccountRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/AccountRepository.cs
@@ -28,7 +28,6 @@ public class AccountRepository(ICurrencyAccountRepository<CurrencyAccount> curre
 
         return result;
     }
-    public Task<int> GetLastAccountId() => throw new NotImplementedException();
     public async Task<int> GetAccountsCount()
     {
         int currencyAccountsCount = await currencyAccountRepository.GetAccountsCount();
@@ -37,35 +36,6 @@ public class AccountRepository(ICurrencyAccountRepository<CurrencyAccount> curre
 
         return currencyAccountsCount + investmentAccountsCount + bondAccountsCount;
     }
-    public async Task<DateTime?> GetStartDate(int id)
-    {
-        var account = await FindAccount(id);
-        if (account is null) return null;
-
-        return account switch
-        {
-            CurrencyAccount currencyAccount => currencyAccount.Start,
-            InvestmentAccount investmentAccount => investmentAccount.Start,
-            BondAccount bondAccount => bondAccount.Start,
-            _ => throw new NotSupportedException($"Account type {account.GetType()} is not supported."),
-        };
-    }
-    public async Task<DateTime?> GetEndDate(int id)
-    {
-        var account = await FindAccount(id);
-        if (account is null) return null;
-
-        return account switch
-        {
-            CurrencyAccount currencyAccount => currencyAccount.End,
-            InvestmentAccount investmentAccount => investmentAccount.End,
-            BondAccount bondAccount => bondAccount.End,
-            _ => throw new NotSupportedException($"Account type {account.GetType()} is not supported."),
-        };
-    }
-
-    public Task<bool> AccountExists(int id) => throw new NotImplementedException();
-
     public async Task<T?> GetAccount<T>(int userId, int accountId, DateTime dateStart, DateTime dateEnd) where T : BasicAccountInformation
     {
         switch (typeof(T))
@@ -239,9 +209,6 @@ public class AccountRepository(ICurrencyAccountRepository<CurrencyAccount> curre
 
         throw new NotSupportedException($"Account type {account.GetType()} is not supported.");
     }
-    public Task AddAccount<AccountType, EntryType>(string accountName, List<EntryType> data)
-        where AccountType : BasicAccountInformation
-        where EntryType : FinancialEntryBase => throw new NotImplementedException();
     public Task UpdateAccount<T>(T account) where T : BasicAccountInformation
     {
         if (account is CurrencyAccount currencyAccount) return currencyAccountRepository.Update(currencyAccount.AccountId, currencyAccount.Name, currencyAccount.AccountType);
@@ -278,61 +245,4 @@ public class AccountRepository(ICurrencyAccountRepository<CurrencyAccount> curre
                 throw new InvalidOperationException($"Account with id {id} not found.");
         }
     }
-
-    public async Task<T?> GetNextYounger<T>(int accountId, DateTime date) where T : FinancialEntryBase => await currencyEntryRepository.GetNextYounger(accountId, date) as T;
-    public async Task AddEntry<T>(T accountEntry, int id) where T : FinancialEntryBase
-    {
-        if (accountEntry is CurrencyAccountEntry currencyEntry)
-            await AddCurrencyAccountEntry(id, currencyEntry.ValueChange, currencyEntry.Description, currencyEntry.ContractorDetails, currencyEntry.PostingDate);
-        else
-            throw new NotSupportedException($"Entry type {accountEntry.GetType()} is not supported.");
-    }
-    public Task<bool> AddLabel<T>(T accountEntry, int labelId) where T : FinancialEntryBase
-    {
-        if (accountEntry is CurrencyAccountEntry currencyEntry)
-            return currencyEntryRepository.AddLabel(currencyEntry.EntryId, labelId);
-
-        throw new NotSupportedException($"Entry type {accountEntry.GetType()} is not supported.");
-    }
-    public async Task UpdateEntry<T>(T accountEntry, int id) where T : FinancialEntryBase
-    {
-        if (accountEntry is CurrencyAccountEntry currencyEntry)
-            await UpdateCurrencyAccountEntry(id, currencyEntry);
-        else
-            throw new NotSupportedException($"Entry type {accountEntry.GetType()} is not supported.");
-    }
-    public async Task RemoveEntry(int accountEntryId, int id)
-    {
-        var account = await FindAccount(id);
-        if (account is null) return;
-
-        switch (account)
-        {
-            case CurrencyAccount currencyAccount:
-                currencyAccount.Remove(accountEntryId);
-                break;
-        }
-    }
-    private Task<object?> FindAccount(int id) => throw new NotImplementedException();
-
-    private async Task AddCurrencyAccountEntry(int id, decimal balanceChange, string description, string? contractorDetails, DateTime? postingDate = null)
-    {
-        var account = await FindAccount<CurrencyAccount>(id);
-        if (account is null) return;
-
-        var finalPostingDate = postingDate ?? DateTime.UtcNow;
-
-        account.AddEntry(new AddCurrencyEntryDto(finalPostingDate, balanceChange, description, contractorDetails, [new() { Name = "Sallary" }]));
-    }
-    private async Task UpdateCurrencyAccountEntry(int id, CurrencyAccountEntry currencyAccountEntry)
-    {
-        var currencyAccount = await FindAccount<CurrencyAccount>(id);
-        if (currencyAccount is null || currencyAccount.Entries is null) return;
-
-        var entryToUpdate = currencyAccount.Entries.FirstOrDefault(x => x.EntryId == currencyAccountEntry.EntryId);
-        if (entryToUpdate is null) return;
-
-        entryToUpdate.Update(currencyAccountEntry);
-    }
-    private Task<T?> FindAccount<T>(int id) where T : BasicAccountInformation => throw new NotImplementedException();
 }


### PR DESCRIPTION
## What changed

- extracted bond and currency running-value calculations into concrete calculators
- kept repository query and persistence behavior unchanged
- removed dead legacy account repository APIs and unimplemented paths

## Why

Entry repositories mixed persistence with provider-specific running-value algorithms, while the legacy account facade exposed unused mutation APIs.

## Validation

- `dotnet build ./code/FinanceManager.slnx`
- 513 unit tests passed

Closes #532