### PR TITLE
Split large financial account UI responsibilities

### DIFF
--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
@@ -13,7 +13,6 @@ using FinanceManager.Domain.MoneyFlow.Entities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using MudBlazor;
-using System.Text.Json;
 
 namespace FinanceManager.Components.Components.Features.FinancialAccounts.BondAccountComponents.TransactionHistory;
 
@@ -62,7 +61,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     [Inject] public required ILoginService LoginService { get; set; }
     [Inject] public required MoneyFlowHttpClient MoneyFlowHttpClient { get; set; }
     [Inject] public required BondDetailsHttpClient BondDetailsHttpClient { get; set; }
-    [Inject] public required ISnapshotService SnapshotService { get; set; }
+    [Inject] public required AccountDetailsSnapshotStore SnapshotStore { get; set; }
     [Inject] public required ILogger<BondAccountDetailsPageContent> Logger { get; set; }
     [Inject] public required IBrowserViewportService BrowserViewportService { get; set; }
 
@@ -401,40 +400,20 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     private void SetDateRangeForSelection()
     {
         var today = DateTime.UtcNow;
-        if (_selectedRange == AccountDetailsHero.CustomRangeKey)
-        {
-            _dateStart = _customDateRange?.Start ?? Account?.Start ?? today.AddMonths(-3);
-            _dateEnd = _customDateRange?.End ?? today;
-            if (_dateEnd > today)
-                _dateEnd = today;
-            return;
-        }
-
-        _dateStart = _selectedRange switch
-        {
-            "Month" => DateRangeHelper.GetCurrentMonthRange().Start,
-            "1M" => today.AddMonths(-1),
-            "3M" => today.AddMonths(-3),
-            "6M" => today.AddMonths(-6),
-            "YTD" => new DateTime(today.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-            _ => DateRangeHelper.GetCurrentMonthRange().Start
-        };
-        _dateEnd = today;
+        (_dateStart, _dateEnd) = DateRangeHelper.GetAccountDetailsRange(
+            _selectedRange, _customDateRange?.Start, _customDateRange?.End,
+            Account?.Start ?? today.AddMonths(-3), new DateTime(today.Year, today.Month, 1, 0, 0, 0, DateTimeKind.Utc), today);
     }
 
     private void ApplyAutomaticCustomRange(DateTime selectedStart)
     {
-        var oldestFetchedEntryDate = Account?.Entries?.MinBy(x => x.PostingDate)?.PostingDate;
-        if (oldestFetchedEntryDate is null || oldestFetchedEntryDate.Value >= selectedStart)
-            return;
+        var expandedStart = DateRangeHelper.GetExpandedStart(selectedStart, Account?.Entries?.MinBy(x => x.PostingDate)?.PostingDate);
+        if (expandedStart is not DateTime oldest) return;
 
         _selectedRange = AccountDetailsHero.CustomRangeKey;
-        _dateStart = oldestFetchedEntryDate.Value;
+        _dateStart = oldest;
         _customDateRange = new DateRange(_dateStart, _dateEnd);
     }
-
-    // Per user + account, with no date component, so a single snapshot per account is overwritten each save.
-    private string BuildSnapshotKey(int userId) => $"account-details:{userId}:{AccountId}";
 
     // Reads the persisted snapshot and paints its entries so the page feels instant on
     // re-navigation. Chart data is not snapshotted; UpdateInfo queues a fresh API load.
@@ -442,18 +421,8 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     {
         if (_user is null) return null;
 
-        AccountDetailsSnapshot<BondAccountEntry>? snapshot = null;
-        try
-        {
-            snapshot = await SnapshotService.GetAsync<AccountDetailsSnapshot<BondAccountEntry>>(BuildSnapshotKey(_user.UserId));
-        }
-        catch (Exception ex)
-        {
-            // A storage/interop failure on read must not abort the load — fall through to the fresh fetch.
-            Logger.LogWarning(ex, "Failed to read account details snapshot; continuing with fresh fetch.");
-        }
-
-        if (snapshot is null || snapshot.AccountId != AccountId) return null;
+        var snapshot = await SnapshotStore.GetAsync<BondAccountEntry>(_user.UserId, AccountId);
+        if (snapshot is null) return null;
 
         Account = new BondAccount(snapshot.UserId, snapshot.AccountId, snapshot.Name, snapshot.Entries, snapshot.AccountType);
         await UpdateInfo();
@@ -467,9 +436,6 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     {
         if (_user is null || Account is null) return;
 
-        if (previous is not null && EntriesMatch(Account.Entries, previous.Entries))
-            return;
-
         var snapshot = new AccountDetailsSnapshot<BondAccountEntry>
         {
             UserId = _user.UserId,
@@ -478,16 +444,6 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
             AccountType = Account.AccountType,
             Entries = Account.Entries,
         };
-        try
-        {
-            await SnapshotService.SetAsync(BuildSnapshotKey(_user.UserId), snapshot);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Account details loaded but snapshot save failed.");
-        }
+        await SnapshotStore.SaveIfChangedAsync(snapshot, previous);
     }
-
-    private static bool EntriesMatch(List<BondAccountEntry> fresh, List<BondAccountEntry> snapshot)
-        => JsonSerializer.Serialize(fresh) == JsonSerializer.Serialize(snapshot);
 }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Import/ImportCurrencyEntriesComponent.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Import/ImportCurrencyEntriesComponent.razor
@@ -148,31 +148,31 @@
                          Disabled="@(_step2Complete == false)">
                     <MudStack Spacing="3" Class="pa-4">
 
-                        @if (ShowImportProgress && _activeJobStatus is not null)
+                        @if (ShowImportProgress && ActiveJobStatus is not null)
                         {
                             <MudStack Spacing="2">
                                 <MudProgressLinear Color="Color.Primary" Value="@ImportProgressValue" BufferValue="100"
                                                    Style="height: 6px;" Rounded="true" />
                                 <MudStack Row="true" Spacing="4">
                                     <MudText Typo="Typo.caption" Class="mud-text-secondary">
-                                        Processed @_activeJobStatus.ProcessedEntries / @_activeJobStatus.TotalEntries
+                                        Processed @ActiveJobStatus.ProcessedEntries / @ActiveJobStatus.TotalEntries
                                     </MudText>
-                                    @if (_activeJobStatus.ConflictCount > 0)
+                                    @if (ActiveJobStatus.ConflictCount > 0)
                                     {
                                         <MudText Typo="Typo.caption" Class="mud-text-secondary">
-                                            @_activeJobStatus.ConflictCount conflicts
+                                            @ActiveJobStatus.ConflictCount conflicts
                                         </MudText>
                                     }
-                                    @if (_activeJobStatus.Failed > 0)
+                                    @if (ActiveJobStatus.Failed > 0)
                                     {
                                         <MudText Typo="Typo.caption" Color="Color.Error">
-                                            @_activeJobStatus.Failed failed
+                                            @ActiveJobStatus.Failed failed
                                         </MudText>
                                     }
                                 </MudStack>
                             </MudStack>
                         }
-                        else if (_isImportingData || (_activeImportJobId.HasValue && _activeJobStatus is null))
+                        else if (_isImportingData || (ActiveImportJobId.HasValue && ActiveJobStatus is null))
                         {
                             <MudSkeleton Height="40px" Animation="Animation.Wave" />
                         }
@@ -187,16 +187,16 @@
                             <MudAlert Severity="Severity.Warning" Variant="Variant.Text" Dense="true">@warningInfo</MudAlert>
                         }
 
-                        @if (!string.IsNullOrWhiteSpace(_jobError))
+                        @if (!string.IsNullOrWhiteSpace(JobError))
                         {
-                            <MudAlert Severity="Severity.Error" Variant="Variant.Text" Dense="true">@_jobError</MudAlert>
+                            <MudAlert Severity="Severity.Error" Variant="Variant.Text" Dense="true">@JobError</MudAlert>
                         }
 
-                        @if (_activeImportJobId.HasValue && _liveConflicts.Any(x => !x.IsResolved && !x.Conflict.IsExactMatch))
+                        @if (ActiveImportJobId.HasValue && LiveConflicts.Any(x => !x.IsResolved && !x.Conflict.IsExactMatch))
                         {
                             <CurrencyEntryConflictResolver @ref="_resolverRef"
-                                JobConflicts="@_liveConflicts.Where(x => !x.IsResolved && !x.Conflict.IsExactMatch).ToList()"
-                                JobId="_activeImportJobId" AccountName="@AccountName"
+                                JobConflicts="@LiveConflicts.Where(x => !x.IsResolved && !x.Conflict.IsExactMatch).ToList()"
+                                JobId="ActiveImportJobId" AccountName="@AccountName"
                                 OnConflictsResolved="OnConflictsResolved"
                                 OnResolutionChanged="StateHasChanged" />
                         }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Import/ImportCurrencyEntriesComponent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Import/ImportCurrencyEntriesComponent.razor.cs
@@ -1,13 +1,13 @@
 using FinanceManager.Components.Components.Features.FinancialAccounts.Shared.Import;
 using FinanceManager.Components.DtoMapping;
 using FinanceManager.Components.HttpClients;
+using FinanceManager.Components.Services;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Shared.Imports;
 using FinanceManager.Infrastructure.Readers;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
 
 namespace FinanceManager.Components.Components.Features.FinancialAccounts.CurrencyAccountComponents.Import;
@@ -16,22 +16,21 @@ public partial class ImportCurrencyEntriesComponent :
     ImportEntriesComponentBase<CurrencyAccount, ImportCurrencyEntriesComponent>,
     IAsyncDisposable
 {
-    private List<ImportJobConflict> _liveConflicts = [];
     private string? _selectedPostingDateHeader;
     private string? _selectedValueChangeHeader;
     private string? _selectedContractorDetailsHeader;
     private string? _selectedDescriptionHeader;
     private List<(DateTime PostingDate, decimal ValueChange, string? ContractorDetails, string? Description)> _mappedPreview = [];
     private ImportResult? _importResult;
-    private Guid? _activeImportJobId;
-    private CurrencyImportJobStatusDto? _activeJobStatus;
-    private string? _jobError;
-    private HubConnection? _hubConnection;
-    private CancellationTokenSource? _jobPollingCts;
 
     [Inject] public required CurrencyAccountImportHttpClient AccountImportHttpClient { get; set; }
     [Inject] public required CurrencyAccountHttpClient AccountHttpClient { get; set; }
-    [Inject] public required NavigationManager NavigationManager { get; set; }
+    [Inject] public required CurrencyImportJobTracker JobTracker { get; set; }
+
+    private IReadOnlyList<ImportJobConflict> LiveConflicts => JobTracker.Conflicts;
+    private Guid? ActiveImportJobId => JobTracker.JobId;
+    private CurrencyImportJobStatusDto? ActiveJobStatus => JobTracker.Status;
+    private string? JobError => JobTracker.Error;
 
     private CurrencyEntryConflictResolver? _resolverRef;
 
@@ -39,22 +38,22 @@ public partial class ImportCurrencyEntriesComponent :
     protected override bool HasMappedPreview => _mappedPreview.Any();
     protected override bool CanSubmitConflicts => _resolverRef?.AllResolved == true;
     protected override bool HasUnresolvedConflicts =>
-        (_activeImportJobId.HasValue && _liveConflicts.Any(x => !x.IsResolved && !x.Conflict.IsExactMatch)) ||
+        (ActiveImportJobId.HasValue && LiveConflicts.Any(x => !x.IsResolved && !x.Conflict.IsExactMatch)) ||
         (_importResult is not null && _importResult.Conflicts.Any());
 
-    private int UnresolvedConflictCount => Math.Max(0, (_activeJobStatus?.ConflictCount ?? 0) - (_activeJobStatus?.ResolvedConflictCount ?? 0));
-    private double ImportProgressValue => _activeJobStatus?.TotalEntries > 0
-        ? (double)_activeJobStatus.ProcessedEntries / _activeJobStatus.TotalEntries * 100d
+    private int UnresolvedConflictCount => Math.Max(0, (ActiveJobStatus?.ConflictCount ?? 0) - (ActiveJobStatus?.ResolvedConflictCount ?? 0));
+    private double ImportProgressValue => ActiveJobStatus?.TotalEntries > 0
+        ? (double)ActiveJobStatus.ProcessedEntries / ActiveJobStatus.TotalEntries * 100d
         : 0d;
-    private bool ShowImportProgress => _activeJobStatus?.Status is AsyncImportJobState.Queued or AsyncImportJobState.Running;
-    private bool CanReturnToAccount => _activeImportJobId.HasValue &&
-        (_activeJobStatus?.IsCompleted ?? false) &&
+    private bool ShowImportProgress => ActiveJobStatus?.Status is AsyncImportJobState.Queued or AsyncImportJobState.Running;
+    private bool CanReturnToAccount => ActiveImportJobId.HasValue &&
+        (ActiveJobStatus?.IsCompleted ?? false) &&
         UnresolvedConflictCount == 0 &&
-        _liveConflicts.All(x => x.IsResolved || x.Conflict.IsExactMatch);
+        LiveConflicts.All(x => x.IsResolved || x.Conflict.IsExactMatch);
     private bool ShowAsyncImportCompletedMessage => _stepIndex == 2 && CanReturnToAccount;
     private bool ShowSynchronousImportCompletedMessage => _stepIndex == 2 &&
-        !_activeImportJobId.HasValue &&
-        (_activeJobStatus?.IsCompleted ?? true) &&
+        !ActiveImportJobId.HasValue &&
+        (ActiveJobStatus?.IsCompleted ?? true) &&
         _step3Complete &&
         _importResult is not null &&
         !_importResult.Conflicts.Any();
@@ -63,8 +62,11 @@ public partial class ImportCurrencyEntriesComponent :
 
     protected override async Task OnInitializedAsync()
     {
+        JobTracker.Changed += OnTrackingChanged;
         await LoadAccountName();
     }
+
+    private void OnTrackingChanged() => _ = InvokeAsync(StateHasChanged);
 
     protected override Task<(List<string> Headers, List<List<string>> Data)?> ReadCsvAsync(
         string content,
@@ -132,10 +134,7 @@ public partial class ImportCurrencyEntriesComponent :
     {
         _isImportingData = true;
         _warnings.Clear();
-        _jobError = null;
-        _liveConflicts.Clear();
-        _activeImportJobId = null;
-        _activeJobStatus = null;
+        await JobTracker.ResetAsync();
 
         if (string.IsNullOrEmpty(_uploadedContent))
         {
@@ -167,12 +166,7 @@ public partial class ImportCurrencyEntriesComponent :
             if (startResponse is null)
                 throw new Exception("Async import could not be started.");
 
-            _activeImportJobId = startResponse.JobId;
-
-            await EnsureHubConnection();
-            await JoinJobRoom();
-            await RefreshJobStatus();
-            StartStatusPolling();
+            await JobTracker.StartAsync(startResponse.JobId);
         }
         catch (Exception ex)
         {
@@ -191,13 +185,8 @@ public partial class ImportCurrencyEntriesComponent :
 
     public override async Task Clear()
     {
-        await StopImportTracking();
+        await JobTracker.ResetAsync();
         await base.Clear();
-
-        _liveConflicts.Clear();
-        _activeImportJobId = null;
-        _activeJobStatus = null;
-        _jobError = null;
         _importResult = null;
     }
 
@@ -249,189 +238,18 @@ public partial class ImportCurrencyEntriesComponent :
             "Failed to save mapping choices");
     }
 
-    private async Task EnsureHubConnection()
-    {
-        if (_hubConnection is not null)
-        {
-            if (_hubConnection.State == HubConnectionState.Disconnected)
-                await _hubConnection.StartAsync();
-
-            return;
-        }
-
-        _hubConnection = new HubConnectionBuilder()
-            .WithUrl(NavigationManager.ToAbsoluteUri("hubs/currency-import"), options =>
-            {
-                options.AccessTokenProvider = async () => (await LoginService.GetLoggedUser())?.Token;
-            })
-            .WithAutomaticReconnect()
-            .Build();
-
-        _hubConnection.On<CurrencyImportJobStatusDto>("ImportStatusUpdated", status =>
-        {
-            if (ApplyJobStatus(status))
-                _ = InvokeAsync(StateHasChanged);
-        });
-
-        _hubConnection.On<ImportJobConflict>("ConflictDiscovered", conflict =>
-        {
-            if (_activeImportJobId is null)
-                return;
-
-            if (_liveConflicts.Any(x => x.ConflictId == conflict.ConflictId))
-                return;
-
-            _liveConflicts.Add(conflict);
-            _ = InvokeAsync(StateHasChanged);
-        });
-
-        await _hubConnection.StartAsync();
-    }
-
-    private async Task JoinJobRoom()
-    {
-        if (_hubConnection is null || _activeImportJobId is null)
-            return;
-
-        await _hubConnection.InvokeAsync("JoinJob", _activeImportJobId.Value.ToString());
-    }
-
-    private void StartStatusPolling()
-    {
-        if (_activeImportJobId is null)
-            return;
-
-        _jobPollingCts?.Cancel();
-        _jobPollingCts?.Dispose();
-        _jobPollingCts = new CancellationTokenSource();
-
-        _ = PollStatus(_jobPollingCts.Token);
-    }
-
-    private async Task PollStatus(CancellationToken cancellationToken)
-    {
-        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(2));
-
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            var hasNext = await timer.WaitForNextTickAsync(cancellationToken);
-            if (!hasNext)
-                break;
-
-            await RefreshJobStatus();
-
-            if (_activeJobStatus?.IsCompleted == true)
-                break;
-        }
-    }
-
-    private async Task RefreshJobStatus()
-    {
-        if (_activeImportJobId is null)
-            return;
-
-        try
-        {
-            var status = await AccountImportHttpClient.GetCurrencyImportStatusAsync(_activeImportJobId.Value);
-            if (status is null)
-                return;
-
-            if (!ApplyJobStatus(status))
-                return;
-
-            if (status.IsCompleted && status.Failed > 0)
-                _jobError = $"Import completed with {status.Failed} failed entr{(status.Failed == 1 ? "y" : "ies")}.";
-
-            if (status.Errors.Count > 0)
-                _jobError = status.Errors.LastOrDefault();
-
-            await InvokeAsync(StateHasChanged);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogDebug(ex, "Unable to refresh import job status");
-        }
-    }
-
     private Task OnConflictsResolved(IReadOnlyCollection<string> conflictIds)
     {
-        if (conflictIds.Count == 0)
-            return Task.CompletedTask;
-
-        _liveConflicts = _liveConflicts
-            .Select(x => conflictIds.Contains(x.ConflictId) ? x with { IsResolved = true } : x)
-            .ToList();
-
-        if (_activeJobStatus is not null)
-        {
-            var resolvedCount = _liveConflicts.Count(x => !x.Conflict.IsExactMatch && x.IsResolved);
-            _activeJobStatus = _activeJobStatus with
-            {
-                ResolvedConflictCount = Math.Max(_activeJobStatus.ResolvedConflictCount, resolvedCount)
-            };
-        }
-
+        JobTracker.MarkResolved(conflictIds);
         return Task.CompletedTask;
-    }
-
-    private bool ApplyJobStatus(CurrencyImportJobStatusDto status)
-    {
-        if (_activeImportJobId != status.JobId)
-            return false;
-
-        if (_activeJobStatus is not null && status.ProcessedEntries < _activeJobStatus.ProcessedEntries)
-            return false;
-
-        _activeJobStatus = status;
-        _liveConflicts = MergeConflicts(_liveConflicts, status.Conflicts);
-        return true;
-    }
-
-    private static List<ImportJobConflict> MergeConflicts(
-        IReadOnlyCollection<ImportJobConflict> current,
-        IReadOnlyCollection<ImportJobConflict> incoming)
-    {
-        var currentById = current.ToDictionary(x => x.ConflictId);
-        var merged = new List<ImportJobConflict>();
-
-        foreach (var incomingConflict in incoming)
-        {
-            if (currentById.TryGetValue(incomingConflict.ConflictId, out var currentConflict) && currentConflict.IsResolved)
-                merged.Add(incomingConflict with { IsResolved = true });
-            else
-                merged.Add(incomingConflict);
-        }
-
-        foreach (var currentConflict in current)
-        {
-            if (!incoming.Any(x => x.ConflictId == currentConflict.ConflictId))
-                merged.Add(currentConflict);
-        }
-
-        return merged;
-    }
-
-    private async Task StopImportTracking()
-    {
-        if (_jobPollingCts is not null)
-        {
-            _jobPollingCts.Cancel();
-            _jobPollingCts.Dispose();
-            _jobPollingCts = null;
-        }
-
-        if (_hubConnection is not null)
-        {
-            await _hubConnection.DisposeAsync();
-            _hubConnection = null;
-        }
     }
 
     public async ValueTask DisposeAsync()
     {
         try
         {
-            await StopImportTracking();
+            JobTracker.Changed -= OnTrackingChanged;
+            await JobTracker.DisposeAsync();
             DisposePreviewRegeneration();
         }
         catch

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor.cs
@@ -13,7 +13,6 @@ using FinanceManager.Domain.MoneyFlow.Entities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using MudBlazor;
-using System.Text.Json;
 
 namespace FinanceManager.Components.Components.Features.FinancialAccounts.CurrencyAccountComponents.TransactionHistory;
 
@@ -60,7 +59,7 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
     [Inject] public required MoneyFlowHttpClient MoneyFlowHttpClient { get; set; }
-    [Inject] public required ISnapshotService SnapshotService { get; set; }
+    [Inject] public required AccountDetailsSnapshotStore SnapshotStore { get; set; }
     [Inject] public required ILogger<CurrencyAccountDetailsPageContent> Logger { get; set; }
     [Inject] public required IBrowserViewportService BrowserViewportService { get; set; }
 
@@ -398,40 +397,20 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
     private void SetDateRangeForSelection()
     {
         var today = DateTime.UtcNow;
-        if (_selectedRange == AccountDetailsHero.CustomRangeKey)
-        {
-            _dateStart = _customDateRange?.Start ?? Account?.Start ?? today.AddMonths(-3);
-            _dateEnd = _customDateRange?.End ?? today;
-            if (_dateEnd > today)
-                _dateEnd = today;
-            return;
-        }
-
-        _dateStart = _selectedRange switch
-        {
-            "Month" => DateRangeHelper.GetCurrentMonthRange().Start,
-            "1M" => today.AddMonths(-1),
-            "3M" => today.AddMonths(-3),
-            "6M" => today.AddMonths(-6),
-            "YTD" => new DateTime(today.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-            _ => DateRangeHelper.GetCurrentMonthRange().Start,
-        };
-        _dateEnd = today;
+        (_dateStart, _dateEnd) = DateRangeHelper.GetAccountDetailsRange(
+            _selectedRange, _customDateRange?.Start, _customDateRange?.End,
+            Account?.Start ?? today.AddMonths(-3), new DateTime(today.Year, today.Month, 1, 0, 0, 0, DateTimeKind.Utc), today);
     }
 
     private void ApplyAutomaticCustomRange(DateTime selectedStart)
     {
-        var oldestFetchedEntryDate = Account?.Entries?.MinBy(x => x.PostingDate)?.PostingDate;
-        if (oldestFetchedEntryDate is null || oldestFetchedEntryDate.Value >= selectedStart)
-            return;
+        var expandedStart = DateRangeHelper.GetExpandedStart(selectedStart, Account?.Entries?.MinBy(x => x.PostingDate)?.PostingDate);
+        if (expandedStart is not DateTime oldest) return;
 
         _selectedRange = AccountDetailsHero.CustomRangeKey;
-        _dateStart = oldestFetchedEntryDate.Value;
+        _dateStart = oldest;
         _customDateRange = new DateRange(_dateStart, _dateEnd);
     }
-
-    // Per user + account, with no date component, so a single snapshot per account is overwritten each save.
-    private string BuildSnapshotKey(int userId) => $"account-details:{userId}:{AccountId}";
 
     // Reads the persisted snapshot and paints its entries so the page feels instant on
     // re-navigation. Chart data is not snapshotted; UpdateInfo queues a fresh API load.
@@ -439,18 +418,8 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
     {
         if (_user is null) return null;
 
-        AccountDetailsSnapshot<CurrencyAccountEntry>? snapshot = null;
-        try
-        {
-            snapshot = await SnapshotService.GetAsync<AccountDetailsSnapshot<CurrencyAccountEntry>>(BuildSnapshotKey(_user.UserId));
-        }
-        catch (Exception ex)
-        {
-            // A storage/interop failure on read must not abort the load — fall through to the fresh fetch.
-            Logger.LogWarning(ex, "Failed to read account details snapshot; continuing with fresh fetch.");
-        }
-
-        if (snapshot is null || snapshot.AccountId != AccountId) return null;
+        var snapshot = await SnapshotStore.GetAsync<CurrencyAccountEntry>(_user.UserId, AccountId);
+        if (snapshot is null) return null;
 
         Account = new CurrencyAccount(snapshot.UserId, snapshot.AccountId, snapshot.Name, snapshot.Entries, snapshot.AccountType);
         await UpdateInfo();
@@ -464,9 +433,6 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
     {
         if (_user is null || Account is null) return;
 
-        if (previous is not null && EntriesMatch(Account.Entries, previous.Entries))
-            return;
-
         var snapshot = new AccountDetailsSnapshot<CurrencyAccountEntry>
         {
             UserId = _user.UserId,
@@ -475,16 +441,6 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
             AccountType = Account.AccountType,
             Entries = Account.Entries,
         };
-        try
-        {
-            await SnapshotService.SetAsync(BuildSnapshotKey(_user.UserId), snapshot);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Account details loaded but snapshot save failed.");
-        }
+        await SnapshotStore.SaveIfChangedAsync(snapshot, previous);
     }
-
-    private static bool EntriesMatch(List<CurrencyAccountEntry> fresh, List<CurrencyAccountEntry> snapshot)
-        => JsonSerializer.Serialize(fresh) == JsonSerializer.Serialize(snapshot);
 }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
@@ -1,5 +1,4 @@
 @namespace FinanceManager.Components.Components.Features.FinancialAccounts.InvestmentAccountComponents
-@using FinanceManager.Domain.Assets.Dtos
 @using FinanceManager.Domain.FinancialAccounts.Investments.Entities
 @using FinanceManager.Components.Components.Features.FinancialAccounts.InvestmentAccountComponents.TransactionHistory
 @using FinanceManager.Components.Components.Features.FinancialAccounts.Shared
@@ -100,45 +99,8 @@ else
     }
 }
 
-<MudOverlay Visible="@_formVisible" DarkBackground="true" ZIndex="1300">
-    <MudPaper Class="pa-5" Style="width: min(460px, 92vw);">
-        <MudText Typo="Typo.h6" Class="mb-3">@(_editingId is null ? "Add transaction" : "Edit transaction")</MudText>
-        <MudStack Spacing="3">
-            <MudAutocomplete T="InstrumentSearchResultDto" Label="Instrument"
-                             Value="_selectedInstrument"
-                             ValueChanged="OnInstrumentSelectedAsync"
-                             SearchFunc="SearchInstrumentsAsync"
-                             ToStringFunc="@(dto => dto is null ? string.Empty : $"{dto.Ticker} — {dto.ExchangeName}")"
-                             MinCharacters="1"
-                             DebounceInterval="300"
-                             ResetValueOnEmptyText="true"
-                             CoerceText="false"
-                             Dense="true" />
-            @if (_editingId is null)
-            {
-                <InstrumentImport ButtonText="Can't find it? Import instrument" Imported="OnInstrumentImportedAsync" />
-            }
-            <MudSelect T="InvestmentTransactionType" Label="Type" @bind-Value="_formType" Dense="true">
-                <MudSelectItem T="InvestmentTransactionType" Value="InvestmentTransactionType.Buy">Buy</MudSelectItem>
-                <MudSelectItem T="InvestmentTransactionType" Value="InvestmentTransactionType.Sell">Sell</MudSelectItem>
-            </MudSelect>
-            <MudNumericField T="decimal" Label="Units" @bind-Value="_formQuantity" Min="0" Step="0.0001M" />
-            <MudTextField T="string" Label="Unit price" Value="@(_selectedInstrument is null ? string.Empty : _formUnitPrice.ToString("N2"))" ReadOnly="true" Disabled="true" />
-            @if (_noPriceAvailable && _selectedInstrument is not null)
-            {
-                <MudAlert Severity="Severity.Info" Dense="true">No price data found for this instrument. You can still save the transaction — the unit price will be recalculated once a price quote is available.</MudAlert>
-            }
-            <MudTextField T="string" Label="Currency" Value="@_formCurrency" ReadOnly="true" Disabled="true" />
-            <MudDatePicker Label="Trade date" Date="_formTradeDate" DateChanged="OnTradeDateChangedAsync" />
-            <MudNumericField T="decimal?" Label="Fee (optional)" @bind-Value="_formFee" Min="0" Step="0.01M" />
-            <MudTextField T="string" Label="Notes (optional)" @bind-Value="_formNotes" />
-            <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="2">
-                <MudButton Variant="Variant.Text" OnClick="CloseForm" Disabled="@_saving">Cancel</MudButton>
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveAsync" Disabled="@(_saving || !CanSave)">Save</MudButton>
-            </MudStack>
-        </MudStack>
-    </MudPaper>
-</MudOverlay>
+<InvestmentTransactionForm AccountId="@AccountId" Visible="@_formVisible" VisibleChanged="OnFormVisibleChanged"
+                           Transaction="@_editingTransaction" OnSaved="OnTransactionSavedAsync" />
 
 <MudScrollToTop TopOffset="400" ScrollBehavior="ScrollBehavior.Smooth">
     <MudFab Color="Color.Primary" Size="Size.Medium" StartIcon="@Icons.Material.Filled.KeyboardArrowUp"

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -1,8 +1,6 @@
 using FinanceManager.Components.Components.Features.FinancialAccounts.Shared;
 using FinanceManager.Components.Helpers;
 using FinanceManager.Components.HttpClients;
-using FinanceManager.Domain.Assets.Discovery;
-using FinanceManager.Domain.Assets.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
@@ -57,18 +55,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
 
     // Add/edit overlay state.
     private bool _formVisible;
-    private long? _editingId;
-    private InstrumentSearchResultDto? _selectedInstrument;
-    private long _formListingId;
-    private InvestmentTransactionType _formType = InvestmentTransactionType.Buy;
-    private decimal _formQuantity = 1m;
-    private decimal _formUnitPrice;
-    private string _formCurrency = string.Empty;
-    private DateTime? _formTradeDate = DateTime.Today;
-    private decimal? _formFee;
-    private string? _formNotes;
-    private bool _saving;
-    private bool _noPriceAvailable;
+    private InvestmentTransactionDto? _editingTransaction;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -290,36 +277,18 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
     private void SetDateRangeForSelection()
     {
         var today = DateTime.UtcNow;
-        if (_selectedRange == AccountDetailsHero.CustomRangeKey)
-        {
-            _dateStart = _customDateRange?.Start ?? today.AddMonths(-3);
-            _dateEnd = _customDateRange?.End ?? today;
-            if (_dateEnd > today)
-                _dateEnd = today;
-            return;
-        }
-
-        _dateStart = _selectedRange switch
-        {
-            "Month" => DateRangeHelper.GetCurrentMonthRange().Start,
-            "1M" => today.AddMonths(-1),
-            "3M" => today.AddMonths(-3),
-            "6M" => today.AddMonths(-6),
-            "YTD" => new DateTime(today.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
-            _ => today.AddMonths(-3)
-        };
-        _dateEnd = today;
+        (_dateStart, _dateEnd) = DateRangeHelper.GetAccountDetailsRange(
+            _selectedRange, _customDateRange?.Start, _customDateRange?.End,
+            today.AddMonths(-3), today.AddMonths(-3), today);
     }
 
     // On the first load, widen the range to the oldest recorded trade when it predates the
     // default window, so navigating in doesn't hide existing history behind an empty range.
     private void ApplyAutomaticCustomRange()
     {
-        var oldestTradeDate = _transactions.MinBy(t => t.TradeDate)?.TradeDate;
-        if (oldestTradeDate is null) return;
-
-        var oldestStart = oldestTradeDate.Value.ToDateTime(TimeOnly.MinValue);
-        if (oldestStart >= _dateStart) return;
+        var oldestTradeDate = _transactions.MinBy(t => t.TradeDate)?.TradeDate.ToDateTime(TimeOnly.MinValue);
+        var expandedStart = DateRangeHelper.GetExpandedStart(_dateStart, oldestTradeDate);
+        if (expandedStart is not DateTime oldestStart) return;
 
         _selectedRange = AccountDetailsHero.CustomRangeKey;
         _dateStart = oldestStart;
@@ -335,155 +304,26 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
 
     private void ShowAdd()
     {
-        _editingId = null;
-        _selectedInstrument = null;
-        _formListingId = 0;
-        _formType = InvestmentTransactionType.Buy;
-        _formQuantity = 1m;
-        _formUnitPrice = 0m;
-        _formCurrency = string.Empty;
-        _formTradeDate = DateTime.Today;
-        _formFee = null;
-        _formNotes = null;
-        _noPriceAvailable = false;
+        _editingTransaction = null;
         _formVisible = true;
     }
 
     private void ShowEdit(InvestmentTransactionDto tx)
     {
-        _editingId = tx.Id;
-        _selectedInstrument = new InstrumentSearchResultDto(tx.AssetListingId, tx.Ticker, tx.ExchangeName, tx.Currency);
-        _formListingId = tx.AssetListingId;
-        _formType = tx.Type;
-        _formQuantity = tx.Quantity;
-        _formUnitPrice = tx.UnitPrice;
-        _formCurrency = tx.Currency;
-        _formTradeDate = tx.TradeDate.ToDateTime(TimeOnly.MinValue);
-        _formFee = tx.Fee;
-        _formNotes = tx.Notes;
+        _editingTransaction = tx;
         _formVisible = true;
     }
 
-    private void CloseForm() => _formVisible = false;
-
-    private bool CanSave => _formListingId > 0 && _formQuantity > 0 && _formUnitPrice >= 0 && _formTradeDate is not null && !string.IsNullOrWhiteSpace(_formCurrency);
-
-    private async Task OnInstrumentSelectedAsync(InstrumentSearchResultDto? dto)
+    private Task OnFormVisibleChanged(bool visible)
     {
-        _selectedInstrument = dto;
-        _noPriceAvailable = false;
-        if (dto is null)
-        {
-            _formListingId = 0;
-            _formCurrency = string.Empty;
-            _formUnitPrice = 0m;
-            return;
-        }
-
-        _formListingId = dto.ListingId;
-        _formCurrency = dto.Currency;
-
-        await RefreshFormPriceAsync();
+        _formVisible = visible;
+        return Task.CompletedTask;
     }
 
-    private async Task OnTradeDateChangedAsync(DateTime? value)
+    private async Task OnTransactionSavedAsync()
     {
-        _formTradeDate = value;
-        await RefreshFormPriceAsync();
-    }
-
-    private async Task RefreshFormPriceAsync()
-    {
-        if (_selectedInstrument is null || _formTradeDate is not DateTime tradeDate)
-        {
-            _formUnitPrice = 0m;
-            return;
-        }
-
-        try
-        {
-            var priceInfo = await TransactionHttpClient.GetListingPriceAsync(
-                _selectedInstrument.ListingId,
-                DateOnly.FromDateTime(tradeDate));
-            if (priceInfo?.LatestPrice is decimal price)
-            {
-                _formUnitPrice = price;
-            }
-            else
-            {
-                _formUnitPrice = 0m;
-                _noPriceAvailable = true;
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Failed to fetch price for listing {ListingId}", _selectedInstrument.ListingId);
-            _formUnitPrice = 0m;
-            _noPriceAvailable = true;
-        }
-    }
-
-    private async Task<IEnumerable<InstrumentSearchResultDto>> SearchInstrumentsAsync(string value, CancellationToken ct)
-    {
-        if (string.IsNullOrWhiteSpace(value)) return [];
-        try
-        {
-            return await TransactionHttpClient.SearchListingsAsync(value);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Failed to search instrument listings for '{Query}'", value);
-            return [];
-        }
-    }
-
-    private async Task OnInstrumentImportedAsync(ImportedInstrumentDto imported)
-    {
-        await OnInstrumentSelectedAsync(new InstrumentSearchResultDto(
-            imported.AssetListingId, imported.Ticker, imported.ExchangeName, imported.TradingCurrency));
-        Snackbar.Add(imported.Warnings.Count == 0 ? "Instrument imported." : $"Instrument imported with {imported.Warnings.Count} warning(s).", Severity.Success);
-    }
-
-    private async Task SaveAsync()
-    {
-        if (!CanSave) return;
-        _saving = true;
-        try
-        {
-            var tradeDate = DateOnly.FromDateTime(_formTradeDate!.Value);
-            bool ok;
-            if (_editingId is long id)
-            {
-                ok = await TransactionHttpClient.UpdateAsync(new UpdateInvestmentTransactionRequest(
-                    id, AccountId, _formListingId, _formType, _formQuantity, _formUnitPrice, _formCurrency, tradeDate, _formFee, _formNotes));
-            }
-            else
-            {
-                var created = await TransactionHttpClient.AddAsync(new AddInvestmentTransactionRequest(
-                    AccountId, _formListingId, _formType, _formQuantity, _formUnitPrice, _formCurrency, tradeDate, _formFee, _formNotes));
-                ok = created is not null;
-            }
-
-            if (ok)
-            {
-                Snackbar.Add(_editingId is null ? "Transaction added." : "Transaction updated.", Severity.Success);
-                _formVisible = false;
-                await LoadAsync();
-            }
-            else
-            {
-                Snackbar.Add("Could not save the transaction.", Severity.Error);
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Failed to save investment transaction for account {AccountId}", AccountId);
-            Snackbar.Add("Could not save the transaction.", Severity.Error);
-        }
-        finally
-        {
-            _saving = false;
-        }
+        _formVisible = false;
+        await LoadAsync();
     }
 
     private async Task DeleteAsync(InvestmentTransactionDto tx)

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentTransactionForm.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentTransactionForm.razor
@@ -1,0 +1,40 @@
+@namespace FinanceManager.Components.Components.Features.FinancialAccounts.InvestmentAccountComponents
+@using FinanceManager.Domain.Assets.Dtos
+@using FinanceManager.Domain.FinancialAccounts.Investments.Entities
+
+<MudOverlay Visible="@Visible" DarkBackground="true" ZIndex="1300">
+    <MudPaper Class="pa-5" Style="width: min(460px, 92vw);" role="dialog" aria-modal="true" aria-label="@(_editingId is null ? "Add transaction" : "Edit transaction")">
+        <MudText Typo="Typo.h6" Class="mb-3">@(_editingId is null ? "Add transaction" : "Edit transaction")</MudText>
+        <MudStack Spacing="3">
+            <MudAutocomplete T="InstrumentSearchResultDto" Label="Instrument"
+                             Value="_selectedInstrument"
+                             ValueChanged="OnInstrumentSelectedAsync"
+                             SearchFunc="SearchInstrumentsAsync"
+                             ToStringFunc="@(dto => dto is null ? string.Empty : $"{dto.Ticker} — {dto.ExchangeName}")"
+                             MinCharacters="1" DebounceInterval="300" ResetValueOnEmptyText="true"
+                             CoerceText="false" Dense="true" />
+            @if (_editingId is null)
+            {
+                <InstrumentImport ButtonText="Can't find it? Import instrument" Imported="OnInstrumentImportedAsync" />
+            }
+            <MudSelect T="InvestmentTransactionType" Label="Type" @bind-Value="_formType" Dense="true">
+                <MudSelectItem T="InvestmentTransactionType" Value="InvestmentTransactionType.Buy">Buy</MudSelectItem>
+                <MudSelectItem T="InvestmentTransactionType" Value="InvestmentTransactionType.Sell">Sell</MudSelectItem>
+            </MudSelect>
+            <MudNumericField T="decimal" Label="Units" @bind-Value="_formQuantity" Min="0" Step="0.0001M" />
+            <MudTextField T="string" Label="Unit price" Value="@(_selectedInstrument is null ? string.Empty : _formUnitPrice.ToString("N2"))" ReadOnly="true" Disabled="true" />
+            @if (_noPriceAvailable && _selectedInstrument is not null)
+            {
+                <MudAlert Severity="Severity.Info" Dense="true">No price data found for this instrument. You can still save the transaction — the unit price will be recalculated once a price quote is available.</MudAlert>
+            }
+            <MudTextField T="string" Label="Currency" Value="@_formCurrency" ReadOnly="true" Disabled="true" />
+            <MudDatePicker Label="Trade date" Date="_formTradeDate" DateChanged="OnTradeDateChangedAsync" />
+            <MudNumericField T="decimal?" Label="Fee (optional)" @bind-Value="_formFee" Min="0" Step="0.01M" />
+            <MudTextField T="string" Label="Notes (optional)" @bind-Value="_formNotes" />
+            <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="2">
+                <MudButton Variant="Variant.Text" OnClick="CloseAsync" Disabled="@_saving">Cancel</MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SaveAsync" Disabled="@(_saving || !CanSave)">Save</MudButton>
+            </MudStack>
+        </MudStack>
+    </MudPaper>
+</MudOverlay>

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentTransactionForm.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentTransactionForm.razor.cs
@@ -1,0 +1,173 @@
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.Assets.Discovery;
+using FinanceManager.Domain.Assets.Dtos;
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+using MudBlazor;
+
+namespace FinanceManager.Components.Components.Features.FinancialAccounts.InvestmentAccountComponents;
+
+public partial class InvestmentTransactionForm : ComponentBase
+{
+    [Parameter] public int AccountId { get; set; }
+    [Parameter] public bool Visible { get; set; }
+    [Parameter] public EventCallback<bool> VisibleChanged { get; set; }
+    [Parameter] public InvestmentTransactionDto? Transaction { get; set; }
+    [Parameter] public EventCallback OnSaved { get; set; }
+
+    [Inject] public required InvestmentTransactionHttpClient TransactionHttpClient { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
+    [Inject] public required ILogger<InvestmentTransactionForm> Logger { get; set; }
+
+    private bool _wasVisible;
+    private long? _initializedTransactionId;
+    private long? _editingId;
+    private InstrumentSearchResultDto? _selectedInstrument;
+    private long _formListingId;
+    private InvestmentTransactionType _formType = InvestmentTransactionType.Buy;
+    private decimal _formQuantity = 1m;
+    private decimal _formUnitPrice;
+    private string _formCurrency = string.Empty;
+    private DateTime? _formTradeDate = DateTime.Today;
+    private decimal? _formFee;
+    private string? _formNotes;
+    private bool _saving;
+    private bool _noPriceAvailable;
+
+    protected override void OnParametersSet()
+    {
+        if (Visible && (!_wasVisible || _initializedTransactionId != Transaction?.Id))
+            ResetForm();
+
+        _wasVisible = Visible;
+    }
+
+    private void ResetForm()
+    {
+        _initializedTransactionId = Transaction?.Id;
+        _editingId = Transaction?.Id;
+        _selectedInstrument = Transaction is null
+            ? null
+            : new InstrumentSearchResultDto(Transaction.AssetListingId, Transaction.Ticker, Transaction.ExchangeName, Transaction.Currency);
+        _formListingId = Transaction?.AssetListingId ?? 0;
+        _formType = Transaction?.Type ?? InvestmentTransactionType.Buy;
+        _formQuantity = Transaction?.Quantity ?? 1m;
+        _formUnitPrice = Transaction?.UnitPrice ?? 0m;
+        _formCurrency = Transaction?.Currency ?? string.Empty;
+        _formTradeDate = Transaction?.TradeDate.ToDateTime(TimeOnly.MinValue) ?? DateTime.Today;
+        _formFee = Transaction?.Fee;
+        _formNotes = Transaction?.Notes;
+        _noPriceAvailable = false;
+    }
+
+    private bool CanSave => _formListingId > 0 && _formQuantity > 0 && _formUnitPrice >= 0
+        && _formTradeDate is not null && !string.IsNullOrWhiteSpace(_formCurrency);
+
+    private async Task CloseAsync() => await VisibleChanged.InvokeAsync(false);
+
+    private async Task OnInstrumentSelectedAsync(InstrumentSearchResultDto? dto)
+    {
+        _selectedInstrument = dto;
+        _noPriceAvailable = false;
+        if (dto is null)
+        {
+            _formListingId = 0;
+            _formCurrency = string.Empty;
+            _formUnitPrice = 0m;
+            return;
+        }
+
+        _formListingId = dto.ListingId;
+        _formCurrency = dto.Currency;
+        await RefreshFormPriceAsync();
+    }
+
+    private async Task OnTradeDateChangedAsync(DateTime? value)
+    {
+        _formTradeDate = value;
+        await RefreshFormPriceAsync();
+    }
+
+    private async Task RefreshFormPriceAsync()
+    {
+        if (_selectedInstrument is null || _formTradeDate is not DateTime tradeDate)
+        {
+            _formUnitPrice = 0m;
+            return;
+        }
+
+        try
+        {
+            var priceInfo = await TransactionHttpClient.GetListingPriceAsync(_selectedInstrument.ListingId, DateOnly.FromDateTime(tradeDate));
+            if (priceInfo?.LatestPrice is decimal price)
+                _formUnitPrice = price;
+            else
+            {
+                _formUnitPrice = 0m;
+                _noPriceAvailable = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to fetch price for listing {ListingId}", _selectedInstrument.ListingId);
+            _formUnitPrice = 0m;
+            _noPriceAvailable = true;
+        }
+    }
+
+    private async Task<IEnumerable<InstrumentSearchResultDto>> SearchInstrumentsAsync(string value, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return [];
+        try
+        {
+            return await TransactionHttpClient.SearchListingsAsync(value);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to search instrument listings for '{Query}'", value);
+            return [];
+        }
+    }
+
+    private async Task OnInstrumentImportedAsync(ImportedInstrumentDto imported)
+    {
+        await OnInstrumentSelectedAsync(new InstrumentSearchResultDto(
+            imported.AssetListingId, imported.Ticker, imported.ExchangeName, imported.TradingCurrency));
+        Snackbar.Add(imported.Warnings.Count == 0 ? "Instrument imported." : $"Instrument imported with {imported.Warnings.Count} warning(s).", Severity.Success);
+    }
+
+    private async Task SaveAsync()
+    {
+        if (!CanSave) return;
+        _saving = true;
+        try
+        {
+            var tradeDate = DateOnly.FromDateTime(_formTradeDate!.Value);
+            var ok = _editingId is long id
+                ? await TransactionHttpClient.UpdateAsync(new UpdateInvestmentTransactionRequest(
+                    id, AccountId, _formListingId, _formType, _formQuantity, _formUnitPrice, _formCurrency, tradeDate, _formFee, _formNotes))
+                : await TransactionHttpClient.AddAsync(new AddInvestmentTransactionRequest(
+                    AccountId, _formListingId, _formType, _formQuantity, _formUnitPrice, _formCurrency, tradeDate, _formFee, _formNotes)) is not null;
+
+            if (!ok)
+            {
+                Snackbar.Add("Could not save the transaction.", Severity.Error);
+                return;
+            }
+
+            Snackbar.Add(_editingId is null ? "Transaction added." : "Transaction updated.", Severity.Success);
+            await OnSaved.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to save investment transaction for account {AccountId}", AccountId);
+            Snackbar.Add("Could not save the transaction.", Severity.Error);
+        }
+        finally
+        {
+            _saving = false;
+        }
+    }
+}

--- a/code/FinanceManager.Components/Helpers/DateRangeHelper.cs
+++ b/code/FinanceManager.Components/Helpers/DateRangeHelper.cs
@@ -2,6 +2,32 @@
 
 public static class DateRangeHelper
 {
+    public static (DateTime Start, DateTime End) GetAccountDetailsRange(
+        string selection,
+        DateTime? customStart,
+        DateTime? customEnd,
+        DateTime customFallbackStart,
+        DateTime defaultStart,
+        DateTime now)
+    {
+        if (selection == "Custom")
+            return (customStart ?? customFallbackStart, customEnd is DateTime end && end < now ? end : now);
+
+        var start = selection switch
+        {
+            "Month" => new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc),
+            "1M" => now.AddMonths(-1),
+            "3M" => now.AddMonths(-3),
+            "6M" => now.AddMonths(-6),
+            "YTD" => new DateTime(now.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            _ => defaultStart,
+        };
+        return (start, now);
+    }
+
+    public static DateTime? GetExpandedStart(DateTime selectedStart, DateTime? oldestEntry) =>
+        oldestEntry is DateTime oldest && oldest < selectedStart ? oldest : null;
+
     public static (DateTime Start, DateTime End) GetCurrentMonthRange()
     {
         var now = DateTime.UtcNow;

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -56,6 +56,8 @@ public static class ServiceCollectionExtension
                 .AddScoped<DashboardHttpClient>()
                 .AddScoped<DashboardOverviewCardsCacheService>()
                 .AddScoped<ISnapshotService, LocalStorageSnapshotService>()
+                .AddScoped<AccountDetailsSnapshotStore>()
+                .AddTransient<CurrencyImportJobTracker>()
                 .AddScoped<AssetsPageCardsCacheService>()
                 .AddScoped<InvestmentPaycheckEstimateCacheService>()
                 .AddScoped<CurrencyHttpClient>()

--- a/code/FinanceManager.Components/Services/AccountDetailsSnapshotStore.cs
+++ b/code/FinanceManager.Components/Services/AccountDetailsSnapshotStore.cs
@@ -1,0 +1,41 @@
+using FinanceManager.Components.Models;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace FinanceManager.Components.Services;
+
+public sealed class AccountDetailsSnapshotStore(
+    ISnapshotService snapshots,
+    ILogger<AccountDetailsSnapshotStore> logger)
+{
+    public async Task<AccountDetailsSnapshot<TEntry>?> GetAsync<TEntry>(int userId, int accountId)
+    {
+        try
+        {
+            var snapshot = await snapshots.GetAsync<AccountDetailsSnapshot<TEntry>>(Key(userId, accountId));
+            return snapshot?.AccountId == accountId ? snapshot : null;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read account details snapshot; continuing with fresh fetch.");
+            return null;
+        }
+    }
+
+    public async Task SaveIfChangedAsync<TEntry>(AccountDetailsSnapshot<TEntry> snapshot, AccountDetailsSnapshot<TEntry>? previous)
+    {
+        if (previous is not null && JsonSerializer.Serialize(snapshot.Entries) == JsonSerializer.Serialize(previous.Entries))
+            return;
+
+        try
+        {
+            await snapshots.SetAsync(Key(snapshot.UserId, snapshot.AccountId), snapshot);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Account details loaded but snapshot save failed.");
+        }
+    }
+
+    private static string Key(int userId, int accountId) => $"account-details:{userId}:{accountId}";
+}

--- a/code/FinanceManager.Components/Services/CurrencyImportJobTracker.cs
+++ b/code/FinanceManager.Components/Services/CurrencyImportJobTracker.cs
@@ -1,0 +1,131 @@
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Dtos;
+using FinanceManager.Domain.FinancialAccounts.Shared.Imports;
+using FinanceManager.Domain.Identity.Services;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Components.Services;
+
+public sealed class CurrencyImportJobTracker(
+    CurrencyAccountImportHttpClient importClient,
+    NavigationManager navigation,
+    ILoginService loginService,
+    ILogger<CurrencyImportJobTracker> logger) : IAsyncDisposable
+{
+    private HubConnection? _hub;
+    private CancellationTokenSource? _polling;
+
+    public event Action? Changed;
+    public Guid? JobId { get; private set; }
+    public CurrencyImportJobStatusDto? Status { get; private set; }
+    public IReadOnlyList<ImportJobConflict> Conflicts { get; private set; } = [];
+    public string? Error { get; private set; }
+
+    public async Task StartAsync(Guid jobId)
+    {
+        await StopAsync();
+        JobId = jobId;
+        Status = null;
+        Conflicts = [];
+        Error = null;
+        await EnsureHubAsync();
+        await _hub!.InvokeAsync("JoinJob", jobId.ToString());
+        await RefreshAsync();
+        _polling = new CancellationTokenSource();
+        _ = PollAsync(_polling.Token);
+    }
+
+    public async Task ResetAsync()
+    {
+        await StopAsync();
+        JobId = null;
+        Status = null;
+        Conflicts = [];
+        Error = null;
+        Changed?.Invoke();
+    }
+
+    public void MarkResolved(IReadOnlyCollection<string> conflictIds)
+    {
+        if (conflictIds.Count == 0) return;
+        Conflicts = Conflicts.Select(x => conflictIds.Contains(x.ConflictId) ? x with { IsResolved = true } : x).ToList();
+        if (Status is not null)
+        {
+            var count = Conflicts.Count(x => !x.Conflict.IsExactMatch && x.IsResolved);
+            Status = Status with { ResolvedConflictCount = Math.Max(Status.ResolvedConflictCount, count) };
+        }
+        Changed?.Invoke();
+    }
+
+    internal bool ApplyStatus(CurrencyImportJobStatusDto status)
+    {
+        if (JobId != status.JobId || Status is not null && status.ProcessedEntries < Status.ProcessedEntries) return false;
+        Status = status;
+        Conflicts = MergeConflicts(Conflicts, status.Conflicts);
+        if (status.IsCompleted && status.Failed > 0)
+            Error = $"Import completed with {status.Failed} failed entr{(status.Failed == 1 ? "y" : "ies")}.";
+        if (status.Errors.Count > 0) Error = status.Errors.LastOrDefault();
+        return true;
+    }
+
+    internal static IReadOnlyList<ImportJobConflict> MergeConflicts(IReadOnlyCollection<ImportJobConflict> current, IReadOnlyCollection<ImportJobConflict> incoming)
+    {
+        var currentById = current.ToDictionary(x => x.ConflictId);
+        return [.. incoming.Select(x => currentById.TryGetValue(x.ConflictId, out var old) && old.IsResolved ? x with { IsResolved = true } : x),
+            .. current.Where(x => incoming.All(y => y.ConflictId != x.ConflictId))];
+    }
+
+    private async Task EnsureHubAsync()
+    {
+        _hub = new HubConnectionBuilder()
+            .WithUrl(navigation.ToAbsoluteUri("hubs/currency-import"), options =>
+                options.AccessTokenProvider = async () => (await loginService.GetLoggedUser())?.Token)
+            .WithAutomaticReconnect().Build();
+        _hub.On<CurrencyImportJobStatusDto>("ImportStatusUpdated", status => { if (ApplyStatus(status)) Changed?.Invoke(); });
+        _hub.On<ImportJobConflict>("ConflictDiscovered", conflict =>
+        {
+            if (JobId is null || Conflicts.Any(x => x.ConflictId == conflict.ConflictId)) return;
+            Conflicts = [.. Conflicts, conflict];
+            Changed?.Invoke();
+        });
+        await _hub.StartAsync();
+    }
+
+    private async Task PollAsync(CancellationToken ct)
+    {
+        try
+        {
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(2));
+            while (await timer.WaitForNextTickAsync(ct))
+            {
+                await RefreshAsync();
+                if (Status?.IsCompleted == true) break;
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    private async Task RefreshAsync()
+    {
+        if (JobId is not Guid jobId) return;
+        try
+        {
+            var status = await importClient.GetCurrencyImportStatusAsync(jobId);
+            if (status is not null && ApplyStatus(status)) Changed?.Invoke();
+        }
+        catch (Exception ex) { logger.LogDebug(ex, "Unable to refresh import job status"); }
+    }
+
+    private async Task StopAsync()
+    {
+        _polling?.Cancel();
+        _polling?.Dispose();
+        _polling = null;
+        if (_hub is not null) await _hub.DisposeAsync();
+        _hub = null;
+    }
+
+    public async ValueTask DisposeAsync() => await StopAsync();
+}

--- a/code/FinanceManager.Tests.Unit/Components/Helpers/DateRangeHelperTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Helpers/DateRangeHelperTests.cs
@@ -1,0 +1,42 @@
+using FinanceManager.Components.Helpers;
+
+namespace FinanceManager.Tests.Unit.Components.Helpers;
+
+[Trait("Category", "Unit")]
+public class DateRangeHelperTests
+{
+    private static readonly DateTime _now = new(2026, 7, 12, 14, 0, 0, DateTimeKind.Utc);
+
+    [Theory]
+    [InlineData("Month", 2026, 7, 1)]
+    [InlineData("1M", 2026, 6, 12)]
+    [InlineData("3M", 2026, 4, 12)]
+    [InlineData("6M", 2026, 1, 12)]
+    [InlineData("YTD", 2026, 1, 1)]
+    public void GetAccountDetailsRange_ResolvesPresetDeterministically(string selection, int year, int month, int day)
+    {
+        var range = DateRangeHelper.GetAccountDetailsRange(selection, null, null, _now.AddMonths(-3), _now.AddYears(-1), _now);
+
+        var expected = new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc);
+        if (selection is not ("Month" or "YTD")) expected = expected.AddHours(_now.Hour);
+        Assert.Equal(expected, range.Start);
+        Assert.Equal(_now, range.End);
+    }
+
+    [Fact]
+    public void GetAccountDetailsRange_CustomRangeClampsFutureEnd()
+    {
+        var start = _now.AddDays(-10);
+        var range = DateRangeHelper.GetAccountDetailsRange("Custom", start, _now.AddDays(1), _now.AddMonths(-3), _now, _now);
+
+        Assert.Equal(start, range.Start);
+        Assert.Equal(_now, range.End);
+    }
+
+    [Fact]
+    public void GetExpandedStart_ReturnsOnlyOlderEntry()
+    {
+        Assert.Equal(_now.AddDays(-1), DateRangeHelper.GetExpandedStart(_now, _now.AddDays(-1)));
+        Assert.Null(DateRangeHelper.GetExpandedStart(_now, _now));
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/Services/AccountDetailsSnapshotStoreTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Services/AccountDetailsSnapshotStoreTests.cs
@@ -1,0 +1,51 @@
+using FinanceManager.Components.Models;
+using FinanceManager.Components.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Components.Services;
+
+[Trait("Category", "Unit")]
+public class AccountDetailsSnapshotStoreTests
+{
+    private readonly Mock<ISnapshotService> _snapshots = new();
+
+    private AccountDetailsSnapshotStore CreateService() =>
+        new(_snapshots.Object, NullLogger<AccountDetailsSnapshotStore>.Instance);
+
+    [Fact]
+    public async Task GetAsync_ReadFailure_ReturnsNull()
+    {
+        _snapshots.Setup(x => x.GetAsync<AccountDetailsSnapshot<int>>("account-details:1:2"))
+            .ThrowsAsync(new InvalidOperationException());
+
+        Assert.Null(await CreateService().GetAsync<int>(1, 2));
+    }
+
+    [Fact]
+    public async Task SaveIfChangedAsync_UnchangedEntries_SkipsWrite()
+    {
+        var previous = Snapshot([1, 2]);
+
+        await CreateService().SaveIfChangedAsync(Snapshot([1, 2]), previous);
+
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<AccountDetailsSnapshot<int>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task SaveIfChangedAsync_ChangedEntries_WritesUserAndAccountScopedKey()
+    {
+        var snapshot = Snapshot([1, 3]);
+
+        await CreateService().SaveIfChangedAsync(snapshot, Snapshot([1, 2]));
+
+        _snapshots.Verify(x => x.SetAsync("account-details:1:2", snapshot), Times.Once);
+    }
+
+    private static AccountDetailsSnapshot<int> Snapshot(List<int> entries) => new()
+    {
+        UserId = 1,
+        AccountId = 2,
+        Entries = entries,
+    };
+}

--- a/code/FinanceManager.Tests.Unit/Components/Services/CurrencyImportJobTrackerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Services/CurrencyImportJobTrackerTests.cs
@@ -1,0 +1,24 @@
+using FinanceManager.Components.Services;
+using FinanceManager.Domain.FinancialAccounts.Shared.Imports;
+
+namespace FinanceManager.Tests.Unit.Components.Services;
+
+[Trait("Category", "Unit")]
+public class CurrencyImportJobTrackerTests
+{
+    [Fact]
+    public void MergeConflicts_PreservesResolvedStateAndLiveOnlyConflicts()
+    {
+        var resolved = Conflict("a") with { IsResolved = true };
+        var liveOnly = Conflict("b");
+        var incoming = Conflict("a");
+
+        var merged = CurrencyImportJobTracker.MergeConflicts([resolved, liveOnly], [incoming]);
+
+        Assert.Contains(merged, x => x.ConflictId == "a" && x.IsResolved);
+        Assert.Contains(merged, x => x.ConflictId == "b");
+    }
+
+    private static ImportJobConflict Conflict(string id) =>
+        new(id, new ImportConflict(1, null, null, "test"));
+}


### PR DESCRIPTION
## What changed

- extracted shared date-range and account snapshot behavior
- moved currency import SignalR/polling lifecycle into a concrete tracker
- extracted the investment transaction form into a child component
- added focused helper and tracker tests

## Why

Large account components combined page rendering with reusable storage, range, background tracking, and transaction-editing responsibilities.

## Validation

- `dotnet build ./code/FinanceManager.slnx`
- 524 unit tests passed

Closes #533