### PR TITLE
Standardize date pickers to DD/MM/YYYY and fix manual stock price card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- Date pickers across the app now consistently display and accept dates in `DD/MM/YYYY` format instead of falling back to the browser locale (which showed US-style `M/D/YYYY` for some users). Affects the manual stock price, admin asset and bond forms, account entry add/edit/remove dialogs, data export, and the account/dashboard date-range pickers.
 - Currency fields are no longer free-text anywhere in the app: the admin asset editor (base and trading currency) and the bond-details form now offer a dropdown of predefined currencies (plus pence-style quote units like GBX for listings), and the API rejects currency codes outside that list. The predefined list now ships with the major world currencies (EUR, GBP, CHF, JPY, CZK, SEK, NOK, DKK, HUF, CAD, AUD) besides PLN and USD.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
+
+### Fixed
+- The **Manual stock price** admin card no longer stretches across the full width of the screen; it is now capped to a compact width, and the price field updates as you type.
 
 ### Security
 - The default admin and test-user accounts are no longer seeded with passwords hard-coded in source. Their passwords are now read from configuration (`Seeding:AdminPassword` / `Seeding:TestUserPassword`); when unset — as in production — the accounts are not created. The stock-price bulk-import endpoint now returns a generic error message and logs the exception server-side instead of echoing the raw exception text to the caller. #450

--- a/code/FinanceManager.Components/Components/Features/Admin/AdminAddBondDetails.razor
+++ b/code/FinanceManager.Components/Components/Features/Admin/AdminAddBondDetails.razor
@@ -25,10 +25,10 @@
         </MudItem>
 
         <MudItem xs="12" sm="6">
-            <MudDatePicker Label="Start emission date" @bind-Date="_startDate" />
+            <MudDatePicker Label="Start emission date" @bind-Date="_startDate" DateFormat="dd/MM/yyyy" />
         </MudItem>
         <MudItem xs="12" sm="6">
-            <MudDatePicker Label="End emission date" @bind-Date="_endDate" />
+            <MudDatePicker Label="End emission date" @bind-Date="_endDate" DateFormat="dd/MM/yyyy" />
         </MudItem>
 
         <MudItem xs="12" sm="6">
@@ -107,7 +107,7 @@
             </MudItem>
 
             <MudItem xs="12" sm="3">
-                <MudDatePicker Label="Date" @bind-Date="_methodDate" />
+                <MudDatePicker Label="Date" @bind-Date="_methodDate" DateFormat="dd/MM/yyyy" />
             </MudItem>
             <MudItem xs="12" sm="3">
                 <MudNumericField T="decimal?" Label="Rate" @bind-Value="_methodRate" Variant="Variant.Text" />

--- a/code/FinanceManager.Components/Components/Features/Admin/AdminEditAsset.razor
+++ b/code/FinanceManager.Components/Components/Features/Admin/AdminEditAsset.razor
@@ -90,7 +90,7 @@ else
                              Variant="Variant.Outlined" Margin="Margin.Dense" HelperText="e.g. 0.0007 for 0.07%" />
         </MudItem>
         <MudItem xs="12" sm="6">
-            <MudDatePicker @bind-Date="InceptionDateTime" Label="Inception date" DateFormat="yyyy-MM-dd"
+            <MudDatePicker @bind-Date="InceptionDateTime" Label="Inception date" DateFormat="dd/MM/yyyy"
                            Variant="Variant.Outlined" Margin="Margin.Dense" Clearable />
         </MudItem>
         <MudItem xs="12" sm="6" Class="d-flex align-center">

--- a/code/FinanceManager.Components/Components/Features/Admin/AdminPrices.razor
+++ b/code/FinanceManager.Components/Components/Features/Admin/AdminPrices.razor
@@ -5,7 +5,7 @@
 
 <PageTitle>Prices - Admin</PageTitle>
 
-<MudPaper Class="pa-4" MaxWidth="MaxWidth.Small">
+<MudPaper Class="pa-4" Style="max-width: 480px;">
     <MudText Typo="Typo.h5" GutterBottom>Manual stock price</MudText>
     <MudText Typo="Typo.body2" Class="mb-4 mud-text-secondary">
         Add a missing daily price or replace an existing manual price for the same listing and date.
@@ -29,8 +29,8 @@
                         <MudSelectItem T="long?" Value="listing.Id">@listing.Label</MudSelectItem>
                     }
                 </MudSelect>
-                <MudDatePicker Label="Price date" @bind-Date="_date" MaxDate="DateTime.Today" Required RequiredError="Select a date" />
-                <MudNumericField T="decimal?" Label="Price" @bind-Value="_price" Min="0.00000001m"
+                <MudDatePicker Label="Price date" @bind-Date="_date" DateFormat="dd/MM/yyyy" MaxDate="DateTime.Today" Required RequiredError="Select a date" />
+                <MudNumericField T="decimal?" Label="Price" @bind-Value="_price" Immediate="true" Min="0.00000001m"
                                  Required RequiredError="Enter a price" Adornment="Adornment.End" AdornmentText="@SelectedCurrency" />
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_isSaving" OnClick="Save">
                     @(_isSaving ? "Saving…" : "Save price")

--- a/code/FinanceManager.Components/Components/Features/Dashboard/DashboardDatePicker.razor
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/DashboardDatePicker.razor
@@ -30,7 +30,7 @@ else
 
             <MudCollapse Expanded="_expanded">
                 <MudPaper Elevation="0" Style="max-width: 350px; min-height:50px">
-                    <MudDateRangePicker @bind-DateRange="dateRange" RelativeWidth="DropdownWidth.Ignore"
+                    <MudDateRangePicker @bind-DateRange="dateRange" DateFormat="dd/MM/yyyy" RelativeWidth="DropdownWidth.Ignore"
                                         Class="px-1 pt-1" />
                 </MudPaper>
             </MudCollapse>

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/AddBondEntry.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/AddBondEntry.razor
@@ -12,7 +12,7 @@
                 <MudText Typo="Typo.subtitle1">@BondAccount.Name</MudText>
             </MudItem>
             <MudItem xs="12" sm="6">
-                <MudDatePicker Label="Posting date" @bind-Date="_postingDate"
+                <MudDatePicker Label="Posting date" @bind-Date="_postingDate" DateFormat="dd/MM/yyyy"
                                Validation="@(new NotInFutureAttribute())" />
             </MudItem>
             <MudItem xs="12" sm="6">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/RemoveBondEntry.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/RemoveBondEntry.razor
@@ -13,7 +13,7 @@
             </MudItem>
 
             <MudItem xs="12" sm="6">
-                <MudDatePicker Label="Posting date" @bind-Date="_date" ReadOnly />
+                <MudDatePicker Label="Posting date" @bind-Date="_date" DateFormat="dd/MM/yyyy" ReadOnly />
             </MudItem>
 
             <MudItem xs="12">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/UpdateBondEntry.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/Crud/UpdateBondEntry.razor
@@ -16,7 +16,7 @@
                     <MudText Typo="Typo.subtitle1">@BondAccount.Name</MudText>
                 </MudItem>
                 <MudItem xs="12" sm="6">
-                    <MudDatePicker Label="Posting date" @bind-Date="_postingDate"
+                    <MudDatePicker Label="Posting date" @bind-Date="_postingDate" DateFormat="dd/MM/yyyy"
                                    Validation="@(new NotInFutureAttribute())" />
                 </MudItem>
                 <MudItem xs="12" sm="6">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/AddCurrencyEntry.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/AddCurrencyEntry.razor
@@ -11,7 +11,7 @@
                 <MudText Typo="Typo.subtitle1">@CurrencyAccount.Name</MudText>
             </MudItem>
             <MudItem xs="12" sm="6">
-                <MudDatePicker Label="Posting date" @bind-Date="_postingDate"
+                <MudDatePicker Label="Posting date" @bind-Date="_postingDate" DateFormat="dd/MM/yyyy"
                     Validation="@(new NotInFutureAttribute())" />
             </MudItem>
             <MudItem xs="12" sm="6">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/RemoveCurrencyEntry.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/RemoveCurrencyEntry.razor
@@ -15,7 +15,7 @@
             </MudItem>
 
             <MudItem xs="12" sm="6">
-                <MudDatePicker Label="Posting date" @bind-Date="_date" ReadOnly />
+                <MudDatePicker Label="Posting date" @bind-Date="_date" DateFormat="dd/MM/yyyy" ReadOnly />
             </MudItem>
 
             <MudItem xs="12" sm="6">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/UpdateCurrencyEntry.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/CurrencyAccountComponents/Crud/UpdateCurrencyEntry.razor
@@ -15,7 +15,7 @@
                     <MudText Typo="Typo.subtitle1">@CurrencyAccount.Name</MudText>
                 </MudItem>
                 <MudItem xs="12" sm="6">
-                    <MudDatePicker Label="Posting date" @bind-Date="_postingDate"
+                    <MudDatePicker Label="Posting date" @bind-Date="_postingDate" DateFormat="dd/MM/yyyy"
                         Validation="@(new NotInFutureAttribute())" />
                 </MudItem>
                 <MudItem xs="12" sm="6">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Export.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Export.razor
@@ -19,9 +19,9 @@
                         @_availableEndDate!.Value.ToString("dd-MM-yyyy")
                     </MudText>
 
-                    <MudDatePicker Label="Start date" @bind-Date="_startDate" MinDate="_availableStartDate"
+                    <MudDatePicker Label="Start date" @bind-Date="_startDate" DateFormat="dd/MM/yyyy" MinDate="_availableStartDate"
                                    MaxDate="_availableEndDate" />
-                    <MudDatePicker Label="End date" @bind-Date="_endDate" MinDate="_availableStartDate"
+                    <MudDatePicker Label="End date" @bind-Date="_endDate" DateFormat="dd/MM/yyyy" MinDate="_availableStartDate"
                                    MaxDate="_availableEndDate" />
                 }
                 else if (string.IsNullOrEmpty(ErrorMessage))

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentTransactionForm.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentTransactionForm.razor
@@ -28,7 +28,7 @@
                 <MudAlert Severity="Severity.Info" Dense="true">No price data found for this instrument. You can still save the transaction — the unit price will be recalculated once a price quote is available.</MudAlert>
             }
             <MudTextField T="string" Label="Currency" Value="@_formCurrency" ReadOnly="true" Disabled="true" />
-            <MudDatePicker Label="Trade date" Date="_formTradeDate" DateChanged="OnTradeDateChangedAsync" />
+            <MudDatePicker Label="Trade date" Date="_formTradeDate" DateFormat="dd/MM/yyyy" DateChanged="OnTradeDateChangedAsync" />
             <MudNumericField T="decimal?" Label="Fee (optional)" @bind-Value="_formFee" Min="0" Step="0.01M" />
             <MudTextField T="string" Label="Notes (optional)" @bind-Value="_formNotes" />
             <MudStack Row="true" Justify="Justify.FlexEnd" Spacing="2">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor
@@ -111,7 +111,7 @@
     @* Hidden picker opened programmatically by the calendar icon; Dialog variant avoids
        the broken nested-popover behaviour of embedding the picker inside a MudMenu. *@
     <div class="fm-custom-range-picker">
-        <MudDateRangePicker @ref="_customDateRangePicker" DateRange="CustomDateRange"
+        <MudDateRangePicker @ref="_customDateRangePicker" DateRange="CustomDateRange" DateFormat="dd/MM/yyyy"
                             DateRangeChanged="OnCustomDateRangeChanged" PickerVariant="PickerVariant.Dialog" />
     </div>
 </MudPaper>


### PR DESCRIPTION
## Summary

Audit of every date picker in the app to guarantee a consistent **DD/MM/YYYY** format, plus a layout fix for the Manual stock price admin card that was requested alongside.

Previously the pickers had no explicit `DateFormat`, so they fell back to the browser locale — which rendered US-style `M/D/YYYY` (e.g. `6/13/2025`) for some users.

## Changes

**Date format (`dd/MM/yyyy`) added to every picker:**
- `MudDatePicker` (14): Manual stock price, admin asset editor (inception — was ISO `yyyy-MM-dd`), admin bond details (×3), bond add/update/remove entry, currency add/update/remove entry, investment trade date, and data export start/end.
- `MudDateRangePicker` (2): account-details custom range picker and the dashboard date-range picker — these were the source of the leftover US-format values.

**Manual stock price card:**
- The card stretched full-width because `MaxWidth="MaxWidth.Small"` is not a valid `MudPaper` parameter (it was silently passed through as an ignored HTML attribute). Replaced with a real `max-width: 480px` so the card is compact.
- Price field is now `Immediate` (updates as you type).

## Verification

- `dotnet build` clean (warnings-as-errors), `dotnet format --verify-no-changes` clean.
- Unit tests: 510 passed / 0 failed.
- Rendered on the running app (guest + seeded admin), mobile and desktop:
  - Guest account-details date-range picker now reads `11/05/2026` / `13/07/2026` (was `5/9/2026` / `7/13/2026`).
  - Add-entry posting date shows `13/07/2026`.
  - Manual stock price card is width-capped and its date reads `13/07/2026`.

## Changelog

Added a **Changed** entry (date format) and a **Fixed** entry (manual stock price card) under `[Unreleased]`.

_No linked issue for this task, so no auto-close keyword._


---
_Generated by [Claude Code](https://claude.ai/code/session_01CPodsrdeqLBCpLaweQ4aHY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Standardized date fields and date-range pickers across administration, dashboard, account, investment, and export screens to use the `dd/MM/yyyy` format.
  * Improved consistency when entering, viewing, and exporting dates.
  * Manual stock price input now updates immediately as values are entered.
  * Adjusted the manual stock price form width for a more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->