### PR TITLE
Update NuGet dependencies to latest stable versions

### DIFF
--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
     <!-- Pinned to patch the transitive MessagePack pulled in by Aspire.Hosting: versions
          below 2.5.301 carry the high-severity LZ4 out-of-bounds read (GHSA-hv8m-jj95-wg3x). -->
-    <PackageVersion Include="MessagePack" Version="3.1.7" />
+    <PackageVersion Include="MessagePack" Version="3.1.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.9" />
@@ -36,7 +36,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
@@ -52,15 +52,15 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MudBlazor" Version="9.6.0" />
+    <PackageVersion Include="MudBlazor" Version="9.7.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />
-    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.10" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.16.11" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />


### PR DESCRIPTION
## Summary

Updated NuGet package dependencies to latest stable versions. All unit tests (510) and integration tests (267) pass.

## Updates Applied

**Patch Updates (backwards-compatible bug fixes):**
- MessagePack: 3.1.7 → 3.1.8
- Npgsql.EntityFrameworkCore.PostgreSQL: 10.0.2 → 10.0.3
- Scalar.AspNetCore: 2.16.10 → 2.16.11

**Minor Updates (backwards-compatible features added):**
- MudBlazor: 9.6.0 → 9.7.0
- OpenTelemetry.Instrumentation.Runtime: 1.15.1 → 1.16.0 (brings consistency with other OpenTelemetry packages already at 1.16.0)

## Updates Skipped

**Breaking Changes Detected:**
- Microsoft.OpenApi: 2.7.5 → 3.8.0 (major version - breaking changes in generated code for IOpenApiMediaType.Example)
- GitHub.Copilot.SDK: 1.0.0-beta.4 → 1.0.7-preview.2 (pre-release - namespace changes in SDK API)

These can be revisited in future updates once the breaking changes are resolved or the APIs stabilize.

## Test Results

✅ Unit Tests: 510/510 passed  
✅ Integration Tests: 267/267 passed  
✅ Build: Success with no warnings or errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVBeYqw7yrjsnuxQ2JmAjC)_