### PR TITLE
Add "Last logged at" column to admin Users page #540

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- The admin **Users** page now shows a **"Last logged at"** column with each user's most recent login date (or `Never` for accounts that have never signed in). #540
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed

--- a/code/FinanceManager.Application/Administration/Users/AdministrationUsersService.cs
+++ b/code/FinanceManager.Application/Administration/Users/AdministrationUsersService.cs
@@ -48,7 +48,9 @@ public class AdministrationUsersService(IFinancialAccountRepository financialAcc
         var users = await userRepository.GetUsers(recordIndex, recordsCount).ToListAsync();
         if (users.Count == 0) yield break;
 
-        var usedCapacities = await userPlanVerifier.GetUsedRecordsCapacity(users.Select(x => x.UserId).ToList());
+        var userIds = users.Select(x => x.UserId).ToList();
+        var usedCapacities = await userPlanVerifier.GetUsedRecordsCapacity(userIds);
+        var lastLoginTimes = await activeUsersRepository.GetLastLoginTimes(userIds);
 
         foreach (var user in users)
         {
@@ -61,7 +63,8 @@ public class AdministrationUsersService(IFinancialAccountRepository financialAcc
                 {
                     UsedCapacity = usedCapacities.TryGetValue(user.UserId, out var used) ? used : 0,
                     TotalCapacity = PricingProvider.GetMaxAllowedEntries(user.PricingLevel)
-                }
+                },
+                LastLoggedAt = lastLoginTimes.TryGetValue(user.UserId, out var lastLogin) ? lastLogin : null
             };
         }
     }

--- a/code/FinanceManager.Components/Components/Features/Admin/AdminUsers.razor
+++ b/code/FinanceManager.Components/Components/Features/Admin/AdminUsers.razor
@@ -25,6 +25,7 @@
         <MudTh>User name</MudTh>
         <MudTh>Pricing Level</MudTh>
         <MudTh>Capacity</MudTh>
+        <MudTh>Last logged at</MudTh>
         <MudTh>Action</MudTh>
     </HeaderContent>
     <RowTemplate>
@@ -33,6 +34,9 @@
         <MudTd DataLabel="Pricing Level">@context.PricingLevel</MudTd>
         <MudTd DataLabel="Capacity">
             <MudProgressLinear Color="Color.Primary" Value="@context.RecordCapacity.GetStorageUsedPercentage()" />
+        </MudTd>
+        <MudTd DataLabel="Last logged at">
+            @(context.LastLoggedAt is DateTime lastLoggedAt ? lastLoggedAt.ToString("yyyy-MM-dd") : "Never")
         </MudTd>
         <MudTd DataLabel="Action">
             <MudMenu Label="Action" Variant="Variant.Text">

--- a/code/FinanceManager.Domain/Administration/Monitoring/IActiveUsersRepository.cs
+++ b/code/FinanceManager.Domain/Administration/Monitoring/IActiveUsersRepository.cs
@@ -8,4 +8,10 @@ public interface IActiveUsersRepository
     Task<ActiveUser?> Get(int userId, DateOnly dateOnly);
     Task<int> GetActiveUsersCount(DateOnly dateOnly);
     Task<IEnumerable<(DateOnly, int)>> GetActiveUsersCount(DateOnly dateStart, DateOnly dateEnd);
+
+    /// <summary>
+    /// Returns the most recent login time for each of the given users, keyed by user id. Users that have never
+    /// logged in are omitted from the result so callers can distinguish "never logged in" from a real timestamp.
+    /// </summary>
+    Task<IReadOnlyDictionary<int, DateTime>> GetLastLoginTimes(IReadOnlyCollection<int> userIds);
 }

--- a/code/FinanceManager.Domain/Identity/Entities/UserDetails.cs
+++ b/code/FinanceManager.Domain/Identity/Entities/UserDetails.cs
@@ -8,4 +8,7 @@ public class UserDetails
     public required string Login { get; set; }
     public PricingLevel PricingLevel { get; set; }
     public required RecordCapacity RecordCapacity { get; set; }
+
+    /// <summary>Most recent login time for the user, or <c>null</c> when the user has never logged in.</summary>
+    public DateTime? LastLoggedAt { get; set; }
 }

--- a/code/FinanceManager.Infrastructure/Repositories/ActiveUsersRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/ActiveUsersRepository.cs
@@ -39,4 +39,17 @@ public class ActiveUsersRepository(AppDbContext context) : IActiveUsersRepositor
 
         return results;
     }
+
+    public async Task<IReadOnlyDictionary<int, DateTime>> GetLastLoginTimes(IReadOnlyCollection<int> userIds)
+    {
+        if (userIds.Count == 0) return new Dictionary<int, DateTime>();
+
+        var lastLogins = await context.ActiveUsers
+            .Where(x => userIds.Contains(x.UserId))
+            .GroupBy(x => x.UserId)
+            .Select(g => new { UserId = g.Key, LastLoginTime = g.Max(x => x.LoginTime) })
+            .ToListAsync();
+
+        return lastLogins.ToDictionary(x => x.UserId, x => x.LastLoginTime);
+    }
 }

--- a/code/FinanceManager.Tests.Unit/Application/Services/AdministrationUsersServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/AdministrationUsersServiceTests.cs
@@ -18,9 +18,14 @@ public class AdministrationUsersServiceTests
     private readonly Mock<IUserPlanVerifier> _userPlanVerifierMock = new();
     private readonly AdministrationUsersService _service;
 
-    public AdministrationUsersServiceTests() => _service = new(
-        _financialAccountRepositoryMock.Object, _userRepositoryMock.Object,
-        _activeUsersRepositoryMock.Object, _userPlanVerifierMock.Object);
+    public AdministrationUsersServiceTests()
+    {
+        _activeUsersRepositoryMock.Setup(r => r.GetLastLoginTimes(It.IsAny<IReadOnlyCollection<int>>()))
+            .ReturnsAsync(new Dictionary<int, DateTime>());
+        _service = new(
+            _financialAccountRepositoryMock.Object, _userRepositoryMock.Object,
+            _activeUsersRepositoryMock.Object, _userPlanVerifierMock.Object);
+    }
 
     [Fact]
     public async Task GetUsers_FetchesPageOnce_AndBatchesUsedCapacity()
@@ -32,9 +37,13 @@ public class AdministrationUsersServiceTests
             new User { UserId = 2, Login = "bob", CreationDate = DateTime.UtcNow, PricingLevel = PricingLevel.Premium },
         };
 
+        var aliceLastLogin = new DateTime(2026, 7, 10, 0, 0, 0, DateTimeKind.Utc);
+
         _userRepositoryMock.Setup(repo => repo.GetUsers(0, 10)).Returns(users.ToAsyncEnumerable());
         _userPlanVerifierMock.Setup(v => v.GetUsedRecordsCapacity(It.IsAny<IReadOnlyCollection<int>>()))
             .ReturnsAsync(new Dictionary<int, int> { [1] = 42, [2] = 100 });
+        _activeUsersRepositoryMock.Setup(r => r.GetLastLoginTimes(It.IsAny<IReadOnlyCollection<int>>()))
+            .ReturnsAsync(new Dictionary<int, DateTime> { [1] = aliceLastLogin });
 
         // Act
         var result = await _service.GetUsers(0, 10).ToListAsync(TestContext.Current.CancellationToken);
@@ -44,6 +53,10 @@ public class AdministrationUsersServiceTests
         Assert.Equal(42, result[0].RecordCapacity.UsedCapacity);
         Assert.Equal(PricingProvider.GetMaxAllowedEntries(PricingLevel.Free), result[0].RecordCapacity.TotalCapacity);
         Assert.Equal(100, result[1].RecordCapacity.UsedCapacity);
+
+        // Last-login times are surfaced per user; a user with no login row stays null.
+        Assert.Equal(aliceLastLogin, result[0].LastLoggedAt);
+        Assert.Null(result[1].LastLoggedAt);
 
         // Capacity is resolved with a single batched call, and there is no per-user GetUser lookup.
         _userPlanVerifierMock.Verify(v => v.GetUsedRecordsCapacity(It.IsAny<IReadOnlyCollection<int>>()), Times.Once);

--- a/code/FinanceManager.Tests.Unit/Application/Services/AdministrationUsersServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/AdministrationUsersServiceTests.cs
@@ -97,5 +97,6 @@ public class AdministrationUsersServiceTests
         // Assert
         Assert.Empty(result);
         _userPlanVerifierMock.Verify(v => v.GetUsedRecordsCapacity(It.IsAny<IReadOnlyCollection<int>>()), Times.Never);
+        _activeUsersRepositoryMock.Verify(r => r.GetLastLoginTimes(It.IsAny<IReadOnlyCollection<int>>()), Times.Never);
     }
 }


### PR DESCRIPTION
## Summary

Adds a **"Last logged at"** column to the admin **Users** page (`/Admin/Users`) so admins can see each user's most recent login date at a glance and spot dormant accounts.

The value is sourced from the existing `ActiveUsers` login records — one row per user per day, written on login by `LoginController` — so **no schema change or migration is required**. Users with no login history render as `Never`.

## Changes

- **Domain**: `UserDetails` gains a nullable `LastLoggedAt` property; `IActiveUsersRepository` gains a batched `GetLastLoginTimes(userIds)` lookup that returns the most recent login per user (omitting users who never logged in).
- **Infrastructure**: `ActiveUsersRepository.GetLastLoginTimes` groups `ActiveUsers` by user and selects the max `LoginTime`.
- **Application**: `AdministrationUsersService.GetUsers` batches the last-login lookup alongside the existing capacity batch and populates `LastLoggedAt`.
- **Components**: `AdminUsers.razor` adds the "Last logged at" column, rendering the date (`yyyy-MM-dd`) or `Never`.
- **Tests**: extended `AdministrationUsersServiceTests` to cover the last-login mapping (real timestamp vs. `null` for a user with no login row).
- **Changelog**: added an `Added` entry.

## Verification

- `dotnet build` clean (0 warnings/errors).
- `dotnet test` unit suite: 510 passed.
- Rendered the page as the seeded admin on mobile and desktop viewports — admin (just logged in) shows `2026-07-13`, a user with no login history shows `Never`.

closes #540

https://claude.ai/code/session_01CQJBFA6FSmRsTZ8WKkQ3yP

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQJBFA6FSmRsTZ8WKkQ3yP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Last logged at” column to the administration users table.
  * Displays each user’s most recent login date, or “Never” when no login is recorded.
  * User records now include last-login information for improved account monitoring.

* **Tests**
  * Added coverage for displaying recorded login times and handling users who have never logged in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->