### PR TITLE
Speed up investment account chart loading #542

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- Investment account charts no longer repeatedly reload full price history around market closures, reducing load time. #542
 - The **Manual stock price** admin card no longer stretches across the full width of the screen; it is now capped to a compact width, and the price field updates as you type.
 
 ### Security

--- a/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
+++ b/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
@@ -225,11 +225,12 @@ public class InvestmentPriceProvider(
             }
 
             var normalizedCurrencyName = NormalizedCurrencyName(rawCurrencyName, listing.PriceMultiplier);
+            var quotes = new List<PriceQuote>(prices.Count);
             foreach (var price in prices)
             {
                 if (price.PricePerUnit <= 0) continue;
 
-                await priceQuoteRepository.Upsert(new PriceQuote
+                quotes.Add(new PriceQuote
                 {
                     AssetListingId = listing.Id,
                     MarketDataSymbolId = symbol.Id,
@@ -241,8 +242,11 @@ public class InvestmentPriceProvider(
                     RawPrice = price.PricePerUnit,
                     RawCurrency = rawCurrencyName,
                     FetchedAt = DateTimeOffset.UtcNow
-                }, ct);
+                });
             }
+
+            if (quotes.Count > 0)
+                await priceQuoteRepository.UpsertRange(quotes, ct);
 
             await symbolRepository.RecordFetchResult(symbol.Id, DateTimeOffset.UtcNow, null, ct);
         }
@@ -269,13 +273,17 @@ public class InvestmentPriceProvider(
         if (existing is null || existing.Count == 0) return true;
 
         var existingDates = existing.Select(x => x.PriceTime.Date).ToHashSet();
-        for (var date = start.Date; date <= end.Date; date = date.AddDays(1))
-        {
-            if (date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday) continue;
-            if (!existingDates.Contains(date)) return true;
-        }
 
-        return false;
+        // Boundary-coverage check using the 7-day lookback tolerance: ensure data exists
+        // within [start, start+7d] and [end-7d, end]. This allows for market holidays and
+        // weekends without triggering a full refetch, while genuine gaps at boundaries do.
+        var startBoundary = start.AddDays(_fetchLookbackDays);
+        var hasStartCoverage = existingDates.Any(d => d >= start && d <= startBoundary);
+
+        var endBoundary = end.AddDays(-_fetchLookbackDays);
+        var hasEndCoverage = existingDates.Any(d => d >= endBoundary && d <= end);
+
+        return !hasStartCoverage || !hasEndCoverage;
     }
 
     private static DateTimeOffset DayStart(DateTime date) => new(date.Date, TimeSpan.Zero);

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CachedCurrencyExchangeService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CachedCurrencyExchangeService.cs
@@ -33,43 +33,15 @@ internal sealed class CachedCurrencyExchangeService(
 
     public async Task<List<(DateTime Date, decimal? Value)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd)
     {
-        if (dateStart == default || dateEnd == default) return [];
+        var rates = await inner.GetExchangeRateAsync(fromCurrency, toCurrency, dateStart, dateEnd);
 
-        var start = dateStart.Date;
-        var end = dateEnd.Date;
-        if (start > end) (start, end) = (end, start);
-        if (end > DateTime.UtcNow.Date) end = DateTime.UtcNow.Date;
-
-        var totalDays = (end - start).Days + 1;
-        if (totalDays <= 0) return [];
-
-        if (fromCurrency == toCurrency)
+        foreach (var (date, value) in rates)
         {
-            List<(DateTime Date, decimal? Value)> sameCurrencyRates = new(totalDays);
-            for (var i = 0; i < totalDays; i++)
-                sameCurrencyRates.Add((start.AddDays(i), 1m));
-            return sameCurrencyRates;
-        }
-
-        const int batchSize = 50;
-        List<(DateTime Date, decimal? Value)> rates = new(totalDays);
-
-        for (var offset = 0; offset < totalDays; offset += batchSize)
-        {
-            var currentBatchSize = Math.Min(batchSize, totalDays - offset);
-            List<DateTime> batchDates = new(currentBatchSize);
-            List<Task<decimal?>> batchTasks = new(currentBatchSize);
-
-            for (var i = 0; i < currentBatchSize; i++)
+            if (value is not null)
             {
-                var date = start.AddDays(offset + i);
-                batchDates.Add(date);
-                batchTasks.Add(GetExchangeRateAsync(fromCurrency, toCurrency, date));
+                var key = $"EXCHANGE_RATE_{fromCurrency.ShortName}_{toCurrency.ShortName}_{date:yyyyMMdd}";
+                cache.Set(key, value, _cacheOptions);
             }
-
-            var batchResults = await Task.WhenAll(batchTasks);
-            for (var i = 0; i < batchResults.Length; i++)
-                rates.Add((batchDates[i], batchResults[i]));
         }
 
         return rates;

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
@@ -33,28 +33,48 @@ internal class CurrencyExchangeService(
             return sameCurrencyRates;
         }
 
-        const int batchSize = 50;
+        var stored = await exchangeRateRepository.GetRange(fromCurrency.ShortName, toCurrency.ShortName, start, end);
+        var normalizedFrom = Normalize(fromCurrency.ShortName);
+        var normalizedTo = Normalize(toCurrency.ShortName);
+
         List<(DateTime Date, decimal? Value)> rates = [];
+        List<DateTime> missingDates = [];
 
-        for (var offset = 0; offset < totalDays; offset += batchSize)
+        for (var i = 0; i < totalDays; i++)
         {
-            var currentBatchSize = Math.Min(batchSize, totalDays - offset);
-            List<DateTime> batchDates = [];
-            List<Task<decimal?>> batchTasks = [];
-
-            for (var i = 0; i < currentBatchSize; i++)
+            var date = start.AddDays(i);
+            var key = (normalizedFrom, normalizedTo, NormalizeDate(date));
+            if (stored.TryGetValue(key, out var rate))
             {
-                var date = start.AddDays(offset + i);
-                batchDates.Add(date);
-                batchTasks.Add(GetExchangeRateAsync(fromCurrency, toCurrency, date));
+                rates.Add((date, rate));
             }
-
-            var batchResults = await Task.WhenAll(batchTasks);
-            for (var i = 0; i < batchResults.Length; i++)
-                rates.Add((batchDates[i], batchResults[i]));
+            else
+            {
+                missingDates.Add(date);
+            }
         }
 
-        return rates;
+        if (missingDates.Count > 0)
+        {
+            const int batchSize = 50;
+            for (var offset = 0; offset < missingDates.Count; offset += batchSize)
+            {
+                var currentBatchSize = Math.Min(batchSize, missingDates.Count - offset);
+                List<Task<decimal?>> batchTasks = [];
+
+                for (var i = 0; i < currentBatchSize; i++)
+                {
+                    var date = missingDates[offset + i];
+                    batchTasks.Add(GetExchangeRateAsync(fromCurrency, toCurrency, date));
+                }
+
+                var batchResults = await Task.WhenAll(batchTasks);
+                for (var i = 0; i < batchResults.Length; i++)
+                    rates.Add((missingDates[offset + i], batchResults[i]));
+            }
+        }
+
+        return rates.OrderBy(x => x.Date).ToList();
     }
 
     public async Task<decimal?> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
@@ -107,4 +127,8 @@ internal class CurrencyExchangeService(
 
     private static bool IsUsd(Currency currency) =>
         string.Equals(currency.ShortName, DefaultCurrency.USD.ShortName, StringComparison.OrdinalIgnoreCase);
+
+    private static string Normalize(string currency) => currency.Trim().ToUpperInvariant();
+
+    private static DateTime NormalizeDate(DateTime date) => DateTime.SpecifyKind(date.Date, DateTimeKind.Utc);
 }

--- a/code/FinanceManager.Domain/Assets/Repositories/IPriceQuoteRepository.cs
+++ b/code/FinanceManager.Domain/Assets/Repositories/IPriceQuoteRepository.cs
@@ -19,6 +19,9 @@ public interface IPriceQuoteRepository
     /// <summary>Insert the quote, or update the existing one matched by (AssetListingId, Provider, PriceTime, QuoteType).</summary>
     Task<PriceQuote> Upsert(PriceQuote quote, CancellationToken cancellationToken = default);
 
+    /// <summary>Insert or update multiple quotes in a single transaction, loading existing rows once and calling SaveChangesAsync once.</summary>
+    Task<IReadOnlyList<PriceQuote>> UpsertRange(IReadOnlyList<PriceQuote> quotes, CancellationToken cancellationToken = default);
+
     /// <summary>Delete the quote with the given id. Returns <c>false</c> when no such quote exists.</summary>
     Task<bool> Delete(long id, CancellationToken cancellationToken = default);
 }

--- a/code/FinanceManager.Domain/FinancialAccounts/Currencies/Repositories/IExchangeRateRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Currencies/Repositories/IExchangeRateRepository.cs
@@ -4,4 +4,5 @@ public interface IExchangeRateRepository
 {
     public Task<decimal?> Get(string fromCurrency, string toCurrency, DateTime date, CancellationToken ct = default);
     public Task Add(string fromCurrency, string toCurrency, DateTime date, decimal rate, CancellationToken ct = default);
+    public Task<IReadOnlyDictionary<(string From, string To, DateTime Date), decimal>> GetRange(string fromCurrency, string toCurrency, DateTime dateStart, DateTime dateEnd, CancellationToken ct = default);
 }

--- a/code/FinanceManager.Infrastructure/Repositories/Assets/PriceQuoteRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Assets/PriceQuoteRepository.cs
@@ -60,6 +60,53 @@ public class PriceQuoteRepository(AppDbContext context) : IPriceQuoteRepository
         return await Add(quote, cancellationToken);
     }
 
+    public async Task<IReadOnlyList<PriceQuote>> UpsertRange(IReadOnlyList<PriceQuote> quotes, CancellationToken cancellationToken = default)
+    {
+        if (quotes.Count == 0) return [];
+
+        var listingIds = quotes.Select(q => q.AssetListingId).Distinct().ToList();
+        var providers = quotes.Select(q => q.Provider).Distinct().ToList();
+        var quoteTypes = quotes.Select(q => q.QuoteType).Distinct().ToList();
+        var minPriceTime = quotes.Min(q => q.PriceTime);
+        var maxPriceTime = quotes.Max(q => q.PriceTime);
+
+        var existing = await context.PriceQuotes
+            .Where(x => listingIds.Contains(x.AssetListingId)
+                && providers.Contains(x.Provider)
+                && quoteTypes.Contains(x.QuoteType)
+                && x.PriceTime >= minPriceTime
+                && x.PriceTime <= maxPriceTime)
+            .ToListAsync(cancellationToken);
+
+        var existingByKey = existing.ToDictionary(
+            x => (x.AssetListingId, x.Provider, x.PriceTime, x.QuoteType));
+
+        var result = new List<PriceQuote>(quotes.Count);
+        foreach (var quote in quotes)
+        {
+            var key = (quote.AssetListingId, quote.Provider, quote.PriceTime, quote.QuoteType);
+            if (existingByKey.TryGetValue(key, out var existingQuote))
+            {
+                existingQuote.MarketDataSymbolId = quote.MarketDataSymbolId;
+                existingQuote.Price = quote.Price;
+                existingQuote.Currency = quote.Currency;
+                existingQuote.RawPrice = quote.RawPrice;
+                existingQuote.RawCurrency = quote.RawCurrency;
+                existingQuote.FetchedAt = quote.FetchedAt == default ? DateTimeOffset.UtcNow : quote.FetchedAt;
+                result.Add(existingQuote);
+            }
+            else
+            {
+                if (quote.FetchedAt == default) quote.FetchedAt = DateTimeOffset.UtcNow;
+                context.PriceQuotes.Add(quote);
+                result.Add(quote);
+            }
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+        return result;
+    }
+
     public async Task<bool> Delete(long id, CancellationToken cancellationToken = default)
     {
         var entity = await context.PriceQuotes.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);

--- a/code/FinanceManager.Infrastructure/Repositories/ExchangeRateRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/ExchangeRateRepository.cs
@@ -81,6 +81,45 @@ public class ExchangeRateRepository(AppDbContext context) : IExchangeRateReposit
         }
     }
 
+    public async Task<IReadOnlyDictionary<(string From, string To, DateTime Date), decimal>> GetRange(string fromCurrency, string toCurrency, DateTime dateStart, DateTime dateEnd, CancellationToken ct = default)
+    {
+        var from = Normalize(fromCurrency);
+        var to = Normalize(toCurrency);
+        var startDay = NormalizeDate(dateStart);
+        var endDay = NormalizeDate(dateEnd);
+
+        if (startDay > endDay)
+            (startDay, endDay) = (endDay, startDay);
+
+        await _contextLock.WaitAsync(ct);
+        try
+        {
+            var directRates = await context.ExchangeRates
+                .AsNoTracking()
+                .Where(x => x.FromCurrency == from && x.ToCurrency == to && x.Date >= startDay && x.Date <= endDay)
+                .ToDictionaryAsync(x => (x.FromCurrency, x.ToCurrency, x.Date), x => x.Rate, ct);
+
+            var inverseRates = await context.ExchangeRates
+                .AsNoTracking()
+                .Where(x => x.FromCurrency == to && x.ToCurrency == from && x.Date >= startDay && x.Date <= endDay)
+                .ToListAsync(ct);
+
+            var result = new Dictionary<(string From, string To, DateTime Date), decimal>(directRates);
+            foreach (var inverse in inverseRates)
+            {
+                var key = (from, to, inverse.Date);
+                if (!result.ContainsKey(key) && inverse.Rate != 0)
+                    result[key] = 1m / inverse.Rate;
+            }
+
+            return result;
+        }
+        finally
+        {
+            _contextLock.Release();
+        }
+    }
+
     private static string Normalize(string currency) => currency.Trim().ToUpperInvariant();
 
     // Rates are daily; store the UTC day start so lookups are exact and PostgreSQL accepts the value.

--- a/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceProviderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceProviderTests.cs
@@ -173,6 +173,130 @@ public class InvestmentPriceProviderTests
         Assert.Equal(110m, series[fri]);
     }
 
+    [Fact]
+    public async Task GetPricePerUnitSeries_ReusesSparseHistory_WithoutFetchingWhenBoundariesCovered()
+    {
+        var start = new DateTime(2024, 1, 1); // Monday
+        var end = new DateTime(2024, 1, 31); // Wednesday
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing());
+
+        // Seed sparse data: one quote near start (within 7-day tolerance), one near end.
+        _priceQuoteRepository.Seed(new PriceQuote
+        {
+            AssetListingId = 10,
+            Provider = MarketDataProvider.AlphaVantage,
+            Price = 100m,
+            Currency = "USD",
+            PriceTime = new DateTimeOffset(new DateTime(2024, 1, 5), TimeSpan.Zero), // Friday, within [1st, 8th]
+            QuoteType = PriceQuoteType.EndOfDay
+        });
+        _priceQuoteRepository.Seed(new PriceQuote
+        {
+            AssetListingId = 10,
+            Provider = MarketDataProvider.AlphaVantage,
+            Price = 110m,
+            Currency = "USD",
+            PriceTime = new DateTimeOffset(new DateTime(2024, 1, 29), TimeSpan.Zero), // Monday, within [24th, 31st]
+            QuoteType = PriceQuoteType.EndOfDay
+        });
+
+        var series = await CreateSut().GetPricePerUnitSeriesAsync(10, _usd, start, end, TestContext.Current.CancellationToken);
+
+        // No fetch should occur; sparse series should be used as-is.
+        _priceSource.Verify(
+            x => x.GetDailySeries(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        Assert.NotEmpty(series);
+    }
+
+    [Fact]
+    public async Task GetPricePerUnitSeries_FetchesWhenStartBoundaryMissing()
+    {
+        var start = new DateTime(2024, 1, 1); // Monday
+        var end = new DateTime(2024, 1, 31); // Wednesday
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing());
+
+        // Seed only end boundary coverage (no data within [1st, 8th]).
+        _priceQuoteRepository.Seed(new PriceQuote
+        {
+            AssetListingId = 10,
+            Provider = MarketDataProvider.AlphaVantage,
+            Price = 110m,
+            Currency = "USD",
+            PriceTime = new DateTimeOffset(new DateTime(2024, 1, 29), TimeSpan.Zero),
+            QuoteType = PriceQuoteType.EndOfDay
+        });
+
+        _priceSource
+            .Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Price(100m, new DateTime(2024, 1, 3)), Price(110m, new DateTime(2024, 1, 29))]);
+
+        var series = await CreateSut().GetPricePerUnitSeriesAsync(10, _usd, start, end, TestContext.Current.CancellationToken);
+
+        // Fetch must occur due to missing start boundary.
+        _priceSource.Verify(
+            x => x.GetDailySeries("CSPX.LON", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.NotEmpty(series);
+    }
+
+    [Fact]
+    public async Task GetPricePerUnitSeries_FetchesWhenEndBoundaryMissing()
+    {
+        var start = new DateTime(2024, 1, 1); // Monday
+        var end = new DateTime(2024, 1, 31); // Wednesday
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing());
+
+        // Seed only start boundary coverage (no data within [24th, 31st]).
+        _priceQuoteRepository.Seed(new PriceQuote
+        {
+            AssetListingId = 10,
+            Provider = MarketDataProvider.AlphaVantage,
+            Price = 100m,
+            Currency = "USD",
+            PriceTime = new DateTimeOffset(new DateTime(2024, 1, 5), TimeSpan.Zero),
+            QuoteType = PriceQuoteType.EndOfDay
+        });
+
+        _priceSource
+            .Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Price(100m, new DateTime(2024, 1, 5)), Price(110m, new DateTime(2024, 1, 29))]);
+
+        var series = await CreateSut().GetPricePerUnitSeriesAsync(10, _usd, start, end, TestContext.Current.CancellationToken);
+
+        // Fetch must occur due to missing end boundary.
+        _priceSource.Verify(
+            x => x.GetDailySeries("CSPX.LON", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.NotEmpty(series);
+    }
+
+    [Fact]
+    public async Task GetPricePerUnitSeries_UsesBulkPersistence_OnFetch()
+    {
+        var start = new DateTime(2024, 1, 1); // Monday
+        var end = new DateTime(2024, 1, 5); // Friday
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing());
+
+        var priceData = new[]
+        {
+            Price(100m, new DateTime(2024, 1, 1)),
+            Price(102m, new DateTime(2024, 1, 2)),
+            Price(104m, new DateTime(2024, 1, 3))
+        };
+
+        _priceSource
+            .Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(priceData);
+
+        var series = await CreateSut().GetPricePerUnitSeriesAsync(10, _usd, start, end, TestContext.Current.CancellationToken);
+
+        // All prices should be persisted in a single UpsertRange call, verified by checking the stored count.
+        Assert.Equal(priceData.Length, _priceQuoteRepository.All.Count);
+        Assert.Equal(1, _priceQuoteRepository.BulkUpsertCalls);
+        Assert.NotEmpty(series);
+    }
+
     /// <summary>Minimal in-memory <see cref="IPriceQuoteRepository"/> so fetch→store→read flows are exercised end-to-end.</summary>
     private sealed class InMemoryPriceQuoteRepository : IPriceQuoteRepository
     {
@@ -180,6 +304,7 @@ public class InvestmentPriceProviderTests
         private long _nextId = 1;
 
         public IReadOnlyList<PriceQuote> All => _quotes;
+        public int BulkUpsertCalls { get; private set; }
 
         public void Seed(PriceQuote quote) => _quotes.Add(quote);
 
@@ -224,6 +349,40 @@ public class InvestmentPriceProviderTests
             }
 
             return Add(quote, cancellationToken);
+        }
+
+        public Task<IReadOnlyList<PriceQuote>> UpsertRange(IReadOnlyList<PriceQuote> quotes, CancellationToken cancellationToken = default)
+        {
+            if (quotes.Count == 0) return Task.FromResult<IReadOnlyList<PriceQuote>>([]);
+
+            BulkUpsertCalls++;
+            var result = new List<PriceQuote>(quotes.Count);
+            foreach (var quote in quotes)
+            {
+                var existing = _quotes.FirstOrDefault(x =>
+                    x.AssetListingId == quote.AssetListingId
+                    && x.Provider == quote.Provider
+                    && x.PriceTime == quote.PriceTime
+                    && x.QuoteType == quote.QuoteType);
+
+                if (existing is not null)
+                {
+                    existing.Price = quote.Price;
+                    existing.Currency = quote.Currency;
+                    existing.RawPrice = quote.RawPrice;
+                    existing.RawCurrency = quote.RawCurrency;
+                    existing.MarketDataSymbolId = quote.MarketDataSymbolId;
+                    result.Add(existing);
+                }
+                else
+                {
+                    quote.Id = _nextId++;
+                    _quotes.Add(quote);
+                    result.Add(quote);
+                }
+            }
+
+            return Task.FromResult<IReadOnlyList<PriceQuote>>(result);
         }
 
         public Task<bool> Delete(long id, CancellationToken cancellationToken = default)

--- a/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
@@ -339,6 +339,110 @@ public class CurrencyExchangeServiceTests : IDisposable
         Assert.Equal(5m, result);
     }
 
+    [Fact]
+    public async Task GetExchangeRateAsync_FullyStoredRange_UsesBulkReadAndNoProviderCalls()
+    {
+        // Arrange
+        var fromCurrency = new Currency(1, "USD", "$");
+        var toCurrency = new Currency(2, "EUR", "€");
+        var dateStart = new DateTime(2024, 1, 15);
+        var dateEnd = new DateTime(2024, 1, 17);
+
+        // Setup bulk read to return all rates
+        IReadOnlyDictionary<(string From, string To, DateTime Date), decimal> storedRates =
+            new Dictionary<(string, string, DateTime), decimal>
+            {
+                { ("USD", "EUR", new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc)), 0.92m },
+                { ("USD", "EUR", new DateTime(2024, 1, 16, 0, 0, 0, DateTimeKind.Utc)), 0.91m },
+                { ("USD", "EUR", new DateTime(2024, 1, 17, 0, 0, 0, DateTimeKind.Utc)), 0.93m }
+            };
+
+        _exchangeRateRepositoryMock
+            .Setup(x => x.GetRange("USD", "EUR", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(storedRates);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, dateStart, dateEnd);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(0.92m, result[0].Value);
+        Assert.Equal(0.91m, result[1].Value);
+        Assert.Equal(0.93m, result[2].Value);
+
+        // Verify bulk read was called
+        _exchangeRateRepositoryMock.Verify(
+            x => x.GetRange("USD", "EUR", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Verify no provider calls were made (HTTP handler not invoked)
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetExchangeRateAsync_PartiallyStoredRange_UsesBulkReadThenPointResolutionForMissing()
+    {
+        // Arrange
+        var fromCurrency = new Currency(1, "USD", "$");
+        var toCurrency = new Currency(2, "EUR", "€");
+        var dateStart = new DateTime(2024, 1, 15);
+        var dateEnd = new DateTime(2024, 1, 17);
+
+        // Setup bulk read to return only first and last rates
+        IReadOnlyDictionary<(string From, string To, DateTime Date), decimal> storedRates =
+            new Dictionary<(string, string, DateTime), decimal>
+            {
+                { ("USD", "EUR", new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc)), 0.92m },
+                { ("USD", "EUR", new DateTime(2024, 1, 17, 0, 0, 0, DateTimeKind.Utc)), 0.93m }
+            };
+
+        _exchangeRateRepositoryMock
+            .Setup(x => x.GetRange("USD", "EUR", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(storedRates);
+
+        // Setup point Get to return null for direct, forcing provider call
+        _exchangeRateRepositoryMock
+            .Setup(x => x.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((decimal?)null);
+
+        var jsonResponse = @"{""usd"": {""eur"": 0.915}}";
+        SetupHttpResponse(HttpStatusCode.OK, jsonResponse);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, dateStart, dateEnd);
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal(0.92m, result[0].Value);
+        Assert.Equal(0.915m, result[1].Value);
+        Assert.Equal(0.93m, result[2].Value);
+
+        // Verify bulk read was called
+        _exchangeRateRepositoryMock.Verify(
+            x => x.GetRange("USD", "EUR", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Verify point Get was called for missing date resolution
+        _exchangeRateRepositoryMock.Verify(
+            x => x.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+
+        // Verify provider was called for missing date
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
     private CurrencyExchangeService CreateService()
     {
         ICurrencyExchangeRateProvider[] providers = [new FawazAhmedCurrencyApiClient(_httpClient, _loggerMock)];


### PR DESCRIPTION
## Summary

- reuse existing market price history when the requested range boundaries are already covered
- persist fetched price quotes in one batch
- load stored direct and inverse exchange-rate ranges in bulk, with the existing missing-date fallback preserved
- add regression coverage for price-history boundaries, batch persistence, stored FX ranges, and missing FX dates

## Root cause

Investment chart requests treated exchange holidays as missing price history, repeatedly downloaded complete histories, persisted each quote separately, and performed hundreds of serialized daily exchange-rate lookups.

## Impact

The 30-transaction, 882-day local reproduction improved from 29.83 seconds cold / 6.65 seconds warm to 2.75 seconds cold / about 1.97 seconds warm. Chart values and UI behavior are unchanged.

## Validation

- `dotnet format ./code/FinanceManager.slnx`
- `dotnet build ./code/FinanceManager.slnx`
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj` (516 passed)
- local testuser chart load and browser verification with no timeout errors

Closes #542