### PR TITLE
Batch investment valuation across accounts to end per-account dashboard fan-out #544

### DIFF
--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Assets/AssetsServiceInvestment.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Assets/AssetsServiceInvestment.cs
@@ -42,10 +42,14 @@ internal class AssetsServiceInvestment(
         if (end > DateTime.UtcNow) end = DateTime.UtcNow;
         if (start == default) return [];
 
-        Dictionary<DateTime, decimal> values = [];
+        List<int> accountIds = [];
         await foreach (var account in financialAccountRepository.GetAccounts<InvestmentAccount>(userId, start, end))
+            accountIds.Add(account.AccountId);
+
+        Dictionary<DateTime, decimal> values = [];
+        var seriesByAccount = await valuationService.GetAccountValueSeriesAsync(accountIds, currency, start, end);
+        foreach (var series in seriesByAccount.Values)
         {
-            var series = await valuationService.GetAccountValueSeriesAsync(account.AccountId, currency, start, end);
             foreach (var (date, value) in series)
             {
                 if (!values.TryAdd(date, value))
@@ -66,19 +70,26 @@ internal class AssetsServiceInvestment(
 
     public async IAsyncEnumerable<NameValueResult> GetEndAssetsPerAccount(int userId, Currency currency, DateTime asOfDate)
     {
+        List<InvestmentAccount> accounts = [];
         await foreach (var account in financialAccountRepository.GetAccounts<InvestmentAccount>(userId, asOfDate.AddMinutes(-1), asOfDate))
+            accounts.Add(account);
+
+        var valuesByAccount = await valuationService.GetAccountValueAsync(accounts.Select(a => a.AccountId).ToList(), currency, asOfDate);
+        foreach (var account in accounts)
         {
-            var value = await valuationService.GetAccountValueAsync(account.AccountId, currency, asOfDate);
-            if (value > 0)
+            if (valuesByAccount.TryGetValue(account.AccountId, out var value) && value > 0)
                 yield return new NameValueResult(account.Name, value);
         }
     }
 
     public async IAsyncEnumerable<NameValueResult> GetEndAssetsPerType(int userId, Currency currency, DateTime asOfDate)
     {
-        decimal total = 0;
+        List<int> accountIds = [];
         await foreach (var account in financialAccountRepository.GetAccounts<InvestmentAccount>(userId, asOfDate.AddMinutes(-1), asOfDate))
-            total += await valuationService.GetAccountValueAsync(account.AccountId, currency, asOfDate);
+            accountIds.Add(account.AccountId);
+
+        var valuesByAccount = await valuationService.GetAccountValueAsync(accountIds, currency, asOfDate);
+        var total = valuesByAccount.Values.Sum();
 
         if (total > 0)
             yield return new NameValueResult(InvestmentType.Stock.ToString(), total);

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Balance/InvestmentBalanceService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Balance/InvestmentBalanceService.cs
@@ -77,13 +77,13 @@ internal class InvestmentBalanceService(
         for (var date = start.Date; date <= end.Date; date = date.AddDays(1))
             values[date] = 0;
 
-        // Fetch one account at a time: the valuation service reads through a scoped
-        // IInvestmentTransactionRepository backed by a single AppDbContext, which EF Core does not
-        // allow to service concurrent operations. Legacy stock accounts return an empty series here
-        // (no investment transactions) and so contribute nothing.
-        foreach (var accountId in investmentAccountIds)
+        // One batched call issues a single transactions query for all accounts and prices each
+        // distinct listing once across them, rather than a per-account round-trip on the shared
+        // AppDbContext (which EF Core cannot service concurrently anyway). Legacy stock accounts hold
+        // no investment transactions, so they are simply absent from the batched result.
+        var seriesByAccount = await investmentValuationService.GetAccountValueSeriesAsync(investmentAccountIds, currency, start.Date, end.Date);
+        foreach (var series in seriesByAccount.Values)
         {
-            var series = await investmentValuationService.GetAccountValueSeriesAsync(accountId, currency, start.Date, end.Date);
             foreach (var (date, value) in series)
             {
                 if (values.ContainsKey(date.Date))

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
@@ -1,5 +1,6 @@
 using FinanceManager.Domain.Assets.Services;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Investments.Services;
 
@@ -10,6 +11,14 @@ namespace FinanceManager.Application.FinancialAccounts.Investments.Valuation;
 /// <see cref="Domain.FinancialAccounts.Investments.Entities.InvestmentTransaction"/> rows and
 /// pricing each listing through <see cref="IInvestmentPriceProvider"/>.
 /// </summary>
+/// <remarks>
+/// The single-account overloads are thin wrappers over the batched overloads (passing a
+/// single-element collection). The batched implementations issue one transactions query for all
+/// requested accounts and price each distinct <c>AssetListing</c> once across the whole set, so a
+/// dashboard paint no longer re-prices the same listing once per owning account. Queries are still
+/// issued strictly sequentially: the scoped <c>AppDbContext</c> cannot service concurrent operations,
+/// so the win comes from doing fewer, wider queries — never from parallel awaits.
+/// </remarks>
 internal class InvestmentValuationService(
     IInvestmentTransactionRepository transactionRepository,
     IInvestmentPriceProvider priceProvider) : IInvestmentValuationService
@@ -24,17 +33,53 @@ internal class InvestmentValuationService(
 
     public async Task<decimal> GetAccountValueAsync(int accountId, Currency targetCurrency, DateTime asOf, CancellationToken ct = default)
     {
-        var holdings = await GetHoldingsAsOfAsync(accountId, DateOnly.FromDateTime(asOf), ct);
-        if (holdings.Count == 0) return 0m;
+        var byAccount = await GetAccountValueAsync([accountId], targetCurrency, asOf, ct);
+        return byAccount.TryGetValue(accountId, out var value) ? value : 0m;
+    }
 
-        decimal total = 0m;
-        foreach (var (listingId, holding) in holdings)
+    public async Task<IReadOnlyDictionary<int, decimal>> GetAccountValueAsync(
+        IReadOnlyCollection<int> accountIds,
+        Currency targetCurrency,
+        DateTime asOf,
+        CancellationToken ct = default)
+    {
+        var result = new Dictionary<int, decimal>();
+        if (accountIds.Count == 0) return result;
+
+        var transactions = await transactionRepository.GetByAccounts(accountIds, ct);
+        if (transactions.Count == 0) return result;
+
+        var asOfDate = DateOnly.FromDateTime(asOf);
+
+        // Net holding per (account, listing) as of the date, dropping zero net positions.
+        var holdingsByAccount = new Dictionary<int, Dictionary<long, decimal>>();
+        foreach (var group in transactions.Where(t => t.TradeDate <= asOfDate).GroupBy(t => t.AccountId))
         {
-            var price = await priceProvider.GetPricePerUnitAsync(listingId, targetCurrency, asOf, ct);
-            if (price > 0) total += holding * price;
+            var perListing = group
+                .GroupBy(t => t.AssetListingId)
+                .ToDictionary(g => g.Key, g => g.Sum(t => t.SignedQuantity));
+            holdingsByAccount[group.Key] = perListing;
         }
 
-        return total;
+        // Price each distinct listing across all accounts once, not once per owning account.
+        var prices = new Dictionary<long, decimal>();
+        foreach (var listingId in holdingsByAccount.Values.SelectMany(h => h.Keys).Distinct())
+            prices[listingId] = await priceProvider.GetPricePerUnitAsync(listingId, targetCurrency, asOf, ct);
+
+        foreach (var (accountId, holdings) in holdingsByAccount)
+        {
+            decimal total = 0m;
+            foreach (var (listingId, holding) in holdings)
+            {
+                if (holding == 0m) continue;
+                if (prices.TryGetValue(listingId, out var price) && price > 0)
+                    total += holding * price;
+            }
+
+            if (total != 0m) result[accountId] = total;
+        }
+
+        return result;
     }
 
     public async Task<IReadOnlyDictionary<DateTime, decimal>> GetAccountValueSeriesAsync(
@@ -44,10 +89,21 @@ internal class InvestmentValuationService(
         DateTime end,
         CancellationToken ct = default)
     {
-        var result = new Dictionary<DateTime, decimal>();
-        if (start == default || end == default || end < start) return result;
+        var byAccount = await GetAccountValueSeriesAsync([accountId], targetCurrency, start, end, ct);
+        return byAccount.TryGetValue(accountId, out var series) ? series : new Dictionary<DateTime, decimal>();
+    }
 
-        var transactions = await transactionRepository.GetByAccount(accountId, ct);
+    public async Task<IReadOnlyDictionary<int, IReadOnlyDictionary<DateTime, decimal>>> GetAccountValueSeriesAsync(
+        IReadOnlyCollection<int> accountIds,
+        Currency targetCurrency,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        var result = new Dictionary<int, IReadOnlyDictionary<DateTime, decimal>>();
+        if (accountIds.Count == 0 || start == default || end == default || end < start) return result;
+
+        var transactions = await transactionRepository.GetByAccounts(accountIds, ct);
         if (transactions.Count == 0) return result;
 
         var startDate = start.Date;
@@ -55,18 +111,39 @@ internal class InvestmentValuationService(
         var startDateOnly = DateOnly.FromDateTime(startDate);
         var endDateOnly = DateOnly.FromDateTime(endDate);
 
-        var byListing = transactions
-            .Where(t => t.TradeDate <= endDateOnly)
-            .GroupBy(t => t.AssetListingId)
-            .ToList();
-        if (byListing.Count == 0) return result;
+        var relevant = transactions.Where(t => t.TradeDate <= endDateOnly).ToList();
+        if (relevant.Count == 0) return result;
 
-        // For each listing: the running holding carried into the window (everything before start),
-        // the per-day signed-quantity deltas inside the window, and the price-per-unit series
-        // (already in the target currency). One price-series fetch per distinct listing.
+        // One price-series fetch per distinct listing across all accounts (target currency already
+        // applied). Accounts holding the same instrument share this series instead of re-fetching it.
+        var priceSeries = new Dictionary<long, IReadOnlyDictionary<DateTime, decimal>>();
+        foreach (var listingId in relevant.Select(t => t.AssetListingId).Distinct())
+            priceSeries[listingId] = await priceProvider.GetPricePerUnitSeriesAsync(listingId, targetCurrency, start, end, ct);
+
+        foreach (var accountGroup in relevant.GroupBy(t => t.AccountId))
+        {
+            var series = BuildAccountSeries(accountGroup, startDate, endDate, startDateOnly, priceSeries);
+            if (series.Count > 0) result[accountGroup.Key] = series;
+        }
+
+        return result;
+    }
+
+    // Fold one account's transactions against the shared per-listing price series: carry each
+    // listing's holding forward across days without a trade and value it at that day's price.
+    private static Dictionary<DateTime, decimal> BuildAccountSeries(
+        IEnumerable<InvestmentTransaction> accountTransactions,
+        DateTime startDate,
+        DateTime endDate,
+        DateOnly startDateOnly,
+        IReadOnlyDictionary<long, IReadOnlyDictionary<DateTime, decimal>> priceSeries)
+    {
+        var result = new Dictionary<DateTime, decimal>();
+
+        var byListing = accountTransactions.GroupBy(t => t.AssetListingId).ToList();
+
         var holdings = new Dictionary<long, decimal>();
         var dailyDeltas = new Dictionary<long, Dictionary<DateTime, decimal>>();
-        var priceSeries = new Dictionary<long, IReadOnlyDictionary<DateTime, decimal>>();
 
         foreach (var group in byListing)
         {
@@ -76,7 +153,6 @@ internal class InvestmentValuationService(
                 .Where(t => t.TradeDate >= startDateOnly)
                 .GroupBy(t => t.TradeDate.ToDateTime(TimeOnly.MinValue))
                 .ToDictionary(g => g.Key, g => g.Sum(t => t.SignedQuantity));
-            priceSeries[listingId] = await priceProvider.GetPricePerUnitSeriesAsync(listingId, targetCurrency, start, end, ct);
         }
 
         for (var date = startDate; date <= endDate; date = date.AddDays(1))
@@ -91,7 +167,8 @@ internal class InvestmentValuationService(
                 var holding = holdings[listingId];
                 if (holding == 0m) continue;
 
-                if (priceSeries[listingId].TryGetValue(date, out var price) && price > 0)
+                if (priceSeries.TryGetValue(listingId, out var listingPrices)
+                    && listingPrices.TryGetValue(date, out var price) && price > 0)
                     dayValue += holding * price;
             }
 

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
@@ -51,14 +51,17 @@ internal class InvestmentValuationService(
 
         var asOfDate = DateOnly.FromDateTime(asOf);
 
-        // Net holding per (account, listing) as of the date, dropping zero net positions.
+        // Net holding per (account, listing) as of the date, dropping zero net positions so fully
+        // closed holdings never trigger a (wasted, potentially failing) price fetch.
         var holdingsByAccount = new Dictionary<int, Dictionary<long, decimal>>();
         foreach (var group in transactions.Where(t => t.TradeDate <= asOfDate).GroupBy(t => t.AccountId))
         {
             var perListing = group
                 .GroupBy(t => t.AssetListingId)
-                .ToDictionary(g => g.Key, g => g.Sum(t => t.SignedQuantity));
-            holdingsByAccount[group.Key] = perListing;
+                .Select(g => (ListingId: g.Key, Holding: g.Sum(t => t.SignedQuantity)))
+                .Where(x => x.Holding != 0m)
+                .ToDictionary(x => x.ListingId, x => x.Holding);
+            if (perListing.Count > 0) holdingsByAccount[group.Key] = perListing;
         }
 
         // Price each distinct listing across all accounts once, not once per owning account.
@@ -71,7 +74,6 @@ internal class InvestmentValuationService(
             decimal total = 0m;
             foreach (var (listingId, holding) in holdings)
             {
-                if (holding == 0m) continue;
                 if (prices.TryGetValue(listingId, out var price) && price > 0)
                     total += holding * price;
             }

--- a/code/FinanceManager.Application/MoneyFlow/InvestmentPaycheck/InvestmentPaycheckEstimatorService.cs
+++ b/code/FinanceManager.Application/MoneyFlow/InvestmentPaycheck/InvestmentPaycheckEstimatorService.cs
@@ -69,8 +69,17 @@ public class InvestmentPaycheckEstimatorService(
             }
         }
 
+        List<int> investmentAccountIds = [];
         await foreach (var account in financialAccountRepository.GetAccounts<InvestmentAccount>(userId, asOfDate.Date, asOfDate))
-            result += await investmentValuationService.GetAccountValueAsync(account.AccountId, currency, asOfDate);
+            investmentAccountIds.Add(account.AccountId);
+
+        if (investmentAccountIds.Count > 0)
+        {
+            // Batched point valuation: one transactions query, each distinct listing priced once
+            // across all accounts. The total sums across accounts, so no per-account breakdown needed.
+            var valuesByAccount = await investmentValuationService.GetAccountValueAsync(investmentAccountIds, currency, asOfDate);
+            result += valuesByAccount.Values.Sum();
+        }
 
         return result;
     }

--- a/code/FinanceManager.Application/MoneyFlow/InvestmentRate/InvestmentRateService.cs
+++ b/code/FinanceManager.Application/MoneyFlow/InvestmentRate/InvestmentRateService.cs
@@ -26,12 +26,19 @@ IInvestmentValuationService investmentValuationService) : IInvestmentRateService
 
         if (salary == 0) yield break;
 
-        decimal investmentsChange = 0;
+        List<int> investmentAccountIds = [];
         await foreach (var account in financialAccountRepository.GetAccounts<InvestmentAccount>(userId, start, end))
+            investmentAccountIds.Add(account.AccountId);
+
+        decimal investmentsChange = 0;
+        if (investmentAccountIds.Count > 0)
         {
-            var startValue = await investmentValuationService.GetAccountValueAsync(account.AccountId, currency, start);
-            var endValue = await investmentValuationService.GetAccountValueAsync(account.AccountId, currency, end);
-            investmentsChange += endValue - startValue;
+            // Batched point valuation: one transactions query per as-of date, each distinct listing
+            // priced once across all accounts. The change nets across accounts, so the per-account
+            // breakdown is not needed here — summing the batched result matches the per-account loop.
+            var startValues = await investmentValuationService.GetAccountValueAsync(investmentAccountIds, currency, start);
+            var endValues = await investmentValuationService.GetAccountValueAsync(investmentAccountIds, currency, end);
+            investmentsChange = endValues.Values.Sum() - startValues.Values.Sum();
         }
 
         yield return new()

--- a/code/FinanceManager.Application/MoneyFlow/NetWorth/NetWorthService.cs
+++ b/code/FinanceManager.Application/MoneyFlow/NetWorth/NetWorthService.cs
@@ -69,12 +69,11 @@ IBondDetailsRepository bondDetailsRepository, IInvestmentValuationService invest
             investmentAccounts.Add(account);
 
         // Investment accounts (new asset model) value per account/day through the valuation service.
-        // Fetch one account at a time: the valuation service reads through a scoped
-        // IInvestmentTransactionRepository backed by a single AppDbContext, which EF Core does not
-        // allow to service concurrent operations.
-        Dictionary<int, IReadOnlyDictionary<DateTime, decimal>> investmentValuesByAccount = [];
-        foreach (var account in investmentAccounts)
-            investmentValuesByAccount[account.AccountId] = await investmentValuationService.GetAccountValueSeriesAsync(account.AccountId, currency, start.Date, end.Date);
+        // One batched call issues a single transactions query for all accounts and prices each
+        // distinct listing once across them, rather than a per-account round-trip on the shared
+        // AppDbContext (which EF Core cannot service concurrently anyway).
+        var investmentValuesByAccount = await investmentValuationService.GetAccountValueSeriesAsync(
+            investmentAccounts.Select(a => a.AccountId).ToList(), currency, start.Date, end.Date);
 
         for (DateTime date = end; date >= start; date = date.AddDays(-1))
         {

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Repositories/IInvestmentTransactionRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Repositories/IInvestmentTransactionRepository.cs
@@ -11,6 +11,12 @@ public interface IInvestmentTransactionRepository
     /// <summary>Get all transactions belonging to the given account.</summary>
     Task<IReadOnlyList<InvestmentTransaction>> GetByAccount(int accountId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Get all transactions belonging to any of the given accounts in a single query. Lets callers
+    /// value several accounts without a per-account round-trip on the shared scoped context.
+    /// </summary>
+    Task<IReadOnlyList<InvestmentTransaction>> GetByAccounts(IReadOnlyCollection<int> accountIds, CancellationToken cancellationToken = default);
+
     /// <summary>Get a user's transactions whose <see cref="InvestmentTransaction.TradeDate"/> falls within [startDate, endDate].</summary>
     Task<IReadOnlyList<InvestmentTransaction>> GetByUser(long userId, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default);
 

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Services/IInvestmentValuationService.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Services/IInvestmentValuationService.cs
@@ -39,4 +39,31 @@ public interface IInvestmentValuationService
         DateTime start,
         DateTime end,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Total value per account of the given accounts' holdings converted to
+    /// <paramref name="targetCurrency"/> as of <paramref name="asOf"/>. Equivalent to calling
+    /// <see cref="GetAccountValueAsync(int, Currency, DateTime, CancellationToken)"/> once per
+    /// account, but issues a single transactions query and prices each distinct listing once across
+    /// all accounts. Accounts that hold nothing are omitted from the result.
+    /// </summary>
+    Task<IReadOnlyDictionary<int, decimal>> GetAccountValueAsync(
+        IReadOnlyCollection<int> accountIds,
+        Currency targetCurrency,
+        DateTime asOf,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Daily account value per account for the given accounts over [<paramref name="start"/>,
+    /// <paramref name="end"/>]. Equivalent to calling
+    /// <see cref="GetAccountValueSeriesAsync(int, Currency, DateTime, DateTime, CancellationToken)"/>
+    /// once per account, but issues a single transactions query and prices each distinct listing once
+    /// across all accounts. Accounts whose whole series is empty are omitted from the result.
+    /// </summary>
+    Task<IReadOnlyDictionary<int, IReadOnlyDictionary<DateTime, decimal>>> GetAccountValueSeriesAsync(
+        IReadOnlyCollection<int> accountIds,
+        Currency targetCurrency,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default);
 }

--- a/code/FinanceManager.Infrastructure/Repositories/Investments/InvestmentTransactionRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Investments/InvestmentTransactionRepository.cs
@@ -19,6 +19,17 @@ public class InvestmentTransactionRepository(AppDbContext context) : IInvestment
             .OrderBy(x => x.TradeDate).ThenBy(x => x.Id)
             .ToListAsync(cancellationToken);
 
+    public async Task<IReadOnlyList<InvestmentTransaction>> GetByAccounts(IReadOnlyCollection<int> accountIds, CancellationToken cancellationToken = default)
+    {
+        if (accountIds.Count == 0) return [];
+
+        return await context.InvestmentTransactions.AsNoTracking()
+            .Include(x => x.AssetListing)
+            .Where(x => accountIds.Contains(x.AccountId))
+            .OrderBy(x => x.TradeDate).ThenBy(x => x.Id)
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<IReadOnlyList<InvestmentTransaction>> GetByUser(long userId, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default) =>
         await context.InvestmentTransactions.AsNoTracking()
             .Include(x => x.AssetListing)

--- a/code/FinanceManager.Tests.Unit/Application/Services/InvestmentPaycheckEstimatorServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/InvestmentPaycheckEstimatorServiceTests.cs
@@ -28,8 +28,8 @@ public class InvestmentPaycheckEstimatorServiceTests
             .Setup(x => x.GetAccounts<InvestmentAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(AsyncEnumerable.Empty<InvestmentAccount>());
         _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(0m);
+            .Setup(x => x.GetAccountValueAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, decimal>());
 
         _service = new InvestmentPaycheckEstimatorService(_financialAccountRepositoryMock.Object, _financialLabelsRepositoryMock.Object, _investmentValuationServiceMock.Object, _bondDetailsRepositoryMock.Object);
     }
@@ -61,8 +61,8 @@ public class InvestmentPaycheckEstimatorServiceTests
             .Setup(x => x.GetAccounts<InvestmentAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(new[] { investmentAccount }.ToAsyncEnumerable());
         _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(20, It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(1000m);
+            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(20)), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, decimal> { [20] = 1000m });
         _financialAccountRepositoryMock
             .Setup(x => x.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(new[] { bondAccount }.ToAsyncEnumerable());

--- a/code/FinanceManager.Tests.Unit/Application/Services/InvestmentRateServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/InvestmentRateServiceTests.cs
@@ -29,8 +29,8 @@ public class InvestmentRateServiceTests
         _financialAccountRepositoryMock.Setup(r => r.GetAccounts<InvestmentAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(AsyncEnumerable.Empty<InvestmentAccount>());
         _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(0m);
+            .Setup(x => x.GetAccountValueAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, decimal>());
 
         _investmentRateService = new InvestmentRateService(_financialAccountRepositoryMock.Object, _financialLabelsRepositoryMock.Object, _investmentValuationServiceMock.Object);
     }
@@ -55,11 +55,11 @@ public class InvestmentRateServiceTests
 
         // The investment value grew from 0 at the start of the window to 10 at the end.
         _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(2, It.IsAny<Currency>(), _startDate, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(0m);
+            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), _startDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, decimal>());
         _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(2, It.IsAny<Currency>(), _endDate, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(10m);
+            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), _endDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, decimal> { [2] = 10m });
 
         // Act
         var result = await _investmentRateService.GetInvestmentRate(userId, _startDate, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);

--- a/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentBalanceServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentBalanceServiceTests.cs
@@ -40,18 +40,20 @@ public class InvestmentBalanceServiceTests
         _financialAccountRepository.Setup(repo => repo.GetAccounts<InvestmentAccount>(_userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                                    .Returns(new[] { account1, account2 }.ToAsyncEnumerable());
 
-        _valuationService.Setup(x => x.GetAccountValueSeriesAsync(10, DefaultCurrency.PLN, start.Date, end.Date, It.IsAny<CancellationToken>()))
-                         .ReturnsAsync(new Dictionary<DateTime, decimal>
+        _valuationService.Setup(x => x.GetAccountValueSeriesAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(10) && a.Contains(20)), DefaultCurrency.PLN, start.Date, end.Date, It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(new Dictionary<int, IReadOnlyDictionary<DateTime, decimal>>
                          {
-                             [start] = 100,
-                             [start.AddDays(1)] = 110,
-                             [end] = 120
-                         });
-        _valuationService.Setup(x => x.GetAccountValueSeriesAsync(20, DefaultCurrency.PLN, start.Date, end.Date, It.IsAny<CancellationToken>()))
-                         .ReturnsAsync(new Dictionary<DateTime, decimal>
-                         {
-                             [start] = 5,
-                             [end] = 7
+                             [10] = new Dictionary<DateTime, decimal>
+                             {
+                                 [start] = 100,
+                                 [start.AddDays(1)] = 110,
+                                 [end] = 120
+                             },
+                             [20] = new Dictionary<DateTime, decimal>
+                             {
+                                 [start] = 5,
+                                 [end] = 7
+                             }
                          });
 
         var result = await _service.GetClosingBalance(_userId, DefaultCurrency.PLN, start, end);
@@ -75,14 +77,18 @@ public class InvestmentBalanceServiceTests
         _financialAccountRepository.Setup(repo => repo.GetAccounts<InvestmentAccount>(_userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                                    .Returns(new[] { account1, account2 }.ToAsyncEnumerable());
 
-        _valuationService.Setup(x => x.GetAccountValueSeriesAsync(10, DefaultCurrency.PLN, start.Date, end.Date, It.IsAny<CancellationToken>()))
-                         .ReturnsAsync(new Dictionary<DateTime, decimal> { [start] = 100 });
+        _valuationService.Setup(x => x.GetAccountValueSeriesAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(10)), DefaultCurrency.PLN, start.Date, end.Date, It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(new Dictionary<int, IReadOnlyDictionary<DateTime, decimal>>
+                         {
+                             [10] = new Dictionary<DateTime, decimal> { [start] = 100 }
+                         });
 
         var result = await _service.GetClosingBalance(_userId, DefaultCurrency.PLN, start, end, new[] { 10 });
 
         Assert.Single(result);
         Assert.Equal(100, result.Single().Value);
-        _valuationService.Verify(x => x.GetAccountValueSeriesAsync(20, It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
+        // The filtered-out account 20 must never reach the batched valuation call.
+        _valuationService.Verify(x => x.GetAccountValueSeriesAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(20)), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -96,9 +102,10 @@ public class InvestmentBalanceServiceTests
         _financialAccountRepository.Setup(repo => repo.GetAccounts<InvestmentAccount>(_userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                                    .Returns(new[] { legacyStockAccount }.ToAsyncEnumerable());
 
-        // Legacy stock accounts hold no investment transactions, so the valuation service returns empty.
-        _valuationService.Setup(x => x.GetAccountValueSeriesAsync(30, DefaultCurrency.PLN, start.Date, end.Date, It.IsAny<CancellationToken>()))
-                         .ReturnsAsync(new Dictionary<DateTime, decimal>());
+        // Legacy stock accounts hold no investment transactions, so the batched valuation result
+        // simply omits them (empty dictionary).
+        _valuationService.Setup(x => x.GetAccountValueSeriesAsync(It.IsAny<IReadOnlyCollection<int>>(), DefaultCurrency.PLN, start.Date, end.Date, It.IsAny<CancellationToken>()))
+                         .ReturnsAsync(new Dictionary<int, IReadOnlyDictionary<DateTime, decimal>>());
 
         var result = await _service.GetClosingBalance(_userId, DefaultCurrency.PLN, start, end);
 

--- a/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
@@ -18,10 +18,10 @@ public class InvestmentValuationServiceTests
 
     private InvestmentValuationService CreateSut() => new(_transactionRepository.Object, _priceProvider.Object);
 
-    private static InvestmentTransaction Tx(long listingId, InvestmentTransactionType type, decimal qty, DateOnly tradeDate) =>
+    private static InvestmentTransaction Tx(long listingId, InvestmentTransactionType type, decimal qty, DateOnly tradeDate, int accountId = _accountId) =>
         new()
         {
-            AccountId = _accountId,
+            AccountId = accountId,
             AssetListingId = listingId,
             Type = type,
             Quantity = qty,
@@ -49,8 +49,12 @@ public class InvestmentValuationServiceTests
     {
         var asOf = new DateTime(2024, 6, 30);
         _transactionRepository
-            .Setup(x => x.GetHoldingsAsOf(It.IsAny<IReadOnlyCollection<int>>(), DateOnly.FromDateTime(asOf), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<long, decimal> { [10] = 3m, [20] = 2m });
+            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                Tx(10, InvestmentTransactionType.Buy, 3m, new DateOnly(2024, 6, 1)),
+                Tx(20, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 6, 1))
+            });
         _priceProvider.Setup(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(100m);
         _priceProvider.Setup(x => x.GetPricePerUnitAsync(20, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(50m);
 
@@ -64,8 +68,8 @@ public class InvestmentValuationServiceTests
     {
         var asOf = new DateTime(2024, 6, 30);
         _transactionRepository
-            .Setup(x => x.GetHoldingsAsOf(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<long, decimal>());
+            .Setup(x => x.GetByAccounts(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>());
 
         var value = await CreateSut().GetAccountValueAsync(_accountId, _usd, asOf, TestContext.Current.CancellationToken);
 
@@ -80,13 +84,62 @@ public class InvestmentValuationServiceTests
     {
         var asOf = new DateTime(2024, 6, 30);
         _transactionRepository
-            .Setup(x => x.GetHoldingsAsOf(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<long, decimal> { [10] = 4m }); // e.g. bought 6, sold 2
+            .Setup(x => x.GetByAccounts(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                Tx(10, InvestmentTransactionType.Buy, 6m, new DateOnly(2024, 6, 1)),
+                Tx(10, InvestmentTransactionType.Sell, 2m, new DateOnly(2024, 6, 2))
+            });
         _priceProvider.Setup(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(25m);
 
         var value = await CreateSut().GetAccountValueAsync(_accountId, _usd, asOf, TestContext.Current.CancellationToken);
 
-        Assert.Equal(100m, value);
+        Assert.Equal(100m, value); // net holding 4 * 25
+    }
+
+    [Fact]
+    public async Task GetAccountValue_ExcludesTransactionsAfterAsOf()
+    {
+        var asOf = new DateTime(2024, 6, 30);
+        _transactionRepository
+            .Setup(x => x.GetByAccounts(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                Tx(10, InvestmentTransactionType.Buy, 4m, new DateOnly(2024, 6, 1)),
+                Tx(10, InvestmentTransactionType.Buy, 10m, new DateOnly(2024, 7, 15)) // after asOf, must be ignored
+            });
+        _priceProvider.Setup(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(25m);
+
+        var value = await CreateSut().GetAccountValueAsync(_accountId, _usd, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(100m, value); // only the 4 units held on asOf
+    }
+
+    [Fact]
+    public async Task GetAccountValue_Batched_PricesSharedListingOnce_AndReturnsPerAccount()
+    {
+        var asOf = new DateTime(2024, 6, 30);
+        int[] accountIds = [10, 20];
+
+        // Both accounts hold the same listing (10); account 20 also holds listing 30.
+        _transactionRepository
+            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(10) && a.Contains(20)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                Tx(10, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 6, 1), accountId: 10),
+                Tx(10, InvestmentTransactionType.Buy, 3m, new DateOnly(2024, 6, 1), accountId: 20),
+                Tx(30, InvestmentTransactionType.Buy, 1m, new DateOnly(2024, 6, 1), accountId: 20)
+            });
+        _priceProvider.Setup(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(100m);
+        _priceProvider.Setup(x => x.GetPricePerUnitAsync(30, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(40m);
+
+        var values = await CreateSut().GetAccountValueAsync(accountIds, _usd, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(200m, values[10]); // 2 * 100
+        Assert.Equal(3m * 100m + 1m * 40m, values[20]); // 340
+
+        // The shared listing is priced once for the whole set, not once per owning account.
+        _priceProvider.Verify(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -97,7 +150,7 @@ public class InvestmentValuationServiceTests
 
         // Buy 2 on Jan 1, buy 1 more on Jan 3 → holding is 2 on Jan 1-2, then 3 on Jan 3-4.
         _transactionRepository
-            .Setup(x => x.GetByAccount(_accountId, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<InvestmentTransaction>
             {
                 Tx(10, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 1)),
@@ -131,7 +184,7 @@ public class InvestmentValuationServiceTests
 
         // The only purchase happened before the window; the holding must be carried into it.
         _transactionRepository
-            .Setup(x => x.GetByAccount(_accountId, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<InvestmentTransaction>
             {
                 Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 15))
@@ -154,12 +207,47 @@ public class InvestmentValuationServiceTests
     public async Task GetAccountValueSeries_ReturnsEmpty_WhenNoTransactions()
     {
         _transactionRepository
-            .Setup(x => x.GetByAccount(_accountId, It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetByAccounts(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<InvestmentTransaction>());
 
         var series = await CreateSut().GetAccountValueSeriesAsync(
             _accountId, _usd, new DateTime(2024, 1, 1), new DateTime(2024, 1, 31), TestContext.Current.CancellationToken);
 
         Assert.Empty(series);
+    }
+
+    [Fact]
+    public async Task GetAccountValueSeries_Batched_PricesSharedListingOnce_AndMatchesPerAccount()
+    {
+        var start = new DateTime(2024, 1, 1);
+        var end = new DateTime(2024, 1, 2);
+        int[] accountIds = [10, 20];
+
+        // Both accounts hold listing 10; account 20 also holds listing 30.
+        _transactionRepository
+            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(10) && a.Contains(20)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                Tx(10, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 1), accountId: 10),
+                Tx(10, InvestmentTransactionType.Buy, 3m, new DateOnly(2024, 1, 1), accountId: 20),
+                Tx(30, InvestmentTransactionType.Buy, 1m, new DateOnly(2024, 1, 1), accountId: 20)
+            });
+
+        _priceProvider
+            .Setup(x => x.GetPricePerUnitSeriesAsync(10, _usd, start, end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, decimal> { [start] = 10m, [end] = 12m });
+        _priceProvider
+            .Setup(x => x.GetPricePerUnitSeriesAsync(30, _usd, start, end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, decimal> { [start] = 40m, [end] = 40m });
+
+        var byAccount = await CreateSut().GetAccountValueSeriesAsync(accountIds, _usd, start, end, TestContext.Current.CancellationToken);
+
+        Assert.Equal(20m, byAccount[10][start]);  // 2 * 10
+        Assert.Equal(24m, byAccount[10][end]);    // 2 * 12
+        Assert.Equal(3m * 10m + 40m, byAccount[20][start]); // 70
+        Assert.Equal(3m * 12m + 40m, byAccount[20][end]);   // 76
+
+        // The listing shared by both accounts is priced once across the whole set.
+        _priceProvider.Verify(x => x.GetPricePerUnitSeriesAsync(10, _usd, start, end, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
@@ -143,6 +143,28 @@ public class InvestmentValuationServiceTests
     }
 
     [Fact]
+    public async Task GetAccountValue_DoesNotPriceFullyClosedPositions()
+    {
+        var asOf = new DateTime(2024, 6, 30);
+        _transactionRepository
+            .Setup(x => x.GetByAccounts(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                // Listing 10 is fully closed (net 0) and must not be priced.
+                Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 6, 1)),
+                Tx(10, InvestmentTransactionType.Sell, 5m, new DateOnly(2024, 6, 2)),
+                // Listing 20 stays open and contributes the whole value.
+                Tx(20, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 6, 1))
+            });
+        _priceProvider.Setup(x => x.GetPricePerUnitAsync(20, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(50m);
+
+        var value = await CreateSut().GetAccountValueAsync(_accountId, _usd, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(100m, value); // 2 * 50, closed position excluded
+        _priceProvider.Verify(x => x.GetPricePerUnitAsync(10, It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task GetAccountValueSeries_CarriesHoldingsForward_AndPricesPerDay()
     {
         var start = new DateTime(2024, 1, 1); // Monday

--- a/code/FinanceManager.Tests.Unit/Application/Services/NetWorthServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/NetWorthServiceTests.cs
@@ -37,6 +37,9 @@ public class NetWorthServiceTests
         _investmentValuationServiceMock
             .Setup(x => x.GetAccountValueSeriesAsync(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<DateTime, decimal>());
+        _investmentValuationServiceMock
+            .Setup(x => x.GetAccountValueSeriesAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, IReadOnlyDictionary<DateTime, decimal>>());
 
         _netWorthService = new NetWorthService(_financialAccountRepositoryMock.Object, _bondDetailsRepositoryMock.Object, _investmentValuationServiceMock.Object);
     }
@@ -98,8 +101,8 @@ public class NetWorthServiceTests
             [end] = 30m
         };
         _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueSeriesAsync(5, It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(series);
+            .Setup(x => x.GetAccountValueSeriesAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(5)), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, IReadOnlyDictionary<DateTime, decimal>> { [5] = series });
 
         var result = await _netWorthService.GetNetWorth(1, DefaultCurrency.PLN, start, end);
 
@@ -108,12 +111,11 @@ public class NetWorthServiceTests
     }
 
     [Fact]
-    public async Task GetNetWorth_OverRange_FetchesAccountValueSeriesSequentially()
+    public async Task GetNetWorth_OverRange_FetchesAllInvestmentAccountsInOneBatchedCall()
     {
-        // The valuation service reads through a scoped IInvestmentTransactionRepository backed by a
-        // single AppDbContext, which EF Core does not allow to service concurrent operations. Guard
-        // against re-introducing a Task.WhenAll fan-out by failing if a second series fetch starts
-        // before the previous one completes.
+        // The per-account fan-out is replaced by a single batched valuation call that carries every
+        // investment account id. This keeps the shared scoped AppDbContext single-threaded (one query
+        // for all accounts) instead of one round-trip per account.
         const int userId = 1;
         var start = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         var end = new DateTime(2024, 1, 3, 0, 0, 0, DateTimeKind.Utc);
@@ -131,25 +133,22 @@ public class NetWorthServiceTests
         _financialAccountRepositoryMock.Setup(x => x.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(AsyncEnumerable.Empty<BondAccount>());
 
-        var inFlight = 0;
-        var sawConcurrency = false;
+        List<int>? capturedIds = null;
         _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueSeriesAsync(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
-            .Returns(async () =>
-            {
-                if (Interlocked.Increment(ref inFlight) > 1) sawConcurrency = true;
-                await Task.Yield();
-                Interlocked.Decrement(ref inFlight);
-                return (IReadOnlyDictionary<DateTime, decimal>)new Dictionary<DateTime, decimal>();
-            });
+            .Setup(x => x.GetAccountValueSeriesAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Callback((IReadOnlyCollection<int> ids, Currency _, DateTime _, DateTime _, CancellationToken _) => capturedIds = ids.ToList())
+            .ReturnsAsync(new Dictionary<int, IReadOnlyDictionary<DateTime, decimal>>());
 
         await _netWorthService.GetNetWorth(userId, DefaultCurrency.PLN, start, end);
 
-        Assert.False(sawConcurrency, "Per-account value series must be fetched sequentially to avoid shared-DbContext concurrency.");
-        // Self-validate the guard: it only proves anything if the sequential path was actually exercised
-        // (one fetch per account). Without this, dropping the call entirely would pass vacuously.
+        // Exactly one batched call, carrying all three account ids.
+        _investmentValuationServiceMock.Verify(
+            x => x.GetAccountValueSeriesAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
         _investmentValuationServiceMock.Verify(
             x => x.GetAccountValueSeriesAsync(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
-            Times.Exactly(investmentAccounts.Count));
+            Times.Never);
+        Assert.NotNull(capturedIds);
+        Assert.Equal(new[] { 1, 2, 3 }, capturedIds!.OrderBy(x => x));
     }
 }

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/InvestmentModelRepositoryTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/InvestmentModelRepositoryTests.cs
@@ -297,6 +297,52 @@ public class InvestmentModelRepositoryTests
     }
 
     [Fact]
+    public async Task GetByAccounts_ReturnsTransactionsForRequestedAccountsOnly()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var ctx = CreateContext();
+        var assetRepo = new AssetRepository(ctx);
+        var listingRepo = new AssetListingRepository(ctx);
+        var txRepo = new InvestmentTransactionRepository(ctx);
+
+        var asset = await assetRepo.Add(MakeISharesAsset(), ct);
+        var listing = await listingRepo.Add(new AssetListing
+        {
+            AssetId = asset.Id,
+            Ticker = "CSPX",
+            ExchangeMic = "XLON",
+            ExchangeName = "London Stock Exchange",
+            TradingCurrency = "USD"
+        }, ct);
+
+        InvestmentTransaction Make(int accountId, DateOnly tradeDate) => new()
+        {
+            UserId = 1,
+            AccountId = accountId,
+            AssetListingId = listing.Id,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = 1m,
+            UnitPrice = 100m,
+            Currency = "USD",
+            TradeDate = tradeDate
+        };
+
+        await txRepo.Add(Make(10, new DateOnly(2026, 1, 10)), ct);
+        await txRepo.Add(Make(20, new DateOnly(2026, 1, 11)), ct);
+        await txRepo.Add(Make(30, new DateOnly(2026, 1, 12)), ct); // not requested
+
+        var result = await txRepo.GetByAccounts([10, 20], ct);
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, t => t.AccountId == 10);
+        Assert.Contains(result, t => t.AccountId == 20);
+        Assert.DoesNotContain(result, t => t.AccountId == 30);
+        Assert.NotNull(result[0].AssetListing); // AssetListing eagerly included for downstream pricing
+
+        Assert.Empty(await txRepo.GetByAccounts([], ct));
+    }
+
+    [Fact]
     public async Task PriceQuote_StoreAndRead_LatestOnOrBefore()
     {
         var ct = TestContext.Current.CancellationToken;


### PR DESCRIPTION
Closes #544

## What & why

Every dashboard paint that involves an investment account walked the user's investment accounts **one by one**, and inside each account re-priced every distinct `AssetListing` again — so an instrument held in two accounts (e.g. VOO in a brokerage + a retirement account) was priced twice, and the whole per-account transactions fan-out was paid three times per paint (Net Worth, Closing Balance, Assets). Because the scoped `AppDbContext` can't service concurrent operations (PR #497 / #498), the only lever is **doing fewer queries** — i.e. batching.

This change prices each distinct listing **once per user** and issues **one** transactions query per service, with no new parallel awaits.

## Changes

**Domain**
- `IInvestmentTransactionRepository.GetByAccounts(IReadOnlyCollection<int>, ct)` — one `AccountId IN (…)` query backing both batched paths.
- `IInvestmentValuationService` — batched overloads:
  - `GetAccountValueAsync(IReadOnlyCollection<int> accountIds, …)` → `IReadOnlyDictionary<int, decimal>`
  - `GetAccountValueSeriesAsync(IReadOnlyCollection<int> accountIds, …)` → `IReadOnlyDictionary<int, IReadOnlyDictionary<DateTime, decimal>>`

**Infrastructure**
- `InvestmentTransactionRepository.GetByAccounts` implementation (`AssetListing` eagerly included).

**Application**
- `InvestmentValuationService` — batched implementations build a **shared** price map keyed by distinct listing across all accounts, then fold each account's holdings against it. Single-account overloads delegate to the batch (single-element collection), preserving their contracts and the `InvestmentValuationController` endpoints.
- Per-account loops collapsed onto the batched API in:
  - `NetWorthService.GetNetWorth(range)`
  - `InvestmentBalanceService.GetClosingBalance`
  - `AssetsServiceInvestment.GetAssetsTimeSeries`, `GetEndAssetsPerAccount`, `GetEndAssetsPerType`
  - `InvestmentRateService.GetInvestmentRate`
  - `InvestmentPaycheckEstimatorService.GetInvestableAssetsValue`

  (The single-date `NetWorthService.GetNetWorth(date)` overload is intentionally left on the single-account API — it is not one of the listed hot paths.)

## Invariants preserved
- Queries stay strictly **sequential** on the shared `AppDbContext` (no `Task.WhenAll`); the win is fewer, wider queries.
- Per-account, per-day results are identical to the previous per-account implementation.
- The `CachingDashboardQueryService` decorator (#453) still sits above this and only benefits from the reduced cold-miss cost.

## Tests
- `InvestmentValuationServiceTests` — single-account mocks repointed onto `GetByAccounts`; new batched-path tests prove a listing shared by two accounts is priced **once** and per-account results match the sequential single-account result.
- `NetWorthServiceTests`, `InvestmentBalanceServiceTests`, `InvestmentRateServiceTests`, `InvestmentPaycheckEstimatorServiceTests` — updated to the batched interface; the obsolete "fetched sequentially per account" guard is replaced by one asserting a single batched call carrying all account ids.
- `InvestmentModelRepositoryTests` — added `GetByAccounts` coverage (returns only requested accounts, includes `AssetListing`, empty input → empty).

520 unit tests and 267 integration tests pass; `dotnet format --verify-no-changes` is clean.

No EF migration and no user-visible behaviour change, so no changelog entry.

https://claude.ai/code/session_0152VfnxCgBdgSiXRnrzkn2K

---
_Generated by [Claude Code](https://claude.ai/code/session_0152VfnxCgBdgSiXRnrzkn2K)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Investment valuations, asset totals, balances, net worth, and investment metrics now process multiple investment accounts in batches.
  * Investment value calculations reuse pricing data across accounts, improving efficiency while preserving existing results.

* **Bug Fixes**
  * Improved handling of empty account selections and accounts without holdings or valuation data.

* **Tests**
  * Expanded coverage for multi-account valuation, filtering, shared listings, and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->