### PR TITLE
Add dashboard card show/hide customization #547

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- The dashboard can now be personalized: a **Customize** menu lets each user show or hide individual cards, and cards with no data for the selected period (e.g. liabilities when you have none) are hidden automatically. Preferences are saved per user in the browser. #547
 - The admin **Users** page now shows a **"Last logged at"** column with each user's most recent login date (or `Never` for accounts that have never signed in). #540
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor
@@ -2,8 +2,30 @@
 @using FinanceManager.Components.Components.Features.Dashboard.Cards.Assets
 @using FinanceManager.Components.Components.Features.Dashboard.Cards.Liabilities
 @using FinanceManager.Components.Components.Features.Dashboard.Cards.TimeSeries
+@using FinanceManager.Components.Components.Features.Dashboard.Models
 
 <MudContainer Class="py-2">
+    <div class="d-flex justify-end mb-2">
+        <MudMenu Label="Customize" StartIcon="@Icons.Material.Filled.Tune" Variant="Variant.Text"
+                 Color="Color.Default" Dense="true" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight">
+            <MudText Typo="Typo.overline" Class="px-4 pt-2 pb-1" Style="display:block">Show cards</MudText>
+            @foreach (var card in DashboardCards.All)
+            {
+                <MudMenuItem OnClick="@(() => ToggleCard(card.Id))" AutoClose="false" Style="padding: 2.65px;">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                        <MudCheckBox Value="@(!CardVisibility.IsHidden(card.Id))" T="bool" Dense="true" ReadOnly="true"
+                                     Color="Color.Primary" />
+                        <MudText Typo="Typo.body2">@card.Title</MudText>
+                        @if (IsAutoHiddenWhenEmpty(card.Id))
+                        {
+                            <MudText Typo="Typo.caption" Class="mud-text-secondary">(no data)</MudText>
+                        }
+                    </MudStack>
+                </MudMenuItem>
+            }
+        </MudMenu>
+    </div>
+
     @if (_overview is null && _isLoading)
     {
         <MudGrid Spacing="2">
@@ -39,49 +61,83 @@
             </MudAlert>
         }
 
+        @if (!AnyCardVisible)
+        {
+            <MudAlert Severity="Severity.Info" Class="mb-2" ShowCloseIcon="false">
+                All cards are hidden. Use <b>Customize</b> above to show the cards you want to see.
+            </MudAlert>
+        }
+
         <MudGrid Spacing="2">
 
-            <MudItem xs="12">
-                <NetWorthTimeSeriesCard StartDateTime="@DisplayStartDate" EndDateTime="@DisplayEndDate" Model="@NetWorthModel" />
-            </MudItem>
+            @if (IsCardVisible(DashboardCards.NetWorth))
+            {
+                <MudItem xs="12">
+                    <NetWorthTimeSeriesCard StartDateTime="@DisplayStartDate" EndDateTime="@DisplayEndDate" Model="@NetWorthModel" />
+                </MudItem>
+            }
 
-            <MudItem xs="12" md="6">
-                <NetCashFlowOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@DisplayStartDate"
-                                         EndDateTime="@DisplayEndDate" Model="@NetCashFlowModel" />
-            </MudItem>
+            @if (IsCardVisible(DashboardCards.NetCashFlow))
+            {
+                <MudItem xs="12" md="6">
+                    <NetCashFlowOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@DisplayStartDate"
+                                             EndDateTime="@DisplayEndDate" Model="@NetCashFlowModel" />
+                </MudItem>
+            }
 
-            <MudItem xs="12" md="6">
-                <ClosingBalanceOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@DisplayStartDate"
-                                            EndDateTime="@DisplayEndDate" Model="@ClosingBalanceModel" />
-            </MudItem>
+            @if (IsCardVisible(DashboardCards.ClosingBalance))
+            {
+                <MudItem xs="12" md="6">
+                    <ClosingBalanceOverviewCard Height="@($"{_unitHeight * 2}px")" StartDateTime="@DisplayStartDate"
+                                                EndDateTime="@DisplayEndDate" Model="@ClosingBalanceModel" />
+                </MudItem>
+            }
 
-            <MudItem xs="12" md="6" lg="4">
-                <LiabilitiesDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
-                                                     EndDateTime="@DisplayEndDate" Model="@LiabilitiesModel" />
-            </MudItem>
+            @if (IsCardVisible(DashboardCards.Liabilities))
+            {
+                <MudItem xs="12" md="6" lg="4">
+                    <LiabilitiesDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
+                                                         EndDateTime="@DisplayEndDate" Model="@LiabilitiesModel" />
+                </MudItem>
+            }
 
-            <MudItem xs="12" md="6" lg="4">
-                <FinancialLabelsListCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
-                                         EndDateTime="@DisplayEndDate" Model="@LabelsModel" />
-            </MudItem>
+            @if (IsCardVisible(DashboardCards.Labels))
+            {
+                <MudItem xs="12" md="6" lg="4">
+                    <FinancialLabelsListCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
+                                             EndDateTime="@DisplayEndDate" Model="@LabelsModel" />
+                </MudItem>
+            }
 
-            <MudItem xs="12" md="6" lg="4">
-                <AssetsDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
-                                                EndDateTime="@DisplayEndDate" Model="@AssetsModel" />
-            </MudItem>
+            @if (IsCardVisible(DashboardCards.Assets))
+            {
+                <MudItem xs="12" md="6" lg="4">
+                    <AssetsDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
+                                                    EndDateTime="@DisplayEndDate" Model="@AssetsModel" />
+                </MudItem>
+            }
 
-            <MudItem xs="12" md="6" lg="4">
-                <ExpenseDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
-                                                 EndDateTime="@DisplayEndDate" Model="@ExpenseModel" />
-            </MudItem>
+            @if (IsCardVisible(DashboardCards.Expenses))
+            {
+                <MudItem xs="12" md="6" lg="4">
+                    <ExpenseDistributionOverviewCard Height="@($"{_unitHeight * 3}px")" StartDateTime="@DisplayStartDate"
+                                                     EndDateTime="@DisplayEndDate" Model="@ExpenseModel" />
+                </MudItem>
+            }
 
-            <MudItem xs="12" md="6" lg="4">
-                <FinancialInsightsCarousel Height="@($"{_unitHeight * 3}px")" Count="3" />
-            </MudItem>
+            @if (IsCardVisible(DashboardCards.Insights))
+            {
+                <MudItem xs="12" md="6" lg="4">
+                    <FinancialInsightsCarousel Height="@($"{_unitHeight * 3}px")" Count="3" />
+                </MudItem>
+            }
 
-            <MudItem xs="12" md="6" lg="4">
-                <RecurringTransactionDetectorCard Height="@($"{_unitHeight * 3}px")" />
-            </MudItem>
+            @if (IsCardVisible(DashboardCards.RecurringTransactions))
+            {
+                <MudItem xs="12" md="6" lg="4">
+                    <RecurringTransactionDetectorCard Height="@($"{_unitHeight * 3}px")" />
+                </MudItem>
+            }
 
         </MudGrid>
     }

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Dashboard.razor.cs
@@ -46,6 +46,7 @@ public partial class Dashboard : ComponentBase
     [Inject] public required ISnapshotService SnapshotService { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
+    [Inject] public required DashboardCardVisibilityService CardVisibility { get; set; }
     [Inject] public required ILogger<Dashboard> Logger { get; set; }
 
     // Card-specific models mapped from the single overview response. They are null
@@ -65,7 +66,25 @@ public partial class Dashboard : ComponentBase
         StartDate = Start;
         EndDate = End;
 
+        await CardVisibility.EnsureLoadedAsync();
         await LoadOverview();
+    }
+
+    // A card renders when the user has not hidden it and it is not auto-hidden as empty.
+    // Empty auto-hiding only applies once an overview is loaded; while self-loading the
+    // dashboard has no data to judge emptiness, so those cards keep rendering.
+    private bool IsCardVisible(string cardId) =>
+        !CardVisibility.IsHidden(cardId) && !IsAutoHiddenWhenEmpty(cardId);
+
+    private bool IsAutoHiddenWhenEmpty(string cardId) =>
+        _overview is not null && DashboardCardVisibilityRules.IsAutoHiddenWhenEmpty(cardId, _overview);
+
+    private bool AnyCardVisible => DashboardCards.All.Any(card => IsCardVisible(card.Id));
+
+    private async Task ToggleCard(string cardId)
+    {
+        await CardVisibility.SetHiddenAsync(cardId, !CardVisibility.IsHidden(cardId));
+        StateHasChanged();
     }
 
     // DashboardDatePicker exposes a synchronous Action callback, so kick off the

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Models/DashboardCardVisibilityRules.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Models/DashboardCardVisibilityRules.cs
@@ -25,5 +25,5 @@ public static class DashboardCardVisibilityRules
         _ => false,
     };
 
-    private static bool IsEmpty(IEnumerable<NameValueResult> data) => !data.Any(x => x.Value != 0);
+    private static bool IsEmpty(IEnumerable<NameValueResult> data) => data.All(x => x.Value == 0);
 }

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Models/DashboardCardVisibilityRules.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Models/DashboardCardVisibilityRules.cs
@@ -1,0 +1,29 @@
+using FinanceManager.Domain.Dashboard.Dtos;
+using FinanceManager.Domain.MoneyFlow.Entities;
+
+namespace FinanceManager.Components.Components.Features.Dashboard.Models;
+
+/// <summary>
+/// Decides whether a card should be automatically hidden because it has no data for the
+/// loaded period (e.g. a user with no liabilities should not see an empty liabilities card).
+/// This is orthogonal to the user's explicit show/hide preference: a card is rendered only
+/// when the user has not hidden it <em>and</em> it is not auto-hidden as empty here.
+/// </summary>
+public static class DashboardCardVisibilityRules
+{
+    /// <summary>
+    /// True when <paramref name="cardId"/> is a data-backed card whose data in
+    /// <paramref name="overview"/> is empty and should therefore collapse. Cards that are not
+    /// data-backed (net worth, insights, recurring transactions) are never auto-hidden.
+    /// </summary>
+    public static bool IsAutoHiddenWhenEmpty(string cardId, DashboardOverviewDto overview) => cardId switch
+    {
+        DashboardCards.Liabilities => IsEmpty(overview.LiabilitiesPerType) && IsEmpty(overview.LiabilitiesPerAccount),
+        DashboardCards.Assets => IsEmpty(overview.AssetsPerType) && IsEmpty(overview.AssetsPerAccount),
+        DashboardCards.Expenses => IsEmpty(overview.ExpenseDistribution),
+        DashboardCards.Labels => IsEmpty(overview.LabelsValue),
+        _ => false,
+    };
+
+    private static bool IsEmpty(IEnumerable<NameValueResult> data) => !data.Any(x => x.Value != 0);
+}

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Models/DashboardCards.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Models/DashboardCards.cs
@@ -1,0 +1,36 @@
+namespace FinanceManager.Components.Components.Features.Dashboard.Models;
+
+/// <summary>Stable identifier and display title for a dashboard card the user can show or hide.</summary>
+public sealed record DashboardCardDescriptor(string Id, string Title);
+
+/// <summary>
+/// Registry of the dashboard cards that participate in show/hide customization.
+/// The <see cref="Id"/> values are persisted in the user's visibility preferences,
+/// so they must stay stable; renaming a card's title is safe, changing its id is not.
+/// </summary>
+public static class DashboardCards
+{
+    public const string NetWorth = "net-worth";
+    public const string NetCashFlow = "net-cash-flow";
+    public const string ClosingBalance = "closing-balance";
+    public const string Liabilities = "liabilities";
+    public const string Labels = "labels";
+    public const string Assets = "assets";
+    public const string Expenses = "expenses";
+    public const string Insights = "insights";
+    public const string RecurringTransactions = "recurring-transactions";
+
+    /// <summary>All customizable cards in the order they appear on the dashboard.</summary>
+    public static readonly IReadOnlyList<DashboardCardDescriptor> All =
+    [
+        new(NetWorth, "Net worth"),
+        new(NetCashFlow, "Net cash flow"),
+        new(ClosingBalance, "Closing balance"),
+        new(Liabilities, "Liabilities"),
+        new(Labels, "Financial labels"),
+        new(Assets, "Assets"),
+        new(Expenses, "Expenses"),
+        new(Insights, "Financial insights"),
+        new(RecurringTransactions, "Recurring transactions"),
+    ];
+}

--- a/code/FinanceManager.Components/Models/DashboardCardVisibilitySnapshot.cs
+++ b/code/FinanceManager.Components/Models/DashboardCardVisibilitySnapshot.cs
@@ -1,0 +1,12 @@
+namespace FinanceManager.Components.Models;
+
+/// <summary>
+/// Persisted per-user set of dashboard cards the user has chosen to hide. Stored in browser
+/// local storage through <c>ISnapshotService</c>, so preferences survive reloads on the same
+/// browser but are not synced across devices.
+/// </summary>
+public sealed class DashboardCardVisibilitySnapshot : SnapshotBase
+{
+    /// <summary>Ids (see <c>DashboardCards</c>) of the cards the user has explicitly hidden.</summary>
+    public List<string> HiddenCardIds { get; set; } = [];
+}

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -55,6 +55,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<NavMenuStateCacheService>()
                 .AddScoped<DashboardHttpClient>()
                 .AddScoped<DashboardOverviewCardsCacheService>()
+                .AddScoped<DashboardCardVisibilityService>()
                 .AddScoped<ISnapshotService, LocalStorageSnapshotService>()
                 .AddScoped<AccountDetailsSnapshotStore>()
                 .AddTransient<CurrencyImportJobTracker>()

--- a/code/FinanceManager.Components/Services/DashboardCardVisibilityService.cs
+++ b/code/FinanceManager.Components/Services/DashboardCardVisibilityService.cs
@@ -32,8 +32,7 @@ public class DashboardCardVisibilityService(
             if (snapshot is not null)
             {
                 _hiddenCardIds.Clear();
-                foreach (var id in snapshot.HiddenCardIds)
-                    _hiddenCardIds.Add(id);
+                _hiddenCardIds.UnionWith(snapshot.HiddenCardIds);
             }
         }
         catch (Exception ex)

--- a/code/FinanceManager.Components/Services/DashboardCardVisibilityService.cs
+++ b/code/FinanceManager.Components/Services/DashboardCardVisibilityService.cs
@@ -1,0 +1,83 @@
+using FinanceManager.Components.Models;
+using FinanceManager.Domain.Identity.Services;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Components.Services;
+
+/// <summary>
+/// Holds the logged-in user's dashboard card show/hide preferences, backed by
+/// <see cref="ISnapshotService"/> (browser local storage). Preferences are loaded once per
+/// circuit and written through on every change, so <see cref="IsHidden"/> can be queried
+/// synchronously while the dashboard renders.
+/// </summary>
+public class DashboardCardVisibilityService(
+    ISnapshotService snapshotService,
+    ILoginService loginService,
+    ILogger<DashboardCardVisibilityService> logger)
+{
+    private readonly HashSet<string> _hiddenCardIds = [];
+    private string? _key;
+    private bool _loaded;
+
+    /// <summary>Loads the persisted preferences once; safe to call repeatedly.</summary>
+    public async Task EnsureLoadedAsync()
+    {
+        if (_loaded)
+            return;
+
+        try
+        {
+            var key = await GetKeyAsync();
+            var snapshot = await snapshotService.GetAsync<DashboardCardVisibilitySnapshot>(key);
+            if (snapshot is not null)
+            {
+                _hiddenCardIds.Clear();
+                foreach (var id in snapshot.HiddenCardIds)
+                    _hiddenCardIds.Add(id);
+            }
+        }
+        catch (Exception ex)
+        {
+            // A failure to read preferences must not break the dashboard; fall back to "all visible".
+            logger.LogWarning(ex, "Failed to load dashboard card visibility preferences.");
+        }
+        finally
+        {
+            _loaded = true;
+        }
+    }
+
+    /// <summary>True when the user has explicitly hidden the card with <paramref name="cardId"/>.</summary>
+    public bool IsHidden(string cardId) => _hiddenCardIds.Contains(cardId);
+
+    /// <summary>Records and persists whether the card with <paramref name="cardId"/> is hidden.</summary>
+    public async Task SetHiddenAsync(string cardId, bool hidden)
+    {
+        await EnsureLoadedAsync();
+
+        var changed = hidden ? _hiddenCardIds.Add(cardId) : _hiddenCardIds.Remove(cardId);
+        if (!changed)
+            return;
+
+        try
+        {
+            var key = await GetKeyAsync();
+            await snapshotService.SetAsync(key, new DashboardCardVisibilitySnapshot { HiddenCardIds = [.. _hiddenCardIds] });
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to persist dashboard card visibility preferences.");
+        }
+    }
+
+    // Per-user key so each account keeps its own preferences within the same browser.
+    private async Task<string> GetKeyAsync()
+    {
+        if (_key is not null)
+            return _key;
+
+        var user = await loginService.GetLoggedUser();
+        _key = $"dashboard-card-visibility:{user?.UserId ?? 0}";
+        return _key;
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/DashboardCardVisibilityRulesTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/DashboardCardVisibilityRulesTests.cs
@@ -1,0 +1,72 @@
+using FinanceManager.Components.Components.Features.Dashboard.Models;
+using FinanceManager.Domain.Dashboard.Dtos;
+using FinanceManager.Domain.MoneyFlow.Entities;
+
+namespace FinanceManager.Tests.Unit.Components.Features.Dashboard;
+
+[Trait("Category", "Unit")]
+public class DashboardCardVisibilityRulesTests
+{
+    [Fact]
+    public void Liabilities_WithNoData_IsAutoHidden()
+    {
+        var overview = new DashboardOverviewDto();
+
+        Assert.True(DashboardCardVisibilityRules.IsAutoHiddenWhenEmpty(DashboardCards.Liabilities, overview));
+    }
+
+    [Fact]
+    public void Liabilities_WithData_IsNotAutoHidden()
+    {
+        var overview = new DashboardOverviewDto
+        {
+            LiabilitiesPerType = [new NameValueResult { Name = "Loan", Value = -1200 }],
+        };
+
+        Assert.False(DashboardCardVisibilityRules.IsAutoHiddenWhenEmpty(DashboardCards.Liabilities, overview));
+    }
+
+    [Fact]
+    public void Liabilities_WithOnlyZeroValues_IsAutoHidden()
+    {
+        var overview = new DashboardOverviewDto
+        {
+            LiabilitiesPerType = [new NameValueResult { Name = "Loan", Value = 0 }],
+        };
+
+        Assert.True(DashboardCardVisibilityRules.IsAutoHiddenWhenEmpty(DashboardCards.Liabilities, overview));
+    }
+
+    [Fact]
+    public void Assets_WithAccountDataButNoTypeData_IsNotAutoHidden()
+    {
+        var overview = new DashboardOverviewDto
+        {
+            AssetsPerAccount = [new NameValueResult { Name = "Wallet", Value = 500 }],
+        };
+
+        Assert.False(DashboardCardVisibilityRules.IsAutoHiddenWhenEmpty(DashboardCards.Assets, overview));
+    }
+
+    [Theory]
+    [InlineData(DashboardCards.NetWorth)]
+    [InlineData(DashboardCards.NetCashFlow)]
+    [InlineData(DashboardCards.ClosingBalance)]
+    [InlineData(DashboardCards.Insights)]
+    [InlineData(DashboardCards.RecurringTransactions)]
+    public void NonDataBackedCards_AreNeverAutoHidden(string cardId)
+    {
+        var overview = new DashboardOverviewDto();
+
+        Assert.False(DashboardCardVisibilityRules.IsAutoHiddenWhenEmpty(cardId, overview));
+    }
+
+    [Fact]
+    public void Expenses_And_Labels_WithNoData_AreAutoHidden()
+    {
+        var overview = new DashboardOverviewDto();
+
+        Assert.True(DashboardCardVisibilityRules.IsAutoHiddenWhenEmpty(DashboardCards.Expenses, overview));
+        Assert.True(DashboardCardVisibilityRules.IsAutoHiddenWhenEmpty(DashboardCards.Labels, overview));
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/Services/DashboardCardVisibilityServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Services/DashboardCardVisibilityServiceTests.cs
@@ -1,0 +1,114 @@
+using FinanceManager.Components.Components.Features.Dashboard.Models;
+using FinanceManager.Components.Models;
+using FinanceManager.Components.Services;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Domain.Identity.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Components.Services;
+
+[Trait("Category", "Unit")]
+public class DashboardCardVisibilityServiceTests
+{
+    private const string _expectedKey = "dashboard-card-visibility:7";
+
+    private static Mock<ILoginService> LoggedInAs(int userId)
+    {
+        var loginService = new Mock<ILoginService>();
+        loginService.Setup(s => s.GetLoggedUser()).ReturnsAsync(new UserSession
+        {
+            UserId = userId,
+            UserName = "tester",
+            Password = "password",
+            UserRole = UserRole.User,
+        });
+        return loginService;
+    }
+
+    [Fact]
+    public async Task EnsureLoadedAsync_HydratesHiddenCardsFromSnapshot()
+    {
+        var snapshotService = new Mock<ISnapshotService>();
+        snapshotService
+            .Setup(s => s.GetAsync<DashboardCardVisibilitySnapshot>(_expectedKey))
+            .ReturnsAsync(new DashboardCardVisibilitySnapshot { HiddenCardIds = [DashboardCards.Liabilities] });
+
+        var service = new DashboardCardVisibilityService(snapshotService.Object, LoggedInAs(7).Object,
+            NullLogger<DashboardCardVisibilityService>.Instance);
+
+        await service.EnsureLoadedAsync();
+
+        Assert.True(service.IsHidden(DashboardCards.Liabilities));
+        Assert.False(service.IsHidden(DashboardCards.Assets));
+    }
+
+    [Fact]
+    public async Task EnsureLoadedAsync_WithNoSnapshot_TreatsAllCardsAsVisible()
+    {
+        var snapshotService = new Mock<ISnapshotService>();
+        snapshotService
+            .Setup(s => s.GetAsync<DashboardCardVisibilitySnapshot>(It.IsAny<string>()))
+            .ReturnsAsync((DashboardCardVisibilitySnapshot?)null);
+
+        var service = new DashboardCardVisibilityService(snapshotService.Object, LoggedInAs(7).Object,
+            NullLogger<DashboardCardVisibilityService>.Instance);
+
+        await service.EnsureLoadedAsync();
+
+        Assert.False(service.IsHidden(DashboardCards.Liabilities));
+    }
+
+    [Fact]
+    public async Task SetHiddenAsync_HidingCard_PersistsUnderPerUserKey()
+    {
+        var snapshotService = new Mock<ISnapshotService>();
+        snapshotService
+            .Setup(s => s.GetAsync<DashboardCardVisibilitySnapshot>(It.IsAny<string>()))
+            .ReturnsAsync((DashboardCardVisibilitySnapshot?)null);
+
+        var service = new DashboardCardVisibilityService(snapshotService.Object, LoggedInAs(7).Object,
+            NullLogger<DashboardCardVisibilityService>.Instance);
+
+        await service.SetHiddenAsync(DashboardCards.Liabilities, true);
+
+        Assert.True(service.IsHidden(DashboardCards.Liabilities));
+        snapshotService.Verify(s => s.SetAsync(_expectedKey,
+            It.Is<DashboardCardVisibilitySnapshot>(x => x.HiddenCardIds.Contains(DashboardCards.Liabilities))), Times.Once);
+    }
+
+    [Fact]
+    public async Task SetHiddenAsync_ShowingPreviouslyHiddenCard_RemovesIt()
+    {
+        var snapshotService = new Mock<ISnapshotService>();
+        snapshotService
+            .Setup(s => s.GetAsync<DashboardCardVisibilitySnapshot>(It.IsAny<string>()))
+            .ReturnsAsync(new DashboardCardVisibilitySnapshot { HiddenCardIds = [DashboardCards.Liabilities] });
+
+        var service = new DashboardCardVisibilityService(snapshotService.Object, LoggedInAs(7).Object,
+            NullLogger<DashboardCardVisibilityService>.Instance);
+
+        await service.SetHiddenAsync(DashboardCards.Liabilities, false);
+
+        Assert.False(service.IsHidden(DashboardCards.Liabilities));
+        snapshotService.Verify(s => s.SetAsync(_expectedKey,
+            It.Is<DashboardCardVisibilitySnapshot>(x => !x.HiddenCardIds.Contains(DashboardCards.Liabilities))), Times.Once);
+    }
+
+    [Fact]
+    public async Task SetHiddenAsync_WhenStateUnchanged_DoesNotPersistAgain()
+    {
+        var snapshotService = new Mock<ISnapshotService>();
+        snapshotService
+            .Setup(s => s.GetAsync<DashboardCardVisibilitySnapshot>(It.IsAny<string>()))
+            .ReturnsAsync((DashboardCardVisibilitySnapshot?)null);
+
+        var service = new DashboardCardVisibilityService(snapshotService.Object, LoggedInAs(7).Object,
+            NullLogger<DashboardCardVisibilityService>.Instance);
+
+        // Card is already visible; asking to show it again is a no-op.
+        await service.SetHiddenAsync(DashboardCards.Liabilities, false);
+
+        snapshotService.Verify(s => s.SetAsync(It.IsAny<string>(), It.IsAny<DashboardCardVisibilitySnapshot>()), Times.Never);
+    }
+}


### PR DESCRIPTION
## Summary

Improves the dashboard UX so users are no longer stuck looking at cards that aren't relevant to them (e.g. an empty **Liabilities** card when they have no liabilities). Two complementary mechanisms:

1. **Auto-hide empty cards** — data-backed cards (liabilities, assets, expenses, financial labels) collapse automatically once the overview has loaded and their data is empty. Auto-hiding only kicks in *after* data loads, never while a card is self-loading, so nothing flickers away mid-fetch.
2. **User-controlled show/hide** — a **Customize** menu on the dashboard lets users toggle any card on or off. The choice is persisted **per user in browser local storage** through the existing `ISnapshotService` / `LocalStorageSnapshotService`, so there is no API or DB change. Preferences are therefore per-device (cross-device sync can be a follow-up).

The previously hardcoded `MudGrid` is now driven by a small card registry (`DashboardCards`) so the markup is data-driven and each `MudItem` is wrapped in a visibility guard.

## Changes

- `DashboardCards` — registry of card ids + titles (stable ids used for persistence).
- `DashboardCardVisibilityRules` — pure, unit-tested logic deciding when a data-backed card is empty.
- `DashboardCardVisibilitySnapshot` — local-storage payload (list of hidden card ids).
- `DashboardCardVisibilityService` — loads/persists per-user preferences via `ISnapshotService`; registered in `AddUIComponents`.
- `Dashboard.razor(.cs)` — Customize `MudMenu`, per-card visibility guards, empty-state hint when everything is hidden.
- Unit tests for the visibility service and the empty-detection rules (11 new tests; 531 total green).
- `CHANGELOG.md` entry under `[Unreleased] → Added`.

## Verification

- `dotnet build` — clean (warnings-as-errors).
- `dotnet format` — no changes.
- `dotnet test` (unit) — 531 passed.
- Rendered on the guest account (mobile + desktop): Customize menu opens as a card checklist, toggling **Assets** off reflows the grid, and the layout is clean on both viewports. Auto-hide-empty is covered by unit tests (the guest account has data for every card, so it can't be shown visually).

closes #547

---
_Generated by [Claude Code](https://claude.ai/code/session_016w4mTLRUtX5MZKCD4jLcX8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Customize** menu for showing or hiding dashboard cards.
  * Dashboard card visibility preferences are saved between sessions.
  * Cards with no applicable data can be automatically hidden and marked “(no data).”
  * Added a message prompting users to restore cards when all are hidden.
* **Tests**
  * Added coverage for card visibility rules and saved preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->