### PR TITLE
Fix investment chart timeout by bounding external FX and price lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- The investment account chart no longer times out on wide date ranges: missing exchange rates are filled from the nearest known rate instead of being fetched from the external provider day by day, failed rate lookups are briefly cached, and price fetches for a symbol whose last attempt just failed are paused for a cooldown. #551
 - Investment account charts no longer repeatedly reload full price history around market closures, reducing load time. #542
 - The **Manual stock price** admin card no longer stretches across the full width of the screen; it is now capped to a compact width, and the price field updates as you type.
 

--- a/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
+++ b/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
@@ -30,6 +30,7 @@ public class InvestmentPriceProvider(
 {
     private const int _fetchLookbackDays = 7;
     private static readonly TimeSpan _cacheTtl = TimeSpan.FromMinutes(60);
+    private static readonly TimeSpan _failedFetchCooldown = TimeSpan.FromMinutes(15);
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> _fetchLocks = new();
 
     // Minor "pence"-style quote units collapse to their major currency once PriceMultiplier is
@@ -116,6 +117,20 @@ public class InvestmentPriceProvider(
                     rateMap[rateDate.Date] = value.Value;
             }
 
+            FillRateGaps(rateMap, startDate, endDate);
+
+            // A currency with no rate anywhere in the range gets one whole-range fallback
+            // conversion (which may cross through USD), never one lookup per day.
+            if (rateMap.Count == 0)
+            {
+                var (unitRate, _) = await ConvertAsync(1m, name, targetCurrency, endDate, ct);
+                if (unitRate > 0)
+                {
+                    for (var date = startDate; date <= endDate; date = date.AddDays(1))
+                        rateMap[date] = unitRate;
+                }
+            }
+
             ratesByCurrency[name] = rateMap;
         }
 
@@ -129,27 +144,41 @@ public class InvestmentPriceProvider(
 
             if (latestKnown is null) continue;
 
-            decimal converted;
+            // Days whose rate is still unknown after prefetch + gap filling are skipped rather
+            // than resolved individually: a per-day fallback multiplies the full provider chain
+            // by the range length and is what pushed chart requests past the client timeout.
+            decimal converted = 0m;
             if (string.Equals(latestKnown.Currency, targetCurrency.ShortName, StringComparison.OrdinalIgnoreCase))
-            {
                 converted = latestKnown.Price;
-            }
             else if (ratesByCurrency.TryGetValue(latestKnown.Currency, out var rateMap) && rateMap.TryGetValue(date, out var rate))
-            {
                 converted = latestKnown.Price * rate;
-            }
-            else
-            {
-                // Dates outside the prefetched range or with a missing rate fall back to the
-                // per-call path so the result matches the point lookup.
-                (converted, _) = await ConvertAsync(latestKnown.Price, latestKnown.Currency, targetCurrency, date, ct);
-            }
 
             if (converted > 0)
                 series[date] = converted;
         }
 
         return series;
+    }
+
+    // FX gaps (weekends, holidays, dates past the exchange service's per-call resolution cap)
+    // reuse the nearest known rate in the range: forward-fill first, then backfill the leading
+    // edge from the earliest known rate.
+    private static void FillRateGaps(Dictionary<DateTime, decimal> rateMap, DateTime startDate, DateTime endDate)
+    {
+        if (rateMap.Count == 0) return;
+
+        decimal? carried = null;
+        for (var date = startDate; date <= endDate; date = date.AddDays(1))
+        {
+            if (rateMap.TryGetValue(date, out var known))
+                carried = known;
+            else if (carried is decimal rate)
+                rateMap[date] = rate;
+        }
+
+        var earliest = rateMap[rateMap.Keys.Min()];
+        for (var date = startDate; date <= endDate && !rateMap.ContainsKey(date); date = date.AddDays(1))
+            rateMap[date] = earliest;
     }
 
     // Direct is false when the returned value is the USD fallback (i.e. not denominated in
@@ -187,6 +216,15 @@ public class InvestmentPriceProvider(
         if (symbol is null)
         {
             logger.LogDebug("Listing {ListingId} has no enabled market-data symbol; cannot fetch prices", listing.Id);
+            return;
+        }
+
+        // A symbol whose most recent attempt failed keeps failing for a while (bad symbol,
+        // rate-limited provider). Without a cooldown every chart request would re-run the whole
+        // provider fallback chain for it, adding external-call latency to each page load.
+        if (symbol.LastError is not null && DateTimeOffset.UtcNow - symbol.UpdatedAt < _failedFetchCooldown)
+        {
+            logger.LogDebug("Skipping price fetch for listing {ListingId}: last attempt failed at {UpdatedAt} and is within the cooldown", listing.Id, symbol.UpdatedAt);
             return;
         }
 

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CachedCurrencyExchangeService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CachedCurrencyExchangeService.cs
@@ -16,6 +16,14 @@ internal sealed class CachedCurrencyExchangeService(
         SlidingExpiration = TimeSpan.FromHours(1)
     };
 
+    // Failed lookups are cached too, with a shorter TTL: a pair/date no provider knows would
+    // otherwise re-run the full provider chain (DB + external HTTP) on every call, and a chart
+    // request can ask for the same unknown rate hundreds of times.
+    private static readonly MemoryCacheEntryOptions _missCacheOptions = new()
+    {
+        AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(15)
+    };
+
     public async Task<decimal?> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
     {
         var key = $"EXCHANGE_RATE_{fromCurrency.ShortName}_{toCurrency.ShortName}_{date:yyyyMMdd}";
@@ -25,8 +33,7 @@ internal sealed class CachedCurrencyExchangeService(
 
         var rate = await inner.GetExchangeRateAsync(fromCurrency, toCurrency, date);
 
-        if (rate is not null)
-            cache.Set(key, rate, _cacheOptions);
+        cache.Set(key, rate, rate is null ? _missCacheOptions : _cacheOptions);
 
         return rate;
     }

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
@@ -8,6 +8,12 @@ internal class CurrencyExchangeService(
     IExchangeRateRepository exchangeRateRepository,
     IEnumerable<ICurrencyExchangeRateProvider> providers) : ICurrencyExchangeService
 {
+    // A wide range (years of chart history) can miss thousands of daily rates. Each provider
+    // resolution is a chain of DB lookups plus external HTTP calls, so resolving every missing
+    // date inside a single request can exceed the browser's 100 s HTTP timeout. Resolved rates
+    // are persisted, so successive requests keep narrowing the gap until the range is covered.
+    private const int _maxProviderResolutionsPerCall = 60;
+
     public async Task<List<(DateTime Date, decimal? Value)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd)
     {
         if (dateStart == default || dateEnd == default) return [];
@@ -56,21 +62,41 @@ internal class CurrencyExchangeService(
 
         if (missingDates.Count > 0)
         {
+            var toResolve = missingDates.Count <= _maxProviderResolutionsPerCall
+                ? missingDates
+                : missingDates.Take(_maxProviderResolutionsPerCall).ToList();
+
             const int batchSize = 50;
-            for (var offset = 0; offset < missingDates.Count; offset += batchSize)
+            for (var offset = 0; offset < toResolve.Count; offset += batchSize)
             {
-                var currentBatchSize = Math.Min(batchSize, missingDates.Count - offset);
+                var currentBatchSize = Math.Min(batchSize, toResolve.Count - offset);
                 List<Task<decimal?>> batchTasks = [];
 
                 for (var i = 0; i < currentBatchSize; i++)
                 {
-                    var date = missingDates[offset + i];
+                    var date = toResolve[offset + i];
                     batchTasks.Add(GetExchangeRateAsync(fromCurrency, toCurrency, date));
                 }
 
                 var batchResults = await Task.WhenAll(batchTasks);
                 for (var i = 0; i < batchResults.Length; i++)
-                    rates.Add((missingDates[offset + i], batchResults[i]));
+                    rates.Add((toResolve[offset + i], batchResults[i]));
+            }
+
+            // Dates past the per-call resolution cap carry the nearest earlier known rate
+            // (daily FX barely moves day-to-day) instead of hitting the providers.
+            if (toResolve.Count < missingDates.Count)
+            {
+                var knownAscending = rates.Where(x => x.Value is not null).OrderBy(x => x.Date).ToList();
+                var knownIndex = 0;
+                decimal? carried = null;
+                foreach (var date in missingDates.Skip(toResolve.Count))
+                {
+                    while (knownIndex < knownAscending.Count && knownAscending[knownIndex].Date <= date)
+                        carried = knownAscending[knownIndex++].Value;
+
+                    rates.Add((date, carried));
+                }
             }
         }
 

--- a/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceProviderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceProviderTests.cs
@@ -297,6 +297,93 @@ public class InvestmentPriceProviderTests
         Assert.NotEmpty(series);
     }
 
+    [Fact]
+    public async Task GetPricePerUnitSeries_FillsFxRateGapsFromNearestKnownRate_WithoutPerDayLookups()
+    {
+        var mon = new DateTime(2024, 1, 1);
+        var wed = new DateTime(2024, 1, 3);
+        var thu = new DateTime(2024, 1, 4);
+        var fri = new DateTime(2024, 1, 5);
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing("GBP"));
+
+        // Quotes cover both range boundaries so no price fetch is needed.
+        _priceQuoteRepository.Seed(new PriceQuote
+        {
+            AssetListingId = 10,
+            Provider = MarketDataProvider.AlphaVantage,
+            Price = 100m,
+            Currency = "GBP",
+            PriceTime = new DateTimeOffset(mon, TimeSpan.Zero),
+            QuoteType = PriceQuoteType.EndOfDay
+        });
+        _priceQuoteRepository.Seed(new PriceQuote
+        {
+            AssetListingId = 10,
+            Provider = MarketDataProvider.AlphaVantage,
+            Price = 110m,
+            Currency = "GBP",
+            PriceTime = new DateTimeOffset(wed, TimeSpan.Zero),
+            QuoteType = PriceQuoteType.EndOfDay
+        });
+
+        // The bulk FX prefetch only knows Monday and Thursday; the gaps must reuse those rates.
+        _currencyExchangeService
+            .Setup(x => x.GetExchangeRateAsync(It.Is<Currency>(c => c.ShortName == "GBP"), _usd, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync([(mon, 1.2m), (thu, 1.3m)]);
+
+        var series = await CreateSut().GetPricePerUnitSeriesAsync(10, _usd, mon, fri, TestContext.Current.CancellationToken);
+
+        Assert.Equal(120m, series[mon]);                       // 100 × 1.2
+        Assert.Equal(120m, series[new DateTime(2024, 1, 2)]);  // carries Monday's rate forward
+        Assert.Equal(132m, series[wed]);                       // 110 × 1.2
+        Assert.Equal(143m, series[thu]);                       // 110 × 1.3
+        Assert.Equal(143m, series[fri]);                       // carries Thursday's rate forward
+
+        // No per-day point conversions may happen for the gap days.
+        _currencyExchangeService.Verify(
+            x => x.GetExchangeRateAsync(It.IsAny<Currency>(), It.IsAny<Currency>(), It.IsAny<DateTime>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPricePerUnitSeries_SkipsFetch_WhenLastAttemptFailedWithinCooldown()
+    {
+        var start = new DateTime(2024, 1, 1);
+        var end = new DateTime(2024, 1, 5);
+        var listing = Listing();
+        listing.MarketDataSymbols.First().LastError = "rate limited";
+        listing.MarketDataSymbols.First().UpdatedAt = DateTimeOffset.UtcNow;
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(listing);
+
+        var series = await CreateSut().GetPricePerUnitSeriesAsync(10, _usd, start, end, TestContext.Current.CancellationToken);
+
+        Assert.Empty(series);
+        _priceSource.Verify(
+            x => x.GetDailySeries(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPricePerUnitSeries_RetriesFetch_WhenLastFailureIsOlderThanCooldown()
+    {
+        var start = new DateTime(2024, 1, 1);
+        var end = new DateTime(2024, 1, 5);
+        var listing = Listing();
+        listing.MarketDataSymbols.First().LastError = "rate limited";
+        listing.MarketDataSymbols.First().UpdatedAt = DateTimeOffset.UtcNow.AddHours(-1);
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(listing);
+        _priceSource
+            .Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Price(100m, start)]);
+
+        var series = await CreateSut().GetPricePerUnitSeriesAsync(10, _usd, start, end, TestContext.Current.CancellationToken);
+
+        Assert.NotEmpty(series);
+        _priceSource.Verify(
+            x => x.GetDailySeries("CSPX.LON", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     /// <summary>Minimal in-memory <see cref="IPriceQuoteRepository"/> so fetch→store→read flows are exercised end-to-end.</summary>
     private sealed class InMemoryPriceQuoteRepository : IPriceQuoteRepository
     {

--- a/code/FinanceManager.Tests.Unit/Application/Services/CachedCurrencyExchangeServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/CachedCurrencyExchangeServiceTests.cs
@@ -1,0 +1,51 @@
+using FinanceManager.Application.FinancialAccounts.Currencies.ExchangeRates;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services;
+
+[Trait("Category", "Unit")]
+public class CachedCurrencyExchangeServiceTests : IDisposable
+{
+    private static readonly Currency _usd = new(1, "USD", "$");
+    private static readonly Currency _eur = new(2, "EUR", "€");
+
+    private readonly Mock<ICurrencyExchangeService> _inner = new();
+    private readonly MemoryCache _cache = new(new MemoryCacheOptions());
+
+    private CachedCurrencyExchangeService CreateSut() => new(_inner.Object, _cache);
+
+    public void Dispose() => _cache.Dispose();
+
+    [Fact]
+    public async Task GetExchangeRate_SecondCall_ServedFromCache()
+    {
+        var date = new DateTime(2024, 1, 15);
+        _inner.Setup(x => x.GetExchangeRateAsync(_usd, _eur, date)).ReturnsAsync(0.92m);
+        var sut = CreateSut();
+
+        var first = await sut.GetExchangeRateAsync(_usd, _eur, date);
+        var second = await sut.GetExchangeRateAsync(_usd, _eur, date);
+
+        Assert.Equal(0.92m, first);
+        Assert.Equal(0.92m, second);
+        _inner.Verify(x => x.GetExchangeRateAsync(_usd, _eur, date), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetExchangeRate_MissIsCached_SoRepeatedLookupsDoNotHitInnerAgain()
+    {
+        var date = new DateTime(2024, 1, 15);
+        _inner.Setup(x => x.GetExchangeRateAsync(_usd, _eur, date)).ReturnsAsync((decimal?)null);
+        var sut = CreateSut();
+
+        var first = await sut.GetExchangeRateAsync(_usd, _eur, date);
+        var second = await sut.GetExchangeRateAsync(_usd, _eur, date);
+
+        Assert.Null(first);
+        Assert.Null(second);
+        _inner.Verify(x => x.GetExchangeRateAsync(_usd, _eur, date), Times.Once);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
@@ -443,6 +443,50 @@ public class CurrencyExchangeServiceTests : IDisposable
             ItExpr.IsAny<CancellationToken>());
     }
 
+    [Fact]
+    public async Task GetExchangeRateAsync_RangeWithManyMissingDates_CapsProviderCallsAndCarriesRatesForward()
+    {
+        // Arrange: a 100-day range with only the first day stored, so 99 dates are missing —
+        // more than the per-call provider resolution cap of 60.
+        var fromCurrency = new Currency(1, "USD", "$");
+        var toCurrency = new Currency(2, "EUR", "€");
+        var dateStart = new DateTime(2024, 1, 1);
+        var dateEnd = dateStart.AddDays(99);
+
+        IReadOnlyDictionary<(string From, string To, DateTime Date), decimal> storedRates =
+            new Dictionary<(string, string, DateTime), decimal>
+            {
+                { ("USD", "EUR", new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)), 0.92m }
+            };
+
+        _exchangeRateRepositoryMock
+            .Setup(x => x.GetRange("USD", "EUR", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(storedRates);
+        _exchangeRateRepositoryMock
+            .Setup(x => x.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((decimal?)null);
+
+        var jsonResponse = @"{""usd"": {""eur"": 0.915}}";
+        SetupHttpResponse(HttpStatusCode.OK, jsonResponse);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, dateStart, dateEnd);
+
+        // Assert: every date has a value — the capped tail is forward-filled, not dropped.
+        Assert.Equal(100, result.Count);
+        Assert.All(result, x => Assert.NotNull(x.Value));
+        Assert.Equal(0.915m, result[^1].Value);
+
+        // Only the first 60 missing dates may reach the external provider.
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(60),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
     private CurrencyExchangeService CreateService()
     {
         ICurrencyExchangeRateProvider[] providers = [new FawazAhmedCurrencyApiClient(_httpClient, _loggerMock)];
@@ -455,7 +499,9 @@ public class CurrencyExchangeServiceTests : IDisposable
             .Setup<Task<HttpResponseMessage>>("SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
+            // A fresh response per request: the content stream is single-use, so a shared
+            // instance would fail every request after the first.
+            .ReturnsAsync(() => new HttpResponseMessage
             {
                 StatusCode = statusCode,
                 Content = new StringContent(content, Encoding.UTF8, "application/json")


### PR DESCRIPTION
Closes #551

## Problem

The investment account details page fails to render its chart: the `ValueSeries` request exceeds the Blazor client's 100 s `HttpClient` timeout (`TaskCanceledException: net_http_request_timedout, 100`). On first load the page widens the range to the account's oldest trade, and for such a wide range the backend could fire an unbounded number of external HTTP calls per request:

- `CurrencyExchangeService` resolved every missing exchange-rate date individually through the full provider chain (DB direct + inverse, CSV, Fawaz Ahmed CDN, then a USD cross-rate repeating the chain twice more).
- `InvestmentPriceProvider.GetPricePerUnitSeriesAsync` fell back to one `ConvertAsync` per day inside its date loop whenever a rate was missing from the prefetched map.
- Failed rate lookups were never cached, so every page load repeated all of the failing external calls.
- A market-data symbol whose fetch keeps failing was re-fetched on every chart request.

## Fix

- **Cap provider resolutions per range call** (60) in `CurrencyExchangeService`; dates past the cap carry the nearest earlier known rate forward. Resolved rates are persisted, so successive requests keep closing the gap until the range is covered from the database.
- **Forward/backfill FX gaps** in `InvestmentPriceProvider` from the prefetched rate map instead of per-day fallback conversions; a currency with no rate anywhere in the range gets one whole-range fallback conversion (keeping the USD cross-rate semantics) instead of one per day.
- **Negative-cache failed single-date rate lookups** for 15 minutes in `CachedCurrencyExchangeService`.
- **Cooldown on failed symbol fetches**: a symbol whose last attempt failed within 15 minutes is not re-fetched.

## Tests

- New unit tests: range cap + forward-fill in `CurrencyExchangeServiceTests`, FX gap filling without per-day lookups and fetch cooldown behaviour in `InvestmentPriceProviderTests`, hit/miss caching in new `CachedCurrencyExchangeServiceTests`.
- Fixed the shared-`HttpResponseMessage` mock in `CurrencyExchangeServiceTests` (single-use content stream broke multi-request tests).
- `dotnet format` clean; unit tests 542/542 and integration tests 267/267 passing.

https://claude.ai/code/session_016dsb8tfra16WiRZakRiZKZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016dsb8tfra16WiRZakRiZKZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced repeated external price and exchange-rate requests after recent failures or missing data.
  * Limited exchange-rate lookups for large date ranges while continuing to provide complete results where possible.

* **Bug Fixes**
  * Improved currency conversion across dates with missing exchange rates by filling gaps from nearby known rates.
  * Avoided unnecessary per-day fallback conversions, improving reliability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->