### PR TITLE
Fix Investment rate card showing 0% when salary and investment land in different months

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- The **Investment rate** card no longer shows 0.00 % and an empty monthly chart when the salary was received in a different month than the investment: months without a salary transaction now fall back to the most recent salary (up to 12 months back) as the denominator, and the month's investments change is reported even when no salary is found. #556
 - The investment account chart no longer times out on wide date ranges: missing exchange rates are filled from the nearest known rate instead of being fetched from the external provider day by day, failed rate lookups are briefly cached, and price fetches for a symbol whose last attempt just failed are paused for a cooldown. #551
 - Investment account charts no longer repeatedly reload full price history around market closures, reducing load time. #542
 - The **Manual stock price** admin card no longer stretches across the full width of the screen; it is now capped to a compact width, and the price field updates as you type.

--- a/code/FinanceManager.Application/MoneyFlow/InvestmentRate/InvestmentRateService.cs
+++ b/code/FinanceManager.Application/MoneyFlow/InvestmentRate/InvestmentRateService.cs
@@ -1,6 +1,7 @@
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Services;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
 using FinanceManager.Domain.Identity.Repositories;
 using FinanceManager.Domain.Identity.Services;
@@ -13,6 +14,8 @@ namespace FinanceManager.Application.MoneyFlow.InvestmentRate;
 public class InvestmentRateService(IFinancialAccountRepository financialAccountRepository, IFinancialLabelsRepository financialLabelsRepository,
 IInvestmentValuationService investmentValuationService) : IInvestmentRateService
 {
+    private const int _salaryLookbackMonths = 12;
+
     public async IAsyncEnumerable<Domain.MoneyFlow.Entities.InvestmentRate> GetInvestmentRate(int userId, DateTime start, DateTime end)
     {
         var labels = await financialLabelsRepository.GetLabels().ToListAsync();
@@ -22,9 +25,12 @@ IInvestmentValuationService investmentValuationService) : IInvestmentRateService
 
         decimal salary = 0;
         await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end))
-            salary += account.Entries.Where(x => x.Labels is not null && x.Labels.Any(y => y.Id == salaryLabel.Id)).Sum(x => x.ValueChange);
+            salary += SumSalary(account, salaryLabel);
 
-        if (salary == 0) yield break;
+        // Salaries and investment purchases regularly land in different months, so a window without a
+        // salary entry still needs a denominator — use the most recent salary before the window.
+        if (salary == 0)
+            salary = await GetMostRecentSalaryBefore(userId, start, salaryLabel);
 
         List<int> investmentAccountIds = [];
         await foreach (var account in financialAccountRepository.GetAccounts<InvestmentAccount>(userId, start, end))
@@ -41,6 +47,8 @@ IInvestmentValuationService investmentValuationService) : IInvestmentRateService
             investmentsChange = endValues.Values.Sum() - startValues.Values.Sum();
         }
 
+        if (salary == 0 && investmentsChange == 0) yield break;
+
         yield return new()
         {
             Start = start,
@@ -49,4 +57,26 @@ IInvestmentValuationService investmentValuationService) : IInvestmentRateService
             InvestmentsChange = investmentsChange
         };
     }
+
+    private async Task<decimal> GetMostRecentSalaryBefore(int userId, DateTime start, FinancialLabel salaryLabel)
+    {
+        List<CurrencyAccountEntry> salaryEntries = [];
+        await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start.AddMonths(-_salaryLookbackMonths), start))
+            salaryEntries.AddRange(GetSalaryEntries(account, salaryLabel).Where(x => x.PostingDate < start));
+
+        if (salaryEntries.Count == 0) return 0;
+
+        // Sum the whole latest salary month rather than taking the single latest entry, so split
+        // payouts (e.g. bi-weekly) still add up to one monthly salary.
+        var latestSalaryDate = salaryEntries.Max(x => x.PostingDate);
+        return salaryEntries
+            .Where(x => x.PostingDate.Year == latestSalaryDate.Year && x.PostingDate.Month == latestSalaryDate.Month)
+            .Sum(x => x.ValueChange);
+    }
+
+    private static decimal SumSalary(CurrencyAccount account, FinancialLabel salaryLabel) =>
+        GetSalaryEntries(account, salaryLabel).Sum(x => x.ValueChange);
+
+    private static IEnumerable<CurrencyAccountEntry> GetSalaryEntries(CurrencyAccount account, FinancialLabel salaryLabel) =>
+        account.Entries.Where(x => x.Labels is not null && x.Labels.Any(y => y.Id == salaryLabel.Id));
 }

--- a/code/FinanceManager.Tests.Unit/Application/Services/InvestmentRateServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/InvestmentRateServiceTests.cs
@@ -69,4 +69,91 @@ public class InvestmentRateServiceTests
         Assert.Equal(1000, result.First().Salary);
         Assert.Equal(10, result.First().InvestmentsChange);
     }
+
+    [Fact]
+    public async Task GetInvestmentRate_NoSalaryInWindow_FallsBackToMostRecentEarlierSalary()
+    {
+        // A salary was paid two months ago and the investments changed this month. Querying just the
+        // current month must not come back empty — the rate should use the most recent earlier salary.
+        // Arrange
+        var userId = 1;
+        var salaryLabel = new FinancialLabel { Id = 1, Name = "Salary" };
+        _financialLabelsRepositoryMock.Setup(repo => repo.GetLabels(It.IsAny<CancellationToken>())).Returns(new[] { salaryLabel }.ToAsyncEnumerable());
+
+        var monthStart = new DateTime(_endDate.Year, _endDate.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var salaryDate = monthStart.AddMonths(-2).AddDays(9);
+
+        var accountWithOldSalary = new CurrencyAccount(userId, 1, "Currency Account 1", AccountLabel.Cash);
+        accountWithOldSalary.Add(new CurrencyAccountEntry(1, 1, salaryDate, 1000, 1000) { Labels = [salaryLabel] }, false);
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, monthStart, _endDate))
+            .Returns(AsyncEnumerable.Empty<CurrencyAccount>());
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, monthStart.AddMonths(-12), monthStart))
+            .Returns(new[] { accountWithOldSalary }.ToAsyncEnumerable());
+
+        var investmentAccount = new InvestmentAccount(userId, 2, "Investments");
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<InvestmentAccount>(userId, monthStart, _endDate))
+            .Returns(new[] { investmentAccount }.ToAsyncEnumerable());
+
+        _investmentValuationServiceMock
+            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), monthStart, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, decimal> { [2] = 100m });
+        _investmentValuationServiceMock
+            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), _endDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, decimal> { [2] = 600m });
+
+        // Act
+        var result = await _investmentRateService.GetInvestmentRate(userId, monthStart, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var rate = Assert.Single(result);
+        Assert.Equal(1000, rate.Salary);
+        Assert.Equal(500, rate.InvestmentsChange);
+        Assert.Equal(0.5m, rate.GetPercentage());
+    }
+
+    [Fact]
+    public async Task GetInvestmentRate_NoSalaryFound_StillReportsInvestmentChange()
+    {
+        // No salary anywhere (window or lookback), but the investments did change — the change must
+        // still be reported instead of the month silently disappearing from the series.
+        // Arrange
+        var userId = 1;
+        var salaryLabel = new FinancialLabel { Id = 1, Name = "Salary" };
+        _financialLabelsRepositoryMock.Setup(repo => repo.GetLabels(It.IsAny<CancellationToken>())).Returns(new[] { salaryLabel }.ToAsyncEnumerable());
+
+        var monthStart = new DateTime(_endDate.Year, _endDate.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var investmentAccount = new InvestmentAccount(userId, 2, "Investments");
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<InvestmentAccount>(userId, monthStart, _endDate))
+            .Returns(new[] { investmentAccount }.ToAsyncEnumerable());
+
+        _investmentValuationServiceMock
+            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), _endDate, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, decimal> { [2] = 250m });
+
+        // Act
+        var result = await _investmentRateService.GetInvestmentRate(userId, monthStart, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var rate = Assert.Single(result);
+        Assert.Equal(0, rate.Salary);
+        Assert.Equal(250, rate.InvestmentsChange);
+        Assert.Equal(0, rate.GetPercentage());
+    }
+
+    [Fact]
+    public async Task GetInvestmentRate_NoSalaryAndNoInvestmentChange_ReturnsEmpty()
+    {
+        // Arrange
+        var userId = 1;
+        var salaryLabel = new FinancialLabel { Id = 1, Name = "Salary" };
+        _financialLabelsRepositoryMock.Setup(repo => repo.GetLabels(It.IsAny<CancellationToken>())).Returns(new[] { salaryLabel }.ToAsyncEnumerable());
+
+        // Act
+        var result = await _investmentRateService.GetInvestmentRate(userId, _startDate, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(result);
+    }
 }

--- a/code/FinanceManager.Tests.Unit/Application/Services/InvestmentRateServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/InvestmentRateServiceTests.cs
@@ -143,6 +143,47 @@ public class InvestmentRateServiceTests
     }
 
     [Fact]
+    public async Task GetInvestmentRate_MonthWithNoActivity_ReportsZeroRate()
+    {
+        // The user's most recent transactions are months old: the queried month has no salary and no
+        // investment value change. The carried-forward salary must not fabricate a non-zero rate —
+        // the month reports 0 %.
+        // Arrange
+        var userId = 1;
+        var salaryLabel = new FinancialLabel { Id = 1, Name = "Salary" };
+        _financialLabelsRepositoryMock.Setup(repo => repo.GetLabels(It.IsAny<CancellationToken>())).Returns(new[] { salaryLabel }.ToAsyncEnumerable());
+
+        var monthStart = new DateTime(_endDate.Year, _endDate.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var salaryDate = monthStart.AddMonths(-3).AddDays(9);
+
+        var accountWithOldSalary = new CurrencyAccount(userId, 1, "Currency Account 1", AccountLabel.Cash);
+        accountWithOldSalary.Add(new CurrencyAccountEntry(1, 1, salaryDate, 1000, 1000) { Labels = [salaryLabel] }, false);
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, monthStart, _endDate))
+            .Returns(AsyncEnumerable.Empty<CurrencyAccount>());
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, monthStart.AddMonths(-12), monthStart))
+            .Returns(new[] { accountWithOldSalary }.ToAsyncEnumerable());
+
+        var investmentAccount = new InvestmentAccount(userId, 2, "Investments");
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<InvestmentAccount>(userId, monthStart, _endDate))
+            .Returns(new[] { investmentAccount }.ToAsyncEnumerable());
+
+        // Portfolio value did not move during the month.
+        _investmentValuationServiceMock
+            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, decimal> { [2] = 100m });
+
+        // Act
+        var result = await _investmentRateService.GetInvestmentRate(userId, monthStart, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var rate = Assert.Single(result);
+        Assert.Equal(1000, rate.Salary);
+        Assert.Equal(0, rate.InvestmentsChange);
+        Assert.Equal(0, rate.GetPercentage());
+    }
+
+    [Fact]
     public async Task GetInvestmentRate_NoSalaryAndNoInvestmentChange_ReturnsEmpty()
     {
         // Arrange


### PR DESCRIPTION
closes #556

## Problem

The Assets page **Investment rate** card showed a headline of **0.00 %** and a mostly empty "Rate by month" chart for a user whose salary-labelled cash transaction landed two months ago while the investment account changed in the current month — even though the card footer (whole-period query) correctly showed both the salary and the investments change.

Root cause: `InvestmentRateService.GetInvestmentRate` did `if (salary == 0) yield break;`, so any per-month query for a month without a salary entry returned nothing — the month's investments change was never computed, and the client filled the gap with an empty 0 % rate.

## Fix

- Test-first: added unit tests reproducing the scenario (salary two months before the queried month, investment change inside it) plus the no-salary-at-all cases — red before the fix, green after.
- `InvestmentRateService`: when the queried window has no salary entry, fall back to the most recent salary in the preceding 12 months (summing the latest salary month, so split payouts count once) as the denominator, and still report the window's investments change even when no salary is found at all. Only when there is neither a salary nor an investments change does the service still return no rate.
- Changelog entry under `[Unreleased]` → `Fixed`.

## Validation

- `dotnet build ./code/FinanceManager.slnx` — 0 warnings/errors
- `dotnet format` — no drift
- Unit tests: 552/552 passed
- Integration tests: 269/269 passed

https://claude.ai/code/session_01N29gAWV8YbbGAR8C3QXZJr

---
_Generated by [Claude Code](https://claude.ai/code/session_01N29gAWV8YbbGAR8C3QXZJr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Investment rate calculations now use the most recent earlier monthly salary when no salary is recorded during the selected period.
  * Investment-only changes are now reported even when no salary data is available.
  * Empty results are returned when neither salary nor investment values changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->