### PR TITLE
Fix transaction log card failing with 500 on the dashboard #549

### DIFF
--- a/code/FinanceManager.Application/Dashboard/TransactionLogService.cs
+++ b/code/FinanceManager.Application/Dashboard/TransactionLogService.cs
@@ -8,6 +8,7 @@ using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Shared.ValueObjects;
 
 namespace FinanceManager.Application.Dashboard;
 
@@ -15,7 +16,9 @@ namespace FinanceManager.Application.Dashboard;
 /// Composes the dashboard transaction log by pulling the newest entries from every
 /// account of every type (currency, bond, investment) and interleaving them into a
 /// single newest-first list. The underlying repositories share a scoped EF Core
-/// DbContext, which is not thread-safe, so queries are awaited sequentially.
+/// DbContext, which allows only one active query at a time — so each account stream
+/// is fully buffered before the per-account entry queries run, and everything is
+/// awaited sequentially.
 /// </summary>
 public class TransactionLogService(
     ICurrencyAccountRepository<CurrencyAccount> currencyAccountRepository,
@@ -34,14 +37,14 @@ public class TransactionLogService(
 
         List<TransactionLogEntryDto> result = [];
 
-        await foreach (var account in currencyAccountRepository.GetAvailableAccounts(userId).WithCancellation(cancellationToken))
+        foreach (var account in await BufferAccounts(currencyAccountRepository.GetAvailableAccounts(userId), cancellationToken))
         {
             var entries = await currencyEntryRepository.Get(account.AccountId, DateTime.MaxValue, count);
             result.AddRange(entries.Select(e => new TransactionLogEntryDto(
                 account.AccountId, account.AccountName, AccountType.Currency, e.EntryId, e.PostingDate, e.ValueChange, GetCurrencyDescription(e))));
         }
 
-        await foreach (var account in bondAccountRepository.GetAvailableAccounts(userId).WithCancellation(cancellationToken))
+        foreach (var account in await BufferAccounts(bondAccountRepository.GetAvailableAccounts(userId), cancellationToken))
         {
             var entries = await bondEntryRepository.Get(account.AccountId, DateTime.MaxValue, count);
             foreach (var entry in entries)
@@ -74,6 +77,16 @@ public class TransactionLogService(
             .OrderByDescending(e => e.Date)
             .ThenByDescending(e => e.EntryId)
             .Take(count)];
+    }
+
+    // The account query must finish streaming before any entry query starts: relational
+    // providers reject a second command while the previous reader is still open.
+    private static async Task<List<AvailableAccount>> BufferAccounts(IAsyncEnumerable<AvailableAccount> accounts, CancellationToken cancellationToken)
+    {
+        List<AvailableAccount> result = [];
+        await foreach (var account in accounts.WithCancellation(cancellationToken))
+            result.Add(account);
+        return result;
     }
 
     private static string GetCurrencyDescription(CurrencyAccountEntry entry) =>

--- a/code/FinanceManager.Tests.Unit/Application/Services/TransactionLogServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/TransactionLogServiceTests.cs
@@ -213,9 +213,15 @@ public class TransactionLogServiceTests
     private static async IAsyncEnumerable<T> TrackedAsyncEnumerable<T>(IEnumerable<T> items, System.Runtime.CompilerServices.StrongBox<bool> isOpen)
     {
         isOpen.Value = true;
-        foreach (var item in items)
-            yield return item;
-        isOpen.Value = false;
-        await Task.CompletedTask;
+        try
+        {
+            foreach (var item in items)
+                yield return item;
+            await Task.CompletedTask;
+        }
+        finally
+        {
+            isOpen.Value = false;
+        }
     }
 }

--- a/code/FinanceManager.Tests.Unit/Application/Services/TransactionLogServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/TransactionLogServiceTests.cs
@@ -147,6 +147,36 @@ public class TransactionLogServiceTests
         Assert.Equal("Shop", Assert.Single(result).Description);
     }
 
+    [Fact]
+    public async Task GetLastTransactions_DoesNotQueryEntries_WhileAccountStreamIsStillOpen()
+    {
+        // A scoped EF Core DbContext allows only one active query: issuing an entry
+        // query while the accounts stream is still enumerating throws on relational
+        // providers ("A second operation was started on this context instance...").
+        var currencyStreamOpen = new System.Runtime.CompilerServices.StrongBox<bool>(false);
+        var bondStreamOpen = new System.Runtime.CompilerServices.StrongBox<bool>(false);
+
+        _currencyAccountRepository.Setup(r => r.GetAvailableAccounts(_userId))
+            .Returns(TrackedAsyncEnumerable([new AvailableAccount(10, "Bank")], currencyStreamOpen));
+        _currencyEntryRepository.Setup(r => r.Get(10, It.IsAny<DateTime>(), It.IsAny<int>(), true))
+            .Callback(() => Assert.False(currencyStreamOpen.Value, "Entry query issued while the currency accounts stream was still open."))
+            .ReturnsAsync([]);
+
+        _bondAccountRepository.Setup(r => r.GetAvailableAccounts(_userId))
+            .Returns(TrackedAsyncEnumerable([new AvailableAccount(20, "Bonds")], bondStreamOpen));
+        _bondEntryRepository.Setup(r => r.Get(20, It.IsAny<DateTime>(), It.IsAny<int>(), true))
+            .Callback(() => Assert.False(bondStreamOpen.Value, "Entry query issued while the bond accounts stream was still open."))
+            .ReturnsAsync([]);
+
+        // Act
+        var result = await _service.GetLastTransactions(_userId, 10, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(result);
+        _currencyEntryRepository.Verify(r => r.Get(10, It.IsAny<DateTime>(), It.IsAny<int>(), true), Times.Once);
+        _bondEntryRepository.Verify(r => r.Get(20, It.IsAny<DateTime>(), It.IsAny<int>(), true), Times.Once);
+    }
+
     private void SetupCurrencyAccount(int accountId, string name, List<CurrencyAccountEntry> entries)
     {
         _currencyAccountRepository.Setup(r => r.GetAvailableAccounts(_userId))
@@ -175,6 +205,17 @@ public class TransactionLogServiceTests
     {
         foreach (var item in items)
             yield return item;
+        await Task.CompletedTask;
+    }
+
+    // Mirrors a deferred EF query: isOpen stays true from the first MoveNextAsync
+    // until the stream is exhausted, like an open data reader.
+    private static async IAsyncEnumerable<T> TrackedAsyncEnumerable<T>(IEnumerable<T> items, System.Runtime.CompilerServices.StrongBox<bool> isOpen)
+    {
+        isOpen.Value = true;
+        foreach (var item in items)
+            yield return item;
+        isOpen.Value = false;
         await Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Problem

The dashboard **Transaction log** card (added in #549) always failed with *"Couldn't load transactions"* — `GET /api/TransactionLog/Get/{userId}` returned 500 against a real database.

## Root cause

`TransactionLogService.GetLastTransactions` iterated `GetAvailableAccounts(userId)` with `await foreach` — a deferred `AsAsyncEnumerable()` query over the scoped EF Core `AppDbContext` — and issued the per-account entry queries **inside the loop body**, on the same context. While the account stream is enumerating, its data reader is still open, so the inner query starts a second operation on the context and EF throws *"A second operation was started on this context instance before a previous operation completed"* → 500.

The bug never surfaced in tests: unit tests mock the repositories, and the integration tests run on the EF InMemory provider, which tolerates the interleaving that relational providers (PostgreSQL/SQL Server) reject.

## Fix

- Buffer each account stream (currency, bond) into a list before running the entry queries, so only one query is ever active on the shared `DbContext` (`TransactionLogService.BufferAccounts`). The investment branch already materialized its accounts into a dictionary before querying, so it was unaffected.
- Added a regression unit test (`GetLastTransactions_DoesNotQueryEntries_WhileAccountStreamIsStillOpen`) using a tracking async enumerable that mimics an open data reader; it fails against the previous interleaved implementation and passes with the fix.

No changelog entry: the Transaction log card itself is still in `[Unreleased]` (#549), so this folds into that entry.

## Validation

- `dotnet build` — 0 warnings/errors
- Unit tests: 554 passed (new test verified to fail on pre-fix code)
- Integration tests: 269 passed
- `dotnet format` — no changes

https://claude.ai/code/session_01T4wrH2uBS4cqMnbWRZ5Gug

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4wrH2uBS4cqMnbWRZ5Gug)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction loading to prevent account entry queries from running while account data is still being retrieved.
  * Ensured account data is fully loaded before related transaction entries are queried, improving reliability with shared database contexts.
* **Tests**
  * Added coverage verifying that transaction entries are queried only after account enumeration is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->