### PR TITLE
Fix date pickers: reload dashboard charts on date change, honor custom range on account pages #559

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- The dashboard date picker has been redesigned into a compact pill: the active preset (This month / This quarter / This year) is now highlighted, and the custom range opens in a calendar dialog — consistent with the account details pages — showing the selected dates next to the presets. #559
 - The app loading screen has been redesigned: an animated logo and branded wordmark replace the plain title, and an indefinite spinner has been replaced with a progress ring showing the real download progress while the app boots. #553
 - The expanded investment transaction details now use a two-column layout on mobile instead of stacking every field in a single narrow column, so the previously empty right half of the screen is used and the details take up roughly half the vertical space.
 - Date pickers across the app now consistently display and accept dates in `DD/MM/YYYY` format instead of falling back to the browser locale (which showed US-style `M/D/YYYY` for some users). Affects the manual stock price, admin asset and bond forms, account entry add/edit/remove dialogs, data export, and the account/dashboard date-range pickers.
@@ -23,6 +24,8 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- Dashboard charts (Net worth, Net cash flow, Closing balance) now redraw when the date range changes; previously only the numbers updated while the charts kept showing the old period. #559
+- Selecting a custom date range on the account details pages (cash, bond, investment) now actually filters to the picked dates instead of silently falling back to the current month, and the selected end day is included in full. #559
 - The **Investment rate** card no longer shows 0.00 % and an empty monthly chart when the salary was received in a different month than the investment: months without a salary transaction now fall back to the most recent salary (up to 12 months back) as the denominator, and the month's investments change is reported even when no salary is found. #556
 - The investment account chart no longer times out on wide date ranges: missing exchange rates are filled from the nearest known rate instead of being fetched from the external provider day by day, failed rate lookups are briefly cached, and price fetches for a symbol whose last attempt just failed are paused for a cooldown. #551
 - Investment account charts no longer repeatedly reload full price history around market closures, reducing load time. #542

--- a/code/FinanceManager.Components/Components/Features/Dashboard/DashboardDatePicker.razor
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/DashboardDatePicker.razor
@@ -1,156 +1,84 @@
-﻿@using FinanceManager.Components.Helpers
+@using FinanceManager.Components.Helpers
 
-@if (StockStyle)
-{
-    <MudToggleGroup T="string" @bind-Value="selectedStockTimeSpan" Outlined=false Delimiters=false>
-        @* <MudToggleItem Value="@("1D")" /> *@
-        <MudToggleItem Value="@("5D")" />
-        <MudToggleItem Value="@("1M")" />
-        <MudToggleItem Value="@("6M")" />
-        <MudToggleItem Value="@("YTD")" />
-        <MudToggleItem Value="@("1Y")" />
-        <MudToggleItem Value="@("5Y")" />
-        <MudToggleItem Value="@("Max")" />
-    </MudToggleGroup>
-}
-else
-{
+<MudPaper Elevation="3" Class="rounded-pill px-1 py-1" Style="right: 30px; position: fixed; bottom: 3vh; z-index: 2;">
+    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="0">
+        @foreach (var (key, label) in _presets)
+        {
+            <MudButton Variant="Variant.Text" Size="Size.Small" Class="rounded-pill px-3"
+                       Color="@(_selected == key ? Color.Primary : Color.Default)"
+                       Style="@($"font-weight: {(_selected == key ? 700 : 500)};")"
+                       OnClick="@(() => SelectPreset(key))">@label</MudButton>
+        }
 
-    <MudPaper Elevation="1" Style="right: 30px; position: fixed; bottom: 3vh; z-index:2;">
-        <MudStack Spacing="0">
+        @if (_selected == DateRangeHelper.CustomRangeKey && _customRange is { Start: DateTime customStart, End: DateTime customEnd })
+        {
+            <MudText Typo="Typo.caption" Color="Color.Primary" Class="px-2"
+                     Style="font-weight: 700; white-space: nowrap;">
+                @customStart.ToString("dd MMM") &ndash; @customEnd.ToString("dd MMM")
+            </MudText>
+        }
 
-            <MudButtonGroup Variant="Variant.Text">
+        <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" Size="Size.Small"
+                       Color="@(_selected == DateRangeHelper.CustomRangeKey ? Color.Primary : Color.Default)"
+                       OnClick="OpenCustomDateRangePicker" aria-label="Select custom date range" />
+    </MudStack>
+</MudPaper>
 
-                <MudButton @onclick=@(() => SetRange(DateRangeHelper.GetCurrentMonthRange()))>This month</MudButton>
-                <MudButton @onclick=@(() => SetRange(DateRangeHelper.GetCurrentQuarterRange()))>This quarter</MudButton>
-                <MudButton @onclick=@(() => SetRange(DateRangeHelper.GetCurrentYearRange()))>This year</MudButton>
-
-                <MudIconButton Icon="@Icons.Material.Filled.ArrowDropDown" OnClick="@(() => _expanded = !_expanded)" aria-label="More date range options" />
-            </MudButtonGroup>
-
-            <MudCollapse Expanded="_expanded">
-                <MudPaper Elevation="0" Style="max-width: 350px; min-height:50px">
-                    <MudDateRangePicker @bind-DateRange="dateRange" DateFormat="dd/MM/yyyy" RelativeWidth="DropdownWidth.Ignore"
-                                        Class="px-1 pt-1" />
-                </MudPaper>
-            </MudCollapse>
-        </MudStack>
-    </MudPaper>
-}
-
+@* Hidden picker opened programmatically by the calendar icon; the Dialog variant matches
+   the custom-range picker on the account details pages. *@
+<div class="fm-dashboard-custom-range-picker">
+    <MudDateRangePicker @ref="_customDateRangePicker" DateRange="_customRange" DateFormat="dd/MM/yyyy"
+                        DateRangeChanged="OnCustomDateRangeChanged" PickerVariant="PickerVariant.Dialog" />
+</div>
 
 @code {
-    private bool _expanded;
+    private static readonly (string Key, string Label)[] _presets =
+    [
+        ("ThisMonth", "This month"),
+        ("Quarter", "This quarter"),
+        ("ThisYear", "This year"),
+    ];
 
-    private string _selectedStockTimeSpan = "1M";
+    private string _selected = "ThisMonth";
+    private DateRange? _customRange;
+    private MudDateRangePicker? _customDateRangePicker;
 
-    public string selectedStockTimeSpan
-    {
-        get { return _selectedStockTimeSpan; }
-        set
-        {
-            _selectedStockTimeSpan = value;
-            StockTimeSpanChanged(value);
-        }
-    }
-
-    private void StockTimeSpanChanged(string value)
-    {
-        switch (_selectedStockTimeSpan)
-        {
-            case "1D":
-                _dateRange = new DateRange(DateTime.UtcNow.AddDays(-1), DateTime.UtcNow);
-                break;
-            case "5D":
-                _dateRange = new DateRange(DateTime.UtcNow.AddDays(-5), DateTime.UtcNow);
-                break;
-            case "1W":
-                _dateRange = new DateRange(DateTime.UtcNow.AddDays(-7), DateTime.UtcNow);
-                break;
-            case "1M":
-                _dateRange = new DateRange(DateTime.UtcNow.AddMonths(-1), DateTime.UtcNow);
-                break;
-            case "6M":
-                _dateRange = new DateRange(DateTime.UtcNow.AddMonths(-6), DateTime.UtcNow);
-                break;
-            case "1YTD":
-                _dateRange = new DateRange(DateTime.UtcNow.AddYears(-1), DateTime.UtcNow);
-                break;
-            case "1Y":
-                _dateRange = new DateRange(DateTime.UtcNow.AddYears(-1), DateTime.UtcNow);
-                break;
-            case "5Y":
-                _dateRange = new DateRange(DateTime.UtcNow.AddYears(-5), DateTime.UtcNow);
-                break;
-            case "Max":
-                _dateRange = new DateRange(DateTime.UtcNow.AddYears(-99), DateTime.UtcNow);
-                break;
-        }
-
-        DateChanged((_dateRange!.Start!.Value, _dateRange!.End!.Value));
-    }
-
-    private DateRange _dateRange = new DateRange();
-
-    public DateRange dateRange
-    {
-        get { return _dateRange; }
-        set
-        {
-            if (_dateRange == value) return;
-
-            _dateRange = value;
-            ApplyDates();
-        }
-    }
-
-
-    [Parameter] public DateRange? InitialDateRange { get; set; } = null;
-    [Parameter] public bool StockStyle { get; set; }
     [Parameter] public string StartingOption { get; set; } = "ThisMonth";
     [Parameter] public required Action<(DateTime Start, DateTime End)> DateChanged { get; set; }
 
     protected override void OnInitialized()
     {
-        (DateTime Start, DateTime End)? range = null;
-        if (InitialDateRange is not null && InitialDateRange.Start is not null)
-            range = (InitialDateRange.Start.Value, InitialDateRange.Start.Value);
-
-        switch (StartingOption)
-        {
-            case "ThisMonth":
-                range = DateRangeHelper.GetCurrentMonthRange();
-                break;
-            case "Quarter":
-                range = DateRangeHelper.GetCurrentQuarterRange();
-                break;
-            case "ThisYear":
-                range = DateRangeHelper.GetCurrentYearRange();
-                break;
-            default:
-                range = DateRangeHelper.GetCurrentMonthRange();
-                break;
-        }
-
-        if (range is not null)
-        {
-            var end = range.Value.End < DateTime.UtcNow ? range.Value.End : DateTime.UtcNow;
-            _dateRange = new DateRange(range.Value.Start, end);
-        }
+        if (_presets.Any(p => p.Key == StartingOption))
+            _selected = StartingOption;
     }
 
-    public void SetRange((DateTime Start, DateTime End) range)
+    private Task OpenCustomDateRangePicker() =>
+        _customDateRangePicker?.OpenAsync() ?? Task.CompletedTask;
+
+    private void SelectPreset(string key)
     {
-        _dateRange = new DateRange(range.Start, range.End);
+        _selected = key;
+        var range = key switch
+        {
+            "Quarter" => DateRangeHelper.GetCurrentQuarterRange(),
+            "ThisYear" => DateRangeHelper.GetCurrentYearRange(),
+            _ => DateRangeHelper.GetCurrentMonthRange(),
+        };
 
-        if (_dateRange.Start is null || _dateRange.End is null) return;
-
-        DateChanged((_dateRange.Start.Value, _dateRange.End.Value < DateTime.UtcNow ? _dateRange.End.Value : DateTime.UtcNow));
+        var now = DateTime.UtcNow;
+        DateChanged((range.Start, range.End < now ? range.End : now));
     }
-    public void ApplyDates()
-    {
-        if (_dateRange.Start is null || _dateRange.End is null) return;
 
-        DateChanged((_dateRange.Start.Value.ToUniversalTime(), _dateRange.End.Value.ToUniversalTime()));
+    private void OnCustomDateRangeChanged(DateRange? range)
+    {
+        _customRange = range;
+        if (range is not { Start: DateTime start, End: DateTime end }) return;
+
+        _selected = DateRangeHelper.CustomRangeKey;
+
+        // The picker returns midnight for the end day; include the whole selected day, clamped to now.
+        var now = DateTime.UtcNow;
+        var inclusiveEnd = end.Date.AddDays(1).AddTicks(-1);
+        DateChanged((start, inclusiveEnd < now ? inclusiveEnd : now));
     }
 }

--- a/code/FinanceManager.Components/Components/Features/Dashboard/DashboardDatePicker.razor.css
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/DashboardDatePicker.razor.css
@@ -1,0 +1,7 @@
+/* The custom date-range picker is driven entirely by the calendar icon button and
+   opened programmatically as a dialog. Hide only its own inline input field so just
+   the icon acts as the trigger. The dialog overlay is rendered separately when opened
+   and is unaffected by this rule. */
+.fm-dashboard-custom-range-picker ::deep .mud-picker > .mud-input-control {
+    display: none;
+}

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.cs
@@ -1,4 +1,5 @@
 using ApexCharts;
+using FinanceManager.Components.Helpers;
 using FinanceManager.Domain.MoneyFlow.Entities;
 using Microsoft.AspNetCore.Components;
 using MudBlazor;
@@ -21,7 +22,9 @@ public partial class AccountDetailsHero
     [Parameter] public List<TimeSeriesModel> ChartData { get; set; } = [];
     [Parameter] public bool IsMobile { get; set; }
 
-    public const string CustomRangeKey = "Range";
+    // Must match the key DateRangeHelper.GetAccountDetailsRange resolves the custom
+    // range with; a diverging literal here made custom ranges fall back to the default.
+    public const string CustomRangeKey = DateRangeHelper.CustomRangeKey;
 
     private readonly string[] _ranges = ["Month", "1M", "3M", "6M", "YTD"];
 

--- a/code/FinanceManager.Components/Components/Shared/Charts/TimeSeriesValueCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Shared/Charts/TimeSeriesValueCard.razor.cs
@@ -22,6 +22,14 @@ public partial class TimeSeriesValueCard
     private string? _builtForAccent;
     private string? _builtForCurrency;
 
+    // ApexCharts draws via JS interop only when the ApexChart component is first
+    // rendered; feeding new Data into an already-rendered chart changes nothing on
+    // screen. Track which chart instance drew which points so OnAfterRenderAsync can
+    // ask the live chart to redraw when the series content actually changed
+    // (e.g. the dashboard reloading all cards after a date-range change).
+    private ApexChart<TimeSeriesModel>? _drawnChart;
+    private List<(DateTime DateTime, decimal Value)> _drawnPoints = [];
+
     /// <summary>Card title shown top-left (e.g. "Assets value over time").</summary>
     [Parameter] public string Title { get; set; } = string.Empty;
 
@@ -129,6 +137,26 @@ public partial class TimeSeriesValueCard
         // Drop a stale hover index if the series shrank (or emptied) between loads.
         if (_hoverIndex is int i && i >= Data.Count)
             _hoverIndex = null;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (State != LoadState.Ready || _chart is null) return;
+
+        var points = Data.Select(p => (p.DateTime, p.Value)).ToList();
+        if (!ReferenceEquals(_chart, _drawnChart))
+        {
+            // A freshly created chart instance (first render, or remounted after a
+            // loading/empty/error state) has just drawn the current data itself.
+            _drawnChart = _chart;
+            _drawnPoints = points;
+            return;
+        }
+
+        if (points.SequenceEqual(_drawnPoints)) return;
+
+        _drawnPoints = points;
+        await _chart.RenderAsync();
     }
 
     // Pin the Y axis to a "nice" zero-based range so the card shows ~5 round

--- a/code/FinanceManager.Components/Components/Shared/Charts/TimeSeriesValueCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Shared/Charts/TimeSeriesValueCard.razor.cs
@@ -143,19 +143,21 @@ public partial class TimeSeriesValueCard
     {
         if (State != LoadState.Ready || _chart is null) return;
 
-        var points = Data.Select(p => (p.DateTime, p.Value)).ToList();
+        // Hover raises StateHasChanged, so this runs often: compare lazily and only
+        // materialize the points when they are actually stored.
+        var points = Data.Select(p => (p.DateTime, p.Value));
         if (!ReferenceEquals(_chart, _drawnChart))
         {
             // A freshly created chart instance (first render, or remounted after a
             // loading/empty/error state) has just drawn the current data itself.
             _drawnChart = _chart;
-            _drawnPoints = points;
+            _drawnPoints = points.ToList();
             return;
         }
 
         if (points.SequenceEqual(_drawnPoints)) return;
 
-        _drawnPoints = points;
+        _drawnPoints = points.ToList();
         await _chart.RenderAsync();
     }
 

--- a/code/FinanceManager.Components/Helpers/DateRangeHelper.cs
+++ b/code/FinanceManager.Components/Helpers/DateRangeHelper.cs
@@ -2,6 +2,13 @@
 
 public static class DateRangeHelper
 {
+    /// <summary>
+    /// Selection key for a user-picked custom date range. Every range selector and
+    /// every consumer comparing against it must use this constant — a mismatched
+    /// literal silently falls through to the default range.
+    /// </summary>
+    public const string CustomRangeKey = "Custom";
+
     public static (DateTime Start, DateTime End) GetAccountDetailsRange(
         string selection,
         DateTime? customStart,
@@ -10,8 +17,13 @@ public static class DateRangeHelper
         DateTime defaultStart,
         DateTime now)
     {
-        if (selection == "Custom")
-            return (customStart ?? customFallbackStart, customEnd is DateTime end && end < now ? end : now);
+        if (selection == CustomRangeKey)
+        {
+            // Date pickers return midnight for the end day; extend it to end-of-day so
+            // the selected day's entries are included, then clamp to now.
+            var inclusiveEnd = customEnd is DateTime end ? end.Date.AddDays(1).AddTicks(-1) : now;
+            return (customStart ?? customFallbackStart, inclusiveEnd < now ? inclusiveEnd : now);
+        }
 
         var start = selection switch
         {

--- a/code/FinanceManager.Tests.Unit/Components/Helpers/DateRangeHelperTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Helpers/DateRangeHelperTests.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Components.Components.Features.FinancialAccounts.Shared;
 using FinanceManager.Components.Helpers;
 
 namespace FinanceManager.Tests.Unit.Components.Helpers;
@@ -27,10 +28,34 @@ public class DateRangeHelperTests
     public void GetAccountDetailsRange_CustomRangeClampsFutureEnd()
     {
         var start = _now.AddDays(-10);
-        var range = DateRangeHelper.GetAccountDetailsRange("Custom", start, _now.AddDays(1), _now.AddMonths(-3), _now, _now);
+        var range = DateRangeHelper.GetAccountDetailsRange(DateRangeHelper.CustomRangeKey, start, _now.AddDays(1), _now.AddMonths(-3), _now, _now);
 
         Assert.Equal(start, range.Start);
         Assert.Equal(_now, range.End);
+    }
+
+    // Pickers hand over midnight for the end day; the selected day itself must still be included.
+    [Fact]
+    public void GetAccountDetailsRange_CustomRangeIncludesWholeEndDay()
+    {
+        var start = _now.AddMonths(-4);
+        var end = _now.AddMonths(-3).Date;
+        var range = DateRangeHelper.GetAccountDetailsRange(DateRangeHelper.CustomRangeKey, start, end, _now.AddMonths(-3), _now, _now);
+
+        Assert.Equal(start, range.Start);
+        Assert.Equal(end.AddDays(1).AddTicks(-1), range.End);
+    }
+
+    // The hero's custom-range key must resolve as a custom selection in the helper —
+    // a mismatch silently falls back to the default range (regression guard).
+    [Fact]
+    public void GetAccountDetailsRange_HeroCustomRangeKeyResolvesCustomRange()
+    {
+        var start = _now.AddMonths(-4);
+        var range = DateRangeHelper.GetAccountDetailsRange(
+            AccountDetailsHero.CustomRangeKey, start, _now, _now.AddMonths(-3), _now.AddYears(-1), _now);
+
+        Assert.Equal(start, range.Start);
     }
 
     [Fact]


### PR DESCRIPTION
closes #559

## What

Audit of the app's date pickers found two real bugs plus a usability gap; all are fixed here, and the dashboard picker got a small redesign.

### Fixed
- **Dashboard charts never redrew on date change.** The shared time-series card (`TimeSeriesValueCard`) draws its ApexCharts chart only when the chart component first renders; feeding new data into an already-rendered chart changed the header numbers but left the chart on the old period — which read as "no card is reloaded". The card now tracks which chart instance drew which points and asks the live chart to re-render when the series content changes.
- **Custom date range ignored on account details pages.** `AccountDetailsHero` reported custom selections under the key `"Range"` while `DateRangeHelper.GetAccountDetailsRange` only recognized `"Custom"`, so every custom range silently fell back to the default current-month range (reproduced: picking a range 3 months back requested `Jul 1 → now`). The key now lives once in `DateRangeHelper.CustomRangeKey` and the hero aliases it; a regression test pins the two together.
- **Custom end day excluded.** Date pickers return midnight for the end day, so the selected end day's entries were effectively excluded (and a single-day range was zero-width). Custom ranges now extend the end to end-of-day, clamped to now.

### Changed
- **Dashboard date picker redesign.** The floating collapsible picker is now a compact pill: the active preset (This month / This quarter / This year) is highlighted, the custom range opens in a calendar dialog (same pattern as the account pages), and the selected custom dates are shown in the pill. Dead `StockStyle`/`InitialDateRange` code removed.

## Verification
- `dotnet build` clean (warnings-as-errors), `dotnet format` applied.
- Unit tests: 555/555 green, including new `DateRangeHelper` tests (custom key resolution, inclusive end day).
- Rendered on the guest account (desktop + mobile): dashboard charts now redraw for presets and custom ranges (request log shows the picked dates, e.g. `start=2026-04-03&end=2026-05-29T23:59:59`), and account details custom range 3 Feb – 29 Mar loads that period's transactions instead of the current month.

https://claude.ai/code/session_01CmWD8AGE5KeyXXRvHJ5xoD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmWD8AGE5KeyXXRvHJ5xoD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added preset date options (This Month, Quarter, This Year) in the dashboard date picker.
  - Added a custom date-range picker opened via a calendar icon, with the selected preset clearly highlighted.
  - Custom date ranges now include the entire selected end day.

- **Bug Fixes**
  - Clamps preset and custom end dates to the current time.
  - Fixed custom range selections incorrectly falling back to the default range.
  - Improved chart redraw behavior when time-series points change.

- **Tests**
  - Added unit coverage for inclusive end-day handling and custom-range resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->