### PR TITLE
Fix misleading investment rate calculation #561

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- The **Investment rate** card now measures net investment purchases instead of portfolio market-value movement, keeps its headline and footer on the same monthly period, and uses a salary-weighted YTD average so every displayed figure reconciles. #561
 - Dashboard charts (Net worth, Net cash flow, Closing balance) now redraw when the date range changes; previously only the numbers updated while the charts kept showing the old period. #559
 - Selecting a custom date range on the account details pages (cash, bond, investment) now actually filters to the picked dates instead of silently falling back to the current month, and the selected end day is included in full. #559
 - The **Investment rate** card no longer shows 0.00 % and an empty monthly chart when the salary was received in a different month than the investment: months without a salary transaction now fall back to the most recent salary (up to 12 months back) as the denominator, and the month's investments change is reported even when no salary is found. #556

--- a/code/FinanceManager.Api/Controllers/MoneyFlowController.cs
+++ b/code/FinanceManager.Api/Controllers/MoneyFlowController.cs
@@ -82,7 +82,9 @@ public class MoneyFlowController(INetWorthService netWorthService, ILabelsValueS
 
     [HttpGet("GetInvestmentRate")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<InvestmentRate>))]
-    public async Task<IActionResult> GetInvestmentRate([FromQuery] int userId, [FromQuery] DateTime start, [FromQuery] DateTime end, [FromQuery] long? step = null, CancellationToken cancellationToken = default) =>
-        ApiAuthenticationHelper.IsAuthenticatedUser(User, userId) ? Ok(await investmentRateService.GetInvestmentRate(userId, start, end).ToListAsync(cancellationToken)) : Forbid();
+    public async Task<IActionResult> GetInvestmentRate([FromQuery] int userId, [FromQuery] int currencyId, [FromQuery] DateTime start, [FromQuery] DateTime end, [FromQuery] long? step = null, CancellationToken cancellationToken = default) =>
+        ApiAuthenticationHelper.IsAuthenticatedUser(User, userId)
+            ? Ok(await investmentRateService.GetInvestmentRate(userId, await currencyRepository.GetCurrencies(cancellationToken).SingleAsync(x => x.Id == currencyId, cancellationToken), start, end).ToListAsync(cancellationToken))
+            : Forbid();
 
 }

--- a/code/FinanceManager.Application/MoneyFlow/InvestmentRate/InvestmentRateService.cs
+++ b/code/FinanceManager.Application/MoneyFlow/InvestmentRate/InvestmentRateService.cs
@@ -1,6 +1,7 @@
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
-using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
-using FinanceManager.Domain.FinancialAccounts.Investments.Services;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
 using FinanceManager.Domain.Identity.Repositories;
@@ -11,17 +12,19 @@ using FinanceManager.Domain.MoneyFlow.Services;
 
 namespace FinanceManager.Application.MoneyFlow.InvestmentRate;
 
-public class InvestmentRateService(IFinancialAccountRepository financialAccountRepository, IFinancialLabelsRepository financialLabelsRepository,
-IInvestmentValuationService investmentValuationService) : IInvestmentRateService
+public class InvestmentRateService(
+    IFinancialAccountRepository financialAccountRepository,
+    IFinancialLabelsRepository financialLabelsRepository,
+    IInvestmentTransactionRepository investmentTransactionRepository,
+    ICurrencyRepository currencyRepository,
+    ICurrencyExchangeService currencyExchangeService) : IInvestmentRateService
 {
     private const int _salaryLookbackMonths = 12;
 
-    public async IAsyncEnumerable<Domain.MoneyFlow.Entities.InvestmentRate> GetInvestmentRate(int userId, DateTime start, DateTime end)
+    public async IAsyncEnumerable<Domain.MoneyFlow.Entities.InvestmentRate> GetInvestmentRate(int userId, Currency currency, DateTime start, DateTime end)
     {
         var labels = await financialLabelsRepository.GetLabels().ToListAsync();
         var salaryLabel = labels.Single(x => x.Name.ToLower() == "salary");
-
-        Currency currency = DefaultCurrency.PLN; // TODO: use user currency settings
 
         decimal salary = 0;
         await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end))
@@ -32,19 +35,23 @@ IInvestmentValuationService investmentValuationService) : IInvestmentRateService
         if (salary == 0)
             salary = await GetMostRecentSalaryBefore(userId, start, salaryLabel);
 
-        List<int> investmentAccountIds = [];
-        await foreach (var account in financialAccountRepository.GetAccounts<InvestmentAccount>(userId, start, end))
-            investmentAccountIds.Add(account.AccountId);
-
         decimal investmentsChange = 0;
-        if (investmentAccountIds.Count > 0)
+        var transactions = await investmentTransactionRepository.GetByUser(userId, DateOnly.FromDateTime(start), DateOnly.FromDateTime(end));
+        foreach (var transaction in transactions)
         {
-            // Batched point valuation: one transactions query per as-of date, each distinct listing
-            // priced once across all accounts. The change nets across accounts, so the per-account
-            // breakdown is not needed here — summing the batched result matches the per-account loop.
-            var startValues = await investmentValuationService.GetAccountValueAsync(investmentAccountIds, currency, start);
-            var endValues = await investmentValuationService.GetAccountValueAsync(investmentAccountIds, currency, end);
-            investmentsChange = endValues.Values.Sum() - startValues.Values.Sum();
+            var amount = transaction.Type == Domain.FinancialAccounts.Investments.Entities.InvestmentTransactionType.Buy
+                ? transaction.Quantity * transaction.UnitPrice + (transaction.Fee ?? 0m)
+                : -transaction.Quantity * transaction.UnitPrice + (transaction.Fee ?? 0m);
+
+            if (!string.Equals(transaction.Currency, currency.ShortName, StringComparison.OrdinalIgnoreCase))
+            {
+                var sourceCurrency = await currencyRepository.GetOrAdd(transaction.Currency, transaction.Currency);
+                var exchangeRate = await currencyExchangeService.GetExchangeRateAsync(
+                    sourceCurrency, currency, transaction.TradeDate.ToDateTime(TimeOnly.MinValue));
+                amount *= exchangeRate ?? throw new InvalidOperationException($"No exchange rate from {sourceCurrency.ShortName} to {currency.ShortName} on {transaction.TradeDate}.");
+            }
+
+            investmentsChange += amount;
         }
 
         if (salary == 0 && investmentsChange == 0) yield break;

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor
@@ -4,7 +4,7 @@
     <MudCardContent Class="d-flex flex-column flex-grow-1 pa-4">
         <div class="mb-2">
             <MudText Typo="Typo.h6">Investment rate</MudText>
-            <MudText Typo="Typo.body2" Color="MudBlazor.Color.Secondary">Investment growth relative to salary.</MudText>
+            <MudText Typo="Typo.body2" Color="MudBlazor.Color.Secondary">Net investment purchases relative to salary.</MudText>
         </div>
 
         @if (_isLoading)
@@ -28,7 +28,7 @@
             </div>
 
             <div class="d-flex justify-space-between mb-1">
-                <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">Rate by month</MudText>
+                <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">Monthly rate · last 12 months</MudText>
                 <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">avg @FormatAveragePercentage(_ytdAveragePercentage)</MudText>
             </div>
             <div class="investment-rate-card__chart">
@@ -52,14 +52,14 @@
             <MudDivider Class="my-1" Style="flex-grow:0;" />
             <MudGrid Spacing="1">
                 <MudItem xs="6">
-                    <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">Salary</MudText>
-                    <MudText Typo="Typo.body2">@FormatAmount(LatestInvestmentRate?.Salary ?? 0)</MudText>
+                    <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">This month salary</MudText>
+                    <MudText Typo="Typo.body2">@FormatAmount(CurrentMonthRate?.Salary ?? 0)</MudText>
                 </MudItem>
                 <MudItem xs="6">
-                    <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">Investments change</MudText>
+                    <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">This month invested</MudText>
                     <MudText Typo="Typo.body2"
-                             Color="@(LatestInvestmentRate?.InvestmentsChange > 0 ? MudBlazor.Color.Success : MudBlazor.Color.Default)">
-                        @FormatChange(LatestInvestmentRate?.InvestmentsChange ?? 0)
+                             Color="@(CurrentMonthRate?.InvestmentsChange > 0 ? MudBlazor.Color.Success : MudBlazor.Color.Default)">
+                        @FormatChange(CurrentMonthRate?.InvestmentsChange ?? 0)
                     </MudText>
                 </MudItem>
             </MudGrid>

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
@@ -24,10 +24,8 @@ public partial class InvestmentRateCard
     private bool _isLoading;
     private Currency _currency = DefaultCurrency.PLN;
 
-    public List<InvestmentRate> InvestmentRates { get; set; } = [];
     public List<InvestmentRate> MonthlyInvestmentRates { get; set; } = [];
 
-    private InvestmentRate? LatestInvestmentRate => InvestmentRates.FirstOrDefault(x => x.Salary != 0);
     private InvestmentRate? CurrentMonthRate => MonthlyInvestmentRates.LastOrDefault();
 
     private decimal _currentMonthPercentage;
@@ -55,7 +53,6 @@ public partial class InvestmentRateCard
         _isLoading = true;
         try
         {
-            InvestmentRates.Clear();
             MonthlyInvestmentRates.Clear();
 
             var user = await LoginService.GetLoggedUser();
@@ -72,7 +69,6 @@ public partial class InvestmentRateCard
                 };
 
                 var snapshot = await AssetsPageCardsCacheService.GetSnapshotAsync(context);
-                InvestmentRates = [.. snapshot.InvestmentRates];
                 MonthlyInvestmentRates = [.. snapshot.MonthlyInvestmentRates];
 
                 BuildDerivedState();
@@ -93,18 +89,12 @@ public partial class InvestmentRateCard
         _currentMonthPercentage = CurrentMonthRate?.GetPercentage() ?? 0m;
 
         var currentYear = EndDateTime.Year;
-        var ytdEntries = MonthlyInvestmentRates
-            .Where(r => r.Start.Year == currentYear && r.Salary != 0)
-            .ToList();
-
-        _ytdAveragePercentage = ytdEntries.Count == 0
-            ? 0m
-            : ytdEntries.Average(r => r.GetPercentage());
+        var ytdEntries = MonthlyInvestmentRates.Where(r => r.Start.Year == currentYear).ToList();
+        var salaryYtd = ytdEntries.Sum(r => r.Salary);
+        var investedYtd = ytdEntries.Sum(r => r.InvestmentsChange);
+        _ytdAveragePercentage = salaryYtd == 0m ? 0m : investedYtd / salaryYtd;
 
         var monthsElapsed = EndDateTime.Month;
-        var investedYtd = MonthlyInvestmentRates
-            .Where(r => r.Start.Year == currentYear)
-            .Sum(r => r.InvestmentsChange);
 
         _endOfYearProjection = monthsElapsed == 0 || investedYtd == 0
             ? null

--- a/code/FinanceManager.Components/HttpClients/MoneyFlowHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/MoneyFlowHttpClient.cs
@@ -72,9 +72,9 @@ public class MoneyFlowHttpClient(HttpClient httpClient)
         return result ?? [];
     }
 
-    public async IAsyncEnumerable<InvestmentRate> GetInvestmentRate(int userId, DateTime start, DateTime end)
+    public async IAsyncEnumerable<InvestmentRate> GetInvestmentRate(int userId, Currency currency, DateTime start, DateTime end)
     {
-        var results = await httpClient.GetFromJsonAsync<List<InvestmentRate>>($"{httpClient.BaseAddress}api/MoneyFlow/GetInvestmentRate?userId={userId}&start={start:O}&end={end:O}");
+        var results = await httpClient.GetFromJsonAsync<List<InvestmentRate>>($"{httpClient.BaseAddress}api/MoneyFlow/GetInvestmentRate?userId={userId}&currencyId={currency.Id}&start={start:O}&end={end:O}");
         if (results is null) yield break;
         foreach (var r in results) yield return r;
     }

--- a/code/FinanceManager.Components/Models/AssetsPageCardsCacheSnapshot.cs
+++ b/code/FinanceManager.Components/Models/AssetsPageCardsCacheSnapshot.cs
@@ -16,7 +16,6 @@ public sealed class AssetsPageCardsCacheSnapshot
     public List<TimeSeriesModel> AssetsTimeSeries { get; set; } = [];
     public List<NameValueResult> EndAssetsPerType { get; set; } = [];
     public List<NameValueResult> EndAssetsPerAccount { get; set; } = [];
-    public List<InvestmentRate> InvestmentRates { get; set; } = [];
     public List<InvestmentRate> MonthlyInvestmentRates { get; set; } = [];
 }
 

--- a/code/FinanceManager.Components/Services/AssetsPageCardsCacheService.cs
+++ b/code/FinanceManager.Components/Services/AssetsPageCardsCacheService.cs
@@ -39,10 +39,9 @@ public class AssetsPageCardsCacheService(
         var assetsTimeSeriesTask = assetsHttpClient.GetAssetsTimeSeries(refreshContext.UserId, currency, startDate, endDate);
         var assetsPerTypeTask = assetsHttpClient.GetEndAssetsPerType(refreshContext.UserId, currency, endDate);
         var assetsPerAccountTask = assetsHttpClient.GetEndAssetsPerAccount(refreshContext.UserId, currency, endDate);
-        var investmentRateTask = moneyFlowHttpClient.GetInvestmentRate(refreshContext.UserId, startDate, endDate).ToListAsync().AsTask();
-        var monthlyInvestmentRatesTask = GetMonthlyInvestmentRatesAsync(refreshContext.UserId, endDate);
+        var monthlyInvestmentRatesTask = GetMonthlyInvestmentRatesAsync(refreshContext.UserId, currency, endDate);
 
-        await Task.WhenAll(assetsTimeSeriesTask, assetsPerTypeTask, assetsPerAccountTask, investmentRateTask, monthlyInvestmentRatesTask);
+        await Task.WhenAll(assetsTimeSeriesTask, assetsPerTypeTask, assetsPerAccountTask, monthlyInvestmentRatesTask);
 
         return new AssetsPageCardsCacheSnapshot
         {
@@ -55,12 +54,11 @@ public class AssetsPageCardsCacheService(
             AssetsTimeSeries = [.. (await assetsTimeSeriesTask)],
             EndAssetsPerType = [.. (await assetsPerTypeTask)],
             EndAssetsPerAccount = [.. (await assetsPerAccountTask)],
-            InvestmentRates = [.. (await investmentRateTask)],
             MonthlyInvestmentRates = await monthlyInvestmentRatesTask,
         };
     }
 
-    private async Task<List<InvestmentRate>> GetMonthlyInvestmentRatesAsync(int userId, DateTime endDate)
+    private async Task<List<InvestmentRate>> GetMonthlyInvestmentRatesAsync(int userId, Currency currency, DateTime endDate)
     {
         const int monthsBack = 12;
         var anchor = new DateTime(endDate.Year, endDate.Month, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -71,16 +69,16 @@ public class AssetsPageCardsCacheService(
             var monthStart = anchor.AddMonths(-(monthsBack - 1 - i));
             var monthEnd = monthStart.AddMonths(1).AddTicks(-1);
             if (monthEnd > endDate) monthEnd = endDate;
-            tasks[i] = FetchMonthAsync(userId, monthStart, monthEnd);
+            tasks[i] = FetchMonthAsync(userId, currency, monthStart, monthEnd);
         }
 
         var results = await Task.WhenAll(tasks);
         return [.. results.Select(r => r.rates.FirstOrDefault() ?? new InvestmentRate { Start = r.start, End = r.end })];
     }
 
-    private async Task<(DateTime start, DateTime end, List<InvestmentRate> rates)> FetchMonthAsync(int userId, DateTime start, DateTime end)
+    private async Task<(DateTime start, DateTime end, List<InvestmentRate> rates)> FetchMonthAsync(int userId, Currency currency, DateTime start, DateTime end)
     {
-        var rates = await moneyFlowHttpClient.GetInvestmentRate(userId, start, end).ToListAsync();
+        var rates = await moneyFlowHttpClient.GetInvestmentRate(userId, currency, start, end).ToListAsync();
         return (start, end, rates);
     }
 

--- a/code/FinanceManager.Domain/MoneyFlow/Services/IInvestmentRateService.cs
+++ b/code/FinanceManager.Domain/MoneyFlow/Services/IInvestmentRateService.cs
@@ -1,8 +1,9 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.MoneyFlow.Entities;
 
 namespace FinanceManager.Domain.MoneyFlow.Services;
 
 public interface IInvestmentRateService
 {
-    IAsyncEnumerable<InvestmentRate> GetInvestmentRate(int userId, DateTime start, DateTime end);
+    IAsyncEnumerable<InvestmentRate> GetInvestmentRate(int userId, Currency currency, DateTime start, DateTime end);
 }

--- a/code/FinanceManager.Tests.Integration/Controllers/MoneyFlowControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/MoneyFlowControllerTests.cs
@@ -225,7 +225,7 @@ public class MoneyFlowControllerTests(OptionsProvider optionsProvider) : Control
         Authorize("TestUser", 1, UserRole.User);
         int days = 7;
 
-        var result = await new MoneyFlowHttpClient(Client).GetInvestmentRate(1, _nowUtc.AddDays(-days), _nowUtc).ToListAsync(TestContext.Current.CancellationToken);
+        var result = await new MoneyFlowHttpClient(Client).GetInvestmentRate(1, DefaultCurrency.USD, _nowUtc.AddDays(-days), _nowUtc).ToListAsync(TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
         Assert.NotEmpty(result);
@@ -586,7 +586,7 @@ public class MoneyFlowControllerTests(OptionsProvider optionsProvider) : Control
         now => $"api/MoneyFlow/GetNetCashFlow/2/{DefaultCurrency.USD.Id}/{now.AddDays(-7):O}/{now:O}",
         now => $"api/MoneyFlow/GetClosingBalance/2/{DefaultCurrency.USD.Id}/{now.AddDays(-7):O}/{now:O}",
         now => $"api/MoneyFlow/GetLabelsValue?userId=2&start={now.AddDays(-7):O}&end={now:O}",
-        now => $"api/MoneyFlow/GetInvestmentRate?userId=2&start={now.AddDays(-7):O}&end={now:O}",
+        now => $"api/MoneyFlow/GetInvestmentRate?userId=2&currencyId={DefaultCurrency.USD.Id}&start={now.AddDays(-7):O}&end={now:O}",
     };
 
     [Theory]

--- a/code/FinanceManager.Tests.Unit/Application/Services/InvestmentRateServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/InvestmentRateServiceTests.cs
@@ -1,7 +1,9 @@
 using FinanceManager.Application.MoneyFlow.InvestmentRate;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
-using FinanceManager.Domain.FinancialAccounts.Investments.Services;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
 using FinanceManager.Domain.Labels.Repositories;
@@ -20,19 +22,24 @@ public class InvestmentRateServiceTests
     private readonly InvestmentRateService _investmentRateService;
     private readonly Mock<IFinancialAccountRepository> _financialAccountRepositoryMock = new();
     private readonly Mock<IFinancialLabelsRepository> _financialLabelsRepositoryMock = new();
-    private readonly Mock<IInvestmentValuationService> _investmentValuationServiceMock = new();
+    private readonly Mock<IInvestmentTransactionRepository> _investmentTransactionRepositoryMock = new();
+    private readonly Mock<ICurrencyRepository> _currencyRepositoryMock = new();
+    private readonly Mock<ICurrencyExchangeService> _currencyExchangeServiceMock = new();
 
     public InvestmentRateServiceTests()
     {
         _financialAccountRepositoryMock.Setup(r => r.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(AsyncEnumerable.Empty<CurrencyAccount>());
-        _financialAccountRepositoryMock.Setup(r => r.GetAccounts<InvestmentAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .Returns(AsyncEnumerable.Empty<InvestmentAccount>());
-        _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<int, decimal>());
+        _investmentTransactionRepositoryMock
+            .Setup(x => x.GetByUser(It.IsAny<long>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
-        _investmentRateService = new InvestmentRateService(_financialAccountRepositoryMock.Object, _financialLabelsRepositoryMock.Object, _investmentValuationServiceMock.Object);
+        _investmentRateService = new InvestmentRateService(
+            _financialAccountRepositoryMock.Object,
+            _financialLabelsRepositoryMock.Object,
+            _investmentTransactionRepositoryMock.Object,
+            _currencyRepositoryMock.Object,
+            _currencyExchangeServiceMock.Object);
     }
 
     [Fact]
@@ -46,23 +53,14 @@ public class InvestmentRateServiceTests
         var currencyAccount = new CurrencyAccount(userId, 1, "Currency Account 1", AccountLabel.Cash);
         currencyAccount.Add(new CurrencyAccountEntry(1, 1, _startDate, 1000, 1000) { Labels = [salaryLabel] }, false);
 
-        var investmentAccount = new InvestmentAccount(userId, 2, "Investments");
-
         _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(new[] { currencyAccount }.ToAsyncEnumerable());
-        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<InvestmentAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-            .Returns(new[] { investmentAccount }.ToAsyncEnumerable());
-
-        // The investment value grew from 0 at the start of the window to 10 at the end.
-        _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), _startDate, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<int, decimal>());
-        _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), _endDate, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<int, decimal> { [2] = 10m });
+        _investmentTransactionRepositoryMock
+            .Setup(x => x.GetByUser(userId, DateOnly.FromDateTime(_startDate), DateOnly.FromDateTime(_endDate), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Transaction(userId, _startDate, InvestmentTransactionType.Buy, 2m, 5m)]);
 
         // Act
-        var result = await _investmentRateService.GetInvestmentRate(userId, _startDate, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var result = await _investmentRateService.GetInvestmentRate(userId, DefaultCurrency.PLN, _startDate, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Single(result);
@@ -91,19 +89,12 @@ public class InvestmentRateServiceTests
         _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, monthStart.AddMonths(-12), monthStart))
             .Returns(new[] { accountWithOldSalary }.ToAsyncEnumerable());
 
-        var investmentAccount = new InvestmentAccount(userId, 2, "Investments");
-        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<InvestmentAccount>(userId, monthStart, _endDate))
-            .Returns(new[] { investmentAccount }.ToAsyncEnumerable());
-
-        _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), monthStart, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<int, decimal> { [2] = 100m });
-        _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), _endDate, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<int, decimal> { [2] = 600m });
+        _investmentTransactionRepositoryMock
+            .Setup(x => x.GetByUser(userId, DateOnly.FromDateTime(monthStart), DateOnly.FromDateTime(_endDate), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Transaction(userId, monthStart, InvestmentTransactionType.Buy, 5m, 100m)]);
 
         // Act
-        var result = await _investmentRateService.GetInvestmentRate(userId, monthStart, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var result = await _investmentRateService.GetInvestmentRate(userId, DefaultCurrency.PLN, monthStart, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         var rate = Assert.Single(result);
@@ -124,16 +115,12 @@ public class InvestmentRateServiceTests
 
         var monthStart = new DateTime(_endDate.Year, _endDate.Month, 1, 0, 0, 0, DateTimeKind.Utc);
 
-        var investmentAccount = new InvestmentAccount(userId, 2, "Investments");
-        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<InvestmentAccount>(userId, monthStart, _endDate))
-            .Returns(new[] { investmentAccount }.ToAsyncEnumerable());
-
-        _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), _endDate, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<int, decimal> { [2] = 250m });
+        _investmentTransactionRepositoryMock
+            .Setup(x => x.GetByUser(userId, DateOnly.FromDateTime(monthStart), DateOnly.FromDateTime(_endDate), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Transaction(userId, monthStart, InvestmentTransactionType.Buy, 1m, 250m)]);
 
         // Act
-        var result = await _investmentRateService.GetInvestmentRate(userId, monthStart, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var result = await _investmentRateService.GetInvestmentRate(userId, DefaultCurrency.PLN, monthStart, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         var rate = Assert.Single(result);
@@ -164,17 +151,8 @@ public class InvestmentRateServiceTests
         _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, monthStart.AddMonths(-12), monthStart))
             .Returns(new[] { accountWithOldSalary }.ToAsyncEnumerable());
 
-        var investmentAccount = new InvestmentAccount(userId, 2, "Investments");
-        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<InvestmentAccount>(userId, monthStart, _endDate))
-            .Returns(new[] { investmentAccount }.ToAsyncEnumerable());
-
-        // Portfolio value did not move during the month.
-        _investmentValuationServiceMock
-            .Setup(x => x.GetAccountValueAsync(It.Is<IReadOnlyCollection<int>>(a => a.Contains(2)), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new Dictionary<int, decimal> { [2] = 100m });
-
         // Act
-        var result = await _investmentRateService.GetInvestmentRate(userId, monthStart, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var result = await _investmentRateService.GetInvestmentRate(userId, DefaultCurrency.PLN, monthStart, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         var rate = Assert.Single(result);
@@ -192,9 +170,72 @@ public class InvestmentRateServiceTests
         _financialLabelsRepositoryMock.Setup(repo => repo.GetLabels(It.IsAny<CancellationToken>())).Returns(new[] { salaryLabel }.ToAsyncEnumerable());
 
         // Act
-        var result = await _investmentRateService.GetInvestmentRate(userId, _startDate, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+        var result = await _investmentRateService.GetInvestmentRate(userId, DefaultCurrency.PLN, _startDate, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(result);
     }
+
+    [Fact]
+    public async Task GetInvestmentRate_BuysSellsAndFees_ReturnsNetContributions()
+    {
+        var userId = 1;
+        var salaryLabel = new FinancialLabel { Id = 1, Name = "Salary" };
+        _financialLabelsRepositoryMock.Setup(repo => repo.GetLabels(It.IsAny<CancellationToken>())).Returns(new[] { salaryLabel }.ToAsyncEnumerable());
+
+        var account = new CurrencyAccount(userId, 1, "Cash", AccountLabel.Cash);
+        account.Add(new CurrencyAccountEntry(1, 1, _startDate, 1000m, 1000m) { Labels = [salaryLabel] }, false);
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, _startDate, _endDate))
+            .Returns(new[] { account }.ToAsyncEnumerable());
+        _investmentTransactionRepositoryMock
+            .Setup(x => x.GetByUser(userId, DateOnly.FromDateTime(_startDate), DateOnly.FromDateTime(_endDate), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                Transaction(userId, _startDate, InvestmentTransactionType.Buy, 10m, 100m, 10m),
+                Transaction(userId, _endDate, InvestmentTransactionType.Sell, 2m, 100m, 5m),
+            ]);
+
+        var result = await _investmentRateService.GetInvestmentRate(userId, DefaultCurrency.PLN, _startDate, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var rate = Assert.Single(result);
+        Assert.Equal(815m, rate.InvestmentsChange);
+        Assert.Equal(0.815m, rate.GetPercentage());
+    }
+
+    [Fact]
+    public async Task GetInvestmentRate_ConvertsTransactionCurrency()
+    {
+        var userId = 1;
+        var salaryLabel = new FinancialLabel { Id = 1, Name = "Salary" };
+        _financialLabelsRepositoryMock.Setup(repo => repo.GetLabels(It.IsAny<CancellationToken>())).Returns(new[] { salaryLabel }.ToAsyncEnumerable());
+        _investmentTransactionRepositoryMock
+            .Setup(x => x.GetByUser(userId, DateOnly.FromDateTime(_startDate), DateOnly.FromDateTime(_endDate), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Transaction(userId, _startDate, InvestmentTransactionType.Buy, 10m, 10m, 2m, "USD")]);
+        _currencyRepositoryMock.Setup(x => x.GetOrAdd("USD", "USD", It.IsAny<CancellationToken>())).ReturnsAsync(DefaultCurrency.USD);
+        _currencyExchangeServiceMock
+            .Setup(x => x.GetExchangeRateAsync(DefaultCurrency.USD, It.Is<Currency>(c => c.ShortName == "PLN"), _startDate.Date))
+            .ReturnsAsync(4m);
+
+        var result = await _investmentRateService.GetInvestmentRate(userId, DefaultCurrency.PLN, _startDate, _endDate).ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        var rate = Assert.Single(result);
+        Assert.Equal(408m, rate.InvestmentsChange);
+    }
+
+    private static InvestmentTransaction Transaction(
+        int userId,
+        DateTime date,
+        InvestmentTransactionType type,
+        decimal quantity,
+        decimal unitPrice,
+        decimal fee = 0m,
+        string currency = "PLN") => new()
+        {
+            UserId = userId,
+            Type = type,
+            Quantity = quantity,
+            UnitPrice = unitPrice,
+            Fee = fee,
+            Currency = currency,
+            TradeDate = DateOnly.FromDateTime(date),
+        };
 }


### PR DESCRIPTION
## Summary
- calculate investment rate from net buy/sell cash flow, including fees, instead of portfolio market-value movement
- pass the preferred currency through the endpoint and convert transaction amounts at trade-date rates
- make the headline, footer, chart, weighted YTD average, and projection use the same rolling monthly data
- clarify the card copy and add focused contribution/FX regression coverage

## Root cause
The card combined two different time scopes: the headline/chart used monthly data while the footer used the dashboard date range. Its numerator was also portfolio value change, which included market and FX movement rather than money actually invested.

## User impact
The percentage now reconciles with the displayed current-month salary and invested amount. Market appreciation no longer inflates the investment rate or year-end contribution projection.

## Validation
- `dotnet build ./code/FinanceManager.slnx`
- `dotnet format ./code/FinanceManager.slnx --verify-no-changes`
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj` (558 passed)
- focused investment-rate integration test
- desktop and mobile guest-account visual verification

Closes #561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Investment rates can now be viewed in the selected currency.
  * Investment change calculations include buy/sell transactions, fees, and currency conversion.
  * Dashboard investment metrics now show monthly invested amounts and a clearer 12-month rate view.

* **Bug Fixes**
  * Improved year-to-date investment rate calculations by using total investments relative to total salary.
  * Months without salary or activity are handled more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->