### PR TITLE
Stop investment paycheck card reloading with date range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- The **Investment paycheck** card now remains a current portfolio projection instead of reloading and changing when the Assets page date range changes. #563
 - The **Investment rate** card now measures net investment purchases instead of portfolio market-value movement, keeps its headline and footer on the same monthly period, and uses a salary-weighted YTD average so every displayed figure reconciles. #561
 - Dashboard charts (Net worth, Net cash flow, Closing balance) now redraw when the date range changes; previously only the numbers updated while the charts kept showing the old period. #559
 - Selecting a custom date range on the account details pages (cash, bond, investment) now actually filters to the picked dates instead of silently falling back to the current month, and the selected end day is included in full. #559

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentPaycheckEstimatorCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentPaycheckEstimatorCard.razor.cs
@@ -16,6 +16,7 @@ public partial class InvestmentPaycheckEstimatorCard
     private const decimal _rateMin = 0.02m;
     private const decimal _rateMax = 0.08m;
     private const decimal _rateStep = 0.001m;
+    private readonly DateTime _asOfDate = DateTime.UtcNow;
 
     private readonly RatePreset[] _presets =
     [
@@ -31,7 +32,6 @@ public partial class InvestmentPaycheckEstimatorCard
     private CancellationTokenSource? _persistCts;
 
     [Parameter] public string Height { get; set; } = "300px";
-    [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
     [Parameter] public int SalaryMonths { get; set; } = 3;
 
     [Inject] public required ILogger<InvestmentPaycheckEstimatorCard> Logger { get; set; }
@@ -54,10 +54,6 @@ public partial class InvestmentPaycheckEstimatorCard
     protected override async Task OnInitializedAsync()
     {
         _currency = await SettingsService.GetCurrencyAsync();
-    }
-
-    protected override async Task OnParametersSetAsync()
-    {
         await RefreshEstimate(showLoading: true);
     }
 
@@ -86,7 +82,7 @@ public partial class InvestmentPaycheckEstimatorCard
             {
                 UserId = user.UserId,
                 CurrencyId = _currency.Id,
-                EndDateTime = EndDateTime,
+                EndDateTime = _asOfDate,
                 WithdrawalRate = withdrawalRate,
                 SalaryMonths = SalaryMonths,
             };

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Pages/AssetsPage.razor
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Pages/AssetsPage.razor
@@ -14,7 +14,7 @@
         </MudItem>
 
         <MudItem xs="12" lg="4">
-            <InvestmentPaycheckEstimatorCard EndDateTime="@EndDate" Height="@($"{2 * _unitHeight}px")" />
+            <InvestmentPaycheckEstimatorCard Height="@($"{2 * _unitHeight}px")" />
         </MudItem>
 
         <MudItem xs="12" lg="4">


### PR DESCRIPTION
## What changed
- Decoupled the Investment Paycheck card from the Assets page date-range end date.
- Captured one current as-of timestamp for the card instance.
- Moved the initial estimate load into component initialization while preserving rate-change refreshes.
- Added the user-visible fix to the changelog.

## Why
The card describes a current portfolio projection ("If you stopped earning today"), but it received the dashboard's historical end date and refreshed unconditionally from `OnParametersSetAsync`. Date preset changes therefore changed the card and produced new cache keys/API requests even when the effective meaning was still "now".

## Impact
The card remains a stable current projection while other Assets dashboard cards continue responding to the selected date range. Historical estimate support remains available in the backend and cache.

## Validation
- `dotnet format ./code/FinanceManager.slnx --no-restore`
- `dotnet build ./code/FinanceManager.slnx --no-restore` — 0 warnings, 0 errors
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --no-build` — 558 passed
- Guest browser check on `/DevelopLogin/guest/Assets`: Investment Paycheck API request count remained 1 after switching This month → This quarter → This year → This month
- Desktop and mobile screenshots inspected

Closes #563