### PR TITLE
Cap investment rate chart bars at 300%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ rules agents must follow when updating this file.
 
 ### Fixed
 - The **Investment paycheck** card now remains a current portfolio projection instead of reloading and changing when the Assets page date range changes. #563
+- The **Investment rate** chart now caps monthly bars at 300% so outlier months do not flatten the rest, while keeping the headline rate uncapped. #565
 - The **Investment rate** card now measures net investment purchases instead of portfolio market-value movement, keeps its headline and footer on the same monthly period, and uses a salary-weighted YTD average so every displayed figure reconciles. #561
 - Dashboard charts (Net worth, Net cash flow, Closing balance) now redraw when the date range changes; previously only the numbers updated while the charts kept showing the old period. #559
 - Selecting a custom date range on the account details pages (cash, bond, investment) now actually filters to the picked dates instead of silently falling back to the current month, and the selected end day is included in full. #559

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
@@ -15,6 +15,7 @@ namespace FinanceManager.Components.Components.Features.Dashboard.Cards.Assets;
 public partial class InvestmentRateCard
 {
     private const string _highlightColor = "#FF9800";
+    private const decimal _maximumChartPercentage = 300m;
     private const string _mutedBarColor = "#5F6368";
     private const string _mutedLabelColor = "var(--mud-palette-text-secondary)";
 
@@ -111,7 +112,7 @@ public partial class InvestmentRateCard
             var rate = i < MonthlyInvestmentRates.Count ? MonthlyInvestmentRates[i] : null;
             var monthIndex = rate is not null ? rate.Start.Month - 1 : i;
             var label = _singleLetterMonths[monthIndex];
-            var pct = rate is not null ? (decimal)rate.GetPercentage() * 100m : 0m;
+            var pct = rate is not null ? Math.Min(rate.GetPercentage() * 100m, _maximumChartPercentage) : 0m;
             bars.Add(new MonthBar(label, pct, IsCurrent: i == 11, Key: $"{i}-{label}"));
         }
 


### PR DESCRIPTION
## What changed

- Cap monthly values plotted by the Investment rate chart at 300%.
- Keep the true headline rate, salary-weighted YTD average, projection, and stored data unchanged.
- Document the behavior in the changelog.

## Why

A single extreme monthly rate, such as 5,373%, controlled the ApexCharts scale and visually flattened otherwise valid monthly bars. Limiting only the plotted height keeps the chart readable without hiding the real value shown in the card headline.

## Validation

- `dotnet format ./code/FinanceManager.slnx --verify-no-changes`
- `dotnet build ./code/FinanceManager.slnx`
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --no-build` (558 passed)
- Guest Assets page rendered and inspected at desktop and mobile viewports

Closes #565