### PR TITLE
Fix cash account category filter menu not opening #567

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- The **Category** filter button on cash account details now opens its dropdown again, so transactions can be filtered by category. #567
 - The **Investment paycheck** card now remains a current portfolio projection instead of reloading and changing when the Assets page date range changes. #563
 - The **Investment rate** card now measures net investment purchases instead of portfolio market-value movement, keeps its headline and footer on the same monthly period, and uses a salary-weighted YTD average so every displayed figure reconciles. #561
 - Dashboard charts (Net worth, Net cash flow, Closing balance) now redraw when the date range changes; previously only the numbers updated while the charts kept showing the old period. #559

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountHistoryToolbar.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountHistoryToolbar.razor
@@ -23,7 +23,7 @@
             <ActivatorContent>
                 <MudButton Variant="Variant.Outlined" Color="@(SelectedLabels.Count > 0 ? Color.Primary : Color.Default)"
                            Size="Size.Medium" StartIcon="@Icons.Material.Filled.FilterList"
-                           EndIcon="@Icons.Material.Filled.KeyboardArrowDown"
+                           EndIcon="@Icons.Material.Filled.KeyboardArrowDown" OnClick="ToggleLabelMenu"
                            Style="text-transform: none; white-space: nowrap; flex-shrink: 0; padding: 6.5px;">
                     @CategoryButtonText
                 </MudButton>

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountHistoryToolbar.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountHistoryToolbar.razor.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor;
 
 namespace FinanceManager.Components.Components.Features.FinancialAccounts.Shared;
@@ -51,6 +52,12 @@ public partial class AccountHistoryToolbar : ComponentBase
     {
         SelectedLabels = [];
         await SelectedLabelsChanged.InvokeAsync(SelectedLabels);
+    }
+
+    private async Task ToggleLabelMenu(MouseEventArgs args)
+    {
+        if (_labelMenu is not null)
+            await _labelMenu.ToggleMenuAsync(args);
     }
 
     private async Task CloseLabelMenu()


### PR DESCRIPTION
## Summary
The **Category** filter button on the cash account details toolbar did nothing when clicked — the dropdown never opened, so transactions could not be filtered by category.

The category `MudMenu` uses a custom `ActivatorContent` with a `MudButton`, which requires the button to explicitly open the menu (per `.claude/skills/mudblazor/SKILL.md`, "Custom activator"); without an `OnClick`, the click was swallowed. Wired the activator button's `OnClick` to toggle the menu via the existing menu ref.

Verified in-browser on the guest account (desktop 1440×900 and mobile 390×844): the menu opens, checking a category filters the list and updates the button label, Clear all / Done work, and the toggle closes it on second click.

closes #567