### PR TITLE
Add weekly investment closing-price backfill triggered by GitHub Actions cron #569

### DIFF
--- a/.github/workflows/weekly-price-backfill.yml
+++ b/.github/workflows/weekly-price-backfill.yml
@@ -1,0 +1,33 @@
+# Triggers the investment closing-price backfill for the past week. The scheduling lives here
+# (not in the app) because the free-tier App Service unloads when idle, so an in-process timer
+# cannot be trusted to fire — this HTTP call both wakes the app and queues the run.
+name: Weekly price backfill
+
+on:
+  schedule:
+    # Saturday 06:00 UTC, after Friday's close is available from the price providers.
+    - cron: '0 6 * * 6'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  trigger-backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call backfill endpoint
+        env:
+          APP_URL: https://financemanager.mikikarkowski.dev
+          MAINTENANCE_KEY: ${{ secrets.MAINTENANCE_API_KEY }}
+        run: |
+          if [ -z "$MAINTENANCE_KEY" ]; then
+            echo "::error::MAINTENANCE_API_KEY secret is not configured."
+            exit 1
+          fi
+          # Retries cover the free-tier cold start: the first request may time out while the app
+          # boots, so give it a few attempts before declaring the trigger failed.
+          curl --fail-with-body --silent --show-error \
+            --retry 5 --retry-delay 15 --retry-all-errors \
+            --max-time 60 \
+            -X POST "$APP_URL/api/PriceBackfill" \
+            -H "X-Maintenance-Key: $MAINTENANCE_KEY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ rules agents must follow when updating this file.
 
 ### Added
 - Investment closing prices are now backfilled automatically every Saturday for every held instrument, so charts and valuations keep a complete weekly price history even for instruments nobody opened recently. #569
+- Admins can generate, roll, or revoke the maintenance API key that authorises the scheduled backfill from the **Admin → Service Keys** page — the key is stored hashed and shown exactly once at generation. #569
 - The dashboard has a new **Transaction log** card showing your most recent transactions across all accounts — currency, bond, and investment — in one newest-first list. #549
 - The dashboard can now be personalized: a **Customize** menu lets each user show or hide individual cards, and cards with no data for the selected period (e.g. liabilities when you have none) are hidden automatically. Preferences are saved per user in the browser. #547
 - The admin **Users** page now shows a **"Last logged at"** column with each user's most recent login date (or `Never` for accounts that have never signed in). #540

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Investment closing prices are now backfilled automatically every Saturday for every held instrument, so charts and valuations keep a complete weekly price history even for instruments nobody opened recently. #569
 - The dashboard has a new **Transaction log** card showing your most recent transactions across all accounts — currency, bond, and investment — in one newest-first list. #549
 - The dashboard can now be personalized: a **Customize** menu lets each user show or hide individual cards, and cards with no data for the selected period (e.g. liabilities when you have none) are hidden automatically. Preferences are saved per user in the browser. #547
 - The admin **Users** page now shows a **"Last logged at"** column with each user's most recent login date (or `Never` for accounts that have never signed in). #540

--- a/code/FinanceManager.Api/ApiConfigurationExtensions.cs
+++ b/code/FinanceManager.Api/ApiConfigurationExtensions.cs
@@ -65,6 +65,7 @@ public static class ApiConfigurationExtensions
             .Validate(o => !string.IsNullOrWhiteSpace(o.BaseUrl), "Ollama:BaseUrl must be configured.")
             .ValidateOnStart();
         services.Configure<AiProviderOptions>(configuration.GetSection("AiProvider"));
+        services.Configure<MaintenanceOptions>(configuration.GetSection(MaintenanceOptions.SectionName));
         services.Configure<List<AiProviderFallbackStrategyOption>>(configuration.GetSection("AIProviderFallbackStrategies"));
 
         return services;
@@ -275,6 +276,8 @@ public static class ApiConfigurationExtensions
         services.AddSingleton<ICurrencyImportJobChannel, CurrencyImportJobChannel>();
         services.AddSingleton<ICurrencyImportJobStore, CurrencyImportJobStore>();
         services.AddHostedService<CurrencyImportBackgroundService>();
+        services.AddSingleton<IPriceBackfillJobChannel, PriceBackfillJobChannel>();
+        services.AddHostedService<PriceBackfillBackgroundService>();
 
         services.Configure<LogRetentionOptions>(configuration.GetSection(LogRetentionOptions.SectionName));
         services.AddSingleton<ILogEntryQueue, LogEntryQueue>();

--- a/code/FinanceManager.Api/Controllers/Admin/AdminMaintenanceKeyController.cs
+++ b/code/FinanceManager.Api/Controllers/Admin/AdminMaintenanceKeyController.cs
@@ -1,0 +1,50 @@
+using FinanceManager.Application.Shared.Maintenance;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinanceManager.Api.Controllers.Admin;
+
+/// <summary>Status of the maintenance key as shown to the admin (never the key itself).</summary>
+public record MaintenanceKeyStatusResponse(bool HasKey, DateTimeOffset? CreatedAt);
+
+/// <summary>Result of generating (or rolling) the key — the only time the plaintext is available.</summary>
+public record GeneratedMaintenanceKeyResponse(string Key, DateTimeOffset CreatedAt);
+
+[Route("api/admin/maintenance-key")]
+[Authorize(Roles = "Admin")]
+[ApiController]
+[Tags("Admin - Maintenance Key")]
+public class AdminMaintenanceKeyController(
+    IMaintenanceKeyService maintenanceKeyService,
+    ILogger<AdminMaintenanceKeyController> logger) : ControllerBase
+{
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(MaintenanceKeyStatusResponse))]
+    public async Task<IActionResult> GetStatus(CancellationToken cancellationToken)
+    {
+        var status = await maintenanceKeyService.GetStatusAsync(cancellationToken);
+        return Ok(new MaintenanceKeyStatusResponse(status.HasKey, status.CreatedAt));
+    }
+
+    /// <summary>Generates a new key; when one already exists this rolls it — the old key stops working immediately.</summary>
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GeneratedMaintenanceKeyResponse))]
+    public async Task<IActionResult> Generate(CancellationToken cancellationToken)
+    {
+        var key = await maintenanceKeyService.GenerateAsync(cancellationToken);
+        logger.LogInformation("Maintenance API key generated/rolled by admin.");
+        return Ok(new GeneratedMaintenanceKeyResponse(key, DateTimeOffset.UtcNow));
+    }
+
+    [HttpDelete]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Revoke(CancellationToken cancellationToken)
+    {
+        if (!await maintenanceKeyService.RevokeAsync(cancellationToken))
+            return NotFound();
+
+        logger.LogInformation("Maintenance API key revoked by admin.");
+        return NoContent();
+    }
+}

--- a/code/FinanceManager.Api/Controllers/PriceBackfillController.cs
+++ b/code/FinanceManager.Api/Controllers/PriceBackfillController.cs
@@ -1,11 +1,8 @@
 using FinanceManager.Api.Services;
-using FinanceManager.Application.Shared.Options;
+using FinanceManager.Application.Shared.Maintenance;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
-using Microsoft.Extensions.Options;
-using System.Security.Cryptography;
-using System.Text;
 
 namespace FinanceManager.Api.Controllers;
 
@@ -20,7 +17,7 @@ namespace FinanceManager.Api.Controllers;
 [Tags("Maintenance")]
 [EnableRateLimiting(RateLimitingServiceCollectionExtension.AuthPolicy)]
 public class PriceBackfillController(
-    IOptions<MaintenanceOptions> maintenanceOptions,
+    IMaintenanceKeyService maintenanceKeyService,
     IPriceBackfillJobChannel channel,
     ILogger<PriceBackfillController> logger) : ControllerBase
 {
@@ -32,18 +29,16 @@ public class PriceBackfillController(
     [ProducesResponseType(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public IActionResult Trigger()
+    public async Task<IActionResult> Trigger(CancellationToken cancellationToken = default)
     {
-        var configuredKey = maintenanceOptions.Value.ApiKey;
-
-        // 404 (not 401) when no key is configured so deployments that never opted into maintenance
-        // endpoints are indistinguishable from ones where the route does not exist (same stance as
-        // DevelopLoginController outside development).
-        if (string.IsNullOrWhiteSpace(configuredKey))
+        // 404 (not 401) when no key exists anywhere so deployments that never opted into
+        // maintenance endpoints are indistinguishable from ones where the route does not exist
+        // (same stance as DevelopLoginController outside development).
+        if (!await maintenanceKeyService.IsConfiguredAsync(cancellationToken))
             return NotFound();
 
         if (!Request.Headers.TryGetValue(ApiKeyHeader, out var providedKey) ||
-            !FixedTimeEquals(configuredKey, providedKey.ToString()))
+            !await maintenanceKeyService.ValidateAsync(providedKey.ToString(), cancellationToken))
         {
             logger.LogWarning("Price backfill trigger rejected: missing or invalid maintenance key.");
             return Unauthorized();
@@ -61,10 +56,4 @@ public class PriceBackfillController(
 
         return Accepted(value: new { start, end, queued });
     }
-
-    // Constant-time comparison so response timing cannot be used to guess the key byte by byte.
-    private static bool FixedTimeEquals(string expected, string provided) =>
-        CryptographicOperations.FixedTimeEquals(
-            Encoding.UTF8.GetBytes(expected),
-            Encoding.UTF8.GetBytes(provided));
 }

--- a/code/FinanceManager.Api/Controllers/PriceBackfillController.cs
+++ b/code/FinanceManager.Api/Controllers/PriceBackfillController.cs
@@ -1,0 +1,70 @@
+using FinanceManager.Api.Services;
+using FinanceManager.Application.Shared.Options;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace FinanceManager.Api.Controllers;
+
+/// <summary>
+/// External-scheduler entry point for the weekly closing-price backfill. The app runs on hosting
+/// where an in-process timer cannot be trusted to be awake (free-tier App Service unloads when
+/// idle), so a scheduled GitHub Actions workflow calls this endpoint instead — the request itself
+/// wakes the app, the job is queued, and the worker finishes after the caller has gone.
+/// </summary>
+[Route("api/[controller]")]
+[ApiController]
+[Tags("Maintenance")]
+[EnableRateLimiting(RateLimitingServiceCollectionExtension.AuthPolicy)]
+public class PriceBackfillController(
+    IOptions<MaintenanceOptions> maintenanceOptions,
+    IPriceBackfillJobChannel channel,
+    ILogger<PriceBackfillController> logger) : ControllerBase
+{
+    public const string ApiKeyHeader = "X-Maintenance-Key";
+    private const int _backfillDays = 7;
+
+    [AllowAnonymous]
+    [HttpPost(Name = "TriggerPriceBackfill")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public IActionResult Trigger()
+    {
+        var configuredKey = maintenanceOptions.Value.ApiKey;
+
+        // 404 (not 401) when no key is configured so deployments that never opted into maintenance
+        // endpoints are indistinguishable from ones where the route does not exist (same stance as
+        // DevelopLoginController outside development).
+        if (string.IsNullOrWhiteSpace(configuredKey))
+            return NotFound();
+
+        if (!Request.Headers.TryGetValue(ApiKeyHeader, out var providedKey) ||
+            !FixedTimeEquals(configuredKey, providedKey.ToString()))
+        {
+            logger.LogWarning("Price backfill trigger rejected: missing or invalid maintenance key.");
+            return Unauthorized();
+        }
+
+        var end = DateTime.UtcNow.Date;
+        var start = end.AddDays(-_backfillDays);
+        var queued = channel.TryQueueJob(new PriceBackfillJobRequest(start, end));
+
+        logger.LogInformation(
+            queued
+                ? "Price backfill for {Start:yyyy-MM-dd}..{End:yyyy-MM-dd} queued."
+                : "Price backfill trigger received while a run was already queued; collapsed into the pending run.",
+            start, end);
+
+        return Accepted(value: new { start, end, queued });
+    }
+
+    // Constant-time comparison so response timing cannot be used to guess the key byte by byte.
+    private static bool FixedTimeEquals(string expected, string provided) =>
+        CryptographicOperations.FixedTimeEquals(
+            Encoding.UTF8.GetBytes(expected),
+            Encoding.UTF8.GetBytes(provided));
+}

--- a/code/FinanceManager.Api/Migrations/20260720180343_AddMaintenanceApiKeys.Designer.cs
+++ b/code/FinanceManager.Api/Migrations/20260720180343_AddMaintenanceApiKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceManager.Infrastructure.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceManager.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260720180343_AddMaintenanceApiKeys")]
+    partial class AddMaintenanceApiKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/code/FinanceManager.Api/Migrations/20260720180343_AddMaintenanceApiKeys.cs
+++ b/code/FinanceManager.Api/Migrations/20260720180343_AddMaintenanceApiKeys.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using System;
+
+#nullable disable
+
+namespace FinanceManager.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMaintenanceApiKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MaintenanceApiKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    KeyHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MaintenanceApiKeys", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MaintenanceApiKeys");
+        }
+    }
+}

--- a/code/FinanceManager.Api/Services/IPriceBackfillJobChannel.cs
+++ b/code/FinanceManager.Api/Services/IPriceBackfillJobChannel.cs
@@ -1,0 +1,15 @@
+namespace FinanceManager.Api.Services;
+
+/// <summary>Date range a queued backfill run should cover (inclusive, UTC dates).</summary>
+public record PriceBackfillJobRequest(DateTime Start, DateTime End);
+
+public interface IPriceBackfillJobChannel
+{
+    /// <summary>
+    /// Queue a backfill run without blocking. Returns <c>false</c> when a run is already queued —
+    /// duplicate triggers (a retried cron request) collapse into the pending run instead of piling up.
+    /// </summary>
+    bool TryQueueJob(PriceBackfillJobRequest request);
+
+    IAsyncEnumerable<PriceBackfillJobRequest> ReadAll(CancellationToken cancellationToken);
+}

--- a/code/FinanceManager.Api/Services/PriceBackfillBackgroundService.cs
+++ b/code/FinanceManager.Api/Services/PriceBackfillBackgroundService.cs
@@ -1,0 +1,38 @@
+using FinanceManager.Application.Assets.Pricing;
+
+namespace FinanceManager.Api.Services;
+
+/// <summary>
+/// Processes queued price-backfill runs off the request path. The trigger endpoint answers 202
+/// immediately; this worker then walks every held listing through the rate-limited provider chain,
+/// which can take far longer than any caller (the scheduled GitHub Actions curl) should wait.
+/// </summary>
+public sealed class PriceBackfillBackgroundService(
+    IPriceBackfillJobChannel channel,
+    IServiceScopeFactory scopeFactory,
+    ILogger<PriceBackfillBackgroundService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Price backfill background service started.");
+        await foreach (var request in channel.ReadAll(stoppingToken))
+        {
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var backfillService = scope.ServiceProvider.GetRequiredService<IInvestmentPriceBackfillService>();
+                await backfillService.BackfillAsync(request.Start, request.End, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Price backfill run for {Start:yyyy-MM-dd}..{End:yyyy-MM-dd} failed.", request.Start, request.End);
+            }
+        }
+
+        logger.LogInformation("Price backfill background service stopped.");
+    }
+}

--- a/code/FinanceManager.Api/Services/PriceBackfillJobChannel.cs
+++ b/code/FinanceManager.Api/Services/PriceBackfillJobChannel.cs
@@ -1,0 +1,20 @@
+using System.Threading.Channels;
+
+namespace FinanceManager.Api.Services;
+
+public sealed class PriceBackfillJobChannel : IPriceBackfillJobChannel
+{
+    private readonly Channel<PriceBackfillJobRequest> _channel = Channel.CreateBounded<PriceBackfillJobRequest>(
+        new BoundedChannelOptions(1)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.DropWrite
+        });
+
+    public bool TryQueueJob(PriceBackfillJobRequest request) =>
+        _channel.Writer.TryWrite(request);
+
+    public IAsyncEnumerable<PriceBackfillJobRequest> ReadAll(CancellationToken cancellationToken) =>
+        _channel.Reader.ReadAllAsync(cancellationToken);
+}

--- a/code/FinanceManager.Api/appsettings.Production.json
+++ b/code/FinanceManager.Api/appsettings.Production.json
@@ -71,6 +71,9 @@
   "LogRetention": {
     "RetentionDays": 30
   },
+  "Maintenance": {
+    "ApiKey": ""
+  },
   "StockApi": {
     "BaseUrl": "https://www.alphavantage.co/query",
     "OutputSize": "full"

--- a/code/FinanceManager.Application/Assets/Pricing/IInvestmentPriceBackfillService.cs
+++ b/code/FinanceManager.Application/Assets/Pricing/IInvestmentPriceBackfillService.cs
@@ -1,0 +1,18 @@
+namespace FinanceManager.Application.Assets.Pricing;
+
+/// <summary>Outcome of one backfill run over the distinct held listings.</summary>
+/// <param name="Listings">How many distinct listings the run covered.</param>
+/// <param name="Covered">Listings that had at least one quote in the range after the run.</param>
+/// <param name="Uncovered">Listings that still had no quote in the range (no symbol, provider empty/failed).</param>
+public record InvestmentPriceBackfillResult(int Listings, int Covered, int Uncovered);
+
+/// <summary>
+/// Ensures stored end-of-day quotes exist for every investment listing anyone holds, over a given
+/// date range. Designed to be triggered by an external scheduler (the weekly GitHub Actions cron)
+/// so price history stays complete even when no user opens a chart.
+/// </summary>
+public interface IInvestmentPriceBackfillService
+{
+    /// <summary>Backfill quotes for all distinct held listings over [<paramref name="start"/>, <paramref name="end"/>].</summary>
+    Task<InvestmentPriceBackfillResult> BackfillAsync(DateTime start, DateTime end, CancellationToken ct = default);
+}

--- a/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceBackfillService.cs
+++ b/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceBackfillService.cs
@@ -1,0 +1,37 @@
+using FinanceManager.Domain.Assets.Services;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Application.Assets.Pricing;
+
+public class InvestmentPriceBackfillService(
+    IInvestmentTransactionRepository transactionRepository,
+    IInvestmentPriceProvider priceProvider,
+    ILogger<InvestmentPriceBackfillService> logger) : IInvestmentPriceBackfillService
+{
+    public async Task<InvestmentPriceBackfillResult> BackfillAsync(DateTime start, DateTime end, CancellationToken ct = default)
+    {
+        var listingIds = await transactionRepository.GetDistinctAssetListingIds(ct);
+
+        var covered = 0;
+        var uncovered = 0;
+        foreach (var listingId in listingIds)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            // Listings are processed sequentially on purpose: the provider chain is rate-limited
+            // (Alpha Vantage free tier) and EnsureQuotesAsync serialises per-symbol fetches anyway,
+            // so parallelism would only trip the limiter faster without finishing sooner.
+            if (await priceProvider.EnsureQuotesAsync(listingId, start, end, ct))
+                covered++;
+            else
+                uncovered++;
+        }
+
+        var result = new InvestmentPriceBackfillResult(listingIds.Count, covered, uncovered);
+        logger.LogInformation(
+            "Price backfill for {Start:yyyy-MM-dd}..{End:yyyy-MM-dd} finished: {Listings} listings, {Covered} covered, {Uncovered} without quotes.",
+            start, end, result.Listings, result.Covered, result.Uncovered);
+        return result;
+    }
+}

--- a/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
+++ b/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
@@ -168,10 +168,19 @@ public class InvestmentPriceProvider(
         var listing = await listingRepository.Get(assetListingId, ct);
         if (listing is null) return false;
 
-        await TryFetchAndStoreAsync(listing, start.Date, end.Date, ct);
+        var startDate = start.Date;
+        var endDate = end.Date;
 
-        var quotes = await priceQuoteRepository.GetRange(assetListingId, DayStart(start), DayEnd(end), ct);
-        return quotes.Count > 0;
+        // Coverage check before the fetch path, mirroring GetPricePerUnitSeriesAsync: an
+        // already-covered listing skips the per-symbol lock and the provider chain entirely.
+        var existing = await priceQuoteRepository.GetRange(assetListingId, DayStart(startDate), DayEnd(endDate), ct);
+        if (!NeedsFetch(existing, startDate, endDate))
+            return existing.Count > 0;
+
+        await TryFetchAndStoreAsync(listing, startDate, endDate, ct);
+
+        existing = await priceQuoteRepository.GetRange(assetListingId, DayStart(startDate), DayEnd(endDate), ct);
+        return existing.Count > 0;
     }
 
     // FX gaps (weekends, holidays, dates past the exchange service's per-call resolution cap)

--- a/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
+++ b/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
@@ -160,6 +160,20 @@ public class InvestmentPriceProvider(
         return series;
     }
 
+    public async Task<bool> EnsureQuotesAsync(long assetListingId, DateTime start, DateTime end, CancellationToken ct = default)
+    {
+        if (assetListingId <= 0 || start == default || end == default || end < start)
+            return false;
+
+        var listing = await listingRepository.Get(assetListingId, ct);
+        if (listing is null) return false;
+
+        await TryFetchAndStoreAsync(listing, start.Date, end.Date, ct);
+
+        var quotes = await priceQuoteRepository.GetRange(assetListingId, DayStart(start), DayEnd(end), ct);
+        return quotes.Count > 0;
+    }
+
     // FX gaps (weekends, holidays, dates past the exchange service's per-call resolution cap)
     // reuse the nearest known rate in the range: forward-fill first, then backfill the leading
     // edge from the earliest known rate.

--- a/code/FinanceManager.Application/FinancialAccounts/Registration.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Registration.cs
@@ -68,6 +68,7 @@ internal static class Registration
                 .AddScoped<IBondAccountExportService, BondAccountExportService>()
                 .AddScoped<IAccountCsvExportService<BondAccountExportDto>, BondAccountCsvExportService>()
                 .AddScoped<IInvestmentPriceProvider, InvestmentPriceProvider>()
+                .AddScoped<IInvestmentPriceBackfillService, InvestmentPriceBackfillService>()
                 .AddScoped<IInvestmentValuationService, InvestmentValuationService>()
                 .AddScoped<IInvestmentInstrumentDiscoveryService, InvestmentInstrumentDiscoveryService>()
                 .AddScoped<IInstrumentImportService, InstrumentImportService>()

--- a/code/FinanceManager.Application/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Application/ServiceCollectionExtension.cs
@@ -6,6 +6,7 @@ using FinanceManager.Application.Identity.Users;
 using FinanceManager.Application.Insights;
 using FinanceManager.Application.Labels;
 using FinanceManager.Application.MoneyFlow;
+using FinanceManager.Application.Shared.Maintenance;
 using FinanceManager.Application.Shared.Time;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
 using FinanceManager.Domain.Identity.Services;
@@ -32,6 +33,7 @@ public static class ServiceCollectionExtension
         // ISeeder registration order (admin/test users, then financial-account
         // detail seeders, then labels).
         services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
+        services.AddScoped<IMaintenanceKeyService, MaintenanceKeyService>();
 
         services
             .AddIdentityApplication()

--- a/code/FinanceManager.Application/Shared/Maintenance/IMaintenanceKeyService.cs
+++ b/code/FinanceManager.Application/Shared/Maintenance/IMaintenanceKeyService.cs
@@ -1,0 +1,30 @@
+namespace FinanceManager.Application.Shared.Maintenance;
+
+/// <summary>Current state of the maintenance key, safe to show an admin (never the key itself).</summary>
+/// <param name="HasKey">Whether an admin-generated key is active in the database.</param>
+/// <param name="CreatedAt">When the active key was generated, or <c>null</c> when none exists.</param>
+public record MaintenanceKeyStatus(bool HasKey, DateTimeOffset? CreatedAt);
+
+/// <summary>
+/// Manages the shared secret that guards the maintenance endpoints (e.g. the weekly price
+/// backfill trigger). The admin generates, rolls, or revokes the key at runtime; the plaintext is
+/// returned exactly once at generation and only its SHA-256 hash is stored. A key supplied via
+/// configuration remains valid as a break-glass fallback alongside the database key.
+/// </summary>
+public interface IMaintenanceKeyService
+{
+    /// <summary>Generate a new key, replacing any existing one (rolling). Returns the plaintext — the only time it is ever available.</summary>
+    Task<string> GenerateAsync(CancellationToken ct = default);
+
+    /// <summary>Revoke the active database key. Returns <c>false</c> when there was none.</summary>
+    Task<bool> RevokeAsync(CancellationToken ct = default);
+
+    /// <summary>Status of the database key for the admin UI.</summary>
+    Task<MaintenanceKeyStatus> GetStatusAsync(CancellationToken ct = default);
+
+    /// <summary>Whether any key (database or configuration) is set — when not, maintenance endpoints answer 404.</summary>
+    Task<bool> IsConfiguredAsync(CancellationToken ct = default);
+
+    /// <summary>Constant-time check of a caller-supplied key against the database key and the configuration fallback.</summary>
+    Task<bool> ValidateAsync(string providedKey, CancellationToken ct = default);
+}

--- a/code/FinanceManager.Application/Shared/Maintenance/MaintenanceKeyService.cs
+++ b/code/FinanceManager.Application/Shared/Maintenance/MaintenanceKeyService.cs
@@ -1,0 +1,65 @@
+using FinanceManager.Application.Shared.Options;
+using FinanceManager.Domain.Shared.Maintenance.Entities;
+using FinanceManager.Domain.Shared.Maintenance.Repositories;
+using Microsoft.Extensions.Options;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace FinanceManager.Application.Shared.Maintenance;
+
+public class MaintenanceKeyService(
+    IMaintenanceKeyRepository repository,
+    IOptions<MaintenanceOptions> options) : IMaintenanceKeyService
+{
+    // Recognisable prefix so a leaked key is identifiable in logs/secret scanners without
+    // revealing what it opens; 32 random bytes give 256 bits of entropy.
+    private const string _keyPrefix = "fmk_";
+
+    public async Task<string> GenerateAsync(CancellationToken ct = default)
+    {
+        var plaintext = _keyPrefix + Convert.ToHexString(RandomNumberGenerator.GetBytes(32)).ToLowerInvariant();
+
+        await repository.Save(new MaintenanceApiKey
+        {
+            KeyHash = Hash(plaintext),
+            CreatedAt = DateTimeOffset.UtcNow
+        }, ct);
+
+        return plaintext;
+    }
+
+    public Task<bool> RevokeAsync(CancellationToken ct = default) => repository.Delete(ct);
+
+    public async Task<MaintenanceKeyStatus> GetStatusAsync(CancellationToken ct = default)
+    {
+        var key = await repository.Get(ct);
+        return new MaintenanceKeyStatus(key is not null, key?.CreatedAt);
+    }
+
+    public async Task<bool> IsConfiguredAsync(CancellationToken ct = default)
+    {
+        if (!string.IsNullOrWhiteSpace(options.Value.ApiKey)) return true;
+        return await repository.Get(ct) is not null;
+    }
+
+    public async Task<bool> ValidateAsync(string providedKey, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(providedKey)) return false;
+
+        var storedKey = await repository.Get(ct);
+        if (storedKey is not null && FixedTimeEquals(Hash(providedKey), storedKey.KeyHash))
+            return true;
+
+        // Config-supplied key stays valid as a break-glass path (e.g. the database is unreachable
+        // for key management but an operator can still set an environment variable).
+        var configuredKey = options.Value.ApiKey;
+        return !string.IsNullOrWhiteSpace(configuredKey) && FixedTimeEquals(providedKey, configuredKey);
+    }
+
+    private static string Hash(string value) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value))).ToLowerInvariant();
+
+    // Constant-time comparison so response timing cannot be used to guess the key byte by byte.
+    private static bool FixedTimeEquals(string a, string b) =>
+        CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(a), Encoding.UTF8.GetBytes(b));
+}

--- a/code/FinanceManager.Application/Shared/Options/MaintenanceOptions.cs
+++ b/code/FinanceManager.Application/Shared/Options/MaintenanceOptions.cs
@@ -1,0 +1,13 @@
+namespace FinanceManager.Application.Shared.Options;
+
+public sealed class MaintenanceOptions
+{
+    public const string SectionName = "Maintenance";
+
+    /// <summary>
+    /// Shared secret required by the maintenance endpoints (e.g. the weekly price backfill trigger
+    /// called from the scheduled GitHub Actions workflow). When empty the endpoints answer 404, so
+    /// deployments that never configure a key expose no maintenance surface at all.
+    /// </summary>
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/code/FinanceManager.Components/Components/Features/Admin/AdminServiceKeys.razor
+++ b/code/FinanceManager.Components/Components/Features/Admin/AdminServiceKeys.razor
@@ -105,5 +105,66 @@ else
                 </MudItem>
             }
         </MudGrid>
+
+        <MudText Typo="Typo.h5" Class="mt-4">Maintenance API Key</MudText>
+        <MudText Typo="Typo.body2" Color="Color.Secondary">
+            Shared secret for scheduled maintenance calls (e.g. the weekly investment price backfill
+            triggered from GitHub Actions). The key is stored hashed and shown only once — copy it into
+            the <code>MAINTENANCE_API_KEY</code> repository secret right after generating.
+        </MudText>
+
+        <MudCard Outlined>
+            <MudCardContent>
+                <MudStack Spacing="3">
+                    <MudStack Row AlignItems="AlignItems.Center" Spacing="1">
+                        @if (_maintenanceKeyStatus?.HasKey == true)
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Size="Size.Small" />
+                            <MudText Typo="Typo.body2" Color="Color.Success">
+                                Key active since @_maintenanceKeyStatus.CreatedAt?.ToString("yyyy-MM-dd HH:mm") UTC
+                            </MudText>
+                        }
+                        else
+                        {
+                            <MudIcon Icon="@Icons.Material.Filled.Warning" Color="Color.Warning" Size="Size.Small" />
+                            <MudText Typo="Typo.body2" Color="Color.Warning">No key generated — maintenance endpoints are disabled</MudText>
+                        }
+                    </MudStack>
+
+                    @if (_generatedMaintenanceKey is not null)
+                    {
+                        <MudAlert Severity="Severity.Info" data-testid="generated-maintenance-key">
+                            <MudStack Spacing="2">
+                                <MudText Typo="Typo.body2">
+                                    Copy this key now — it cannot be shown again. Rolling or revoking invalidates it.
+                                </MudText>
+                                <MudTextField T="string" Value="@_generatedMaintenanceKey" ReadOnly
+                                              Variant="Variant.Outlined" Margin="Margin.Dense"
+                                              Label="Maintenance API key" />
+                            </MudStack>
+                        </MudAlert>
+                    }
+                </MudStack>
+            </MudCardContent>
+            <MudCardActions>
+                <MudStack Row Spacing="2">
+                    <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                               OnClick="GenerateMaintenanceKeyAsync"
+                               Disabled="@_maintenanceKeyBusy"
+                               data-testid="generate-maintenance-key">
+                        @(_maintenanceKeyStatus?.HasKey == true ? "Roll key" : "Generate key")
+                    </MudButton>
+                    @if (_maintenanceKeyStatus?.HasKey == true)
+                    {
+                        <MudButton Variant="Variant.Outlined" Color="Color.Error"
+                                   OnClick="RevokeMaintenanceKeyAsync"
+                                   Disabled="@_maintenanceKeyBusy"
+                                   data-testid="revoke-maintenance-key">
+                            Revoke
+                        </MudButton>
+                    }
+                </MudStack>
+            </MudCardActions>
+        </MudCard>
     </MudStack>
 }

--- a/code/FinanceManager.Components/Components/Features/Admin/AdminServiceKeys.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Admin/AdminServiceKeys.razor.cs
@@ -33,6 +33,7 @@ public partial class AdminServiceKeys : ComponentBase
     }
 
     [Inject] public AdminServiceKeysHttpClient ApiClient { get; set; } = default!;
+    [Inject] public AdminMaintenanceKeyHttpClient MaintenanceKeyClient { get; set; } = default!;
     [Inject] public ISnackbar Snackbar { get; set; } = default!;
 
     private bool _isLoading = true;
@@ -40,6 +41,10 @@ public partial class AdminServiceKeys : ComponentBase
     private readonly List<ServiceModel> _services = [];
     private readonly HashSet<string> _savingServices = [];
     private readonly Dictionary<string, bool> _showApiKey = [];
+
+    private MaintenanceKeyStatusResponse? _maintenanceKeyStatus;
+    private string? _generatedMaintenanceKey;
+    private bool _maintenanceKeyBusy;
 
     protected override async Task OnInitializedAsync()
     {
@@ -62,6 +67,8 @@ public partial class AdminServiceKeys : ComponentBase
                 _services.Add(ToModel(s));
                 _showApiKey[s.ServiceName] = false;
             }
+
+            _maintenanceKeyStatus = await MaintenanceKeyClient.GetStatusAsync();
         }
         catch (Exception ex)
         {
@@ -119,5 +126,52 @@ public partial class AdminServiceKeys : ComponentBase
     private void ToggleApiKeyVisibility(string serviceName)
     {
         _showApiKey[serviceName] = !_showApiKey.GetValueOrDefault(serviceName);
+    }
+
+    private async Task GenerateMaintenanceKeyAsync()
+    {
+        _maintenanceKeyBusy = true;
+        try
+        {
+            var generated = await MaintenanceKeyClient.GenerateAsync();
+            if (generated is null)
+            {
+                _errors.Add("Failed to generate the maintenance key: empty response.");
+                return;
+            }
+
+            _generatedMaintenanceKey = generated.Key;
+            _maintenanceKeyStatus = new MaintenanceKeyStatusResponse(true, generated.CreatedAt);
+            Snackbar.Add("Maintenance key generated. Copy it now — it will not be shown again.", Severity.Success);
+        }
+        catch (Exception ex)
+        {
+            _errors.Add($"Failed to generate the maintenance key: {ex.Message}");
+        }
+        finally
+        {
+            _maintenanceKeyBusy = false;
+        }
+    }
+
+    private async Task RevokeMaintenanceKeyAsync()
+    {
+        _maintenanceKeyBusy = true;
+        try
+        {
+            var revoked = await MaintenanceKeyClient.RevokeAsync();
+            _generatedMaintenanceKey = null;
+            _maintenanceKeyStatus = new MaintenanceKeyStatusResponse(false, null);
+            Snackbar.Add(revoked ? "Maintenance key revoked." : "There was no maintenance key to revoke.",
+                revoked ? Severity.Success : Severity.Info);
+        }
+        catch (Exception ex)
+        {
+            _errors.Add($"Failed to revoke the maintenance key: {ex.Message}");
+        }
+        finally
+        {
+            _maintenanceKeyBusy = false;
+        }
     }
 }

--- a/code/FinanceManager.Components/HttpClients/AdminMaintenanceKeyHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/AdminMaintenanceKeyHttpClient.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Components.HttpClients;
+
+public sealed record MaintenanceKeyStatusResponse(bool HasKey, DateTimeOffset? CreatedAt);
+public sealed record GeneratedMaintenanceKeyResponse(string Key, DateTimeOffset CreatedAt);
+
+public class AdminMaintenanceKeyHttpClient(HttpClient httpClient)
+{
+    public async Task<MaintenanceKeyStatusResponse?> GetStatusAsync(CancellationToken ct = default) =>
+        await httpClient.GetFromJsonAsync<MaintenanceKeyStatusResponse>("api/admin/maintenance-key", ct);
+
+    public async Task<GeneratedMaintenanceKeyResponse?> GenerateAsync(CancellationToken ct = default)
+    {
+        var response = await httpClient.PostAsync("api/admin/maintenance-key", content: null, ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<GeneratedMaintenanceKeyResponse>(ct);
+    }
+
+    /// <summary>Returns <c>false</c> when there was no key to revoke.</summary>
+    public async Task<bool> RevokeAsync(CancellationToken ct = default)
+    {
+        var response = await httpClient.DeleteAsync("api/admin/maintenance-key", ct);
+        if (response.StatusCode == HttpStatusCode.NotFound) return false;
+
+        response.EnsureSuccessStatusCode();
+        return true;
+    }
+}

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -49,6 +49,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<AdministrationUsersHttpClient>()
                 .AddScoped<AdminAiProvidersHttpClient>()
                 .AddScoped<AdminServiceKeysHttpClient>()
+                .AddScoped<AdminMaintenanceKeyHttpClient>()
                 .AddScoped<AdminLogsHttpClient>()
                 .AddScoped<NewVisitorsHttpClient>()
                 .AddScoped<CsvHeaderMappingHttpClient>()

--- a/code/FinanceManager.Domain/Assets/Services/IInvestmentPriceProvider.cs
+++ b/code/FinanceManager.Domain/Assets/Services/IInvestmentPriceProvider.cs
@@ -31,4 +31,12 @@ public interface IInvestmentPriceProvider
         DateTime start,
         DateTime end,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Ensure stored end-of-day quotes exist for <paramref name="assetListingId"/> over
+    /// [<paramref name="start"/>, <paramref name="end"/>], fetching from the provider chain and
+    /// persisting when coverage is missing. Performs no currency conversion. Returns <c>true</c>
+    /// when at least one quote exists in the range after the attempt.
+    /// </summary>
+    Task<bool> EnsureQuotesAsync(long assetListingId, DateTime start, DateTime end, CancellationToken ct = default);
 }

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Repositories/IInvestmentTransactionRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Repositories/IInvestmentTransactionRepository.cs
@@ -42,4 +42,11 @@ public interface IInvestmentTransactionRepository
     /// Replaces the old per-ISIN running-balance boundary lookups with a single grouped query.
     /// </summary>
     Task<IReadOnlyDictionary<long, decimal>> GetHoldingsAsOf(IReadOnlyCollection<int> accountIds, DateOnly asOf, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The distinct <see cref="AssetListing"/> ids referenced by any investment transaction across all
+    /// users, resolved in a single grouped query. Feeds maintenance jobs (e.g. the weekly price
+    /// backfill) that must cover every instrument anyone holds without materialising transactions.
+    /// </summary>
+    Task<IReadOnlyList<long>> GetDistinctAssetListingIds(CancellationToken cancellationToken = default);
 }

--- a/code/FinanceManager.Domain/Shared/Maintenance/Entities/MaintenanceApiKey.cs
+++ b/code/FinanceManager.Domain/Shared/Maintenance/Entities/MaintenanceApiKey.cs
@@ -1,0 +1,13 @@
+namespace FinanceManager.Domain.Shared.Maintenance.Entities;
+
+/// <summary>
+/// The single active maintenance API key, stored as a SHA-256 hash so a database leak never
+/// reveals the key itself. The plaintext is shown to the admin exactly once at generation time;
+/// rolling the key replaces this row, revoking deletes it.
+/// </summary>
+public class MaintenanceApiKey
+{
+    public int Id { get; set; }
+    public string KeyHash { get; set; } = string.Empty;
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/code/FinanceManager.Domain/Shared/Maintenance/Repositories/IMaintenanceKeyRepository.cs
+++ b/code/FinanceManager.Domain/Shared/Maintenance/Repositories/IMaintenanceKeyRepository.cs
@@ -1,0 +1,16 @@
+using FinanceManager.Domain.Shared.Maintenance.Entities;
+
+namespace FinanceManager.Domain.Shared.Maintenance.Repositories;
+
+/// <summary>Persistence for the single active <see cref="MaintenanceApiKey"/> row.</summary>
+public interface IMaintenanceKeyRepository
+{
+    /// <summary>Get the active key, or <c>null</c> when none has been generated (or it was revoked).</summary>
+    Task<MaintenanceApiKey?> Get(CancellationToken cancellationToken = default);
+
+    /// <summary>Store the key, replacing any existing one — generating and rolling are the same write.</summary>
+    Task Save(MaintenanceApiKey key, CancellationToken cancellationToken = default);
+
+    /// <summary>Delete the active key. Returns <c>false</c> when there was none to revoke.</summary>
+    Task<bool> Delete(CancellationToken cancellationToken = default);
+}

--- a/code/FinanceManager.Infrastructure/Contexts/AppDbContext.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/AppDbContext.cs
@@ -12,6 +12,7 @@ using FinanceManager.Domain.Identity.Entities;
 using FinanceManager.Domain.Insights.Entities;
 using FinanceManager.Domain.Shared.Ai.Entities;
 using FinanceManager.Domain.Shared.ExternalServices.Entities;
+using FinanceManager.Domain.Shared.Maintenance.Entities;
 using FinanceManager.Infrastructure.Contexts.Configurations;
 using Microsoft.EntityFrameworkCore;
 
@@ -45,6 +46,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<AiProviderModel> AiProviderModels { get; set; } = default!;
     public DbSet<LogEntry> LogEntries { get; set; } = default!;
     public DbSet<ExternalServiceConfiguration> ExternalServiceConfigurations { get; set; } = default!;
+    public DbSet<MaintenanceApiKey> MaintenanceApiKeys { get; set; } = default!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -75,6 +77,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.ApplyConfiguration(new AiProviderModelConfiguration());
         modelBuilder.ApplyConfiguration(new LogEntryConfiguration());
         modelBuilder.ApplyConfiguration(new ExternalServiceConfigurationConfiguration());
+        modelBuilder.ApplyConfiguration(new MaintenanceApiKeyConfiguration());
 
         base.OnModelCreating(modelBuilder);
     }

--- a/code/FinanceManager.Infrastructure/Contexts/Configurations/MaintenanceApiKeyConfiguration.cs
+++ b/code/FinanceManager.Infrastructure/Contexts/Configurations/MaintenanceApiKeyConfiguration.cs
@@ -1,0 +1,18 @@
+using FinanceManager.Domain.Shared.Maintenance.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FinanceManager.Infrastructure.Contexts.Configurations;
+
+public class MaintenanceApiKeyConfiguration : IEntityTypeConfiguration<MaintenanceApiKey>
+{
+    public void Configure(EntityTypeBuilder<MaintenanceApiKey> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        // SHA-256 rendered as hex is exactly 64 characters.
+        builder.Property(e => e.KeyHash)
+            .IsRequired()
+            .HasMaxLength(64);
+    }
+}

--- a/code/FinanceManager.Infrastructure/Repositories/Investments/InvestmentTransactionRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Investments/InvestmentTransactionRepository.cs
@@ -103,4 +103,11 @@ public class InvestmentTransactionRepository(AppDbContext context) : IInvestment
                 g => g.Key,
                 g => g.Sum(t => t.Type == InvestmentTransactionType.Sell ? -t.Quantity : t.Quantity));
     }
+
+    public async Task<IReadOnlyList<long>> GetDistinctAssetListingIds(CancellationToken cancellationToken = default) =>
+        await context.InvestmentTransactions.AsNoTracking()
+            .Select(x => x.AssetListingId)
+            .Distinct()
+            .OrderBy(x => x)
+            .ToListAsync(cancellationToken);
 }

--- a/code/FinanceManager.Infrastructure/Repositories/MaintenanceKeyRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/MaintenanceKeyRepository.cs
@@ -1,0 +1,31 @@
+using FinanceManager.Domain.Shared.Maintenance.Entities;
+using FinanceManager.Domain.Shared.Maintenance.Repositories;
+using FinanceManager.Infrastructure.Contexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Infrastructure.Repositories;
+
+internal sealed class MaintenanceKeyRepository(AppDbContext dbContext) : IMaintenanceKeyRepository
+{
+    public Task<MaintenanceApiKey?> Get(CancellationToken cancellationToken = default) =>
+        dbContext.MaintenanceApiKeys.AsNoTracking().FirstOrDefaultAsync(cancellationToken);
+
+    public async Task Save(MaintenanceApiKey key, CancellationToken cancellationToken = default)
+    {
+        // Only one key may be active: rolling replaces the row rather than accumulating history.
+        var existing = await dbContext.MaintenanceApiKeys.ToListAsync(cancellationToken);
+        dbContext.MaintenanceApiKeys.RemoveRange(existing);
+        dbContext.MaintenanceApiKeys.Add(key);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<bool> Delete(CancellationToken cancellationToken = default)
+    {
+        var existing = await dbContext.MaintenanceApiKeys.ToListAsync(cancellationToken);
+        if (existing.Count == 0) return false;
+
+        dbContext.MaintenanceApiKeys.RemoveRange(existing);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+}

--- a/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
@@ -25,6 +25,7 @@ using FinanceManager.Domain.MoneyFlow.Services;
 using FinanceManager.Domain.Shared.Ai.Repositories;
 using FinanceManager.Domain.Shared.Charting;
 using FinanceManager.Domain.Shared.ExternalServices.Repositories;
+using FinanceManager.Domain.Shared.Maintenance.Repositories;
 using FinanceManager.Infrastructure.Contexts;
 using FinanceManager.Infrastructure.Guest;
 using FinanceManager.Infrastructure.Providers;
@@ -98,6 +99,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<IInflationDataProvider, InMemoryInflationDataProvider>()
                 .AddScoped<IAiProviderConfigRepository, AiProviderConfigRepository>()
                 .AddScoped<IExternalServiceConfigRepository, ExternalServiceConfigRepository>()
+                .AddScoped<IMaintenanceKeyRepository, MaintenanceKeyRepository>()
                 .AddScoped<ILogEntryRepository, LogEntryRepository>()
 
                 .AddSingleton<IInsightsPromptProvider, InsightsPromptProvider>()

--- a/code/FinanceManager.Tests.Integration/Controllers/AdminMaintenanceKeyControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/AdminMaintenanceKeyControllerTests.cs
@@ -1,0 +1,83 @@
+using FinanceManager.Domain.Identity.Entities;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public class AdminMaintenanceKeyControllerTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider)
+{
+    private sealed record StatusResponse(bool HasKey, DateTimeOffset? CreatedAt);
+    private sealed record GeneratedResponse(string Key, DateTimeOffset CreatedAt);
+
+    [Fact]
+    public async Task Endpoints_WithoutAuthentication_ReturnUnauthorized()
+    {
+        var response = await Client.GetAsync("api/admin/maintenance-key", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoints_AsNonAdmin_ReturnForbidden()
+    {
+        Authorize("user", 2, UserRole.User);
+
+        var response = await Client.PostAsync("api/admin/maintenance-key", content: null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GenerateRollRevoke_FullLifecycle_WorksEndToEnd()
+    {
+        Authorize("admin", 1, UserRole.Admin);
+        var ct = TestContext.Current.CancellationToken;
+
+        // Initially no key.
+        var status = await Client.GetFromJsonAsync<StatusResponse>("api/admin/maintenance-key", ct);
+        Assert.NotNull(status);
+        Assert.False(status.HasKey);
+
+        // Generate: plaintext returned once, status flips to active.
+        var generateResponse = await Client.PostAsync("api/admin/maintenance-key", content: null, ct);
+        Assert.Equal(HttpStatusCode.OK, generateResponse.StatusCode);
+        var generated = await generateResponse.Content.ReadFromJsonAsync<GeneratedResponse>(ct);
+        Assert.NotNull(generated);
+        Assert.StartsWith("fmk_", generated.Key);
+
+        status = await Client.GetFromJsonAsync<StatusResponse>("api/admin/maintenance-key", ct);
+        Assert.NotNull(status);
+        Assert.True(status.HasKey);
+
+        // The generated key authorises the maintenance endpoint end-to-end.
+        using (var trigger = new HttpRequestMessage(HttpMethod.Post, "api/PriceBackfill"))
+        {
+            trigger.Headers.Add("X-Maintenance-Key", generated.Key);
+            var triggerResponse = await Client.SendAsync(trigger, ct);
+            Assert.Equal(HttpStatusCode.Accepted, triggerResponse.StatusCode);
+        }
+
+        // Roll: a new key replaces the old one, which stops working.
+        var rollResponse = await Client.PostAsync("api/admin/maintenance-key", content: null, ct);
+        var rolled = await rollResponse.Content.ReadFromJsonAsync<GeneratedResponse>(ct);
+        Assert.NotNull(rolled);
+        Assert.NotEqual(generated.Key, rolled.Key);
+
+        using (var trigger = new HttpRequestMessage(HttpMethod.Post, "api/PriceBackfill"))
+        {
+            trigger.Headers.Add("X-Maintenance-Key", generated.Key);
+            var triggerResponse = await Client.SendAsync(trigger, ct);
+            Assert.Equal(HttpStatusCode.Unauthorized, triggerResponse.StatusCode);
+        }
+
+        // Revoke: key gone, second revoke reports nothing to do.
+        var revokeResponse = await Client.DeleteAsync("api/admin/maintenance-key", ct);
+        Assert.Equal(HttpStatusCode.NoContent, revokeResponse.StatusCode);
+
+        var secondRevoke = await Client.DeleteAsync("api/admin/maintenance-key", ct);
+        Assert.Equal(HttpStatusCode.NotFound, secondRevoke.StatusCode);
+    }
+}

--- a/code/FinanceManager.Tests.Integration/Controllers/PriceBackfillControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/PriceBackfillControllerTests.cs
@@ -1,0 +1,68 @@
+using FinanceManager.Application.Shared.Options;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public class PriceBackfillControllerTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider)
+{
+    private const string _maintenanceKey = "integration-test-maintenance-key";
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.PostConfigure<MaintenanceOptions>(options => options.ApiKey = _maintenanceKey);
+    }
+
+    [Fact]
+    public async Task Trigger_WithoutKeyHeader_ReturnsUnauthorized()
+    {
+        var response = await Client.PostAsync("api/PriceBackfill", content: null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Trigger_WithWrongKey_ReturnsUnauthorized()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "api/PriceBackfill");
+        request.Headers.Add("X-Maintenance-Key", "wrong-key");
+
+        var response = await Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Trigger_WithValidKey_ReturnsAccepted()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "api/PriceBackfill");
+        request.Headers.Add("X-Maintenance-Key", _maintenanceKey);
+
+        var response = await Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+}
+
+/// <summary>
+/// Runs against the default test app, whose configuration leaves <c>Maintenance:ApiKey</c> empty —
+/// the endpoint must be indistinguishable from an unmapped route in that state.
+/// </summary>
+[Collection("api")]
+[Trait("Category", "Integration")]
+public class PriceBackfillControllerUnconfiguredTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider)
+{
+    [Fact]
+    public async Task Trigger_WithoutConfiguredKey_ReturnsNotFound()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "api/PriceBackfill");
+        request.Headers.Add("X-Maintenance-Key", "any-key");
+
+        var response = await Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/PriceBackfillControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/PriceBackfillControllerTests.cs
@@ -1,0 +1,84 @@
+using FinanceManager.Api.Controllers;
+using FinanceManager.Api.Services;
+using FinanceManager.Application.Shared.Options;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Api.Controllers;
+
+[Trait("Category", "Unit")]
+public class PriceBackfillControllerTests
+{
+    private const string _configuredKey = "test-maintenance-key";
+
+    private readonly Mock<IPriceBackfillJobChannel> _channel = new();
+
+    private PriceBackfillController CreateController(string? configuredKey, string? providedKey)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (providedKey is not null)
+            httpContext.Request.Headers[PriceBackfillController.ApiKeyHeader] = providedKey;
+
+        return new PriceBackfillController(
+            Options.Create(new MaintenanceOptions { ApiKey = configuredKey ?? string.Empty }),
+            _channel.Object,
+            NullLogger<PriceBackfillController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Trigger_WithoutConfiguredKey_ReturnsNotFound(string? configuredKey)
+    {
+        var result = CreateController(configuredKey, _configuredKey).Trigger();
+
+        Assert.IsType<NotFoundResult>(result);
+        _channel.Verify(x => x.TryQueueJob(It.IsAny<PriceBackfillJobRequest>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("wrong-key")]
+    [InlineData("")]
+    public void Trigger_WithMissingOrWrongKey_ReturnsUnauthorized(string? providedKey)
+    {
+        var result = CreateController(_configuredKey, providedKey).Trigger();
+
+        Assert.IsType<UnauthorizedResult>(result);
+        _channel.Verify(x => x.TryQueueJob(It.IsAny<PriceBackfillJobRequest>()), Times.Never);
+    }
+
+    [Fact]
+    public void Trigger_WithValidKey_QueuesPastWeekAndReturnsAccepted()
+    {
+        PriceBackfillJobRequest? queued = null;
+        _channel
+            .Setup(x => x.TryQueueJob(It.IsAny<PriceBackfillJobRequest>()))
+            .Callback((PriceBackfillJobRequest request) => queued = request)
+            .Returns(true);
+
+        var result = CreateController(_configuredKey, _configuredKey).Trigger();
+
+        Assert.IsType<AcceptedResult>(result);
+        Assert.NotNull(queued);
+        Assert.Equal(DateTime.UtcNow.Date, queued.End);
+        Assert.Equal(queued.End.AddDays(-7), queued.Start);
+    }
+
+    [Fact]
+    public void Trigger_WhenRunAlreadyQueued_StillReturnsAccepted()
+    {
+        _channel.Setup(x => x.TryQueueJob(It.IsAny<PriceBackfillJobRequest>())).Returns(false);
+
+        var result = CreateController(_configuredKey, _configuredKey).Trigger();
+
+        Assert.IsType<AcceptedResult>(result);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Api/Controllers/PriceBackfillControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Controllers/PriceBackfillControllerTests.cs
@@ -1,10 +1,9 @@
 using FinanceManager.Api.Controllers;
 using FinanceManager.Api.Services;
-using FinanceManager.Application.Shared.Options;
+using FinanceManager.Application.Shared.Maintenance;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Moq;
 
 namespace FinanceManager.Tests.Unit.Api.Controllers;
@@ -12,18 +11,19 @@ namespace FinanceManager.Tests.Unit.Api.Controllers;
 [Trait("Category", "Unit")]
 public class PriceBackfillControllerTests
 {
-    private const string _configuredKey = "test-maintenance-key";
+    private const string _validKey = "fmk_test-maintenance-key";
 
+    private readonly Mock<IMaintenanceKeyService> _keyService = new();
     private readonly Mock<IPriceBackfillJobChannel> _channel = new();
 
-    private PriceBackfillController CreateController(string? configuredKey, string? providedKey)
+    private PriceBackfillController CreateController(string? providedKey)
     {
         var httpContext = new DefaultHttpContext();
         if (providedKey is not null)
             httpContext.Request.Headers[PriceBackfillController.ApiKeyHeader] = providedKey;
 
         return new PriceBackfillController(
-            Options.Create(new MaintenanceOptions { ApiKey = configuredKey ?? string.Empty }),
+            _keyService.Object,
             _channel.Object,
             NullLogger<PriceBackfillController>.Instance)
         {
@@ -31,13 +31,20 @@ public class PriceBackfillControllerTests
         };
     }
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public void Trigger_WithoutConfiguredKey_ReturnsNotFound(string? configuredKey)
+    private void SetupConfiguredKey()
     {
-        var result = CreateController(configuredKey, _configuredKey).Trigger();
+        _keyService.Setup(x => x.IsConfiguredAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _keyService
+            .Setup(x => x.ValidateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string key, CancellationToken _) => key == _validKey);
+    }
+
+    [Fact]
+    public async Task Trigger_WithoutAnyConfiguredKey_ReturnsNotFound()
+    {
+        _keyService.Setup(x => x.IsConfiguredAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var result = await CreateController(_validKey).Trigger(TestContext.Current.CancellationToken);
 
         Assert.IsType<NotFoundResult>(result);
         _channel.Verify(x => x.TryQueueJob(It.IsAny<PriceBackfillJobRequest>()), Times.Never);
@@ -47,24 +54,27 @@ public class PriceBackfillControllerTests
     [InlineData(null)]
     [InlineData("wrong-key")]
     [InlineData("")]
-    public void Trigger_WithMissingOrWrongKey_ReturnsUnauthorized(string? providedKey)
+    public async Task Trigger_WithMissingOrWrongKey_ReturnsUnauthorized(string? providedKey)
     {
-        var result = CreateController(_configuredKey, providedKey).Trigger();
+        SetupConfiguredKey();
+
+        var result = await CreateController(providedKey).Trigger(TestContext.Current.CancellationToken);
 
         Assert.IsType<UnauthorizedResult>(result);
         _channel.Verify(x => x.TryQueueJob(It.IsAny<PriceBackfillJobRequest>()), Times.Never);
     }
 
     [Fact]
-    public void Trigger_WithValidKey_QueuesPastWeekAndReturnsAccepted()
+    public async Task Trigger_WithValidKey_QueuesPastWeekAndReturnsAccepted()
     {
+        SetupConfiguredKey();
         PriceBackfillJobRequest? queued = null;
         _channel
             .Setup(x => x.TryQueueJob(It.IsAny<PriceBackfillJobRequest>()))
             .Callback((PriceBackfillJobRequest request) => queued = request)
             .Returns(true);
 
-        var result = CreateController(_configuredKey, _configuredKey).Trigger();
+        var result = await CreateController(_validKey).Trigger(TestContext.Current.CancellationToken);
 
         Assert.IsType<AcceptedResult>(result);
         Assert.NotNull(queued);
@@ -73,11 +83,12 @@ public class PriceBackfillControllerTests
     }
 
     [Fact]
-    public void Trigger_WhenRunAlreadyQueued_StillReturnsAccepted()
+    public async Task Trigger_WhenRunAlreadyQueued_StillReturnsAccepted()
     {
+        SetupConfiguredKey();
         _channel.Setup(x => x.TryQueueJob(It.IsAny<PriceBackfillJobRequest>())).Returns(false);
 
-        var result = CreateController(_configuredKey, _configuredKey).Trigger();
+        var result = await CreateController(_validKey).Trigger(TestContext.Current.CancellationToken);
 
         Assert.IsType<AcceptedResult>(result);
     }

--- a/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceBackfillServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceBackfillServiceTests.cs
@@ -1,0 +1,73 @@
+using FinanceManager.Application.Assets.Pricing;
+using FinanceManager.Domain.Assets.Services;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services.Assets;
+
+[Trait("Category", "Unit")]
+public class InvestmentPriceBackfillServiceTests
+{
+    private static readonly DateTime _start = new(2026, 7, 11);
+    private static readonly DateTime _end = new(2026, 7, 18);
+
+    private readonly Mock<IInvestmentTransactionRepository> _transactionRepository = new();
+    private readonly Mock<IInvestmentPriceProvider> _priceProvider = new();
+
+    private InvestmentPriceBackfillService CreateSut() => new(
+        _transactionRepository.Object,
+        _priceProvider.Object,
+        NullLogger<InvestmentPriceBackfillService>.Instance);
+
+    [Fact]
+    public async Task Backfill_EnsuresQuotesForEveryDistinctListing()
+    {
+        _transactionRepository
+            .Setup(x => x.GetDistinctAssetListingIds(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([10L, 20L, 30L]);
+        _priceProvider
+            .Setup(x => x.EnsureQuotesAsync(It.IsAny<long>(), _start, _end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await CreateSut().BackfillAsync(_start, _end, TestContext.Current.CancellationToken);
+
+        Assert.Equal(new InvestmentPriceBackfillResult(3, 3, 0), result);
+        _priceProvider.Verify(x => x.EnsureQuotesAsync(10L, _start, _end, It.IsAny<CancellationToken>()), Times.Once);
+        _priceProvider.Verify(x => x.EnsureQuotesAsync(20L, _start, _end, It.IsAny<CancellationToken>()), Times.Once);
+        _priceProvider.Verify(x => x.EnsureQuotesAsync(30L, _start, _end, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Backfill_CountsListingsWithoutQuotesAsUncovered()
+    {
+        _transactionRepository
+            .Setup(x => x.GetDistinctAssetListingIds(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([10L, 20L]);
+        _priceProvider
+            .Setup(x => x.EnsureQuotesAsync(10L, _start, _end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _priceProvider
+            .Setup(x => x.EnsureQuotesAsync(20L, _start, _end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await CreateSut().BackfillAsync(_start, _end, TestContext.Current.CancellationToken);
+
+        Assert.Equal(new InvestmentPriceBackfillResult(2, 1, 1), result);
+    }
+
+    [Fact]
+    public async Task Backfill_WithNoHeldListings_DoesNotTouchPriceProvider()
+    {
+        _transactionRepository
+            .Setup(x => x.GetDistinctAssetListingIds(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var result = await CreateSut().BackfillAsync(_start, _end, TestContext.Current.CancellationToken);
+
+        Assert.Equal(new InvestmentPriceBackfillResult(0, 0, 0), result);
+        _priceProvider.Verify(
+            x => x.EnsureQuotesAsync(It.IsAny<long>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceProviderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceProviderTests.cs
@@ -384,6 +384,85 @@ public class InvestmentPriceProviderTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task EnsureQuotes_FetchesAndPersists_WhenRangeIsEmpty()
+    {
+        var start = new DateTime(2024, 1, 1);
+        var end = new DateTime(2024, 1, 5);
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing());
+        _priceSource
+            .Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Price(100m, start), Price(105m, end)]);
+
+        var covered = await CreateSut().EnsureQuotesAsync(10, start, end, TestContext.Current.CancellationToken);
+
+        Assert.True(covered);
+        Assert.Equal(2, _priceQuoteRepository.All.Count);
+        _currencyExchangeService.Verify(
+            x => x.GetExchangeRateAsync(It.IsAny<Currency>(), It.IsAny<Currency>(), It.IsAny<DateTime>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnsureQuotes_DoesNotFetch_WhenRangeAlreadyCovered()
+    {
+        var start = new DateTime(2024, 1, 1);
+        var end = new DateTime(2024, 1, 5);
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing());
+        _priceQuoteRepository.Seed(new PriceQuote
+        {
+            AssetListingId = 10,
+            Provider = MarketDataProvider.AlphaVantage,
+            Price = 100m,
+            Currency = "USD",
+            PriceTime = new DateTimeOffset(new DateTime(2024, 1, 3), TimeSpan.Zero),
+            QuoteType = PriceQuoteType.EndOfDay
+        });
+
+        var covered = await CreateSut().EnsureQuotesAsync(10, start, end, TestContext.Current.CancellationToken);
+
+        Assert.True(covered);
+        _priceSource.Verify(
+            x => x.GetDailySeries(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnsureQuotes_ReturnsFalse_WhenProviderHasNoData()
+    {
+        var start = new DateTime(2024, 1, 1);
+        var end = new DateTime(2024, 1, 5);
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(Listing());
+        _priceSource
+            .Setup(x => x.GetDailySeries(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<Currency>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var covered = await CreateSut().EnsureQuotesAsync(10, start, end, TestContext.Current.CancellationToken);
+
+        Assert.False(covered);
+        Assert.Empty(_priceQuoteRepository.All);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task EnsureQuotes_ReturnsFalse_ForInvalidListingId(long listingId)
+    {
+        var covered = await CreateSut().EnsureQuotesAsync(listingId, new DateTime(2024, 1, 1), new DateTime(2024, 1, 5), TestContext.Current.CancellationToken);
+
+        Assert.False(covered);
+    }
+
+    [Fact]
+    public async Task EnsureQuotes_ReturnsFalse_WhenListingDoesNotExist()
+    {
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync((AssetListing?)null);
+
+        var covered = await CreateSut().EnsureQuotesAsync(10, new DateTime(2024, 1, 1), new DateTime(2024, 1, 5), TestContext.Current.CancellationToken);
+
+        Assert.False(covered);
+    }
+
     /// <summary>Minimal in-memory <see cref="IPriceQuoteRepository"/> so fetch→store→read flows are exercised end-to-end.</summary>
     private sealed class InMemoryPriceQuoteRepository : IPriceQuoteRepository
     {

--- a/code/FinanceManager.Tests.Unit/Application/Services/Maintenance/MaintenanceKeyServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Maintenance/MaintenanceKeyServiceTests.cs
@@ -1,0 +1,115 @@
+using FinanceManager.Application.Shared.Maintenance;
+using FinanceManager.Application.Shared.Options;
+using FinanceManager.Domain.Shared.Maintenance.Entities;
+using FinanceManager.Domain.Shared.Maintenance.Repositories;
+using Microsoft.Extensions.Options;
+
+namespace FinanceManager.Tests.Unit.Application.Services.Maintenance;
+
+[Trait("Category", "Unit")]
+public class MaintenanceKeyServiceTests
+{
+    private readonly InMemoryMaintenanceKeyRepository _repository = new();
+
+    private MaintenanceKeyService CreateSut(string? configuredKey = null) => new(
+        _repository,
+        Options.Create(new MaintenanceOptions { ApiKey = configuredKey ?? string.Empty }));
+
+    [Fact]
+    public async Task Generate_StoresHashOnly_AndGeneratedKeyValidates()
+    {
+        var sut = CreateSut();
+
+        var plaintext = await sut.GenerateAsync(TestContext.Current.CancellationToken);
+
+        Assert.StartsWith("fmk_", plaintext);
+        Assert.NotNull(_repository.Stored);
+        Assert.DoesNotContain(plaintext, _repository.Stored.KeyHash);
+        Assert.True(await sut.ValidateAsync(plaintext, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Generate_RollsExistingKey_OldKeyStopsValidating()
+    {
+        var sut = CreateSut();
+        var oldKey = await sut.GenerateAsync(TestContext.Current.CancellationToken);
+
+        var newKey = await sut.GenerateAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotEqual(oldKey, newKey);
+        Assert.False(await sut.ValidateAsync(oldKey, TestContext.Current.CancellationToken));
+        Assert.True(await sut.ValidateAsync(newKey, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Revoke_RemovesKey_AndEndpointBecomesUnconfigured()
+    {
+        var sut = CreateSut();
+        var key = await sut.GenerateAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(await sut.RevokeAsync(TestContext.Current.CancellationToken));
+        Assert.False(await sut.ValidateAsync(key, TestContext.Current.CancellationToken));
+        Assert.False(await sut.IsConfiguredAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Revoke_WithoutKey_ReturnsFalse()
+    {
+        Assert.False(await CreateSut().RevokeAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Validate_AcceptsConfiguredFallbackKey_EvenAfterDbKeyRevoked()
+    {
+        var sut = CreateSut(configuredKey: "config-break-glass-key");
+        await sut.GenerateAsync(TestContext.Current.CancellationToken);
+        await sut.RevokeAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(await sut.IsConfiguredAsync(TestContext.Current.CancellationToken));
+        Assert.True(await sut.ValidateAsync("config-break-glass-key", TestContext.Current.CancellationToken));
+        Assert.False(await sut.ValidateAsync("wrong", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetStatus_ReflectsActiveKey()
+    {
+        var sut = CreateSut();
+        Assert.Equal(new MaintenanceKeyStatus(false, null), await sut.GetStatusAsync(TestContext.Current.CancellationToken));
+
+        await sut.GenerateAsync(TestContext.Current.CancellationToken);
+
+        var status = await sut.GetStatusAsync(TestContext.Current.CancellationToken);
+        Assert.True(status.HasKey);
+        Assert.NotNull(status.CreatedAt);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task Validate_RejectsEmptyKey(string? providedKey)
+    {
+        var sut = CreateSut(configuredKey: "config-key");
+
+        Assert.False(await sut.ValidateAsync(providedKey!, TestContext.Current.CancellationToken));
+    }
+
+    private sealed class InMemoryMaintenanceKeyRepository : IMaintenanceKeyRepository
+    {
+        public MaintenanceApiKey? Stored { get; private set; }
+
+        public Task<MaintenanceApiKey?> Get(CancellationToken cancellationToken = default) => Task.FromResult(Stored);
+
+        public Task Save(MaintenanceApiKey key, CancellationToken cancellationToken = default)
+        {
+            Stored = key;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> Delete(CancellationToken cancellationToken = default)
+        {
+            var existed = Stored is not null;
+            Stored = null;
+            return Task.FromResult(existed);
+        }
+    }
+}


### PR DESCRIPTION
closes #569

## What

Every Saturday at 06:00 UTC a scheduled GitHub Actions workflow calls a new key-protected `POST /api/PriceBackfill` endpoint, which backfills the past week's end-of-day closing prices for every investment listing anyone holds. The maintenance key that authorises the call is managed by the admin at runtime — generate, roll, or revoke from **Admin → Service Keys** — with no redeploy or Azure configuration needed.

## Why external scheduling

The app runs on a free-tier Azure Web App, which unloads the process when idle — an in-process timer/`BackgroundService` cron cannot be trusted to be awake on Saturday morning. The workflow's HTTP request both wakes the app and queues the run, while all backfill logic stays inside the monolith (no separate Azure Functions deployable, no duplicated secrets or EF configuration).

## How

- **Domain**: `IInvestmentTransactionRepository.GetDistinctAssetListingIds()`; `IInvestmentPriceProvider.EnsureQuotesAsync(listingId, start, end)`; `MaintenanceApiKey` entity (stores a SHA-256 hash, never the plaintext) + `IMaintenanceKeyRepository`.
- **Infrastructure**: repository implementations and the `AddMaintenanceApiKeys` EF migration (single small table).
- **Application**: `InvestmentPriceBackfillService` walks the distinct listings sequentially (the provider chain is rate-limited) and reuses `InvestmentPriceProvider`'s existing fetch/upsert path — coverage checks, failure cooldowns, per-symbol locks, and the Alpha Vantage → EODHD fallback all behave exactly as they do for chart-driven fetches. `MaintenanceKeyService` generates 256-bit keys (`fmk_…`, plaintext returned exactly once), validates in constant time against the stored hash, and keeps `Maintenance:ApiKey` from configuration as a break-glass fallback.
- **Api**: `PriceBackfillController` validates `X-Maintenance-Key` through the key service (404 when no key exists anywhere, auth rate-limit policy), queues the job on a bounded single-slot channel (duplicate triggers collapse), and returns 202; `PriceBackfillBackgroundService` processes it off the request path. `AdminMaintenanceKeyController` (Admin role): GET status, POST generate/roll, DELETE revoke.
- **Components**: new **Maintenance API Key** section on the Admin → Service Keys page — status, generate/roll, revoke, and a one-time display of the generated key.
- **CI**: `.github/workflows/weekly-price-backfill.yml` — Saturday cron + `workflow_dispatch`, curl with retries to cover the cold start, key from the `MAINTENANCE_API_KEY` repository secret.

## Setup after merge

1. Deploy (the migration creates the `MaintenanceApiKeys` table).
2. As admin, open **Admin → Service Keys → Maintenance API Key** and click **Generate key**.
3. Paste the shown key into the `MAINTENANCE_API_KEY` repository secret on GitHub. Rolling the key later just means repeating steps 2–3; revoking disables the endpoint entirely.

## Testing

- Unit (581): backfill service, maintenance-key service (hash-only storage, roll invalidates old key, config fallback), backfill controller (404/401/202), `EnsureQuotesAsync` coverage paths.
- Integration (276): admin key lifecycle end-to-end (generate → trigger backfill with the key → roll → old key 401 → revoke → 404), plus auth (401 anonymous, 403 non-admin) and the config-key fallback path.
- Architecture (9): controller coverage rule satisfied for both new controllers.
- Verified live against a running instance (Development, in-memory DB): generate → 202 queued, wrong key → 401, revoked → 404; admin UI screenshotted on mobile and desktop viewports.
- `dotnet format` clean.