### PR TITLE
Fix CSV import failing during browser file read #571

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ bld/
 [Ll]ogs/
 
 # Root-level static publish output from the old GitHub Pages deployment.
+/output/
 /_content/
 /_framework/
 /css/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- CSV files can now be imported into cash and bond accounts without the upload failing while the browser reads the selected file, including exports encoded as Windows-1250. #571
 - The **Category** filter button on cash account details now opens its dropdown again, so transactions can be filtered by category. #567
 - The **Investment paycheck** card now remains a current portfolio projection instead of reloading and changing when the Assets page date range changes. #563
 - The **Investment rate** chart now caps monthly bars at 300% so outlier months do not flatten the rest, while keeping the headline rate uncapped. #565

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/Import/ImportCsvFileStep.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/Import/ImportCsvFileStep.razor
@@ -6,7 +6,7 @@
         <MudAlert Severity="Severity.Error" Variant="Variant.Text" Dense="true">@error</MudAlert>
     }
 
-    @if (!RawPreview.Any() && (IsLoading || !string.IsNullOrEmpty(FileName)))
+    @if (!RawPreview.Any() && !string.IsNullOrEmpty(FileName))
     {
         <MudStack AlignItems="AlignItems.Center" Justify="Justify.Center" Spacing="2" Class="py-12">
             <MudProgressCircular Color="Color.Primary" Indeterminate="true" />

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/Import/UploadedCsvFileReader.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/Import/UploadedCsvFileReader.cs
@@ -1,10 +1,13 @@
 using Microsoft.AspNetCore.Components.Forms;
+using System.Text;
 
 namespace FinanceManager.Components.Components.Features.FinancialAccounts.Shared.Import;
 
 public static class UploadedCsvFileReader
 {
     private const long _maxFileSize = 20 * 1024 * 1024;
+    private static readonly Encoding _strictUtf8 = new UTF8Encoding(false, true);
+    private static readonly Encoding _windows1250 = CreateWindows1250Encoding();
 
     public static async Task<UploadedCsvFileReadResult> ReadAsync(IBrowserFile? file)
     {
@@ -15,12 +18,35 @@ public static class UploadedCsvFileReader
             return UploadedCsvFileReadResult.Failed($"{file.Name} is not a csv file. Select csv file to continue.");
 
         using var stream = file.OpenReadStream(maxAllowedSize: _maxFileSize);
-        using StreamReader reader = new(stream);
+        using MemoryStream buffer = new();
+        await stream.CopyToAsync(buffer);
 
-        var content = await reader.ReadToEndAsync();
+        var content = Decode(buffer.ToArray());
         return string.IsNullOrWhiteSpace(content)
             ? UploadedCsvFileReadResult.Failed("File is empty.")
             : UploadedCsvFileReadResult.Succeeded(file.Name, file.Size, content);
+    }
+
+    private static string Decode(byte[] bytes)
+    {
+        ReadOnlySpan<byte> content = bytes;
+        if (content.StartsWith(_strictUtf8.Preamble))
+            content = content[_strictUtf8.Preamble.Length..];
+
+        try
+        {
+            return _strictUtf8.GetString(content);
+        }
+        catch (DecoderFallbackException)
+        {
+            return _windows1250.GetString(bytes);
+        }
+    }
+
+    private static Encoding CreateWindows1250Encoding()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        return Encoding.GetEncoding(1250);
     }
 }
 

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/Import/UploadedCsvFileReader.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/Import/UploadedCsvFileReader.cs
@@ -30,8 +30,8 @@ public static class UploadedCsvFileReader
     private static string Decode(byte[] bytes)
     {
         ReadOnlySpan<byte> content = bytes;
-        if (content.StartsWith(_strictUtf8.Preamble))
-            content = content[_strictUtf8.Preamble.Length..];
+        if (content.StartsWith(Encoding.UTF8.Preamble))
+            content = content[Encoding.UTF8.Preamble.Length..];
 
         try
         {

--- a/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Shared/Import/UploadedCsvFileReaderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Shared/Import/UploadedCsvFileReaderTests.cs
@@ -1,0 +1,27 @@
+using FinanceManager.Components.Components.Features.FinancialAccounts.Shared.Import;
+using Microsoft.AspNetCore.Components.Forms;
+using Moq;
+using System.Text;
+
+namespace FinanceManager.Tests.Unit.Components.Features.FinancialAccounts.Shared.Import;
+
+[Trait("Category", "Unit")]
+public class UploadedCsvFileReaderTests
+{
+    [Fact]
+    public async Task ReadAsync_DecodesWindows1250Content()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        var bytes = Encoding.GetEncoding(1250).GetBytes("Data księgowania,Nazwa odbiorcy\n2026-07-20,Mikołaj");
+        var file = new Mock<IBrowserFile>();
+        file.SetupGet(x => x.Name).Returns("transactions.csv");
+        file.SetupGet(x => x.Size).Returns(bytes.Length);
+        file.Setup(x => x.OpenReadStream(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Returns(() => new MemoryStream(bytes));
+
+        var result = await UploadedCsvFileReader.ReadAsync(file.Object);
+
+        Assert.True(result.Success);
+        Assert.Equal("Data księgowania,Nazwa odbiorcy\n2026-07-20,Mikołaj", result.Content);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Shared/Import/UploadedCsvFileReaderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Shared/Import/UploadedCsvFileReaderTests.cs
@@ -9,6 +9,23 @@ namespace FinanceManager.Tests.Unit.Components.Features.FinancialAccounts.Shared
 public class UploadedCsvFileReaderTests
 {
     [Fact]
+    public async Task ReadAsync_StripsUtf8Preamble()
+    {
+        const string content = "Id,Data księgowania\n1,2026-07-20";
+        byte[] bytes = [.. Encoding.UTF8.Preamble, .. Encoding.UTF8.GetBytes(content)];
+        var file = new Mock<IBrowserFile>();
+        file.SetupGet(x => x.Name).Returns("transactions.csv");
+        file.SetupGet(x => x.Size).Returns(bytes.Length);
+        file.Setup(x => x.OpenReadStream(It.IsAny<long>(), It.IsAny<CancellationToken>()))
+            .Returns(() => new MemoryStream(bytes));
+
+        var result = await UploadedCsvFileReader.ReadAsync(file.Object);
+
+        Assert.True(result.Success);
+        Assert.Equal(content, result.Content);
+    }
+
+    [Fact]
     public async Task ReadAsync_DecodesWindows1250Content()
     {
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);


### PR DESCRIPTION
## What changed

- keep the CSV upload input mounted until Blazor finishes copying the browser file stream
- decode valid UTF-8 strictly and fall back to Windows-1250 for Polish bank exports
- add focused coverage for Windows-1250 decoding

## Why

The loading render branch removed `MudFileUpload` as soon as the async callback yielded. Blazor then tried to continue reading through a detached input element, causing the `_blazorFilesById` JS interop exception. The attached bank export also exposed that the advertised Windows-1250 support was not implemented.

## Impact

Cash and bond CSV imports can read the selected file reliably, and Polish characters are preserved in Windows-1250 exports.

## Validation

- `dotnet build ./code/FinanceManager.slnx`
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj` (582 passed)
- uploaded `Main_07_2026.csv` through the guest cash-account import at desktop and mobile viewports (45 rows, 11 columns detected)

Closes #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV import handling for files with UTF-8 byte-order marks.
  * Added support for CSV files encoded with Windows-1250, including regional characters.
  * Improved transitions between file reading and preview states during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->