### PR TITLE
Keep investment rate independent of date range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ rules agents must follow when updating this file.
 ### Fixed
 - CSV files can now be imported into cash and bond accounts without the upload failing while the browser reads the selected file, including exports encoded as Windows-1250. #571
 - The **Category** filter button on cash account details now opens its dropdown again, so transactions can be filtered by category. #567
-- The **Investment paycheck** card now remains a current portfolio projection instead of reloading and changing when the Assets page date range changes. #563
+- The **Investment paycheck** and **Investment rate** cards now remain current portfolio projections instead of reloading and changing when the Assets page date range changes. #563
 - The **Investment rate** chart now caps monthly bars at 300% so outlier months do not flatten the rest, while keeping the headline rate uncapped. #565
 - The **Investment rate** card now measures net investment purchases instead of portfolio market-value movement, keeps its headline and footer on the same monthly period, and uses a salary-weighted YTD average so every displayed figure reconciles. #561
 - Dashboard charts (Net worth, Net cash flow, Closing balance) now redraw when the date range changes; previously only the numbers updated while the charts kept showing the old period. #559

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
@@ -22,6 +22,7 @@ public partial class InvestmentRateCard
     private static readonly string[] _singleLetterMonths =
         ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"];
 
+    private readonly DateTime _asOfDate = DateTime.UtcNow;
     private bool _isLoading;
     private Currency _currency = DefaultCurrency.PLN;
 
@@ -36,20 +37,19 @@ public partial class InvestmentRateCard
     private ApexChartOptions<MonthBar>? _chartOptions;
 
     [Parameter] public string Height { get; set; } = "300px";
-    [Parameter] public DateTime StartDateTime { get; set; }
-    [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
 
     [Inject] public required ILogger<InvestmentRateCard> Logger { get; set; }
-    [Inject] public required AssetsPageCardsCacheService AssetsPageCardsCacheService { get; set; }
+    [Inject] public required InvestmentRateCacheService InvestmentRateCacheService { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
         _currency = await SettingsService.GetCurrencyAsync();
+        await LoadInvestmentRatesAsync();
     }
 
-    protected override async Task OnParametersSetAsync()
+    private async Task LoadInvestmentRatesAsync()
     {
         _isLoading = true;
         try
@@ -61,15 +61,14 @@ public partial class InvestmentRateCard
 
             try
             {
-                var context = new AssetsPageCardsRefreshContext
+                var context = new InvestmentRateRefreshContext
                 {
                     UserId = user.UserId,
                     CurrencyId = _currency.Id,
-                    StartDateTime = StartDateTime,
-                    EndDateTime = EndDateTime,
+                    EndDateTime = _asOfDate,
                 };
 
-                var snapshot = await AssetsPageCardsCacheService.GetSnapshotAsync(context);
+                var snapshot = await InvestmentRateCacheService.GetSnapshotAsync(context);
                 MonthlyInvestmentRates = [.. snapshot.MonthlyInvestmentRates];
 
                 BuildDerivedState();
@@ -89,13 +88,13 @@ public partial class InvestmentRateCard
     {
         _currentMonthPercentage = CurrentMonthRate?.GetPercentage() ?? 0m;
 
-        var currentYear = EndDateTime.Year;
+        var currentYear = _asOfDate.Year;
         var ytdEntries = MonthlyInvestmentRates.Where(r => r.Start.Year == currentYear).ToList();
         var salaryYtd = ytdEntries.Sum(r => r.Salary);
         var investedYtd = ytdEntries.Sum(r => r.InvestmentsChange);
         _ytdAveragePercentage = salaryYtd == 0m ? 0m : investedYtd / salaryYtd;
 
-        var monthsElapsed = EndDateTime.Month;
+        var monthsElapsed = _asOfDate.Month;
 
         _endOfYearProjection = monthsElapsed == 0 || investedYtd == 0
             ? null

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Pages/AssetsPage.razor
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Pages/AssetsPage.razor
@@ -18,7 +18,7 @@
         </MudItem>
 
         <MudItem xs="12" lg="4">
-            <InvestmentRateCard StartDateTime=StartDate EndDateTime="@EndDate" Height="@($"{2 * _unitHeight}px")" />
+            <InvestmentRateCard Height="@($"{2 * _unitHeight}px")" />
         </MudItem>
 
         <MudItem xs="12" lg="4">

--- a/code/FinanceManager.Components/Models/InvestmentRateCacheSnapshot.cs
+++ b/code/FinanceManager.Components/Models/InvestmentRateCacheSnapshot.cs
@@ -1,0 +1,22 @@
+using FinanceManager.Domain.MoneyFlow.Entities;
+
+namespace FinanceManager.Components.Models;
+
+public sealed class InvestmentRateCacheSnapshot
+{
+    public const int CurrentSchemaVersion = 1;
+
+    public int SchemaVersion { get; set; } = CurrentSchemaVersion;
+    public int UserId { get; set; }
+    public int CurrencyId { get; set; }
+    public DateTime EndDateTime { get; set; }
+    public DateTime FetchedAtUtc { get; set; }
+    public List<InvestmentRate> MonthlyInvestmentRates { get; set; } = [];
+}
+
+public sealed class InvestmentRateRefreshContext
+{
+    public int UserId { get; set; }
+    public int CurrencyId { get; set; }
+    public DateTime EndDateTime { get; set; }
+}

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -63,6 +63,7 @@ public static class ServiceCollectionExtension
                 .AddTransient<CurrencyImportJobTracker>()
                 .AddScoped<AssetsPageCardsCacheService>()
                 .AddScoped<InvestmentPaycheckEstimateCacheService>()
+                .AddScoped<InvestmentRateCacheService>()
                 .AddScoped<CurrencyHttpClient>()
                 .AddScoped<IUserService, UserService>()
                 .AddScoped<IFinancialAccountService, FinancialAccountService>()

--- a/code/FinanceManager.Components/Services/AssetsPageCardsCacheService.cs
+++ b/code/FinanceManager.Components/Services/AssetsPageCardsCacheService.cs
@@ -2,7 +2,6 @@ using Blazored.LocalStorage;
 using FinanceManager.Components.HttpClients;
 using FinanceManager.Components.Models;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
-using FinanceManager.Domain.MoneyFlow.Entities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
@@ -12,7 +11,6 @@ public class AssetsPageCardsCacheService(
     ILocalStorageService localStorageService,
     IMemoryCache memoryCache,
     AssetsHttpClient assetsHttpClient,
-    MoneyFlowHttpClient moneyFlowHttpClient,
     ILogger<AssetsPageCardsCacheService> logger)
     : LocalStorageStateCacheService<AssetsPageCardsCacheSnapshot, AssetsPageCardsRefreshContext, string>(
         localStorageService,
@@ -39,9 +37,7 @@ public class AssetsPageCardsCacheService(
         var assetsTimeSeriesTask = assetsHttpClient.GetAssetsTimeSeries(refreshContext.UserId, currency, startDate, endDate);
         var assetsPerTypeTask = assetsHttpClient.GetEndAssetsPerType(refreshContext.UserId, currency, endDate);
         var assetsPerAccountTask = assetsHttpClient.GetEndAssetsPerAccount(refreshContext.UserId, currency, endDate);
-        var monthlyInvestmentRatesTask = GetMonthlyInvestmentRatesAsync(refreshContext.UserId, currency, endDate);
-
-        await Task.WhenAll(assetsTimeSeriesTask, assetsPerTypeTask, assetsPerAccountTask, monthlyInvestmentRatesTask);
+        await Task.WhenAll(assetsTimeSeriesTask, assetsPerTypeTask, assetsPerAccountTask);
 
         return new AssetsPageCardsCacheSnapshot
         {
@@ -54,32 +50,7 @@ public class AssetsPageCardsCacheService(
             AssetsTimeSeries = [.. (await assetsTimeSeriesTask)],
             EndAssetsPerType = [.. (await assetsPerTypeTask)],
             EndAssetsPerAccount = [.. (await assetsPerAccountTask)],
-            MonthlyInvestmentRates = await monthlyInvestmentRatesTask,
         };
-    }
-
-    private async Task<List<InvestmentRate>> GetMonthlyInvestmentRatesAsync(int userId, Currency currency, DateTime endDate)
-    {
-        const int monthsBack = 12;
-        var anchor = new DateTime(endDate.Year, endDate.Month, 1, 0, 0, 0, DateTimeKind.Utc);
-
-        var tasks = new Task<(DateTime start, DateTime end, List<InvestmentRate> rates)>[monthsBack];
-        for (int i = 0; i < monthsBack; i++)
-        {
-            var monthStart = anchor.AddMonths(-(monthsBack - 1 - i));
-            var monthEnd = monthStart.AddMonths(1).AddTicks(-1);
-            if (monthEnd > endDate) monthEnd = endDate;
-            tasks[i] = FetchMonthAsync(userId, currency, monthStart, monthEnd);
-        }
-
-        var results = await Task.WhenAll(tasks);
-        return [.. results.Select(r => r.rates.FirstOrDefault() ?? new InvestmentRate { Start = r.start, End = r.end })];
-    }
-
-    private async Task<(DateTime start, DateTime end, List<InvestmentRate> rates)> FetchMonthAsync(int userId, Currency currency, DateTime start, DateTime end)
-    {
-        var rates = await moneyFlowHttpClient.GetInvestmentRate(userId, currency, start, end).ToListAsync();
-        return (start, end, rates);
     }
 
     protected override bool IsUsable(AssetsPageCardsCacheSnapshot? state, string cacheKey, DateTime utcNow)

--- a/code/FinanceManager.Components/Services/InvestmentRateCacheService.cs
+++ b/code/FinanceManager.Components/Services/InvestmentRateCacheService.cs
@@ -1,0 +1,88 @@
+using Blazored.LocalStorage;
+using FinanceManager.Components.HttpClients;
+using FinanceManager.Components.Models;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.MoneyFlow.Entities;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Components.Services;
+
+public class InvestmentRateCacheService(
+    ILocalStorageService localStorageService,
+    IMemoryCache memoryCache,
+    MoneyFlowHttpClient moneyFlowHttpClient,
+    ILogger<InvestmentRateCacheService> logger)
+    : LocalStorageStateCacheService<InvestmentRateCacheSnapshot, InvestmentRateRefreshContext, string>(
+        localStorageService,
+        memoryCache,
+        logger,
+        _cacheKeyPrefix)
+{
+    private const string _cacheKeyPrefix = "investment-rate-cache-v1";
+    private const int _monthsBack = 12;
+    private static readonly TimeSpan _maxStale = TimeSpan.FromMinutes(5);
+
+    public Task<InvestmentRateCacheSnapshot> GetSnapshotAsync(InvestmentRateRefreshContext context)
+        => GetOrRefreshAsync(context);
+
+    protected override string GetCacheKey(InvestmentRateRefreshContext refreshContext)
+        => BuildCacheKey(refreshContext.UserId, refreshContext.CurrencyId, refreshContext.EndDateTime);
+
+    protected override async Task<InvestmentRateCacheSnapshot> BuildStateAsync(InvestmentRateRefreshContext refreshContext)
+    {
+        var endDate = refreshContext.EndDateTime;
+        var currency = new Currency { Id = refreshContext.CurrencyId };
+        var monthlyInvestmentRates = await GetMonthlyInvestmentRatesAsync(refreshContext.UserId, currency, endDate);
+
+        return new InvestmentRateCacheSnapshot
+        {
+            SchemaVersion = InvestmentRateCacheSnapshot.CurrentSchemaVersion,
+            UserId = refreshContext.UserId,
+            CurrencyId = refreshContext.CurrencyId,
+            EndDateTime = endDate,
+            FetchedAtUtc = DateTime.UtcNow,
+            MonthlyInvestmentRates = monthlyInvestmentRates,
+        };
+    }
+
+    private async Task<List<InvestmentRate>> GetMonthlyInvestmentRatesAsync(int userId, Currency currency, DateTime endDate)
+    {
+        var anchor = new DateTime(endDate.Year, endDate.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        var tasks = new Task<(DateTime start, DateTime end, List<InvestmentRate> rates)>[_monthsBack];
+        for (int i = 0; i < _monthsBack; i++)
+        {
+            var monthStart = anchor.AddMonths(-(_monthsBack - 1 - i));
+            var monthEnd = monthStart.AddMonths(1).AddTicks(-1);
+            if (monthEnd > endDate) monthEnd = endDate;
+            tasks[i] = FetchMonthAsync(userId, currency, monthStart, monthEnd);
+        }
+
+        var results = await Task.WhenAll(tasks);
+        return [.. results.Select(r => r.rates.FirstOrDefault() ?? new InvestmentRate { Start = r.start, End = r.end })];
+    }
+
+    private async Task<(DateTime start, DateTime end, List<InvestmentRate> rates)> FetchMonthAsync(int userId, Currency currency, DateTime start, DateTime end)
+    {
+        var rates = await moneyFlowHttpClient.GetInvestmentRate(userId, currency, start, end).ToListAsync();
+        return (start, end, rates);
+    }
+
+    protected override bool IsUsable(InvestmentRateCacheSnapshot? state, string cacheKey, DateTime utcNow)
+    {
+        if (state is null)
+            return false;
+
+        if (state.SchemaVersion != InvestmentRateCacheSnapshot.CurrentSchemaVersion)
+            return false;
+
+        if (utcNow - state.FetchedAtUtc > _maxStale)
+            return false;
+
+        return BuildCacheKey(state.UserId, state.CurrencyId, state.EndDateTime) == cacheKey;
+    }
+
+    private static string BuildCacheKey(int userId, int currencyId, DateTime endDateTime)
+        => $"{userId}:{currencyId}:{endDateTime:O}";
+}


### PR DESCRIPTION
## What changed

- give the Investment rate card its own cached snapshot
- load that snapshot once using the current as-of date
- remove Investment rate requests from the date-range-dependent Assets page cache
- stop passing Assets page date parameters into the card

## Why

The Investment rate card represents a current portfolio projection, but it shared the Assets page cache. Changing the page date range rebuilt that cache and re-fetched monthly investment rates, causing the card to reload and change even though its meaning is independent of the selected range.

## Impact

The Investment paycheck and Investment rate cards now remain stable when the Assets page date range changes. Other Assets cards continue to follow the selected range.

## Validation

- `dotnet format ./code/FinanceManager.slnx`
- `dotnet build ./code/FinanceManager.slnx`
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj` (583 passed)
- guest Assets page checked at 430×920 and 1280×1000
- verified Investment rate remained 28.46% after switching from This month to This year

Closes #563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated caching for monthly investment rates.
  * Investment rates now refresh automatically for the latest 12 months.
  * Missing monthly rate data is represented with default values, ensuring consistent dashboard calculations.

* **Bug Fixes**
  * Dashboard investment rate calculations now use a consistent point-in-time date, preventing date-range changes from shifting results unexpectedly.
  * Improved cache freshness with automatic refreshes after five minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->