### PR TITLE
Improve time-series chart Y-axis scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- Dashboard time-series charts now scale to the displayed values with padding, making smaller changes clearly visible. #574
 - CSV files can now be imported into cash and bond accounts without the upload failing while the browser reads the selected file, including exports encoded as Windows-1250. #571
 - The **Category** filter button on cash account details now opens its dropdown again, so transactions can be filtered by category. #567
 - The **Investment paycheck** and **Investment rate** cards now remain current portfolio projections instead of reloading and changing when the Assets page date range changes. #563

--- a/code/FinanceManager.Components/Components/Shared/Charts/TimeSeriesValueCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Shared/Charts/TimeSeriesValueCard.razor.cs
@@ -161,33 +161,25 @@ public partial class TimeSeriesValueCard
         await _chart.RenderAsync();
     }
 
-    // Pin the Y axis to a "nice" zero-based range so the card shows ~5 round
-    // gridline labels (2.5k / 5k / …) like the design, instead of ApexCharts
-    // collapsing forceNiceScale to one or two ticks. Always spans the zero
-    // baseline so the area fill reads correctly for positive (assets) and
-    // negative (liabilities) series alike.
+    // Keep small changes visible by padding the displayed data range instead
+    // of forcing every series through zero.
     private void ApplyYScale()
     {
         var axis = _options?.Yaxis?.FirstOrDefault();
         if (axis is null || Data.Count == 0) return;
 
-        double lo = Math.Min(0d, (double)Data.Min(p => p.Value));
-        double hi = Math.Max(0d, (double)Data.Max(p => p.Value));
-        if (hi <= lo) hi = lo + 1d;
-
-        double rawStep = (hi - lo) / 5d;
-        double mag = Math.Pow(10, Math.Floor(Math.Log10(rawStep)));
-        double norm = rawStep / mag;
-        double step = (norm <= 1 ? 1 : norm <= 2 ? 2 : norm <= 2.5 ? 2.5 : norm <= 5 ? 5 : 10) * mag;
-
-        double niceMin = Math.Floor(lo / step) * step;
-        double niceMax = Math.Ceiling(hi / step) * step;
-        int ticks = Math.Max(1, (int)Math.Round((niceMax - niceMin) / step));
-
-        axis.Min = niceMin;
-        axis.Max = niceMax;
-        axis.TickAmount = ticks;
+        var bounds = AddYRangePadding((double)Data.Min(p => p.Value), (double)Data.Max(p => p.Value));
+        axis.Min = bounds.Min;
+        axis.Max = bounds.Max;
+        axis.TickAmount = 5;
         axis.ForceNiceScale = false;
+    }
+
+    internal static (double Min, double Max) AddYRangePadding(double minimum, double maximum)
+    {
+        var range = maximum - minimum;
+        var padding = range == 0 ? Math.Max(Math.Abs(minimum) * 0.05, 1) : range * 0.05;
+        return (minimum - padding, maximum + padding);
     }
 
     private void OnPointEnter(HoverData<TimeSeriesModel> hoverData)

--- a/code/FinanceManager.Tests.Unit/Components/Shared/Charts/TimeSeriesValueCardTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Shared/Charts/TimeSeriesValueCardTests.cs
@@ -1,0 +1,25 @@
+using FinanceManager.Components.Components.Shared.Charts;
+
+namespace FinanceManager.Tests.Unit.Components.Shared.Charts;
+
+[Trait("Category", "Unit")]
+public class TimeSeriesValueCardTests
+{
+    [Fact]
+    public void AddYRangePadding_AddsFivePercentBelowAndAboveDisplayedRange()
+    {
+        var bounds = TimeSeriesValueCard.AddYRangePadding(68_000, 72_000);
+
+        Assert.Equal(67_800, bounds.Min);
+        Assert.Equal(72_200, bounds.Max);
+    }
+
+    [Fact]
+    public void AddYRangePadding_ConstantValueStillProducesVisibleRange()
+    {
+        var bounds = TimeSeriesValueCard.AddYRangePadding(1_000, 1_000);
+
+        Assert.Equal(950, bounds.Min);
+        Assert.Equal(1_050, bounds.Max);
+    }
+}


### PR DESCRIPTION
## What changed

- Scale dashboard time-series charts from the displayed minimum to maximum with 5% padding on both sides.
- Preserve a visible Y-axis range when all displayed values are equal.
- Add focused unit coverage for normal and constant-value ranges.

## Why

The charts forced their Y-axis through zero, which flattened small changes whenever values were far from zero. Using the displayed data range makes those movements clearly visible.

## Validation

- `dotnet format .\FinanceManager.slnx`
- `dotnet test --project .\FinanceManager.Tests.Unit\FinanceManager.Tests.Unit.csproj` (585 passed)
- `dotnet build .\FinanceManager.slnx` (0 warnings, 0 errors)
- Desktop and mobile guest-dashboard screenshots reviewed

Closes #574