### PR TITLE
Make investment rate chart interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- The **Investment rate** chart is now interactive: selecting a month highlights its bar and shows that month's salary and invested amount, while the average line displays its value. #576
 - The dashboard date picker has been redesigned into a compact pill: the active preset (This month / This quarter / This year) is now highlighted, and the custom range opens in a calendar dialog — consistent with the account details pages — showing the selected dates next to the presets. #559
 - The app loading screen has been redesigned: an animated logo and branded wordmark replace the plain title, and an indefinite spinner has been replaced with a progress ring showing the real download progress while the app boots. #553
 - The expanded investment transaction details now use a two-column layout on mobile instead of stacking every field in a single narrow column, so the previously empty right half of the screen is used and the details take up roughly half the vertical space.

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor
@@ -36,6 +36,8 @@
                 {
                     <ApexChart TItem="MonthBar"
                                Options="@_chartOptions"
+                               OnDataPointSelection="OnBarSelected"
+                               @key="_selectedRateIndex"
                                Height="@("100%")">
                         <ApexPointSeries TItem="MonthBar"
                                          Items="@_series"
@@ -43,7 +45,7 @@
                                          SeriesType="SeriesType.Bar"
                                          XValue="@(p => (object)p.Label)"
                                          YValue="@(p => (decimal?)p.Percentage)"
-                                         PointColor="@(p => p.IsCurrent ? _highlightColor : _mutedBarColor)" />
+                                         PointColor="@(p => p.IsSelected ? _highlightColor : _mutedBarColor)" />
                     </ApexChart>
                 }
             </div>
@@ -52,14 +54,14 @@
             <MudDivider Class="my-1" Style="flex-grow:0;" />
             <MudGrid Spacing="1">
                 <MudItem xs="6">
-                    <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">This month salary</MudText>
-                    <MudText Typo="Typo.body2">@FormatAmount(CurrentMonthRate?.Salary ?? 0)</MudText>
+                    <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">@SelectedMonthName salary</MudText>
+                    <MudText Typo="Typo.body2">@FormatAmount(SelectedMonthRate?.Salary ?? 0)</MudText>
                 </MudItem>
                 <MudItem xs="6">
-                    <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">This month invested</MudText>
+                    <MudText Typo="Typo.caption" Color="MudBlazor.Color.Secondary">@SelectedMonthName invested</MudText>
                     <MudText Typo="Typo.body2"
-                             Color="@(CurrentMonthRate?.InvestmentsChange > 0 ? MudBlazor.Color.Success : MudBlazor.Color.Default)">
-                        @FormatChange(CurrentMonthRate?.InvestmentsChange ?? 0)
+                             Color="@(SelectedMonthRate?.InvestmentsChange > 0 ? MudBlazor.Color.Success : MudBlazor.Color.Default)">
+                        @FormatChange(SelectedMonthRate?.InvestmentsChange ?? 0)
                     </MudText>
                 </MudItem>
             </MudGrid>

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.cs
@@ -9,6 +9,7 @@ using FinanceManager.Domain.MoneyFlow.Entities;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using MudBlazor;
+using System.Globalization;
 
 namespace FinanceManager.Components.Components.Features.Dashboard.Cards.Assets;
 
@@ -30,9 +31,18 @@ public partial class InvestmentRateCard
 
     private InvestmentRate? CurrentMonthRate => MonthlyInvestmentRates.LastOrDefault();
 
+    internal InvestmentRate? SelectedMonthRate =>
+        _selectedRateIndex >= 0 && _selectedRateIndex < MonthlyInvestmentRates.Count
+            ? MonthlyInvestmentRates[_selectedRateIndex]
+            : null;
+
+    private string SelectedMonthName =>
+        SelectedMonthRate?.Start.ToString("MMMM", CultureInfo.InvariantCulture) ?? "Month";
+
     private decimal _currentMonthPercentage;
     private decimal _ytdAveragePercentage;
     private decimal? _endOfYearProjection;
+    private int _selectedRateIndex;
     private List<MonthBar> _series = [];
     private ApexChartOptions<MonthBar>? _chartOptions;
 
@@ -86,6 +96,7 @@ public partial class InvestmentRateCard
 
     private void BuildDerivedState()
     {
+        _selectedRateIndex = MonthlyInvestmentRates.Count - 1;
         _currentMonthPercentage = CurrentMonthRate?.GetPercentage() ?? 0m;
 
         var currentYear = _asOfDate.Year;
@@ -112,13 +123,13 @@ public partial class InvestmentRateCard
             var monthIndex = rate is not null ? rate.Start.Month - 1 : i;
             var label = _singleLetterMonths[monthIndex];
             var pct = rate is not null ? Math.Min(rate.GetPercentage() * 100m, _maximumChartPercentage) : 0m;
-            bars.Add(new MonthBar(label, pct, IsCurrent: i == 11, Key: $"{i}-{label}"));
+            bars.Add(new MonthBar(label, pct, IsSelected: i == _selectedRateIndex, Key: $"{i}-{label}"));
         }
 
         _series = bars;
 
         var labelColors = bars
-            .Select(b => b.IsCurrent ? _highlightColor : _mutedLabelColor)
+            .Select(b => b.IsSelected ? _highlightColor : _mutedLabelColor)
             .ToArray();
 
         _chartOptions = new ApexChartOptions<MonthBar>
@@ -179,10 +190,35 @@ public partial class InvestmentRateCard
                         BorderColor = _mutedLabelColor,
                         StrokeDashArray = 4,
                         BorderWidth = 1,
+                        Label = new Label
+                        {
+                            Text = FormatAveragePercentage(_ytdAveragePercentage),
+                            Position = LabelPosition.Right,
+                            BorderColor = "transparent",
+                            Style = new Style
+                            {
+                                Background = "transparent",
+                                Color = _mutedLabelColor,
+                                FontSize = "11px",
+                            },
+                        },
                     },
                 ],
             };
         }
+    }
+
+    private void OnBarSelected(SelectedData<MonthBar> selection)
+    {
+        if (!SelectMonth(selection.DataPointIndex)) return;
+        BuildChart();
+    }
+
+    internal bool SelectMonth(int index)
+    {
+        if (index < 0 || index >= MonthlyInvestmentRates.Count) return false;
+        _selectedRateIndex = index;
+        return true;
     }
 
     private static string FormatRateNumber(decimal value) => $"{value * 100m:0.00}";
@@ -197,5 +233,5 @@ public partial class InvestmentRateCard
         ? "—"
         : $"{_endOfYearProjection.Value:N0} {_currency.ShortName}";
 
-    internal record MonthBar(string Label, decimal Percentage, bool IsCurrent, string Key);
+    internal record MonthBar(string Label, decimal Percentage, bool IsSelected, string Key);
 }

--- a/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.css
+++ b/code/FinanceManager.Components/Components/Features/Dashboard/Cards/Assets/InvestmentRateCard.razor.css
@@ -12,3 +12,7 @@
 .investment-rate-card__chart ::deep .apexcharts-toolbar {
     display: none !important;
 }
+
+.investment-rate-card__chart ::deep .apexcharts-bar-area {
+    cursor: pointer;
+}

--- a/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Cards/Assets/InvestmentRateCardTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Cards/Assets/InvestmentRateCardTests.cs
@@ -1,0 +1,23 @@
+using FinanceManager.Components.Components.Features.Dashboard.Cards.Assets;
+using FinanceManager.Domain.MoneyFlow.Entities;
+using System.Runtime.CompilerServices;
+
+namespace FinanceManager.Tests.Unit.Components.Features.Dashboard.Cards.Assets;
+
+[Trait("Category", "Unit")]
+public class InvestmentRateCardTests
+{
+    [Fact]
+    public void SelectMonth_UpdatesSelectionAndIgnoresPlaceholderBars()
+    {
+        var january = new InvestmentRate { Start = new DateTime(2026, 1, 1) };
+        var february = new InvestmentRate { Start = new DateTime(2026, 2, 1) };
+        var card = (InvestmentRateCard)RuntimeHelpers.GetUninitializedObject(typeof(InvestmentRateCard));
+        card.MonthlyInvestmentRates = [january, february];
+
+        Assert.True(card.SelectMonth(0));
+        Assert.Same(january, card.SelectedMonthRate);
+        Assert.False(card.SelectMonth(2));
+        Assert.Same(january, card.SelectedMonthRate);
+    }
+}


### PR DESCRIPTION
## What changed

- update the salary and invested footer values when a monthly bar is selected
- highlight the selected month and keep the latest month selected initially
- show the numeric percentage on the dashed average line
- ignore clicks on placeholder bars

## Why

The chart showed monthly history, but its supporting values were fixed to the current month and the average line had no value attached to it. The card is now directly explorable without changing the existing headline projection.

## Validation

- `dotnet build ./FinanceManager.slnx`
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj` — 586 passed
- desktop and mobile guest-account UI checks, including selecting February and confirming the footer values and orange highlight update

Closes #576