### PR TITLE
Show investment asset appreciation #578

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- Investment accounts now show asset appreciation based on current holdings value minus the remaining buy cost, with transaction-date currency conversion. #578
 - The dashboard date picker has been redesigned into a compact pill: the active preset (This month / This quarter / This year) is now highlighted, and the custom range opens in a calendar dialog — consistent with the account details pages — showing the selected dates next to the presets. #559
 - The app loading screen has been redesigned: an animated logo and branded wordmark replace the plain title, and an indefinite spinner has been replaced with a progress ring showing the real download progress while the app boots. #553
 - The expanded investment transaction details now use a two-column layout on mobile instead of stacking every field in a single narrow column, so the previously empty right half of the screen is used and the details take up roughly half the vertical space.

--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -65,7 +65,9 @@
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="System.Memory.Data" Version="10.0.9" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <!-- 10.0.9 carries high-severity advisories (GHSA-23rf-6693-g89p, GHSA-8q5v-6pqq-x66h,
+         GHSA-cvvh-rhrc-wg4q, GHSA-g8r8-53c2-pm3f); first patched in 10.0.10. -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="System.Security.Permissions" Version="10.0.9" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.9" />
     <PackageVersion Include="System.Windows.Extensions" Version="10.0.9" />

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Assets/AssetsServiceInvestment.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Assets/AssetsServiceInvestment.cs
@@ -1,5 +1,6 @@
 using FinanceManager.Domain.Assets.Services;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Investments.Services;
@@ -19,7 +20,8 @@ internal class AssetsServiceInvestment(
     IFinancialAccountRepository financialAccountRepository,
     IInvestmentValuationService valuationService,
     IInvestmentTransactionRepository transactionRepository,
-    IInvestmentPriceProvider priceProvider) : IAssetsServiceTyped
+    IInvestmentPriceProvider priceProvider,
+    ICurrencyExchangeService currencyExchangeService) : IAssetsServiceTyped
 {
     public bool IsOfType<T>() => typeof(T) == typeof(InvestmentAccount);
 
@@ -113,23 +115,35 @@ internal class AssetsServiceInvestment(
                 var listing = group.First().AssetListing;
                 var instrumentName = listing?.Ticker ?? group.Key.ToString();
 
-                // Average-cost basis from buy legs (including fees). Cost basis is recorded in each
-                // transaction's currency; when that differs from the requested display currency we
-                // cannot convert historical FX here, so flag the instrument and exclude it from totals.
                 var buys = group.Where(t => t.Type == InvestmentTransactionType.Buy).ToList();
                 var boughtQty = buys.Sum(t => t.Quantity);
-                var boughtCost = buys.Sum(t => t.Quantity * t.UnitPrice + (t.Fee ?? 0));
+                decimal boughtCost = 0m;
+                var missingExchangeRate = false;
+                foreach (var buy in buys)
+                {
+                    var sourceCurrency = new Currency { ShortName = buy.Currency, Symbol = buy.Currency };
+                    var exchangeRate = string.Equals(buy.Currency, currency.ShortName, StringComparison.OrdinalIgnoreCase)
+                        ? 1m
+                        : await currencyExchangeService.GetExchangeRateAsync(
+                            sourceCurrency, currency, buy.TradeDate.ToDateTime(TimeOnly.MinValue));
+                    if (exchangeRate is not decimal rate || rate <= 0m)
+                    {
+                        missingExchangeRate = true;
+                        break;
+                    }
+
+                    boughtCost += (buy.Quantity * buy.UnitPrice + (buy.Fee ?? 0m)) * rate;
+                }
                 var avgCost = boughtQty > 0 ? boughtCost / boughtQty : 0;
                 var costBasis = avgCost * holding;
 
                 var price = await priceProvider.GetPricePerUnitAsync(group.Key, currency, asOfDate);
                 var currentValue = holding * price;
 
-                var crossCurrency = group.Any(t => !string.Equals(t.Currency, currency.ShortName, StringComparison.OrdinalIgnoreCase));
-                var excluded = price <= 0 || crossCurrency;
+                var excluded = price <= 0 || missingExchangeRate;
                 string? warning = price <= 0
                     ? "No price available for this instrument."
-                    : crossCurrency ? "Cost basis is in a different currency; excluded from totals." : null;
+                    : missingExchangeRate ? "No exchange rate available for the transaction date." : null;
 
                 var unrealized = currentValue - costBasis;
                 var unrealizedPercent = costBasis == 0 ? 0 : unrealized / costBasis * 100;

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
@@ -22,6 +22,7 @@ else
 {
     <AccountDetailsHero AccountName="@_accountName" AccountTypeLabel="@_accountTypeLabel" Currency="@_currency.ShortName"
                         Balance="@_currentBalance" BalanceChange="@_balanceChange" BalanceChangePercent="@_balanceChangePercent"
+                        ChangeLabel="Asset appreciation" ShowChangeRange="false"
                         SelectedRange="@_selectedRange" SelectedRangeChanged="OnRangeChanged" IsChartLoading="@_isChartLoading"
                         CustomDateRange="@_customDateRange" CustomDateRangeChanged="OnCustomDateRangeChanged"
                         ChartData="@ChartData" IsMobile="@_isMobile" />
@@ -65,6 +66,8 @@ else
                 <MudItem lg="4">
                     <MudStack Spacing="4">
                         <BalanceChangeCard BalanceChange="@_balanceChange" Currency="@_currency.ShortName"
+                                           Label="Asset appreciation" ShowRange="false"
+                                           Description="Current value minus remaining buy cost"
                                            RangeLabel="@_selectedRange" FromDate="@_dateStart" ToDate="@_dateEnd" />
 
                         @HoldingsCard
@@ -88,7 +91,9 @@ else
             </MudStack>
             <MudDivider />
             <MudStack Spacing="4" Class="pa-4">
-                <BalanceChangeCard BalanceChange="@_balanceChange" Currency="@_currency.ShortName" RangeLabel="@_selectedRange"
+                <BalanceChangeCard BalanceChange="@_balanceChange" Currency="@_currency.ShortName"
+                                   Label="Asset appreciation" ShowRange="false"
+                                   Description="Current value minus remaining buy cost" RangeLabel="@_selectedRange"
                                    FromDate="@_dateStart" ToDate="@_dateEnd" />
 
                 @HoldingsCard

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -1,6 +1,7 @@
 using FinanceManager.Components.Components.Features.FinancialAccounts.Shared;
 using FinanceManager.Components.Helpers;
 using FinanceManager.Components.HttpClients;
+using FinanceManager.Components.Services;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
@@ -18,7 +19,9 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
 
     [Inject] public required InvestmentTransactionHttpClient TransactionHttpClient { get; set; }
     [Inject] public required InvestmentValuationHttpClient ValuationHttpClient { get; set; }
+    [Inject] public required AssetsHttpClient AssetsHttpClient { get; set; }
     [Inject] public required InvestmentAccountHttpClient InvestmentAccountHttpClient { get; set; }
+    [Inject] public required ILoginService LoginService { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ISnackbar Snackbar { get; set; }
     [Inject] public required IBrowserViewportService BrowserViewportService { get; set; }
@@ -173,6 +176,11 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
     {
         var series = await ValuationHttpClient.GetValueSeriesAsync(accountId, currency.Id, dateStart, dateEnd);
         var holdings = await ValuationHttpClient.GetHoldingsAsync(accountId, dateEnd);
+        var user = await LoginService.GetLoggedUser();
+        var appreciation = user is null
+            ? null
+            : (await AssetsHttpClient.GetUnrealizedGainLossPerAccount(user.UserId, currency, dateEnd))
+                .SingleOrDefault(x => x.AccountId == accountId);
         if (refreshVersion != _chartRefreshVersion || accountId != AccountId) return;
 
         // Keep the full ordered series for balance maths; trim only leading zeros for the chart so
@@ -184,17 +192,17 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
 
         ChartData.Clear();
         ChartData.AddRange(orderedSeries.SkipWhile(x => x.Value == 0));
-        UpdateBalanceFromChartData(orderedSeries);
+        UpdateBalanceFromChartData(orderedSeries, appreciation);
         UpdateHoldings(holdings, dateEnd);
     }
 
-    private void UpdateBalanceFromChartData(IReadOnlyList<TimeSeriesModel> balanceSeries)
+    private void UpdateBalanceFromChartData(
+        IReadOnlyList<TimeSeriesModel> balanceSeries,
+        UnrealizedGainLossAccountResult? appreciation)
     {
         _currentBalance = balanceSeries.LastOrDefault()?.Value ?? 0;
-        _balanceChange = balanceSeries.Count >= 2 ? balanceSeries[^1].Value - balanceSeries[0].Value : 0;
-
-        var startBalance = _currentBalance - _balanceChange;
-        _balanceChangePercent = startBalance == 0 ? null : _balanceChange / startBalance * 100m;
+        _balanceChange = appreciation?.UnrealizedGainLoss ?? 0m;
+        _balanceChangePercent = appreciation is null ? null : appreciation.UnrealizedGainLossPercent;
     }
 
     private void UpdateHoldings(IReadOnlyDictionary<long, decimal> holdings, DateTime asOf)

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor
@@ -53,7 +53,7 @@
                 </MudStack>
 
                 <MudStack Spacing="1" AlignItems="AlignItems.End">
-                    <MudText Typo="Typo.overline" Color="MudBlazor.Color.Default">Change · @SelectedRange</MudText>
+                    <MudText Typo="Typo.overline" Color="MudBlazor.Color.Default">@ChangeLabel@(ShowChangeRange ? $" · {SelectedRange}" : null)</MudText>
                     <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                         <MudIcon
                         Icon="@(BalanceChange >= 0 ? Icons.Material.Filled.TrendingUp : Icons.Material.Filled.TrendingDown)"

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.cs
@@ -14,6 +14,8 @@ public partial class AccountDetailsHero
     [Parameter] public decimal Balance { get; set; }
     [Parameter] public decimal BalanceChange { get; set; }
     [Parameter] public decimal? BalanceChangePercent { get; set; }
+    [Parameter] public string ChangeLabel { get; set; } = "Change";
+    [Parameter] public bool ShowChangeRange { get; set; } = true;
     [Parameter] public string SelectedRange { get; set; } = "3M";
     [Parameter] public EventCallback<string> SelectedRangeChanged { get; set; }
     [Parameter] public DateRange? CustomDateRange { get; set; }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/BalanceChangeCard.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/BalanceChangeCard.razor
@@ -1,6 +1,6 @@
 <MudCard Outlined="true" Style="background-color: transparent;">
     <MudCardContent>
-        <MudText Typo="Typo.overline" Color="Color.Default">Balance change · @RangeLabel</MudText>
+        <MudText Typo="Typo.overline" Color="Color.Default">@Label@(ShowRange ? $" · {RangeLabel}" : null)</MudText>
         <MudText Typo="Typo.h3" Class="fm-tabular"
                  Color="@(BalanceChange >= 0 ? Color.Success : Color.Error)">
             @(BalanceChange >= 0 ? "+" : "")@BalanceChange.ToString("N2") @Currency
@@ -10,7 +10,7 @@
                      Icon="@(BalanceChange >= 0 ? Icons.Material.Filled.ArrowUpward : Icons.Material.Filled.ArrowDownward)"
                      Color="@(BalanceChange >= 0 ? Color.Success : Color.Error)" />
             <MudText Typo="Typo.caption" Color="Color.Default">
-                From @FromDate.ToString("dd MMM yyyy") to @ToDate.ToString("dd MMM yyyy")
+                @(Description ?? $"From {FromDate:dd MMM yyyy} to {ToDate:dd MMM yyyy}")
             </MudText>
         </MudStack>
     </MudCardContent>
@@ -19,6 +19,9 @@
 @code {
     [Parameter] public decimal BalanceChange { get; set; }
     [Parameter] public required string Currency { get; set; }
+    [Parameter] public string Label { get; set; } = "Balance change";
+    [Parameter] public bool ShowRange { get; set; } = true;
+    [Parameter] public string? Description { get; set; }
     [Parameter] public string RangeLabel { get; set; } = string.Empty;
     [Parameter] public DateTime FromDate { get; set; }
     [Parameter] public DateTime ToDate { get; set; }

--- a/code/FinanceManager.Tests.Unit/Application/Services/AssetsServiceInvestmentTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/AssetsServiceInvestmentTests.cs
@@ -1,0 +1,81 @@
+using FinanceManager.Application.FinancialAccounts.Investments.Assets;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Services;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Services;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class AssetsServiceInvestmentTests
+{
+    [Fact]
+    public async Task GetUnrealizedGainLossPerAccount_ConvertsRemainingBuyCostAtTradeDate()
+    {
+        var accountRepository = new Mock<IFinancialAccountRepository>();
+        var transactionRepository = new Mock<IInvestmentTransactionRepository>();
+        var priceProvider = new Mock<IInvestmentPriceProvider>();
+        var exchangeService = new Mock<ICurrencyExchangeService>();
+        var valuationService = new Mock<IInvestmentValuationService>();
+        var account = new InvestmentAccount(1, 7, "Broker");
+        var tradeDate = new DateOnly(2026, 1, 10);
+        var listing = new AssetListing { Id = 11, Ticker = "CSPX" };
+        var transactions = new List<InvestmentTransaction>
+        {
+            new()
+            {
+                AccountId = account.AccountId,
+                AssetListingId = listing.Id,
+                AssetListing = listing,
+                Type = InvestmentTransactionType.Buy,
+                Quantity = 10m,
+                UnitPrice = 100m,
+                Fee = 20m,
+                Currency = "USD",
+                TradeDate = tradeDate,
+            },
+            new()
+            {
+                AccountId = account.AccountId,
+                AssetListingId = listing.Id,
+                AssetListing = listing,
+                Type = InvestmentTransactionType.Sell,
+                Quantity = 5m,
+                UnitPrice = 120m,
+                Currency = "USD",
+                TradeDate = tradeDate.AddDays(1),
+            },
+        };
+
+        accountRepository
+            .Setup(x => x.GetAccounts<InvestmentAccount>(1, DateTime.MinValue, It.IsAny<DateTime>()))
+            .Returns(new[] { account }.ToAsyncEnumerable());
+        transactionRepository.Setup(x => x.GetByAccount(account.AccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+        priceProvider.Setup(x => x.GetPricePerUnitAsync(listing.Id, DefaultCurrency.PLN, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(500m);
+        exchangeService.Setup(x => x.GetExchangeRateAsync(
+                It.Is<Currency>(c => c.ShortName == "USD"), DefaultCurrency.PLN,
+                tradeDate.ToDateTime(TimeOnly.MinValue)))
+            .ReturnsAsync(4m);
+
+        var service = new AssetsServiceInvestment(
+            accountRepository.Object,
+            valuationService.Object,
+            transactionRepository.Object,
+            priceProvider.Object,
+            exchangeService.Object);
+
+        var result = Assert.Single(await service.GetUnrealizedGainLossPerAccount(1, DefaultCurrency.PLN, DateTime.UtcNow));
+
+        Assert.Equal(2040m, result.CostBasis);
+        Assert.Equal(2500m, result.CurrentValue);
+        Assert.Equal(460m, result.UnrealizedGainLoss);
+    }
+}


### PR DESCRIPTION
## What changed
- Replace the investment account's range-based balance change with asset appreciation.
- Calculate appreciation from current holdings value minus the average buy cost of remaining units.
- Convert buy amounts and fees into the display currency using transaction-date exchange rates.
- Keep cash and bond account change displays unchanged.
- Add focused unit coverage and update the changelog.

## Why
A value change across the selected chart range mostly reflects contributions and withdrawals, so it does not explain whether the held assets appreciated. The investment view now presents unrealized gain/loss against the remaining buy cost basis instead.

## User impact
Investment account headers and insight cards show **Asset appreciation** and explain that it is current value minus remaining buy cost. The calculation works across transaction and display currencies.

## Validation
- `dotnet format ./code/FinanceManager.slnx`
- `dotnet build ./code/FinanceManager.slnx`
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj` (586 passed)
- Desktop and mobile guest-account visual verification; no browser console errors

Closes #578