### PR TITLE
Bump System.Security.Cryptography.Xml to 10.0.10 to fix CI restore failure

### DIFF
--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -65,7 +65,9 @@
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.9" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="System.Memory.Data" Version="10.0.9" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <!-- 10.0.9 carries high-severity advisories (GHSA-23rf-6693-g89p, GHSA-8q5v-6pqq-x66h,
+         GHSA-cvvh-rhrc-wg4q, GHSA-g8r8-53c2-pm3f); first patched in 10.0.10. -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="System.Security.Permissions" Version="10.0.9" />
     <PackageVersion Include="System.Threading.RateLimiting" Version="10.0.9" />
     <PackageVersion Include="System.Windows.Extensions" Version="10.0.9" />


### PR DESCRIPTION
## What changed
- Bump the central `System.Security.Cryptography.Xml` pin in `code/Directory.Packages.props` from 10.0.9 to 10.0.10, with a comment documenting the advisories.

## Why
CI on PR #579 (and any branch merged with current `develop`) fails during `dotnet restore` with `NU1903`: `System.Security.Cryptography.Xml` 10.0.9 is flagged by four high-severity GitHub advisories (GHSA-23rf-6693-g89p, GHSA-8q5v-6pqq-x66h, GHSA-cvvh-rhrc-wg4q, GHSA-g8r8-53c2-pm3f), and the build treats NuGet audit warnings as errors. 10.0.10 is the first patched version.

## User impact
None — dependency bump only, no behavioural change (no changelog entry per repo policy).

## Validation
- `dotnet restore ./code/FinanceManager.slnx` — clean, no NU1903
- `dotnet build ./code/FinanceManager.slnx` — 0 warnings, 0 errors
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj` — 586 passed

https://claude.ai/code/session_01CK8N7Lh4pAsK8ck3rA8xfX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CK8N7Lh4pAsK8ck3rA8xfX)_