### PR TITLE
Allow users to have both user and admin access #585

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Admin access can now be assigned alongside normal user access, with direct links between the Finance Manager and admin dashboards and role controls on the admin user editor. #585
 - Investment closing prices are now backfilled automatically every Saturday for every held instrument, so charts and valuations keep a complete weekly price history even for instruments nobody opened recently. #569
 - Admins can generate, roll, or revoke the maintenance API key that authorises the scheduled backfill from the **Admin → Service Keys** page — the key is stored hashed and shown exactly once at generation. #569
 - The dashboard has a new **Transaction log** card showing your most recent transactions across all accounts — currency, bond, and investment — in one newest-first list. #549

--- a/code/FinanceManager.Api/Controllers/UserController.cs
+++ b/code/FinanceManager.Api/Controllers/UserController.cs
@@ -157,4 +157,18 @@ public class UserController(IUserRepository userRepository, UsersService usersSe
         var result = await userRepository.UpdatePricingPlan(updatePricingPlan.UserId, updatePricingPlan.PricingLevel);
         return result ? Ok(result) : NotFound();
     }
+
+    [Authorize(Roles = "Admin")]
+    [HttpPut]
+    [Route("UpdateUserRole")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(bool))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateUserRole(UpdateUserRole updateUserRole, CancellationToken cancellationToken = default)
+    {
+        if (!Enum.IsDefined(updateUserRole.UserRole)) return BadRequest();
+
+        var result = await userRepository.UpdateRole(updateUserRole.UserId, updateUserRole.UserRole);
+        return result ? Ok(result) : NotFound();
+    }
 }

--- a/code/FinanceManager.Api/Services/JwtTokenGenerator.cs
+++ b/code/FinanceManager.Api/Services/JwtTokenGenerator.cs
@@ -22,8 +22,8 @@ public partial class JwtTokenGenerator(IOptions<JwtAuthOptions> jwtOptions)
         {
             new(JwtRegisteredClaimNames.Name, userName),
             new(ClaimTypes.NameIdentifier, userId.ToString()),
-            new(ClaimTypes.Role, userRole.ToString()),
         };
+        claims.AddRange(userRole.GetAssignedRoles().Select(role => new Claim(ClaimTypes.Role, role)));
         if (isGuest)
             claims.Add(new(GuestClaims.IsGuest, "true"));
 

--- a/code/FinanceManager.Application/Identity/CustomAuthenticationStateProvider.cs
+++ b/code/FinanceManager.Application/Identity/CustomAuthenticationStateProvider.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components.Authorization;
+﻿using FinanceManager.Domain.Identity.Entities;
+using Microsoft.AspNetCore.Components.Authorization;
 using System.Security.Claims;
 
 namespace FinanceManager.Application.Identity;
@@ -10,7 +11,7 @@ public class CustomAuthenticationStateProvider : AuthenticationStateProvider
     public override Task<AuthenticationState> GetAuthenticationStateAsync() =>
         Task.FromResult(new AuthenticationState(this.CurrentUser));
 
-    public Task<AuthenticationState> ChangeUser(string username, string id, string role)
+    public Task<AuthenticationState> ChangeUser(string username, string id, UserRole role)
     {
         this.CurrentUser = GetUser(username, id, role);
         var task = this.GetAuthenticationStateAsync();
@@ -26,12 +27,12 @@ public class CustomAuthenticationStateProvider : AuthenticationStateProvider
         return task;
     }
 
-    private static ClaimsPrincipal GetUser(string userName, string id, string role) =>
+    private static ClaimsPrincipal GetUser(string userName, string id, UserRole role) =>
        new(new ClaimsIdentity(
        [
             new(ClaimTypes. Sid, id),
             new(ClaimTypes.Name, userName),
-            new(ClaimTypes.Role, role)
+            .. role.GetAssignedRoles().Select(roleName => new Claim(ClaimTypes.Role, roleName))
        ], "Bearer"));
 
 

--- a/code/FinanceManager.Components/Components/Features/Admin/EditUserPage.razor
+++ b/code/FinanceManager.Components/Components/Features/Admin/EditUserPage.razor
@@ -39,42 +39,35 @@
             <MudDivider Class="my-3" />
         </MudItem>
 
-        @if (_userData.UserRole != UserRole.Admin)
-        {
-            <MudItem xs="12">
-                <MudText Typo="Typo.h6">Change pricing plan</MudText>
-                <MudGrid>
-                    <MudItem xs="8">
-                        <MudSelect T="string" Label="Select Plan" @bind-Value="_selectedPlan">
-                            @foreach (var plan in _plans)
-                            {
-                                <MudSelectItem Value="@plan">@plan</MudSelectItem>
-                            }
-                        </MudSelect>
-                    </MudItem>
-                    <MudItem xs="4">
-                        <MudButton @onclick=UpgradePricingPlan Variant="Variant.Text" Color="Color.Primary" Class="mt-4"
-                            FullWidth Disabled=@(_userData?.PricingLevel.ToString() == _selectedPlan )>Upgrade Plan</MudButton>
-                    </MudItem>
-                </MudGrid>
-                <MudDivider Class="my-3" />
-            </MudItem>
-        }
-
         <MudItem xs="12">
-            <MudText Typo="Typo.h6">Change role</MudText>
+            <MudText Typo="Typo.h6">Change pricing plan</MudText>
             <MudGrid>
                 <MudItem xs="8">
-                    <MudSelect T="string" Label="Select role" @bind-Value="_selectedUserRole">
-                        @foreach (var plan in _roles)
+                    <MudSelect T="string" Label="Select Plan" @bind-Value="_selectedPlan">
+                        @foreach (var plan in _plans)
                         {
                             <MudSelectItem Value="@plan">@plan</MudSelectItem>
                         }
                     </MudSelect>
                 </MudItem>
                 <MudItem xs="4">
+                    <MudButton @onclick=UpgradePricingPlan Variant="Variant.Text" Color="Color.Primary" Class="mt-4"
+                        FullWidth Disabled=@(_userData?.PricingLevel.ToString() == _selectedPlan )>Upgrade Plan</MudButton>
+                </MudItem>
+            </MudGrid>
+            <MudDivider Class="my-3" />
+        </MudItem>
+
+        <MudItem xs="12">
+            <MudText Typo="Typo.h6">Roles</MudText>
+            <MudGrid>
+                <MudItem xs="8">
+                    <MudCheckBox T="bool" Value="true" Label="User" ReadOnly />
+                    <MudCheckBox T="bool" @bind-Value="_isAdmin" Label="Admin" Color="Color.Primary" />
+                </MudItem>
+                <MudItem xs="4">
                     <MudButton @onclick=ChangeUserRole Variant="Variant.Text" Color="Color.Primary" Class="mt-4" FullWidth
-                        Disabled=@(_userData?.UserRole.ToString() == _selectedUserRole )>Change role</MudButton>
+                        Disabled="@((_userData.UserRole == UserRole.Admin) == _isAdmin)">Save roles</MudButton>
                 </MudItem>
             </MudGrid>
             <MudDivider Class="my-3" />

--- a/code/FinanceManager.Components/Components/Features/Admin/EditUserPage.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/Admin/EditUserPage.razor.cs
@@ -18,13 +18,12 @@ public partial class EditUserPage : ComponentBase
     private bool _isLoadingPage;
     private bool _success;
     private string _selectedPlan = $"{PricingLevel.Free}";
-    private string? _selectedUserRole;
+    private bool _isAdmin;
     private string? _password;
     private string? _confirmPassword;
     private MudForm? _passwordForm;
     private MudTextField<string>? _passwordField;
     private List<string> _plans = [$"{PricingLevel.Free}", $"{PricingLevel.Basic}", $"{PricingLevel.Premium}"];
-    private List<string> _roles = [$"{UserRole.User}", $"{UserRole.Admin}"];
     private RecordCapacity? _recordCapacity;
 
     [Parameter] public required int UserId { get; set; }
@@ -40,7 +39,7 @@ public partial class EditUserPage : ComponentBase
         try
         {
             _userData = await UserService.GetUser(UserId);
-            _selectedUserRole = _userData?.UserRole.ToString() ?? $"{UserRole.User}";
+            _isAdmin = _userData?.UserRole == UserRole.Admin;
             _selectedPlan = _userData?.PricingLevel.ToString() ?? $"{PricingLevel.Free}";
         }
         catch (Exception ex)
@@ -86,16 +85,18 @@ public partial class EditUserPage : ComponentBase
     private async Task ChangeUserRole()
     {
         if (_userData is null) return;
-        if (string.IsNullOrEmpty(_selectedUserRole)) return;
 
         try
         {
-
-            var result = await UserService.UpdateRole(_userData.UserId, (UserRole)Enum.Parse(typeof(UserRole), _selectedUserRole));
+            var role = _isAdmin ? UserRole.Admin : UserRole.User;
+            var result = await UserService.UpdateRole(_userData.UserId, role);
             if (!result)
                 _errors.Insert(0, "Failed to change role.");
             else
-                _info.Insert(0, $"Successfully changed role");
+            {
+                _userData.UserRole = role;
+                _info.Insert(0, "Successfully changed roles.");
+            }
         }
         catch (Exception ex)
         {

--- a/code/FinanceManager.Components/Components/Layout/AdminLayout.razor
+++ b/code/FinanceManager.Components/Components/Layout/AdminLayout.razor
@@ -21,6 +21,8 @@
             <MudText Typo="Typo.h6" Class="px-4" Color="Color.Primary">FinanceManager</MudText>
             <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary">Admin panel</MudText>
             <MudDivider Class="my-2" />
+            <MudNavLink Icon="@Icons.Material.Filled.AccountBalanceWallet" Href="" Match="NavLinkMatch.All" data-testid="nav-finance-manager">Finance Manager</MudNavLink>
+            <MudDivider Class="my-2" />
             <MudNavLink Icon="@Icons.Material.Filled.Dashboard" Href="Admin/Dashboard" data-testid="nav-admin-dashboard">Dashboard</MudNavLink>
             <MudNavLink Icon="@Icons.Material.Filled.People" Href="Admin/Users" data-testid="nav-admin-users">Users</MudNavLink>
             <MudNavLink Icon="@Icons.Material.Filled.Label" Href="Admin/Labels" data-testid="nav-admin-labels">Labels</MudNavLink>

--- a/code/FinanceManager.Components/Components/Layout/NavMenu.razor
+++ b/code/FinanceManager.Components/Components/Layout/NavMenu.razor
@@ -7,8 +7,8 @@
     }
     else
     {
-        <MudText Typo="Typo.h6" Class="px-4" Color="Color.Primary">FM</MudText>
-        <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary" Style="color:transparent">@ApplicationVersion.Version</MudText>
+        <MudText Typo="Typo.h6" Class="px-4" Color="Color.Primary" aria-label="FinanceManager">FM</MudText>
+        <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary" Style="color:transparent" aria-hidden="true">@ApplicationVersion.Version</MudText>
     }
     <MudDivider Class="my-2" />
     <MudNavLink Icon="@Icons.Material.Filled.Dashboard" Href="" Match="NavLinkMatch.All" data-testid="nav-dashboard">Dashboard</MudNavLink>

--- a/code/FinanceManager.Components/Components/Layout/NavMenu.razor
+++ b/code/FinanceManager.Components/Components/Layout/NavMenu.razor
@@ -1,27 +1,15 @@
 ﻿@using FinanceManager.Domain.Identity.Entities
 <MudNavMenu Class="pt-2" aria-label="Primary">
-    <AuthorizeView>
-        <Authorized>
-            @if (@context.User.IsInRole(UserRole.Admin.ToString()))
-            {
-                <MudNavLink Icon="@Icons.Material.Filled.Dashboard" href="Admin/Dashboard">Finance Manager</MudNavLink>
-            }
-            else if (@context.User.IsInRole(UserRole.User.ToString()))
-            {
-                @if (DrawerIsOpen)
-                {
-                    <MudText Typo="Typo.h6" Class="px-4" Color="Color.Primary">FinanceManager</MudText>
-                    <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary">@ApplicationVersion.Version</MudText>
-                }
-                else
-                {
-                    <MudText Typo="Typo.h6" Class="px-4" Color="Color.Primary">FM</MudText>
-                    <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary" Style="color:transparent">@ApplicationVersion.Version</MudText>
-                }
-                
-            }
-        </Authorized>
-    </AuthorizeView>
+    @if (DrawerIsOpen)
+    {
+        <MudText Typo="Typo.h6" Class="px-4" Color="Color.Primary">FinanceManager</MudText>
+        <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary">@ApplicationVersion.Version</MudText>
+    }
+    else
+    {
+        <MudText Typo="Typo.h6" Class="px-4" Color="Color.Primary">FM</MudText>
+        <MudText Typo="Typo.body2" Class="px-4 mud-text-secondary" Style="color:transparent">@ApplicationVersion.Version</MudText>
+    }
     <MudDivider Class="my-2" />
     <MudNavLink Icon="@Icons.Material.Filled.Dashboard" Href="" Match="NavLinkMatch.All" data-testid="nav-dashboard">Dashboard</MudNavLink>
 
@@ -60,7 +48,7 @@
         <Authorized>
             @if (@context.User.IsInRole(UserRole.Admin.ToString()))
             {
-                <MudNavLink Icon="@Icons.Material.Filled.AdminPanelSettings" Href="Admin/Dashboard" data-testid="nav-admin">Admin page</MudNavLink>
+                <MudNavLink Icon="@Icons.Material.Filled.AdminPanelSettings" Href="Admin/Dashboard" data-testid="nav-admin">Admin</MudNavLink>
             }
         </Authorized>
     </AuthorizeView>

--- a/code/FinanceManager.Components/Services/LoginService.cs
+++ b/code/FinanceManager.Components/Services/LoginService.cs
@@ -222,6 +222,6 @@ public class LoginService : ILoginService
         _antiforgeryTokenService.ClearToken();
 
         await ((CustomAuthenticationStateProvider)_authStateProvider)
-            .ChangeUser(session.UserName, session.UserId.ToString(), session.UserRole.ToString());
+            .ChangeUser(session.UserName, session.UserId.ToString(), session.UserRole);
     }
 }

--- a/code/FinanceManager.Domain/Identity/Entities/UserRole.cs
+++ b/code/FinanceManager.Domain/Identity/Entities/UserRole.cs
@@ -5,3 +5,9 @@ public enum UserRole
     User,
     Admin
 }
+
+public static class UserRoleExtensions
+{
+    public static IReadOnlyList<string> GetAssignedRoles(this UserRole role) =>
+        role == UserRole.Admin ? [nameof(UserRole.User), nameof(UserRole.Admin)] : [nameof(UserRole.User)];
+}

--- a/code/FinanceManager.Domain/Identity/Repositories/IUserRepository.cs
+++ b/code/FinanceManager.Domain/Identity/Repositories/IUserRepository.cs
@@ -14,6 +14,7 @@ public interface IUserRepository
     Task<bool> UpdatePassword(int userId, string password);
     Task<bool> UpdatePricingPlan(int userId, PricingLevel pricingLevel);
     Task<bool> UpdatePreferredCurrency(int userId, int currencyId);
+    Task<bool> UpdateRole(int userId, UserRole userRole);
     Task<bool> AddUser(string login, string password, PricingLevel pricingLevel, UserRole userRole, string? firstName = null, string? lastName = null);
 
     /// <summary>

--- a/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
@@ -224,4 +224,15 @@ public class UserRepository(AppDbContext context) : IUserRepository
 
         return await Task.FromResult(true);
     }
+
+    public async Task<bool> UpdateRole(int userId, UserRole userRole)
+    {
+        var user = await context.Users.FirstOrDefaultAsync(x => x.Id == userId);
+        if (user is null) return false;
+
+        user.UserRole = userRole;
+        await context.SaveChangesAsync();
+
+        return true;
+    }
 }

--- a/code/FinanceManager.Tests.Integration/Controllers/UserControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/UserControllerTests.cs
@@ -198,6 +198,21 @@ public class UserControllerTests(OptionsProvider optionsProvider) : ControllerTe
     }
 
     [Fact]
+    public async Task UpdateUserRole_AddsAdminAccessWithoutRemovingUserAccess()
+    {
+        await SeedUser();
+        Authorize("admin", 1, UserRole.Admin);
+
+        var result = await new UserHttpClient(Client).UpdateRole(new(_testUserId, UserRole.Admin));
+
+        Assert.True(result);
+        var updatedUser = await _testDatabase!.Context.Users
+            .SingleAsync(user => user.Id == _testUserId, TestContext.Current.CancellationToken);
+        Assert.Equal(UserRole.Admin, updatedUser.UserRole);
+        Assert.Equal([nameof(UserRole.User), nameof(UserRole.Admin)], updatedUser.UserRole.GetAssignedRoles());
+    }
+
+    [Fact]
     public async Task Delete_ReturnsOkTrue()
     {
         // arrange

--- a/code/FinanceManager.Tests.Unit/Api/Services/JwtTokenGeneratorTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Services/JwtTokenGeneratorTests.cs
@@ -1,0 +1,37 @@
+using FinanceManager.Api.Services;
+using FinanceManager.Application.Identity;
+using FinanceManager.Domain.Identity.Entities;
+using Microsoft.Extensions.Options;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace FinanceManager.Tests.Unit.Api.Services;
+
+[Trait("Category", "Unit")]
+public class JwtTokenGeneratorTests
+{
+    [Theory]
+    [InlineData(UserRole.User, false)]
+    [InlineData(UserRole.Admin, true)]
+    public async Task Role_IsAppliedToServerTokenAndClientAuthenticationState(UserRole role, bool isAdmin)
+    {
+        var generator = new JwtTokenGenerator(Options.Create(new JwtAuthOptions
+        {
+            TokenValidityMins = 15,
+            Issuer = "test",
+            Audience = "test",
+            Key = new string('k', 64),
+        }));
+
+        var token = new JwtSecurityTokenHandler().ReadJwtToken(generator.GenerateToken("user", 1, role).AccessToken);
+        var tokenRoles = token.Claims.Where(claim => claim.Type is ClaimTypes.Role or "role").Select(claim => claim.Value).ToList();
+
+        var provider = new CustomAuthenticationStateProvider();
+        var state = await provider.ChangeUser("user", "1", role);
+
+        Assert.Contains(nameof(UserRole.User), tokenRoles);
+        Assert.Equal(isAdmin, tokenRoles.Contains(nameof(UserRole.Admin)));
+        Assert.True(state.User.IsInRole(nameof(UserRole.User)));
+        Assert.Equal(isAdmin, state.User.IsInRole(nameof(UserRole.Admin)));
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Api/Services/JwtTokenGeneratorTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Services/JwtTokenGeneratorTests.cs
@@ -29,8 +29,8 @@ public class JwtTokenGeneratorTests
         var provider = new CustomAuthenticationStateProvider();
         var state = await provider.ChangeUser("user", "1", role);
 
-        Assert.Contains(nameof(UserRole.User), tokenRoles);
-        Assert.Equal(isAdmin, tokenRoles.Contains(nameof(UserRole.Admin)));
+        string[] expectedRoles = isAdmin ? [nameof(UserRole.User), nameof(UserRole.Admin)] : [nameof(UserRole.User)];
+        Assert.Equal(expectedRoles, tokenRoles);
         Assert.True(state.User.IsInRole(nameof(UserRole.User)));
         Assert.Equal(isAdmin, state.User.IsInRole(nameof(UserRole.Admin)));
     }


### PR DESCRIPTION
## What changed

- issue both `User` and `Admin` authorization claims to admin-capable accounts
- add direct navigation between the Finance Manager and admin dashboards
- replace the exclusive role selector with persistent User/Admin controls
- implement the missing admin-only role update endpoint and repository persistence
- cover server/client claims and role persistence with focused tests

## Why

The stored role and generated authentication state were mutually exclusive, so an administrator could not use ordinary Finance Manager features with the same account. The admin editor also called a role-update route that did not exist server-side.

## Impact

Any existing user can now be granted admin access without losing normal user access. Removing admin access leaves the account as an ordinary user. Existing persisted role values remain compatible, so no database migration is required.

## Validation

- `dotnet format .\code\FinanceManager.slnx`
- `dotnet build .\code\FinanceManager.slnx` — 0 warnings, 0 errors
- unit tests — 583 passed
- user-controller integration tests — 10 passed
- desktop and mobile UI validation of dashboard links and role controls

Closes #585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin controls for updating a user’s roles.
  * Admin users now retain standard user access while receiving additional administrator permissions.
  * Added a dedicated Finance Manager link to the admin navigation.
  * Simplified role editing with selectable User and Admin options.
* **Improvements**
  * The pricing-plan section is now available when editing any user.
  * Updated navigation labels and branding for a clearer experience.
* **Bug Fixes**
  * Improved consistency of role permissions across login sessions and authenticated access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->