### PR TITLE
Implement MCP OAuth server, authorization flow, and login bridge #588

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- MCP clients can now securely sign in through Finance Manager and receive scoped, refreshable access tokens. #588
 - Admin access can now be assigned alongside normal user access, with direct links between the Finance Manager and admin dashboards and role controls on the admin user editor. #585
 - Investment closing prices are now backfilled automatically every Saturday for every held instrument, so charts and valuations keep a complete weekly price history even for instruments nobody opened recently. #569
 - Admins can generate, roll, or revoke the maintenance API key that authorises the scheduled backfill from the **Admin → Service Keys** page — the key is stored hashed and shown exactly once at generation. #569

--- a/code/FinanceManager.Api/ApiConfigurationExtensions.cs
+++ b/code/FinanceManager.Api/ApiConfigurationExtensions.cs
@@ -1,15 +1,20 @@
 using FinanceManager.Api.Logging;
+using FinanceManager.Api.OAuth;
 using FinanceManager.Api.Services;
 using FinanceManager.Api.Services.Guest;
 using FinanceManager.Application.Shared.Options;
 using FinanceManager.Domain.Identity.Services;
 using FinanceManager.Infrastructure.OAuth;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Abstractions;
+using OpenIddict.Validation.AspNetCore;
 using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 namespace FinanceManager.Api;
@@ -210,7 +215,94 @@ public static class ApiConfigurationExtensions
                     return Task.CompletedTask;
                 }
             };
+        }).AddCookie(McpOAuthAuthentication.SessionScheme, options =>
+        {
+            options.Cookie.Name = "fm_mcp_authorization";
+            options.Cookie.HttpOnly = true;
+            options.Cookie.IsEssential = true;
+            options.Cookie.Path = "/connect";
+            options.Cookie.SameSite = SameSiteMode.Lax;
+            options.Cookie.SecurePolicy = environment.IsDevelopment() || environment.IsEnvironment("Test")
+                ? CookieSecurePolicy.SameAsRequest
+                : CookieSecurePolicy.Always;
+            options.ExpireTimeSpan = configuration.GetValue(
+                $"{McpOAuthOptions.SectionName}:AuthorizationSessionLifetime",
+                TimeSpan.FromMinutes(10));
+            options.SlidingExpiration = false;
+            options.Events = new CookieAuthenticationEvents
+            {
+                OnRedirectToLogin = context =>
+                {
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    return Task.CompletedTask;
+                },
+                OnRedirectToAccessDenied = context =>
+                {
+                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    return Task.CompletedTask;
+                }
+            };
         });
+
+        var mcpOAuth = configuration.GetSection(McpOAuthOptions.SectionName).Get<McpOAuthOptions>() ?? new();
+        if (mcpOAuth.Enabled)
+        {
+            var allowHttp = environment.IsDevelopment() || environment.IsEnvironment("Test");
+            services.AddOpenIddict()
+                .AddServer(options =>
+                {
+                    options.Configure(serverOptions =>
+                        serverOptions.CodeChallengeMethods.Remove(OpenIddictConstants.CodeChallengeMethods.Plain));
+                    options.SetIssuer(new Uri(mcpOAuth.Issuer))
+                        .SetAuthorizationEndpointUris("/connect/authorize")
+                        .SetTokenEndpointUris("/connect/token")
+                        .AllowAuthorizationCodeFlow()
+                        .AllowRefreshTokenFlow()
+                        .RegisterScopes("mcp")
+                        .RegisterResources(mcpOAuth.Resource)
+                        .SetAuthorizationCodeLifetime(mcpOAuth.AuthorizationCodeLifetime)
+                        .SetAccessTokenLifetime(mcpOAuth.AccessTokenLifetime)
+                        .SetRefreshTokenLifetime(mcpOAuth.RefreshTokenLifetime)
+                        .SetRefreshTokenReuseLeeway(TimeSpan.Zero);
+
+                    if (environment.IsEnvironment("Test"))
+                    {
+                        options.AddEphemeralEncryptionKey()
+                            .AddEphemeralSigningKey();
+                    }
+                    else if (environment.IsDevelopment())
+                    {
+                        options.AddDevelopmentEncryptionCertificate()
+                            .AddDevelopmentSigningCertificate();
+                    }
+                    else
+                    {
+                        options.AddSigningCertificate(X509CertificateLoader.LoadPkcs12FromFile(
+                            mcpOAuth.SigningCertificatePath!, mcpOAuth.SigningCertificatePassword));
+                        options.AddEncryptionCertificate(X509CertificateLoader.LoadPkcs12FromFile(
+                            mcpOAuth.EncryptionCertificatePath!, mcpOAuth.EncryptionCertificatePassword));
+                    }
+
+                    var aspNetCore = options.UseAspNetCore().EnableAuthorizationEndpointPassthrough();
+                    if (allowHttp)
+                        aspNetCore.DisableTransportSecurityRequirement();
+                })
+                .AddValidation(options =>
+                {
+                    options.UseLocalServer();
+                    options.EnableTokenEntryValidation();
+                    options.UseAspNetCore();
+                });
+        }
+
+        services.AddScoped<McpOAuthBridgeTokenValidator>();
+        services.AddAuthorization(options => options.AddPolicy(McpOAuthAuthentication.PolicyName, policy =>
+        {
+            policy.AddAuthenticationSchemes(OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme);
+            policy.RequireAuthenticatedUser();
+            policy.RequireAssertion(context =>
+                context.User.HasScope("mcp") && context.User.GetAudiences().Contains(mcpOAuth.Resource, StringComparer.Ordinal));
+        }));
 
         // The app runs behind a TLS-terminating reverse proxy (Cloudflare) in production, so the request
         // arriving at Kestrel is plain HTTP from the proxy. Honour X-Forwarded-Proto/For so Request.IsHttps,

--- a/code/FinanceManager.Api/Controllers/McpOAuthBridgeController.cs
+++ b/code/FinanceManager.Api/Controllers/McpOAuthBridgeController.cs
@@ -1,0 +1,76 @@
+using FinanceManager.Api.OAuth;
+using FinanceManager.Domain.Identity.Repositories;
+using FinanceManager.Domain.Identity.Services;
+using FinanceManager.Infrastructure.OAuth;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+
+namespace FinanceManager.Api.Controllers;
+
+[ApiController]
+[ApiExplorerSettings(IgnoreApi = true)]
+[Route("api/Auth/oauth-bridge")]
+[EnableRateLimiting(RateLimitingServiceCollectionExtension.AuthPolicy)]
+public sealed class McpOAuthBridgeController(
+    IOptions<McpOAuthOptions> options,
+    McpOAuthBridgeTokenValidator tokenValidator,
+    IUserRepository users,
+    IAntiforgery antiforgery,
+    ILogger<McpOAuthBridgeController> logger) : ControllerBase
+{
+    [HttpPost]
+    [Consumes("application/x-www-form-urlencoded")]
+    public async Task<IActionResult> Bridge([FromForm] McpOAuthBridgeRequest request)
+    {
+        if (!options.Value.Enabled)
+            return NotFound();
+        if (!await ValidateAntiforgeryToken())
+            return Forbid();
+        if (!McpOAuthReturnUrlValidator.IsValid(request.ReturnUrl, options.Value))
+            return BadRequest(new { message = "The return URL is invalid." });
+
+        var principal = tokenValidator.Validate(request.Token);
+        if (principal is null)
+            return Unauthorized();
+        if (string.Equals(principal.FindFirstValue(GuestClaims.IsGuest), "true", StringComparison.OrdinalIgnoreCase))
+            return StatusCode(StatusCodes.Status403Forbidden);
+        if (!int.TryParse(principal.FindFirstValue(ClaimTypes.NameIdentifier), out var userId) ||
+            await users.GetUser(userId) is null)
+        {
+            return Unauthorized();
+        }
+
+        var sessionIdentity = new ClaimsIdentity(McpOAuthAuthentication.SessionScheme);
+        sessionIdentity.AddClaim(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
+        await HttpContext.SignInAsync(
+            McpOAuthAuthentication.SessionScheme,
+            new ClaimsPrincipal(sessionIdentity),
+            new AuthenticationProperties
+            {
+                IsPersistent = false,
+                ExpiresUtc = DateTimeOffset.UtcNow.Add(options.Value.AuthorizationSessionLifetime)
+            });
+
+        return Redirect(request.ReturnUrl!);
+    }
+
+    private async Task<bool> ValidateAntiforgeryToken()
+    {
+        try
+        {
+            await antiforgery.ValidateRequestAsync(HttpContext);
+            return true;
+        }
+        catch (AntiforgeryValidationException ex)
+        {
+            logger.LogWarning(ex, "Rejected MCP OAuth bridge request with an invalid antiforgery token.");
+            return false;
+        }
+    }
+}
+
+public sealed record McpOAuthBridgeRequest(string? Token, string? ReturnUrl);

--- a/code/FinanceManager.Api/Controllers/McpOAuthController.cs
+++ b/code/FinanceManager.Api/Controllers/McpOAuthController.cs
@@ -1,0 +1,96 @@
+using FinanceManager.Api.OAuth;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Domain.Identity.Repositories;
+using FinanceManager.Domain.Identity.Services;
+using FinanceManager.Infrastructure.OAuth;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using OpenIddict.Abstractions;
+using OpenIddict.Server.AspNetCore;
+using System.Security.Claims;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace FinanceManager.Api.Controllers;
+
+[ApiController]
+[ApiExplorerSettings(IgnoreApi = true)]
+[EnableRateLimiting(RateLimitingServiceCollectionExtension.AuthPolicy)]
+public sealed class McpOAuthController(
+    IOptions<McpOAuthOptions> options,
+    IUserRepository users) : ControllerBase
+{
+    [AcceptVerbs("GET", "POST")]
+    [Route("connect/authorize")]
+    public async Task<IActionResult> Authorize(CancellationToken cancellationToken)
+    {
+        if (!options.Value.Enabled)
+            return NotFound();
+
+        var request = HttpContext.GetOpenIddictServerRequest()
+            ?? throw new InvalidOperationException("The OAuth authorization request is unavailable.");
+        var resources = request.GetResources().ToArray();
+        if (resources.Length != 1 ||
+            !string.Equals(resources[0], options.Value.Resource, StringComparison.Ordinal))
+        {
+            return OAuthError(Errors.InvalidTarget, "The requested MCP resource is invalid.");
+        }
+
+        var scopes = request.GetScopes().ToArray();
+        if (!scopes.Contains("mcp", StringComparer.Ordinal) ||
+            scopes.Any(scope => scope is not "mcp" and not Scopes.OfflineAccess))
+        {
+            return OAuthError(Errors.InvalidScope, "The MCP scope is required and no other scopes are supported.");
+        }
+
+        var session = await HttpContext.AuthenticateAsync(McpOAuthAuthentication.SessionScheme);
+        var subject = session.Principal?.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!session.Succeeded || !int.TryParse(subject, out var userId))
+            return RedirectToLogin();
+
+        var user = await users.GetUser(userId);
+        if (user is null)
+        {
+            await HttpContext.SignOutAsync(McpOAuthAuthentication.SessionScheme);
+            return RedirectToLogin();
+        }
+
+        var identity = new ClaimsIdentity(
+            TokenValidationParameters.DefaultAuthenticationType,
+            Claims.Name,
+            Claims.Role);
+        identity.AddClaim(Claims.Subject, user.UserId.ToString());
+        identity.AddClaim(Claims.Name, user.Login);
+        foreach (var role in user.UserRole.GetAssignedRoles())
+            identity.AddClaim(Claims.Role, role);
+
+        var principal = new ClaimsPrincipal(identity);
+        principal.SetScopes(scopes);
+        principal.SetResources(resources[0]);
+        principal.SetDestinations(static _ => [Destinations.AccessToken]);
+
+        return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+    }
+
+    private IActionResult RedirectToLogin()
+    {
+        var returnUrl = Request.GetEncodedUrl();
+        if (!McpOAuthReturnUrlValidator.IsValid(returnUrl, options.Value))
+            return OAuthError(Errors.InvalidRequest, "The authorization request origin is invalid.");
+
+        return Redirect(QueryHelpers.AddQueryString(options.Value.LoginUrl, "returnUrl", returnUrl));
+    }
+
+    private IActionResult OAuthError(string error, string description) => Forbid(
+        new AuthenticationProperties(new Dictionary<string, string?>
+        {
+            [OpenIddictServerAspNetCoreConstants.Properties.Error] = error,
+            [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] = description
+        }),
+        OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+}

--- a/code/FinanceManager.Api/OAuth/McpOAuthAuthentication.cs
+++ b/code/FinanceManager.Api/OAuth/McpOAuthAuthentication.cs
@@ -1,0 +1,52 @@
+using FinanceManager.Infrastructure.OAuth;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace FinanceManager.Api.OAuth;
+
+public static class McpOAuthAuthentication
+{
+    public const string PolicyName = "Mcp";
+    public const string SessionScheme = "McpOAuthSession";
+}
+
+public sealed class McpOAuthBridgeTokenValidator(IOptionsMonitor<JwtBearerOptions> jwtOptions)
+{
+    public ClaimsPrincipal? Validate(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return null;
+
+        try
+        {
+            var parameters = jwtOptions.Get(JwtBearerDefaults.AuthenticationScheme).TokenValidationParameters.Clone();
+            parameters.ClockSkew = TimeSpan.FromSeconds(30);
+            return new JwtSecurityTokenHandler().ValidateToken(token, parameters, out _);
+        }
+        catch (Exception exception) when (exception is SecurityTokenException or ArgumentException)
+        {
+            return null;
+        }
+    }
+}
+
+internal static class McpOAuthReturnUrlValidator
+{
+    public static bool IsValid(string? returnUrl, McpOAuthOptions options)
+    {
+        if (!Uri.TryCreate(returnUrl, UriKind.Absolute, out var target) ||
+            !Uri.TryCreate(options.Issuer, UriKind.Absolute, out var issuer))
+        {
+            return false;
+        }
+
+        var authorizeEndpoint = new Uri(issuer, "connect/authorize");
+        return string.IsNullOrEmpty(target.Fragment) &&
+               string.Equals(target.GetLeftPart(UriPartial.Authority),
+                   authorizeEndpoint.GetLeftPart(UriPartial.Authority), StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(target.AbsolutePath, authorizeEndpoint.AbsolutePath, StringComparison.Ordinal);
+    }
+}

--- a/code/FinanceManager.Api/appsettings.test.json
+++ b/code/FinanceManager.Api/appsettings.test.json
@@ -11,6 +11,12 @@
         "DisplayName": "Finance Manager MCP (Test)",
         "RequirePkce": true,
         "RedirectUris": [ "http://127.0.0.1:6274/oauth/callback" ]
+      },
+      {
+        "ClientId": "finance-manager-mcp-test-no-pkce",
+        "DisplayName": "Finance Manager MCP without PKCE (Test)",
+        "RequirePkce": false,
+        "RedirectUris": [ "http://127.0.0.1:6274/oauth/no-pkce-callback" ]
       }
     ]
   },

--- a/code/FinanceManager.Components/Components/Features/User/Components/LoginComponent.razor
+++ b/code/FinanceManager.Components/Components/Features/User/Components/LoginComponent.razor
@@ -11,6 +11,10 @@
             <MudPaper Class="p-5">
                 <MudText Typo="Typo.h4" Class="text-center mb-3 mt-3">Finance Manager</MudText>
                 <MudText Typo="Typo.h2" Class="mb-4 fs-6 fw-normal text-center"> Sign in to your account</MudText>
+                @if (!string.IsNullOrWhiteSpace(ReturnUrl))
+                {
+                    <MudAlert Severity="Severity.Info" Class="my-3">Sign in to authorize MCP access to your Finance Manager account.</MudAlert>
+                }
                 @if (_errors is not null)
                 {
                     @foreach (var error in _errors)
@@ -37,9 +41,12 @@
                     <MudLink Href="landingpage" Class="mt-3">
                         <MudText Typo="Typo.subtitle1">Learn more</MudText>
                     </MudLink>
-                    <MudLink @onclick=LogGuest data-testid="login-demo" aria-label="Check out demo account">
-                        <MudText Typo="Typo.subtitle1">Check out demo</MudText>
-                    </MudLink>
+                    @if (string.IsNullOrWhiteSpace(ReturnUrl))
+                    {
+                        <MudLink @onclick=LogGuest data-testid="login-demo" aria-label="Check out demo account">
+                            <MudText Typo="Typo.subtitle1">Check out demo</MudText>
+                        </MudLink>
+                    }
                 </MudForm>
             </MudPaper>
         </MudItem>

--- a/code/FinanceManager.Components/Components/Features/User/Components/LoginComponent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/User/Components/LoginComponent.razor.cs
@@ -2,10 +2,12 @@ using Blazored.LocalStorage;
 using FinanceManager.Components.Models;
 using FinanceManager.Components.Services;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
+using FinanceManager.Domain.Identity.Entities;
 using FinanceManager.Domain.Identity.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
 using MudBlazor;
 
 namespace FinanceManager.Components.Components.Features.User.Components;
@@ -26,6 +28,9 @@ public partial class LoginComponent
     [Inject] public required ILocalStorageService LocalStorageService { get; set; }
     [Inject] public required IFinancialAccountService FinancialAccountService { get; set; }
     [Inject] public required ISnackbar Snackbar { get; set; }
+    [Inject] public required IJSRuntime JSRuntime { get; set; }
+
+    [Parameter] public string? ReturnUrl { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
@@ -43,7 +48,7 @@ public partial class LoginComponent
         await NotifyIfSessionExpired();
 
         bool firstVisit = !(await LocalStorageService.ContainKeyAsync("isThisFirstVisit"));
-        if (firstVisit)
+        if (firstVisit && string.IsNullOrWhiteSpace(ReturnUrl))
         {
             await LocalStorageService.SetItemAsync("isThisFirstVisit", true);
             Navigation.NavigateTo("landingpage");
@@ -54,7 +59,12 @@ public partial class LoginComponent
         // user returning within the refresh window lands straight back in the app without re-entering credentials.
         var loggedUser = await LoginService.GetLoggedUser();
         if (loggedUser is not null)
+        {
+            if (await ContinueOAuth(loggedUser))
+                return;
+
             Navigation.NavigateTo("");
+        }
     }
 
     private async Task NotifyIfSessionExpired()
@@ -84,6 +94,8 @@ public partial class LoginComponent
             {
                 var loggedUser = await LoginService.GetLoggedUser();
                 if (loggedUser is null) return;
+                if (await ContinueOAuth(loggedUser))
+                    return;
 
                 switch (loggedUser.UserRole)
                 {
@@ -108,6 +120,15 @@ public partial class LoginComponent
         {
             _isProcessing = false;
         }
+    }
+
+    private async Task<bool> ContinueOAuth(UserSession user)
+    {
+        if (string.IsNullOrWhiteSpace(ReturnUrl) || string.IsNullOrWhiteSpace(user.Token))
+            return false;
+
+        await JSRuntime.InvokeVoidAsync("financeManager.postOAuthBridge", user.Token, ReturnUrl);
+        return true;
     }
 
 

--- a/code/FinanceManager.Components/Components/Features/User/LoginPage.razor
+++ b/code/FinanceManager.Components/Components/Features/User/LoginPage.razor
@@ -3,4 +3,10 @@
 
 <PageTitle>Sign in</PageTitle>
 
-<LoginComponent />
+<LoginComponent ReturnUrl="@ReturnUrl" />
+
+@code {
+    [Parameter]
+    [SupplyParameterFromQuery(Name = "returnUrl")]
+    public string? ReturnUrl { get; set; }
+}

--- a/code/FinanceManager.Infrastructure/OAuth/McpOAuthOptions.cs
+++ b/code/FinanceManager.Infrastructure/OAuth/McpOAuthOptions.cs
@@ -13,6 +13,10 @@ public sealed class McpOAuthOptions
     public string? SigningCertificatePassword { get; init; }
     public string? EncryptionCertificatePath { get; init; }
     public string? EncryptionCertificatePassword { get; init; }
+    public TimeSpan AuthorizationCodeLifetime { get; init; } = TimeSpan.FromMinutes(2);
+    public TimeSpan AccessTokenLifetime { get; init; } = TimeSpan.FromMinutes(15);
+    public TimeSpan RefreshTokenLifetime { get; init; } = TimeSpan.FromDays(30);
+    public TimeSpan AuthorizationSessionLifetime { get; init; } = TimeSpan.FromMinutes(10);
     public McpOAuthClientOptions[] Clients { get; init; } = [];
 }
 

--- a/code/FinanceManager.Infrastructure/OAuth/McpOAuthOptionsValidator.cs
+++ b/code/FinanceManager.Infrastructure/OAuth/McpOAuthOptionsValidator.cs
@@ -19,6 +19,14 @@ public sealed class McpOAuthOptionsValidator(IHostEnvironment environment) : IVa
 
         if (string.IsNullOrWhiteSpace(options.DisplayName))
             failures.Add("McpOAuth:DisplayName must be configured.");
+        if (options.AuthorizationCodeLifetime <= TimeSpan.Zero)
+            failures.Add("McpOAuth:AuthorizationCodeLifetime must be greater than zero.");
+        if (options.AccessTokenLifetime <= TimeSpan.Zero)
+            failures.Add("McpOAuth:AccessTokenLifetime must be greater than zero.");
+        if (options.RefreshTokenLifetime <= TimeSpan.Zero)
+            failures.Add("McpOAuth:RefreshTokenLifetime must be greater than zero.");
+        if (options.AuthorizationSessionLifetime <= TimeSpan.Zero)
+            failures.Add("McpOAuth:AuthorizationSessionLifetime must be greater than zero.");
         var clients = options.Clients ?? [];
         if (clients.Length == 0)
             failures.Add("McpOAuth:Clients must contain at least one client.");

--- a/code/FinanceManager.Tests.Integration/Controllers/McpOAuthBridgeControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/McpOAuthBridgeControllerTests.cs
@@ -1,0 +1,28 @@
+using System.Net;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public sealed class McpOAuthBridgeControllerTests : IDisposable
+{
+    private readonly FinanceManagerApiTestApp _app = new(environmentName: "Release");
+
+    [Fact]
+    public async Task Bridge_WhenMcpOAuthIsDisabled_ReturnsNotFound()
+    {
+        using var response = await _app.Client.PostAsync(
+            "/api/Auth/oauth-bridge",
+            new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["token"] = "unused",
+                ["returnUrl"] = "https://localhost/connect/authorize"
+            }),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    public void Dispose() => _app.Dispose();
+}

--- a/code/FinanceManager.Tests.Integration/Controllers/McpOAuthControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/McpOAuthControllerTests.cs
@@ -1,0 +1,375 @@
+using FinanceManager.Api.Controllers;
+using FinanceManager.Api.Services;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Domain.Identity.Repositories;
+using FinanceManager.Infrastructure.Contexts;
+using FinanceManager.Infrastructure.OAuth;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public sealed class McpOAuthControllerTests : IDisposable
+{
+    private const int _userId = 7842;
+    private const string _userLogin = "mcp-user@example.com";
+    private readonly FinanceManagerApiTestApp _app;
+
+    public McpOAuthControllerTests()
+    {
+        var user = new User
+        {
+            UserId = _userId,
+            Login = _userLogin,
+            UserRole = UserRole.User,
+            CreationDate = DateTime.UtcNow
+        };
+        var users = new Mock<IUserRepository>();
+        users.Setup(repository => repository.GetUser(_userId)).ReturnsAsync(user);
+
+        _app = new FinanceManagerApiTestApp(services =>
+        {
+            services.RemoveAll<IUserRepository>();
+            services.AddSingleton(users.Object);
+        }, hostSettings: new Dictionary<string, string?>
+        {
+            ["UseInMemoryDatabase"] = "true"
+        });
+
+        using var scope = _app.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<AppDbContext>().Database.EnsureCreated();
+        var options = scope.ServiceProvider.GetRequiredService<IOptions<McpOAuthOptions>>().Value;
+        scope.ServiceProvider.GetRequiredService<McpOAuthConfigurationReconciler>()
+            .ReconcileAsync(options, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    [Fact]
+    public async Task AuthorizationCodeFlow_UsesBridgePkceRefreshRotationAndMcpResource()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var browser = CreateBrowser();
+        var metadata = await browser.GetFromJsonAsync<JsonElement>("/.well-known/openid-configuration", cancellationToken);
+        Assert.EndsWith("/connect/authorize", metadata.GetProperty("authorization_endpoint").GetString());
+        Assert.EndsWith("/connect/token", metadata.GetProperty("token_endpoint").GetString());
+        Assert.Equal(["S256"], metadata.GetProperty("code_challenge_methods_supported")
+            .EnumerateArray().Select(value => value.GetString()));
+        var csrfToken = await BootstrapCsrfToken(browser, cancellationToken);
+
+        var authorizationUrl = AuthorizationUrl(
+            "finance-manager-mcp-test",
+            "http://127.0.0.1:6274/oauth/callback",
+            includePkce: true,
+            out var verifier);
+        var anonymous = await browser.GetAsync(authorizationUrl, cancellationToken);
+        Assert.Equal(HttpStatusCode.Redirect, anonymous.StatusCode);
+        Assert.StartsWith("http://localhost/login?returnUrl=", anonymous.Headers.Location!.AbsoluteUri);
+
+        var bridge = await browser.PostAsync(
+            "/api/Auth/oauth-bridge", BridgeForm(IssueJwt(), authorizationUrl, csrfToken), cancellationToken);
+        Assert.Equal(HttpStatusCode.Redirect, bridge.StatusCode);
+        Assert.Equal("/connect/authorize", bridge.Headers.Location!.AbsolutePath);
+        var sessionCookie = Assert.Single(bridge.Headers.GetValues("Set-Cookie"));
+        Assert.Contains("fm_mcp_authorization=", sessionCookie);
+        Assert.Contains("path=/connect", sessionCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("httponly", sessionCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("samesite=lax", sessionCookie, StringComparison.OrdinalIgnoreCase);
+
+        var authorize = await browser.GetAsync(authorizationUrl, cancellationToken);
+        Assert.Equal(HttpStatusCode.Redirect, authorize.StatusCode);
+        var callback = QueryHelpers.ParseQuery(authorize.Headers.Location!.Query);
+        Assert.Equal("test-state", callback["state"]);
+        var code = Assert.Single(callback["code"]);
+
+        var tokenResponse = await ExchangeCode(
+            browser,
+            "finance-manager-mcp-test",
+            "http://127.0.0.1:6274/oauth/callback",
+            code!,
+            verifier,
+            cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, tokenResponse.StatusCode);
+        var token = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+        Assert.False(string.IsNullOrWhiteSpace(token.GetProperty("access_token").GetString()));
+        Assert.Contains("mcp", token.GetProperty("scope").GetString()!.Split(' '));
+        var refreshToken = token.GetProperty("refresh_token").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(refreshToken));
+
+        var refreshResponse = await browser.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["client_id"] = "finance-manager-mcp-test",
+            ["refresh_token"] = refreshToken!,
+            ["resource"] = "http://localhost/mcp"
+        }), cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, refreshResponse.StatusCode);
+        var refreshed = await refreshResponse.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+        Assert.NotEqual(refreshToken, refreshed.GetProperty("refresh_token").GetString());
+
+        var replay = await browser.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["client_id"] = "finance-manager-mcp-test",
+            ["refresh_token"] = refreshToken!,
+            ["resource"] = "http://localhost/mcp"
+        }), cancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, replay.StatusCode);
+        Assert.Equal("invalid_grant", (await replay.Content.ReadFromJsonAsync<JsonElement>(cancellationToken)).GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task ClientWithoutPkce_CanCompleteItsConfiguredFlow()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var browser = CreateBrowser();
+        var csrfToken = await BootstrapCsrfToken(browser, cancellationToken);
+        var authorizationUrl = AuthorizationUrl(
+            "finance-manager-mcp-test-no-pkce",
+            "http://127.0.0.1:6274/oauth/no-pkce-callback",
+            includePkce: false,
+            out _);
+        var bridge = await browser.PostAsync(
+            "/api/Auth/oauth-bridge", BridgeForm(IssueJwt(), authorizationUrl, csrfToken), cancellationToken);
+        Assert.Equal(HttpStatusCode.Redirect, bridge.StatusCode);
+
+        var authorize = await browser.GetAsync(authorizationUrl, cancellationToken);
+        var code = Assert.Single(QueryHelpers.ParseQuery(authorize.Headers.Location!.Query)["code"]);
+        var token = await ExchangeCode(
+            browser,
+            "finance-manager-mcp-test-no-pkce",
+            "http://127.0.0.1:6274/oauth/no-pkce-callback",
+            code!,
+            verifier: null,
+            cancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, token.StatusCode);
+    }
+
+    [Fact]
+    public async Task AuthorizationAndBridge_RejectInvalidInputsAndGuests()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var browser = CreateBrowser();
+        var csrfToken = await BootstrapCsrfToken(browser, cancellationToken);
+        var valid = AuthorizationUrl(
+            "finance-manager-mcp-test",
+            "http://127.0.0.1:6274/oauth/callback",
+            includePkce: true,
+            out var verifier);
+
+        var invalidResource = await browser.GetAsync(valid.Replace(
+            Uri.EscapeDataString("http://localhost/mcp"),
+            Uri.EscapeDataString("http://localhost/not-mcp"),
+            StringComparison.Ordinal), cancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, invalidResource.StatusCode);
+        Assert.Contains("invalid_target", await invalidResource.Content.ReadAsStringAsync(cancellationToken));
+
+        var missingScope = await browser.GetAsync(
+            valid.Replace("mcp%20offline_access", "offline_access", StringComparison.Ordinal), cancellationToken);
+        Assert.Equal(HttpStatusCode.Redirect, missingScope.StatusCode);
+        Assert.Equal("invalid_scope", QueryHelpers.ParseQuery(missingScope.Headers.Location!.Query)["error"]);
+
+        var invalidRedirect = await browser.GetAsync(valid.Replace(
+            Uri.EscapeDataString("http://127.0.0.1:6274/oauth/callback"),
+            Uri.EscapeDataString("http://127.0.0.1:6274/oauth/wrong"),
+            StringComparison.Ordinal), cancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, invalidRedirect.StatusCode);
+
+        var invalidClient = await browser.GetAsync(
+            valid.Replace("finance-manager-mcp-test", "unknown-client", StringComparison.Ordinal), cancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, invalidClient.StatusCode);
+
+        var foreignBridge = await browser.PostAsync("/api/Auth/oauth-bridge",
+            BridgeForm(IssueJwt(), "https://evil.example/connect/authorize", csrfToken), cancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, foreignBridge.StatusCode);
+
+        var invalidToken = await browser.PostAsync(
+            "/api/Auth/oauth-bridge", BridgeForm("invalid", valid, csrfToken), cancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, invalidToken.StatusCode);
+
+        var guestToken = IssueJwt(isGuest: true);
+        var guest = await browser.PostAsync(
+            "/api/Auth/oauth-bridge", BridgeForm(guestToken, valid, csrfToken), cancellationToken);
+        Assert.Equal(HttpStatusCode.Forbidden, guest.StatusCode);
+
+        var validBridge = await browser.PostAsync(
+            "/api/Auth/oauth-bridge", BridgeForm(IssueJwt(), valid, csrfToken), cancellationToken);
+        Assert.Equal(HttpStatusCode.Redirect, validBridge.StatusCode);
+        var authorize = await browser.GetAsync(valid, cancellationToken);
+        var code = Assert.Single(QueryHelpers.ParseQuery(authorize.Headers.Location!.Query)["code"]);
+        var invalidVerifier = await ExchangeCode(
+            browser,
+            "finance-manager-mcp-test",
+            "http://127.0.0.1:6274/oauth/callback",
+            code!,
+            verifier + "wrong",
+            cancellationToken);
+        Assert.Equal(HttpStatusCode.BadRequest, invalidVerifier.StatusCode);
+        Assert.Equal("invalid_grant",
+            (await invalidVerifier.Content.ReadFromJsonAsync<JsonElement>(cancellationToken)).GetProperty("error").GetString());
+    }
+
+    [Fact]
+    public async Task Bridge_RequiresValidAntiforgeryToken()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var browser = CreateBrowser();
+        var authorizationUrl = AuthorizationUrl(
+            "finance-manager-mcp-test",
+            "http://127.0.0.1:6274/oauth/callback",
+            includePkce: true,
+            out _);
+
+        var missing = await browser.PostAsync(
+            "/api/Auth/oauth-bridge", BridgeForm(IssueJwt(), authorizationUrl), cancellationToken);
+        Assert.Equal(HttpStatusCode.Forbidden, missing.StatusCode);
+
+        await BootstrapCsrfToken(browser, cancellationToken);
+        var invalid = await browser.PostAsync(
+            "/api/Auth/oauth-bridge", BridgeForm(IssueJwt(), authorizationUrl, "invalid"), cancellationToken);
+        Assert.Equal(HttpStatusCode.Forbidden, invalid.StatusCode);
+    }
+
+    [Fact]
+    public async Task Authorization_UsesForwardedHttpsSchemeBehindKnownProxy()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var app = new FinanceManagerApiTestApp(hostSettings: new Dictionary<string, string?>
+        {
+            ["UseInMemoryDatabase"] = "true",
+            ["McpOAuth:Issuer"] = "https://localhost/",
+            ["McpOAuth:Resource"] = "https://localhost/mcp",
+            ["McpOAuth:LoginUrl"] = "https://localhost/login"
+        });
+        using (var scope = app.Services.CreateScope())
+        {
+            scope.ServiceProvider.GetRequiredService<AppDbContext>().Database.EnsureCreated();
+            var options = scope.ServiceProvider.GetRequiredService<IOptions<McpOAuthOptions>>().Value;
+            await scope.ServiceProvider.GetRequiredService<McpOAuthConfigurationReconciler>()
+                .ReconcileAsync(options, cancellationToken);
+        }
+
+        using var browser = app.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("http://localhost/")
+        });
+        var authorizationUrl = AuthorizationUrl(
+            "finance-manager-mcp-test",
+            "http://127.0.0.1:6274/oauth/callback",
+            includePkce: true,
+            out _,
+            resource: "https://localhost/mcp");
+        using var request = new HttpRequestMessage(HttpMethod.Get, authorizationUrl);
+        request.Headers.TryAddWithoutValidation("X-Forwarded-Proto", "https");
+
+        var response = await browser.SendAsync(request, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.StartsWith("https://localhost/login?returnUrl=https%3A%2F%2Flocalhost%2Fconnect%2Fauthorize",
+            response.Headers.Location!.AbsoluteUri);
+    }
+
+    public void Dispose()
+    {
+        _app.Dispose();
+    }
+
+    private HttpClient CreateBrowser() => _app.CreateClient(new WebApplicationFactoryClientOptions
+    {
+        AllowAutoRedirect = false,
+        BaseAddress = new Uri("http://localhost/")
+    });
+
+    private string IssueJwt(bool isGuest = false)
+    {
+        using var scope = _app.Services.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<JwtTokenGenerator>()
+            .GenerateToken(_userLogin, isGuest ? -1 : _userId, UserRole.User, isGuest)
+            .AccessToken;
+    }
+
+    private static async Task<string> BootstrapCsrfToken(HttpClient browser, CancellationToken cancellationToken)
+    {
+        var response = await browser.GetAsync("/api/Auth/csrf-token", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var cookies = response.Headers.TryGetValues("Set-Cookie", out var values)
+            ? values
+            : throw new InvalidOperationException("CSRF endpoint did not return cookies.");
+        var cookie = cookies.Single(value => value.StartsWith(
+            $"{AuthController.CsrfTokenCookieName}=", StringComparison.OrdinalIgnoreCase));
+        return WebUtility.UrlDecode(cookie.Split(';', 2)[0]
+            .Substring(AuthController.CsrfTokenCookieName.Length + 1));
+    }
+
+    private static FormUrlEncodedContent BridgeForm(
+        string token,
+        string returnUrl,
+        string? csrfToken = null) => new(new Dictionary<string, string>
+        {
+            ["token"] = token,
+            ["returnUrl"] = Uri.TryCreate(returnUrl, UriKind.Absolute, out _) ? returnUrl : "http://localhost" + returnUrl,
+            ["__RequestVerificationToken"] = csrfToken ?? string.Empty
+        });
+
+    private static string AuthorizationUrl(
+        string clientId,
+        string redirectUri,
+        bool includePkce,
+        out string? verifier,
+        string resource = "http://localhost/mcp")
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["client_id"] = clientId,
+            ["response_type"] = "code",
+            ["redirect_uri"] = redirectUri,
+            ["scope"] = "mcp offline_access",
+            ["resource"] = resource,
+            ["state"] = "test-state"
+        };
+        verifier = null;
+        if (includePkce)
+        {
+            verifier = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+            values["code_challenge"] = WebEncoders.Base64UrlEncode(
+                SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
+            values["code_challenge_method"] = "S256";
+        }
+
+        return QueryHelpers.AddQueryString("/connect/authorize", values);
+    }
+
+    private static Task<HttpResponseMessage> ExchangeCode(
+        HttpClient browser,
+        string clientId,
+        string redirectUri,
+        string code,
+        string? verifier,
+        CancellationToken cancellationToken)
+    {
+        var values = new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["client_id"] = clientId,
+            ["code"] = code,
+            ["redirect_uri"] = redirectUri,
+            ["resource"] = "http://localhost/mcp"
+        };
+        if (verifier is not null)
+            values["code_verifier"] = verifier;
+
+        return browser.PostAsync("/connect/token", new FormUrlEncodedContent(values), cancellationToken);
+    }
+}

--- a/code/FinanceManager.Tests.Integration/Controllers/McpOAuthControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/McpOAuthControllerTests.cs
@@ -319,7 +319,9 @@ public sealed class McpOAuthControllerTests : IDisposable
         string? csrfToken = null) => new(new Dictionary<string, string>
         {
             ["token"] = token,
-            ["returnUrl"] = Uri.TryCreate(returnUrl, UriKind.Absolute, out _) ? returnUrl : "http://localhost" + returnUrl,
+            ["returnUrl"] = returnUrl.StartsWith("/", StringComparison.Ordinal)
+            ? "http://localhost" + returnUrl
+            : returnUrl,
             ["__RequestVerificationToken"] = csrfToken ?? string.Empty
         });
 

--- a/code/FinanceManager.Tests.Integration/FinanceManagerApiTestApp.cs
+++ b/code/FinanceManager.Tests.Integration/FinanceManagerApiTestApp.cs
@@ -14,6 +14,7 @@ internal sealed class FinanceManagerApiTestApp : WebApplicationFactory<ApiEntryP
 {
     private readonly string _environmentName;
     private readonly Action<IServiceCollection>? _services;
+    private readonly IReadOnlyDictionary<string, string?>? _hostSettings;
 
     static FinanceManagerApiTestApp()
     {
@@ -27,16 +28,31 @@ internal sealed class FinanceManagerApiTestApp : WebApplicationFactory<ApiEntryP
 
     public HttpClient Client { get; }
 
-    public FinanceManagerApiTestApp(Action<IServiceCollection>? services = null, string environmentName = "test")
+    public FinanceManagerApiTestApp(
+        Action<IServiceCollection>? services = null,
+        string environmentName = "test",
+        IReadOnlyDictionary<string, string?>? hostSettings = null)
     {
         _services = services;
         _environmentName = environmentName;
+        _hostSettings = hostSettings;
         Client = CreateClient();
         Client.BaseAddress = new Uri("http://localhost/");
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
+        // WebApplicationFactory instances must never fall through to the production SQL provider when a
+        // controller test doesn't replace AppDbContext itself. Each factory receives an isolated EF in-memory
+        // root, which is sufficient for host-level integration tests and avoids external database dependencies.
+        builder.UseSetting("UseInMemoryDatabase", "true");
+
+        if (_hostSettings is not null)
+        {
+            foreach (var setting in _hostSettings)
+                builder.UseSetting(setting.Key, setting.Value);
+        }
+
         builder.ConfigureServices(s =>
         {
             // Remove hosted services that access DB on startup to avoid
@@ -87,7 +103,10 @@ internal sealed class FinanceManagerApiTestApp : WebApplicationFactory<ApiEntryP
             builder.UseSetting("JwtConfig:TokenValidityMins", "60");
             builder.UseSetting("ReverseProxy:KnownProxies:0", "127.0.0.1");
             builder.UseSetting("Cors:AllowedOrigins:0", "https://localhost:7206");
-            builder.UseSetting("McpOAuth:Enabled", "true");
+            // Non-Test environment hosts exercise unrelated production guards and do not carry real OAuth
+            // certificates. Keep the rollout gate closed there; dedicated OAuth tests run in Test with
+            // ephemeral keys, while unit tests cover the production certificate requirements.
+            builder.UseSetting("McpOAuth:Enabled", "false");
             builder.UseSetting("McpOAuth:Issuer", "https://localhost/");
             builder.UseSetting("McpOAuth:Resource", "https://localhost/mcp");
             builder.UseSetting("McpOAuth:LoginUrl", "https://localhost/login");

--- a/code/FinanceManager.Tests.Unit/Api/OAuth/McpOAuthSecurityTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/OAuth/McpOAuthSecurityTests.cs
@@ -1,0 +1,96 @@
+using FinanceManager.Api.OAuth;
+using FinanceManager.Api.Services;
+using FinanceManager.Application.Shared.Options;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Infrastructure.OAuth;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace FinanceManager.Tests.Unit.Api.OAuth;
+
+public sealed class McpOAuthSecurityTests
+{
+    private const string _issuer = "FinanceManager.api";
+    private const string _audience = "FinanceManager.Frontend";
+    private const string _key = "unit-test-only-insecure-jwt-signing-key-not-for-production-use-123456";
+
+    [Theory]
+    [InlineData("https://finance.example/connect/authorize?client_id=client", true)]
+    [InlineData("https://evil.example/connect/authorize", false)]
+    [InlineData("http://finance.example/connect/authorize", false)]
+    [InlineData("https://finance.example/connect/token", false)]
+    [InlineData("https://finance.example/connect/authorize#fragment", false)]
+    [InlineData("/connect/authorize", false)]
+    public void ReturnUrlValidator_AllowsOnlyTheIssuerAuthorizationEndpoint(string returnUrl, bool expected)
+    {
+        var options = new McpOAuthOptions { Issuer = "https://finance.example/" };
+
+        Assert.Equal(expected, McpOAuthReturnUrlValidator.IsValid(returnUrl, options));
+    }
+
+    [Fact]
+    public void BridgeTokenValidator_AcceptsValidFinanceManagerToken()
+    {
+        var validator = CreateValidator();
+        var token = new JwtTokenGenerator(Options.Create(JwtOptions()))
+            .GenerateToken("mcp@example.com", 42, UserRole.User)
+            .AccessToken;
+
+        var principal = validator.Validate(token);
+
+        Assert.NotNull(principal);
+        Assert.Equal("42", principal.FindFirstValue(ClaimTypes.NameIdentifier));
+    }
+
+    [Fact]
+    public void BridgeTokenValidator_RejectsExpiredToken()
+    {
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, "42")]),
+            Issuer = _issuer,
+            Audience = _audience,
+            NotBefore = DateTime.UtcNow.AddMinutes(-10),
+            Expires = DateTime.UtcNow.AddMinutes(-5),
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_key)),
+                SecurityAlgorithms.HmacSha512Signature)
+        };
+        var handler = new JwtSecurityTokenHandler();
+        var token = handler.WriteToken(handler.CreateToken(descriptor));
+
+        Assert.Null(CreateValidator().Validate(token));
+    }
+
+    private static McpOAuthBridgeTokenValidator CreateValidator()
+    {
+        var monitor = new Mock<IOptionsMonitor<JwtBearerOptions>>();
+        monitor.Setup(options => options.Get(JwtBearerDefaults.AuthenticationScheme)).Returns(new JwtBearerOptions
+        {
+            TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidIssuer = _issuer,
+                ValidAudience = _audience,
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_key)),
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true
+            }
+        });
+        return new McpOAuthBridgeTokenValidator(monitor.Object);
+    }
+
+    private static JwtAuthOptions JwtOptions() => new()
+    {
+        Issuer = _issuer,
+        Audience = _audience,
+        Key = _key,
+        TokenValidityMins = 15
+    };
+}

--- a/code/FinanceManager.Tests.Unit/Infrastructure/OAuth/McpOAuthTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/OAuth/McpOAuthTests.cs
@@ -33,6 +33,17 @@ public class McpOAuthTests
     }
 
     [Fact]
+    public void Validator_RejectsNonPositiveTokenAndSessionLifetimes()
+    {
+        var options = CreateOptions(lifetime: TimeSpan.Zero);
+
+        var result = CreateValidator(Environments.Development).Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(4, result.Failures!.Count(failure => failure.Contains("Lifetime", StringComparison.Ordinal)));
+    }
+
+    [Fact]
     public async Task Reconciler_ReplacesRedirectUrisPermissionsAndPkceRequirement()
     {
         var services = new ServiceCollection();
@@ -88,12 +99,17 @@ public class McpOAuthTests
         string redirectUri = "http://localhost/callback",
         string resource = "http://localhost/mcp",
         bool requirePkce = true,
-        string clientId = "finance-manager-mcp-test") => new()
+        string clientId = "finance-manager-mcp-test",
+        TimeSpan? lifetime = null) => new()
         {
             Enabled = true,
             Issuer = "http://localhost/",
             Resource = resource,
             LoginUrl = "http://localhost/login",
+            AuthorizationCodeLifetime = lifetime ?? TimeSpan.FromMinutes(2),
+            AccessTokenLifetime = lifetime ?? TimeSpan.FromMinutes(15),
+            RefreshTokenLifetime = lifetime ?? TimeSpan.FromDays(30),
+            AuthorizationSessionLifetime = lifetime ?? TimeSpan.FromMinutes(10),
             Clients =
             [
                 new McpOAuthClientOptions

--- a/code/FinanceManager/wwwroot/index.html
+++ b/code/FinanceManager/wwwroot/index.html
@@ -222,6 +222,34 @@
 
                 return null;
             },
+            postOAuthBridge: async function (token, returnUrl) {
+                let csrfToken = window.financeManager.getCookie('fm_csrf');
+                if (!csrfToken) {
+                    const response = await fetch('/api/Auth/csrf-token', { credentials: 'same-origin' });
+                    if (!response.ok) throw new Error('Unable to initialize the OAuth security token.');
+                    csrfToken = window.financeManager.getCookie('fm_csrf');
+                }
+                if (!csrfToken) throw new Error('The OAuth security token was not issued.');
+
+                const form = document.createElement('form');
+                form.method = 'post';
+                form.action = '/api/Auth/oauth-bridge';
+                form.style.display = 'none';
+
+                const addField = function (name, value) {
+                    const input = document.createElement('input');
+                    input.type = 'hidden';
+                    input.name = name;
+                    input.value = value;
+                    form.appendChild(input);
+                };
+
+                addField('token', token);
+                addField('returnUrl', returnUrl);
+                addField('__RequestVerificationToken', csrfToken);
+                document.body.appendChild(form);
+                form.submit();
+            },
             downloadFileFromBase64: function (fileName, contentType, base64Content) {
                 const byteCharacters = atob(base64Content);
                 const byteNumbers = new Array(byteCharacters.length);


### PR DESCRIPTION
## Summary
- configure OpenIddict authorization-code and refresh-token flows with local token validation
- add strict MCP resource/scope/client/redirect and client-specific PKCE enforcement
- bridge the existing Finance Manager login into a short-lived OAuth session with guest and antiforgery rejection
- add responsive MCP sign-in guidance and comprehensive OAuth/security integration coverage

## Validation
- `dotnet format .\\code --verify-no-changes --verbosity diagnostic`
- `dotnet build .\\code\\FinanceManager.slnx --no-restore --configuration Debug --verbosity minimal` (0 warnings)
- unit tests: 595 passed
- integration tests: 278 passed
- architecture tests: 9 passed
- NuGet vulnerability audit: clean
- desktop and mobile OAuth login visual QA completed
- GPT-5.6-Sol security review: no remaining actionable findings

Closes #588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP OAuth authorization with authorization-code and refresh-token flows.
  * Added secure login handoff for MCP access, including session bridging and validated redirect handling.
  * Login now explains MCP authorization and continues OAuth flows after authentication.
  * Added configurable authorization, token, refresh-token, and session lifetimes.

* **Bug Fixes**
  * Strengthened validation for OAuth requests, return URLs, tokens, guests, and antiforgery protection.

* **Tests**
  * Added comprehensive coverage for OAuth flows, security validation, PKCE, token rotation, and invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->