### PR TITLE
Add protected MCP endpoint, discovery metadata, and onboarding UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- AI clients can now connect to a protected MCP endpoint, discover its OAuth settings automatically, verify the signed-in identity, and follow a responsive setup guide with copyable and downloadable configuration. #589
 - MCP clients can now securely sign in through Finance Manager and receive scoped, refreshable access tokens. #588
 - Admin access can now be assigned alongside normal user access, with direct links between the Finance Manager and admin dashboards and role controls on the admin user editor. #585
 - Investment closing prices are now backfilled automatically every Saturday for every held instrument, so charts and valuations keep a complete weekly price history even for instruments nobody opened recently. #569

--- a/code/FinanceManager.Api/ApiConfigurationExtensions.cs
+++ b/code/FinanceManager.Api/ApiConfigurationExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using ModelContextProtocol.AspNetCore.Authentication;
 using OpenIddict.Abstractions;
 using OpenIddict.Validation.AspNetCore;
 using System.Security.Claims;
@@ -140,7 +141,7 @@ public static class ApiConfigurationExtensions
                 "Cors:AllowedOrigins is not configured. Provide explicit allowed origins via the " +
                 "Cors__AllowedOrigins configuration; AllowAnyOrigin is only permitted in Development.");
 
-        services.AddCors(options =>
+        var authentication = services.AddCors(options =>
         {
             options.AddPolicy("ApiCorsPolicy",
                 corsPolicyBuilder =>
@@ -248,6 +249,21 @@ public static class ApiConfigurationExtensions
         if (mcpOAuth.Enabled)
         {
             var allowHttp = environment.IsDevelopment() || environment.IsEnvironment("Test");
+            authentication
+                .AddPolicyScheme(McpOAuthAuthentication.SchemeName, "MCP OAuth", options =>
+                {
+                    options.ForwardAuthenticate = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme;
+                    options.ForwardChallenge = McpAuthenticationDefaults.AuthenticationScheme;
+                    options.ForwardForbid = OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme;
+                })
+                .AddMcp(options => options.ResourceMetadata = new()
+                {
+                    Resource = mcpOAuth.Resource,
+                    AuthorizationServers = { mcpOAuth.Issuer },
+                    ScopesSupported = ["mcp"],
+                    ResourceName = mcpOAuth.DisplayName
+                });
+
             services.AddOpenIddict()
                 .AddServer(options =>
                 {
@@ -298,7 +314,7 @@ public static class ApiConfigurationExtensions
         services.AddScoped<McpOAuthBridgeTokenValidator>();
         services.AddAuthorization(options => options.AddPolicy(McpOAuthAuthentication.PolicyName, policy =>
         {
-            policy.AddAuthenticationSchemes(OpenIddictValidationAspNetCoreDefaults.AuthenticationScheme);
+            policy.AddAuthenticationSchemes(McpOAuthAuthentication.SchemeName);
             policy.RequireAuthenticatedUser();
             policy.RequireAssertion(context =>
                 context.User.HasScope("mcp") && context.User.GetAudiences().Contains(mcpOAuth.Resource, StringComparer.Ordinal));

--- a/code/FinanceManager.Api/Mcp/IdentityTools.cs
+++ b/code/FinanceManager.Api/Mcp/IdentityTools.cs
@@ -1,0 +1,37 @@
+using ModelContextProtocol.Server;
+using OpenIddict.Abstractions;
+using System.ComponentModel;
+using System.Security.Claims;
+
+namespace FinanceManager.Api.Mcp;
+
+[McpServerToolType]
+public sealed class IdentityTools(IHttpContextAccessor httpContextAccessor)
+{
+    [McpServerTool(Name = "who_am_i")]
+    [Description("Return the authenticated Finance Manager user's id, login, and roles.")]
+    public McpIdentity WhoAmI()
+    {
+        var user = httpContextAccessor.HttpContext?.User
+            ?? throw new InvalidOperationException("The authenticated MCP request is unavailable.");
+        var subject = user.FindFirstValue(OpenIddictConstants.Claims.Subject)
+            ?? user.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? throw new InvalidOperationException("The authenticated MCP identity has no subject.");
+        var login = user.FindFirstValue(OpenIddictConstants.Claims.Name)
+            ?? user.Identity?.Name
+            ?? string.Empty;
+        var roles = user.FindAll(OpenIddictConstants.Claims.Role)
+            .Concat(user.FindAll(ClaimTypes.Role))
+            .Select(claim => claim.Value)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        return new McpIdentity(subject, login, roles);
+    }
+}
+
+public sealed record McpIdentity(
+    [property: Description("Stable Finance Manager user id.")] string UserId,
+    [property: Description("Finance Manager login name.")] string Login,
+    [property: Description("Roles granted to the user.")] string[] Roles);

--- a/code/FinanceManager.Api/Mcp/McpDiscoveryDocument.cs
+++ b/code/FinanceManager.Api/Mcp/McpDiscoveryDocument.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace FinanceManager.Api.Mcp;
+
+public sealed record McpDiscoveryDocument(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("version")] string Version,
+    [property: JsonPropertyName("description")] string Description,
+    [property: JsonPropertyName("mcp_endpoint")] string McpEndpoint,
+    [property: JsonPropertyName("authorization_server")] string AuthorizationServer,
+    [property: JsonPropertyName("authorization_endpoint")] string AuthorizationEndpoint,
+    [property: JsonPropertyName("token_endpoint")] string TokenEndpoint,
+    [property: JsonPropertyName("client_id")] string ClientId,
+    [property: JsonPropertyName("scopes_supported")] string[] ScopesSupported);

--- a/code/FinanceManager.Api/Mcp/McpFeatureExtensions.cs
+++ b/code/FinanceManager.Api/Mcp/McpFeatureExtensions.cs
@@ -1,0 +1,66 @@
+using FinanceManager.Api.OAuth;
+using FinanceManager.Infrastructure.OAuth;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Server;
+
+namespace FinanceManager.Api.Mcp;
+
+public static class McpFeatureExtensions
+{
+    public static IServiceCollection AddMcpFeature(this IServiceCollection services, IConfiguration configuration)
+    {
+        var options = configuration.GetSection(McpOAuthOptions.SectionName).Get<McpOAuthOptions>() ?? new();
+        if (!options.Enabled)
+            return services;
+
+        services.AddMcpServer(server => server.ServerInstructions =
+                "Finance Manager tools operate only on the authenticated user's financial data. " +
+                "Call who_am_i to confirm the current identity before working with user-specific data.")
+            .WithHttpTransport(transport => transport.Stateless = true)
+            .WithTools<IdentityTools>();
+        return services;
+    }
+
+    public static IEndpointRouteBuilder MapMcpFeature(this IEndpointRouteBuilder endpoints, IConfiguration configuration)
+    {
+        var options = configuration.GetSection(McpOAuthOptions.SectionName).Get<McpOAuthOptions>() ?? new();
+        if (!options.Enabled)
+        {
+            endpoints.MapMethods("/mcp", [HttpMethods.Get, HttpMethods.Post, HttpMethods.Delete], () => Results.NotFound());
+            foreach (var path in new[]
+                     {
+                         "/.well-known/mcp.json",
+                         "/.well-known/oauth-protected-resource",
+                         "/.well-known/oauth-protected-resource/mcp",
+                         "/.well-known/openid-configuration",
+                         "/.well-known/oauth-authorization-server"
+                     })
+            {
+                endpoints.MapGet(path, () => Results.NotFound());
+            }
+
+            return endpoints;
+        }
+
+        endpoints.MapMcp("/mcp").RequireAuthorization(McpOAuthAuthentication.PolicyName);
+        endpoints.MapGet("/.well-known/mcp.json", (IOptions<McpOAuthOptions> configuredOptions) =>
+        {
+            var oauth = configuredOptions.Value;
+            var issuer = oauth.Issuer.TrimEnd('/');
+            var clientId = oauth.Clients.FirstOrDefault()?.ClientId ?? string.Empty;
+            var document = new McpDiscoveryDocument(
+                Name: oauth.DisplayName,
+                Version: typeof(McpFeatureExtensions).Assembly.GetName().Version?.ToString(3) ?? "1.0.0",
+                Description: "Secure access to your Finance Manager data through Model Context Protocol.",
+                McpEndpoint: oauth.Resource,
+                AuthorizationServer: oauth.Issuer,
+                AuthorizationEndpoint: $"{issuer}/connect/authorize",
+                TokenEndpoint: $"{issuer}/connect/token",
+                ClientId: clientId,
+                ScopesSupported: ["mcp"]);
+            return Results.Ok(document);
+        }).AllowAnonymous();
+
+        return endpoints;
+    }
+}

--- a/code/FinanceManager.Api/OAuth/McpOAuthAuthentication.cs
+++ b/code/FinanceManager.Api/OAuth/McpOAuthAuthentication.cs
@@ -9,6 +9,7 @@ namespace FinanceManager.Api.OAuth;
 
 public static class McpOAuthAuthentication
 {
+    public const string SchemeName = "McpOAuth";
     public const string PolicyName = "Mcp";
     public const string SessionScheme = "McpOAuthSession";
 }

--- a/code/FinanceManager.Api/Program.cs
+++ b/code/FinanceManager.Api/Program.cs
@@ -1,5 +1,6 @@
 using FinanceManager.Api;
 using FinanceManager.Api.Logging;
+using FinanceManager.Api.Mcp;
 using FinanceManager.Api.Middleware;
 using FinanceManager.Application;
 using FinanceManager.Application.Shared.Diagnostics;
@@ -48,6 +49,7 @@ builder.WebHost.ConfigureKestrel(options =>
 
 builder.Services.AddApiOptions(builder.Configuration);
 builder.Services.AddApiSecurity(builder.Configuration, builder.Environment);
+builder.Services.AddMcpFeature(builder.Configuration);
 
 builder.Services.AddApiRateLimiting(builder.Configuration);
 builder.Services.AddMemoryCache();
@@ -123,6 +125,7 @@ app.UseAuthorization();
 app.MapDefaultEndpoints("Admin");
 
 app.MapControllers();
+app.MapMcpFeature(app.Configuration);
 app.MapHub<FinanceManager.Api.Hubs.CurrencyImportHub>("/hubs/currency-import");
 app.MapHub<FinanceManager.Api.Hubs.LabelSetterProgressHub>("/hubs/label-setter-progress");
 app.MapHub<FinanceManager.Api.Hubs.AdminLogsHub>("/hubs/admin-logs");

--- a/code/FinanceManager.Components/Components/Features/Mcp/McpConnectPage.razor
+++ b/code/FinanceManager.Components/Components/Features/Mcp/McpConnectPage.razor
@@ -1,0 +1,196 @@
+@page "/connect/mcp"
+@layout NoNavbarLayout
+@using System.Net.Http.Json
+@using System.Text.Json
+@using Microsoft.JSInterop
+
+<PageTitle>Connect an AI client</PageTitle>
+
+<main class="mcp-connect">
+    <header class="hero">
+        <div class="back-link"><MudLink Href="/" Underline="Underline.None">← Finance Manager</MudLink></div>
+        <MudText Typo="Typo.overline" Color="Color.Primary">MODEL CONTEXT PROTOCOL</MudText>
+        <MudText Typo="Typo.h2" HtmlTag="h1">Connect your AI client</MudText>
+        <MudText Typo="Typo.body1" Class="hero-copy">
+            Give ChatGPT, Claude, or another MCP client secure access to your Finance Manager account.
+            You sign in with OAuth, so there is no API key or password to paste into the client.
+        </MudText>
+    </header>
+
+    @if (_loading)
+    {
+        <MudProgressLinear Indeterminate="true" Color="Color.Primary" aria-label="Loading MCP connection details" />
+    }
+    else if (_discovery is null)
+    {
+        <MudAlert Severity="Severity.Error" data-testid="mcp-discovery-error">
+            Connection details are unavailable. MCP access may not be enabled on this Finance Manager server.
+        </MudAlert>
+    }
+    else
+    {
+        <section class="connect-card" aria-labelledby="server-title">
+            <MudText Typo="Typo.h4" HtmlTag="h2" id="server-title">Server details</MudText>
+            <MudText Typo="Typo.body2" Class="section-copy">Most clients only need the server URL and discover the OAuth settings automatically.</MudText>
+
+            <div class="value-block">
+                <span class="value-label">MCP server URL</span>
+                <div class="copy-row">
+                    <code data-testid="mcp-server-url">@_discovery.McpEndpoint</code>
+                    <MudButton Variant="Variant.Outlined" Color="Color.Primary" OnClick="@(() => CopyAsync(_discovery.McpEndpoint, "server"))">Copy</MudButton>
+                </div>
+                @if (_copied == "server")
+                {
+                    <span class="copied" role="status">Copied to clipboard</span>
+                }
+            </div>
+
+            <div class="client-grid">
+                <article>
+                    <MudText Typo="Typo.h6" HtmlTag="h3">Claude</MudText>
+                    <ol>
+                        <li>Open <strong>Settings → Connectors</strong> and choose to add a custom connector.</li>
+                        <li>Paste the MCP server URL above.</li>
+                        <li>Complete the Finance Manager sign-in and authorization window.</li>
+                    </ol>
+                </article>
+                <article>
+                    <MudText Typo="Typo.h6" HtmlTag="h3">ChatGPT</MudText>
+                    <ol>
+                        <li>Enable developer mode for apps/connectors, then create a custom MCP app.</li>
+                        <li>Choose OAuth with a user-defined public client and enter the values below.</li>
+                        <li>Save the app and complete the Finance Manager sign-in.</li>
+                    </ol>
+                </article>
+            </div>
+        </section>
+
+        <section class="connect-card" aria-labelledby="config-title">
+            <MudText Typo="Typo.h4" HtmlTag="h2" id="config-title">Copy or download configuration</MudText>
+            <MudText Typo="Typo.body2" Class="section-copy">Use this JSON when your client accepts an MCP configuration file.</MudText>
+            <pre><code data-testid="mcp-config">@ConfigurationJson</code></pre>
+            <div class="actions">
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Download" OnClick="DownloadConfigurationAsync">
+                    Download JSON
+                </MudButton>
+                <MudButton Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="@(() => CopyAsync(ConfigurationJson, "config"))">
+                    Copy JSON
+                </MudButton>
+            </div>
+            @if (_copied == "config")
+            {
+                <span class="copied" role="status">Configuration copied to clipboard</span>
+            }
+        </section>
+
+        <section class="connect-card" aria-labelledby="manual-title">
+            <MudText Typo="Typo.h4" HtmlTag="h2" id="manual-title">Manual OAuth settings</MudText>
+            <dl>
+                <div><dt>Transport</dt><dd>Streamable HTTP</dd></div>
+                <div><dt>Authentication</dt><dd>OAuth 2.0 Authorization Code with PKCE</dd></div>
+                <div><dt>Client ID</dt><dd><code>@_discovery.ClientId</code></dd></div>
+                <div><dt>Client secret</dt><dd>Leave empty (public client)</dd></div>
+                <div><dt>Scope</dt><dd><code>@string.Join(' ', _discovery.ScopesSupported)</code></dd></div>
+                <div><dt>Resource</dt><dd><code>@_discovery.McpEndpoint</code></dd></div>
+                <div><dt>Authorization server</dt><dd><code>@_discovery.AuthorizationServer</code></dd></div>
+                <div><dt>Authorization URL</dt><dd><code>@_discovery.AuthorizationEndpoint</code></dd></div>
+                <div><dt>Token URL</dt><dd><code>@_discovery.TokenEndpoint</code></dd></div>
+            </dl>
+            <MudButton Class="mt-5" Variant="Variant.Text" Color="Color.Primary" OnClick="@(() => CopyAsync(ManualSettings, "manual"))">
+                Copy all settings
+            </MudButton>
+            @if (_copied == "manual")
+            {
+                <span class="copied" role="status">Settings copied to clipboard</span>
+            }
+        </section>
+
+        <section class="connect-card guidance" aria-labelledby="help-title">
+            <MudText Typo="Typo.h4" HtmlTag="h2" id="help-title">Troubleshooting and disconnecting</MudText>
+            <MudExpansionPanels Elevation="0" Class="mt-4">
+                <MudExpansionPanel Text="The OAuth redirect or callback is rejected">
+                    Copy the exact callback URL shown by your client. It must be registered by the Finance Manager administrator;
+                    do not substitute a similar URL or add a trailing slash.
+                </MudExpansionPanel>
+                <MudExpansionPanel Text="Sign-in does not return to the client on mobile">
+                    Keep the client open while signing in. If the authorization window opens another browser, return to the client after approval.
+                    When that fails, reconnect from the desktop client where the callback can reopen it directly.
+                </MudExpansionPanel>
+                <MudExpansionPanel Text="The client reports an expired or unauthorized session">
+                    Disconnect and reconnect the Finance Manager integration. This starts a new OAuth authorization and replaces the client's saved tokens.
+                </MudExpansionPanel>
+                <MudExpansionPanel Text="Remove access">
+                    Remove or disconnect Finance Manager in the AI client's connector settings. That deletes the credentials held by that client;
+                    any already-issued short-lived access token expires automatically.
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+        </section>
+    }
+</main>
+
+@code {
+    [Inject] public required HttpClient Http { get; set; }
+    [Inject] public required IJSRuntime JS { get; set; }
+
+    private McpDiscovery? _discovery;
+    private bool _loading = true;
+    private string? _copied;
+
+    private string ConfigurationJson => _discovery is null ? string.Empty : JsonSerializer.Serialize(new
+    {
+        mcpServers = new Dictionary<string, object>
+        {
+            ["finance-manager"] = new { type = "http", url = _discovery.McpEndpoint }
+        }
+    }, new JsonSerializerOptions { WriteIndented = true });
+
+    private string ManualSettings => _discovery is null ? string.Empty :
+        $"Server URL: {_discovery.McpEndpoint}\n" +
+        "Transport: Streamable HTTP\n" +
+        "Authentication: OAuth 2.0 Authorization Code with PKCE\n" +
+        $"Client ID: {_discovery.ClientId}\n" +
+        "Client secret: (leave empty)\n" +
+        $"Scope: {string.Join(' ', _discovery.ScopesSupported)}\n" +
+        $"Resource: {_discovery.McpEndpoint}\n" +
+        $"Authorization URL: {_discovery.AuthorizationEndpoint}\n" +
+        $"Token URL: {_discovery.TokenEndpoint}";
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _discovery = await Http.GetFromJsonAsync<McpDiscovery>("/.well-known/mcp.json");
+        }
+        catch (Exception exception) when (exception is HttpRequestException or JsonException)
+        {
+            _discovery = null;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task CopyAsync(string value, string marker)
+    {
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", value);
+        _copied = marker;
+    }
+
+    private Task DownloadConfigurationAsync() => JS.InvokeVoidAsync(
+        "financeManager.downloadFileFromBase64",
+        "finance-manager-mcp.json",
+        "application/json",
+        Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(ConfigurationJson))).AsTask();
+
+    private sealed record McpDiscovery(
+        [property: System.Text.Json.Serialization.JsonPropertyName("name")] string Name,
+        [property: System.Text.Json.Serialization.JsonPropertyName("version")] string Version,
+        [property: System.Text.Json.Serialization.JsonPropertyName("description")] string Description,
+        [property: System.Text.Json.Serialization.JsonPropertyName("mcp_endpoint")] string McpEndpoint,
+        [property: System.Text.Json.Serialization.JsonPropertyName("authorization_server")] string AuthorizationServer,
+        [property: System.Text.Json.Serialization.JsonPropertyName("authorization_endpoint")] string AuthorizationEndpoint,
+        [property: System.Text.Json.Serialization.JsonPropertyName("token_endpoint")] string TokenEndpoint,
+        [property: System.Text.Json.Serialization.JsonPropertyName("client_id")] string ClientId,
+        [property: System.Text.Json.Serialization.JsonPropertyName("scopes_supported")] string[] ScopesSupported);
+}

--- a/code/FinanceManager.Components/Components/Features/Mcp/McpConnectPage.razor.css
+++ b/code/FinanceManager.Components/Components/Features/Mcp/McpConnectPage.razor.css
@@ -1,0 +1,167 @@
+.mcp-connect {
+    width: min(58rem, calc(100% - 2rem));
+    margin: 0 auto;
+    padding: clamp(2rem, 6vw, 4.5rem) 0 5rem;
+}
+
+.hero {
+    max-width: 45rem;
+    margin-bottom: 2rem;
+}
+
+.back-link {
+    margin-bottom: 2rem;
+}
+
+.hero ::deep h1:focus {
+    outline: none;
+}
+
+.hero-copy,
+.section-copy {
+    color: var(--mud-palette-text-secondary);
+}
+
+.hero-copy {
+    max-width: 42rem;
+    margin-top: .75rem;
+    font-size: 1.05rem;
+    line-height: 1.7;
+}
+
+.connect-card {
+    margin-top: 1.25rem;
+    padding: clamp(1.25rem, 4vw, 2rem);
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: 1rem;
+    background: var(--mud-palette-surface);
+    box-shadow: 0 .7rem 2.4rem rgb(0 0 0 / 6%);
+}
+
+.section-copy {
+    margin-top: .35rem;
+}
+
+.value-block {
+    margin-top: 1.5rem;
+}
+
+.value-label {
+    display: block;
+    margin-bottom: .4rem;
+    color: var(--mud-palette-text-secondary);
+    font-size: .8rem;
+    font-weight: 700;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+}
+
+.copy-row,
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: .75rem;
+}
+
+.copy-row code {
+    flex: 1 1 20rem;
+}
+
+code {
+    overflow-wrap: anywhere;
+}
+
+.copy-row code,
+dl code {
+    padding: .45rem .65rem;
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: .4rem;
+    background: var(--mud-palette-background-gray);
+}
+
+.copied {
+    display: inline-block;
+    margin-top: .55rem;
+    color: var(--mud-palette-success);
+    font-size: .85rem;
+    font-weight: 600;
+}
+
+.client-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.25rem;
+    margin-top: 2rem;
+}
+
+.client-grid article {
+    padding: 1.25rem;
+    border-radius: .75rem;
+    background: var(--mud-palette-background-gray);
+}
+
+ol {
+    display: grid;
+    gap: .55rem;
+    margin: .75rem 0 0;
+    padding-left: 1.25rem;
+    line-height: 1.55;
+}
+
+pre {
+    margin: 1.25rem 0 1rem;
+    padding: 1rem;
+    border-radius: .65rem;
+    background: #1f2430;
+    color: #f5f7fa;
+    overflow-x: auto;
+}
+
+pre code {
+    overflow-wrap: normal;
+}
+
+dl {
+    display: grid;
+    gap: 0;
+    margin: 1.25rem 0 0;
+}
+
+dl > div {
+    display: grid;
+    grid-template-columns: minmax(9rem, 13rem) minmax(0, 1fr);
+    gap: 1rem;
+    padding: .8rem 0;
+    border-bottom: 1px solid var(--mud-palette-lines-default);
+}
+
+dt {
+    color: var(--mud-palette-text-secondary);
+    font-weight: 600;
+}
+
+dd {
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 42rem) {
+    .mcp-connect {
+        width: min(100% - 1.25rem, 58rem);
+    }
+
+    .client-grid {
+        grid-template-columns: 1fr;
+    }
+
+    dl > div {
+        grid-template-columns: 1fr;
+        gap: .35rem;
+    }
+
+    .copy-row > ::deep .mud-button-root,
+    .actions > ::deep .mud-button-root {
+        width: 100%;
+    }
+}

--- a/code/FinanceManager.Tests.Integration/Mcp/McpEndpointTests.cs
+++ b/code/FinanceManager.Tests.Integration/Mcp/McpEndpointTests.cs
@@ -1,0 +1,267 @@
+using FinanceManager.Api.Controllers;
+using FinanceManager.Api.Services;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Domain.Identity.Repositories;
+using FinanceManager.Infrastructure.Contexts;
+using FinanceManager.Infrastructure.OAuth;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Mcp;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public sealed class McpEndpointTests : IDisposable
+{
+    private const int _userId = 8459;
+    private const string _userLogin = "mcp-protocol-user@example.com";
+    private readonly FinanceManagerApiTestApp _app;
+
+    public McpEndpointTests()
+    {
+        var user = new User
+        {
+            UserId = _userId,
+            Login = _userLogin,
+            UserRole = UserRole.User,
+            CreationDate = DateTime.UtcNow
+        };
+        var users = new Mock<IUserRepository>();
+        users.Setup(repository => repository.GetUser(_userId)).ReturnsAsync(user);
+        _app = new FinanceManagerApiTestApp(services =>
+        {
+            services.RemoveAll<IUserRepository>();
+            services.AddSingleton(users.Object);
+        });
+
+        using var scope = _app.Services.CreateScope();
+        scope.ServiceProvider.GetRequiredService<AppDbContext>().Database.EnsureCreated();
+        var options = scope.ServiceProvider.GetRequiredService<IOptions<McpOAuthOptions>>().Value;
+        scope.ServiceProvider.GetRequiredService<McpOAuthConfigurationReconciler>()
+            .ReconcileAsync(options, CancellationToken.None).GetAwaiter().GetResult();
+    }
+
+    [Fact]
+    public async Task DiscoveryDocuments_DescribeProtectedMcpResourceAndOAuthServer()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = CreateBrowser();
+
+        var discovery = await client.GetFromJsonAsync<JsonElement>("/.well-known/mcp.json", cancellationToken);
+        Assert.Equal("Finance Manager MCP", discovery.GetProperty("name").GetString());
+        Assert.Equal("http://localhost/mcp", discovery.GetProperty("mcp_endpoint").GetString());
+        Assert.Equal("http://localhost/", discovery.GetProperty("authorization_server").GetString());
+        Assert.Equal("http://localhost/connect/authorize", discovery.GetProperty("authorization_endpoint").GetString());
+        Assert.Equal("http://localhost/connect/token", discovery.GetProperty("token_endpoint").GetString());
+        Assert.Equal("finance-manager-mcp-test", discovery.GetProperty("client_id").GetString());
+        Assert.Contains("mcp", discovery.GetProperty("scopes_supported").EnumerateArray().Select(value => value.GetString()));
+
+        var protectedResource = await client.GetFromJsonAsync<JsonElement>(
+            "/.well-known/oauth-protected-resource/mcp", cancellationToken);
+        Assert.Equal("http://localhost/mcp", protectedResource.GetProperty("resource").GetString());
+        Assert.Contains("http://localhost/", protectedResource.GetProperty("authorization_servers")
+            .EnumerateArray().Select(value => value.GetString()));
+        Assert.Contains("mcp", protectedResource.GetProperty("scopes_supported")
+            .EnumerateArray().Select(value => value.GetString()));
+
+        var authorizationServer = await client.GetFromJsonAsync<JsonElement>(
+            "/.well-known/openid-configuration", cancellationToken);
+        Assert.Equal("http://localhost/connect/authorize", authorizationServer.GetProperty("authorization_endpoint").GetString());
+        Assert.Equal("http://localhost/connect/token", authorizationServer.GetProperty("token_endpoint").GetString());
+        Assert.Contains("S256", authorizationServer.GetProperty("code_challenge_methods_supported")
+            .EnumerateArray().Select(value => value.GetString()));
+
+        var oauthAuthorizationServer = await client.GetFromJsonAsync<JsonElement>(
+            "/.well-known/oauth-authorization-server", cancellationToken);
+        Assert.Equal("http://localhost/connect/authorize", oauthAuthorizationServer.GetProperty("authorization_endpoint").GetString());
+        Assert.Equal("http://localhost/connect/token", oauthAuthorizationServer.GetProperty("token_endpoint").GetString());
+    }
+
+    [Fact]
+    public async Task McpWithoutValidToken_ReturnsChallengePointingToResourceMetadata()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = CreateBrowser();
+        using var request = McpRequest("tools/list", 1, new { });
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "not-a-token");
+
+        var response = await client.SendAsync(request, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Contains(response.Headers.WwwAuthenticate, header =>
+            string.Equals(header.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase) &&
+            header.Parameter?.Contains("resource_metadata=", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
+    public async Task AuthenticatedClient_CanInitializeListToolsAndCallWhoAmI()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = CreateBrowser();
+        var accessToken = await GetAccessToken(client, cancellationToken);
+
+        using var initializeRequest = McpRequest("initialize", 1, new
+        {
+            protocolVersion = "2025-06-18",
+            capabilities = new { },
+            clientInfo = new { name = "FinanceManager integration tests", version = "1.0" }
+        }, accessToken);
+        var initialize = await client.SendAsync(initializeRequest, cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, initialize.StatusCode);
+        var initializeJson = await ReadMcpJson(initialize, cancellationToken);
+        Assert.Equal("2.0", initializeJson.GetProperty("jsonrpc").GetString());
+        Assert.Equal("2025-06-18", initializeJson.GetProperty("result").GetProperty("protocolVersion").GetString());
+
+        using var listRequest = McpRequest("tools/list", 2, new { }, accessToken);
+        listRequest.Headers.TryAddWithoutValidation("MCP-Protocol-Version", "2025-06-18");
+        var list = await client.SendAsync(listRequest, cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, list.StatusCode);
+        var listJson = await ReadMcpJson(list, cancellationToken);
+        var tools = listJson.GetProperty("result").GetProperty("tools").EnumerateArray().ToArray();
+        Assert.Contains(tools, tool => tool.GetProperty("name").GetString() == "who_am_i");
+
+        using var callRequest = McpRequest("tools/call", 3, new
+        {
+            name = "who_am_i",
+            arguments = new { }
+        }, accessToken);
+        callRequest.Headers.TryAddWithoutValidation("MCP-Protocol-Version", "2025-06-18");
+        var call = await client.SendAsync(callRequest, cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, call.StatusCode);
+        var callJson = await ReadMcpJson(call, cancellationToken);
+        var resultText = callJson.GetProperty("result").GetRawText();
+        Assert.Contains(_userId.ToString(), resultText, StringComparison.Ordinal);
+        Assert.Contains(_userLogin, resultText, StringComparison.Ordinal);
+        Assert.Contains("User", resultText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DisabledFeature_DoesNotPublishMcpOrOAuthEndpoints()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var app = new FinanceManagerApiTestApp(hostSettings: new Dictionary<string, string?>
+        {
+            ["McpOAuth:Enabled"] = "false"
+        });
+        using var client = app.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("http://localhost/")
+        });
+
+        foreach (var path in new[]
+                 {
+                     "/.well-known/mcp.json",
+                     "/.well-known/oauth-protected-resource/mcp",
+                     "/.well-known/openid-configuration",
+                     "/.well-known/oauth-authorization-server"
+                 })
+        {
+            Assert.Equal(HttpStatusCode.NotFound, (await client.GetAsync(path, cancellationToken)).StatusCode);
+        }
+
+        using var request = McpRequest("tools/list", 1, new { });
+        Assert.Equal(HttpStatusCode.NotFound, (await client.SendAsync(request, cancellationToken)).StatusCode);
+    }
+
+    public void Dispose() => _app.Dispose();
+
+    private HttpClient CreateBrowser() => _app.CreateClient(new WebApplicationFactoryClientOptions
+    {
+        AllowAutoRedirect = false,
+        BaseAddress = new Uri("http://localhost/")
+    });
+
+    private async Task<string> GetAccessToken(HttpClient client, CancellationToken cancellationToken)
+    {
+        var verifier = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
+        var challenge = WebEncoders.Base64UrlEncode(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
+        var authorizationUrl = QueryHelpers.AddQueryString("/connect/authorize", new Dictionary<string, string?>
+        {
+            ["client_id"] = "finance-manager-mcp-test",
+            ["response_type"] = "code",
+            ["redirect_uri"] = "http://127.0.0.1:6274/oauth/callback",
+            ["scope"] = "mcp offline_access",
+            ["resource"] = "http://localhost/mcp",
+            ["state"] = "mcp-protocol-test",
+            ["code_challenge"] = challenge,
+            ["code_challenge_method"] = "S256"
+        });
+        var csrfToken = await BootstrapCsrfToken(client, cancellationToken);
+        var bridge = await client.PostAsync("/api/Auth/oauth-bridge", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["token"] = IssueJwt(),
+            ["returnUrl"] = "http://localhost" + authorizationUrl,
+            ["__RequestVerificationToken"] = csrfToken
+        }), cancellationToken);
+        Assert.Equal(HttpStatusCode.Redirect, bridge.StatusCode);
+
+        var authorize = await client.GetAsync(authorizationUrl, cancellationToken);
+        Assert.Equal(HttpStatusCode.Redirect, authorize.StatusCode);
+        var code = Assert.Single(QueryHelpers.ParseQuery(authorize.Headers.Location!.Query)["code"]);
+        var tokenResponse = await client.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "authorization_code",
+            ["client_id"] = "finance-manager-mcp-test",
+            ["code"] = code!,
+            ["redirect_uri"] = "http://127.0.0.1:6274/oauth/callback",
+            ["resource"] = "http://localhost/mcp",
+            ["code_verifier"] = verifier
+        }), cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, tokenResponse.StatusCode);
+        var token = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+        return token.GetProperty("access_token").GetString()!;
+    }
+
+    private string IssueJwt()
+    {
+        using var scope = _app.Services.CreateScope();
+        return scope.ServiceProvider.GetRequiredService<JwtTokenGenerator>()
+            .GenerateToken(_userLogin, _userId, UserRole.User, false)
+            .AccessToken;
+    }
+
+    private static async Task<string> BootstrapCsrfToken(HttpClient client, CancellationToken cancellationToken)
+    {
+        var response = await client.GetAsync("/api/Auth/csrf-token", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var cookie = response.Headers.GetValues("Set-Cookie").Single(value =>
+            value.StartsWith($"{AuthController.CsrfTokenCookieName}=", StringComparison.OrdinalIgnoreCase));
+        return WebUtility.UrlDecode(cookie.Split(';', 2)[0][(AuthController.CsrfTokenCookieName.Length + 1)..]);
+    }
+
+    private static HttpRequestMessage McpRequest(string method, int id, object parameters, string? accessToken = null)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/mcp")
+        {
+            Content = JsonContent.Create(new { jsonrpc = "2.0", id, method, @params = parameters })
+        };
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+        if (accessToken is not null)
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return request;
+    }
+
+    private static async Task<JsonElement> ReadMcpJson(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (response.Content.Headers.ContentType?.MediaType == "text/event-stream")
+        {
+            body = body.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Single(line => line.StartsWith("data: ", StringComparison.Ordinal))[6..];
+        }
+        return JsonDocument.Parse(body).RootElement.Clone();
+    }
+}


### PR DESCRIPTION

## Summary

- add a stateless, OAuth-protected MCP endpoint with protected-resource and authorization-server discovery
- expose a minimal who_am_i tool derived only from the validated OAuth principal
- add a responsive /connect/mcp guide with client setup, manual OAuth values, copy/download configuration, and troubleshooting
- cover feature gating, discovery, challenge metadata, and initialize/list/call protocol flow

## Validation

- dotnet build ./code/FinanceManager.slnx --no-restore
- dotnet format ./code --verify-no-changes --verbosity diagnostic
- 595 unit tests
- 282 integration tests
- 9 architecture tests
- transitive NuGet vulnerability audit
- desktop and mobile browser QA
- GPT-5.6-Sol review: no remaining findings

Closes #589
