### PR TITLE
Add initial read-only Finance Manager MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Connected AI clients can now read the signed-in user's financial accounts, filtered transaction history, investment positions and valuations, currencies, and financial labels through owner-isolated MCP tools. #590
 - AI clients can now connect to a protected MCP endpoint, discover its OAuth settings automatically, verify the signed-in identity, and follow a responsive setup guide with copyable and downloadable configuration. #589
 - MCP clients can now securely sign in through Finance Manager and receive scoped, refreshable access tokens. #588
 - Admin access can now be assigned alongside normal user access, with direct links between the Finance Manager and admin dashboards and role controls on the admin user editor. #585

--- a/code/FinanceManager.Api/Mcp/FinancialAccountTools.cs
+++ b/code/FinanceManager.Api/Mcp/FinancialAccountTools.cs
@@ -1,0 +1,38 @@
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace FinanceManager.Api.Mcp;
+
+[McpServerToolType]
+public sealed class FinancialAccountTools(
+    McpUserContext userContext,
+    ICurrencyAccountRepository<CurrencyAccount> currencyAccounts,
+    IAccountRepository<BondAccount> bondAccounts,
+    IAccountRepository<InvestmentAccount> investmentAccounts)
+{
+    [McpServerTool(Name = "list_financial_accounts", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [Description("List financial accounts owned by the authenticated user. Never accepts or reads another user's id.")]
+    public async Task<IReadOnlyList<McpFinancialAccount>> ListFinancialAccounts()
+    {
+        var userId = userContext.GetUserId();
+        List<McpFinancialAccount> result = [];
+        result.AddRange((await currencyAccounts.GetAll(userId)).Where(account => account.UserId == userId).Select(McpResponseMapper.Account));
+        result.AddRange((await bondAccounts.GetAll(userId)).Where(account => account.UserId == userId).Select(McpResponseMapper.Account));
+        result.AddRange((await investmentAccounts.GetAll(userId)).Where(account => account.UserId == userId).Select(McpResponseMapper.Account));
+        return [.. result.OrderBy(account => account.Name, StringComparer.OrdinalIgnoreCase).ThenBy(account => account.AccountId)];
+    }
+
+    [McpServerTool(Name = "get_financial_account", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [Description("Get one financial account only when it belongs to the authenticated user. Returns null for missing or foreign accounts.")]
+    public async Task<McpFinancialAccount?> GetFinancialAccount(
+        [Description("Finance Manager account id returned by list_financial_accounts.")] int accountId)
+    {
+        var accounts = await ListFinancialAccounts();
+        return accounts.SingleOrDefault(account => account.AccountId == accountId);
+    }
+}

--- a/code/FinanceManager.Api/Mcp/IdentityTools.cs
+++ b/code/FinanceManager.Api/Mcp/IdentityTools.cs
@@ -6,17 +6,14 @@ using System.Security.Claims;
 namespace FinanceManager.Api.Mcp;
 
 [McpServerToolType]
-public sealed class IdentityTools(IHttpContextAccessor httpContextAccessor)
+public sealed class IdentityTools(McpUserContext userContext)
 {
-    [McpServerTool(Name = "who_am_i")]
+    [McpServerTool(Name = "who_am_i", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description("Return the authenticated Finance Manager user's id, login, and roles.")]
     public McpIdentity WhoAmI()
     {
-        var user = httpContextAccessor.HttpContext?.User
-            ?? throw new InvalidOperationException("The authenticated MCP request is unavailable.");
-        var subject = user.FindFirstValue(OpenIddictConstants.Claims.Subject)
-            ?? user.FindFirstValue(ClaimTypes.NameIdentifier)
-            ?? throw new InvalidOperationException("The authenticated MCP identity has no subject.");
+        var user = userContext.Principal;
+        var subject = userContext.GetUserId().ToString();
         var login = user.FindFirstValue(OpenIddictConstants.Claims.Name)
             ?? user.Identity?.Name
             ?? string.Empty;

--- a/code/FinanceManager.Api/Mcp/InvestmentTools.cs
+++ b/code/FinanceManager.Api/Mcp/InvestmentTools.cs
@@ -1,0 +1,60 @@
+using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Services;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace FinanceManager.Api.Mcp;
+
+[McpServerToolType]
+public sealed class InvestmentTools(
+    McpUserContext userContext,
+    IAccountRepository<InvestmentAccount> investmentAccounts,
+    IInvestmentValuationService valuationService,
+    ICurrencyRepository currencies,
+    IAssetListingRepository assetListings)
+{
+    [McpServerTool(Name = "get_investment_portfolio", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true)]
+    [Description("Return the authenticated user's investment positions and account values as of a date, using Finance Manager's valuation service.")]
+    public async Task<McpInvestmentPortfolio> GetInvestmentPortfolio(
+        [Description("Valuation date. Defaults to today.")] DateOnly? asOfDate = null,
+        [Description("Target ISO currency code. Defaults to PLN.")] string currencyCode = "PLN",
+        CancellationToken cancellationToken = default)
+    {
+        var userId = userContext.GetUserId();
+        var asOf = asOfDate ?? DateOnly.FromDateTime(DateTime.UtcNow);
+        var currency = await currencies.GetByCode(currencyCode, cancellationToken)
+            ?? throw new ArgumentException($"Unknown currency code '{currencyCode}'.", nameof(currencyCode));
+        var accounts = (await investmentAccounts.GetAll(userId)).Where(account => account.UserId == userId).ToList();
+        var accountMap = accounts.ToDictionary(account => account.AccountId);
+        if (accounts.Count == 0)
+            return new McpInvestmentPortfolio(asOf, currency.ShortName, 0, [], []);
+
+        var values = await valuationService.GetAccountValueAsync(
+            [.. accountMap.Keys], currency, asOf.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc), cancellationToken);
+        List<McpInvestmentPosition> positions = [];
+        foreach (var account in accounts)
+        {
+            var holdings = await valuationService.GetHoldingsAsOfAsync(account.AccountId, asOf, cancellationToken);
+            foreach (var (listingId, quantity) in holdings)
+            {
+                var listing = await assetListings.Get(listingId, cancellationToken);
+                if (listing is not null)
+                    positions.Add(McpResponseMapper.InvestmentPosition(account.AccountId, account.Name, listing, quantity));
+            }
+        }
+        positions = [.. positions
+            .OrderBy(position => position.AccountName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(position => position.Ticker, StringComparer.OrdinalIgnoreCase)];
+        var accountValues = accounts
+            .Select(account => new McpInvestmentAccountValue(
+                account.AccountId,
+                account.Name,
+                values.GetValueOrDefault(account.AccountId)))
+            .OrderBy(account => account.AccountName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return new McpInvestmentPortfolio(asOf, currency.ShortName, accountValues.Sum(account => account.Value), accountValues, positions);
+    }
+}

--- a/code/FinanceManager.Api/Mcp/McpFeatureExtensions.cs
+++ b/code/FinanceManager.Api/Mcp/McpFeatureExtensions.cs
@@ -17,7 +17,12 @@ public static class McpFeatureExtensions
                 "Finance Manager tools operate only on the authenticated user's financial data. " +
                 "Call who_am_i to confirm the current identity before working with user-specific data.")
             .WithHttpTransport(transport => transport.Stateless = true)
-            .WithTools<IdentityTools>();
+            .WithTools<IdentityTools>()
+            .WithTools<FinancialAccountTools>()
+            .WithTools<TransactionTools>()
+            .WithTools<InvestmentTools>()
+            .WithTools<ReferenceDataTools>();
+        services.AddScoped<McpUserContext>();
         return services;
     }
 

--- a/code/FinanceManager.Api/Mcp/McpResponseModels.cs
+++ b/code/FinanceManager.Api/Mcp/McpResponseModels.cs
@@ -1,0 +1,119 @@
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+
+namespace FinanceManager.Api.Mcp;
+
+public sealed record McpFinancialAccount(int AccountId, string Name, string Type, string Category);
+
+public sealed record McpTransaction(
+    long TransactionId,
+    int AccountId,
+    string AccountName,
+    string AccountType,
+    DateOnly Date,
+    decimal Amount,
+    string Description,
+    string[] Labels,
+    string? Currency = null,
+    decimal? Quantity = null,
+    decimal? UnitPrice = null);
+
+public sealed record McpTransactionPage(
+    IReadOnlyList<McpTransaction> Transactions,
+    int Offset,
+    int Limit,
+    bool HasMore);
+
+public sealed record McpInvestmentPosition(
+    int AccountId,
+    string AccountName,
+    long AssetListingId,
+    string Ticker,
+    string Exchange,
+    string TradingCurrency,
+    decimal Quantity);
+
+public sealed record McpInvestmentAccountValue(int AccountId, string AccountName, decimal Value);
+
+public sealed record McpInvestmentPortfolio(
+    DateOnly AsOfDate,
+    string ValuationCurrency,
+    decimal TotalValue,
+    IReadOnlyList<McpInvestmentAccountValue> Accounts,
+    IReadOnlyList<McpInvestmentPosition> Positions);
+
+public sealed record McpCurrency(int Id, string Code, string Symbol);
+public sealed record McpLabelClassification(string Kind, string Value);
+public sealed record McpFinancialLabel(int Id, string Name, IReadOnlyList<McpLabelClassification> Classifications);
+public sealed record McpReferenceData(IReadOnlyList<McpCurrency> Currencies, IReadOnlyList<McpFinancialLabel> Labels);
+
+internal static class McpResponseMapper
+{
+    public static McpFinancialAccount Account(CurrencyAccount account) =>
+        new(account.AccountId, account.Name, "currency", account.AccountType.ToString());
+
+    public static McpFinancialAccount Account(BondAccount account) =>
+        new(account.AccountId, account.Name, "bond", AccountLabel.Bond.ToString());
+
+    public static McpFinancialAccount Account(InvestmentAccount account) =>
+        new(account.AccountId, account.Name, "investment", AccountLabel.Stock.ToString());
+
+    public static McpTransaction Transaction(CurrencyAccountEntry entry, string accountName) => new(
+        entry.EntryId,
+        entry.AccountId,
+        accountName,
+        "currency",
+        DateOnly.FromDateTime(entry.PostingDate),
+        entry.ValueChange,
+        entry.Description ?? string.Empty,
+        [.. entry.Labels.Select(label => label.Name).Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.OrdinalIgnoreCase)]);
+
+    public static McpTransaction Transaction(BondAccountEntry entry, string accountName, string bondName) => new(
+        entry.EntryId,
+        entry.AccountId,
+        accountName,
+        "bond",
+        DateOnly.FromDateTime(entry.PostingDate),
+        entry.ValueChange,
+        bondName,
+        [.. entry.Labels.Select(label => label.Name).Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.OrdinalIgnoreCase)]);
+
+    public static McpTransaction Transaction(InvestmentTransaction transaction, string accountName) => new(
+        transaction.Id,
+        transaction.AccountId,
+        accountName,
+        "investment",
+        transaction.TradeDate,
+        transaction.SignedQuantity * transaction.UnitPrice,
+        $"{transaction.Type} {transaction.AssetListing?.Ticker}".TrimEnd(),
+        [],
+        transaction.Currency,
+        transaction.Quantity,
+        transaction.UnitPrice);
+
+    public static McpInvestmentPosition InvestmentPosition(
+        int accountId,
+        string accountName,
+        AssetListing listing,
+        decimal quantity) => new(
+            accountId,
+            accountName,
+            listing.Id,
+            listing.Ticker,
+            listing.ExchangeName,
+            listing.TradingCurrency,
+            quantity);
+
+    public static McpCurrency Currency(Currency currency) =>
+        new(currency.Id, currency.ShortName, currency.Symbol);
+
+    public static McpFinancialLabel Label(FinancialLabel label) => new(
+        label.Id,
+        label.Name,
+        [.. label.Classifications
+            .OrderBy(classification => classification.Kind, StringComparer.Ordinal)
+            .Select(classification => new McpLabelClassification(classification.Kind, classification.Value))]);
+}

--- a/code/FinanceManager.Api/Mcp/McpUserContext.cs
+++ b/code/FinanceManager.Api/Mcp/McpUserContext.cs
@@ -1,0 +1,19 @@
+using OpenIddict.Abstractions;
+using System.Security.Claims;
+
+namespace FinanceManager.Api.Mcp;
+
+public sealed class McpUserContext(IHttpContextAccessor httpContextAccessor)
+{
+    public ClaimsPrincipal Principal => httpContextAccessor.HttpContext?.User
+        ?? throw new InvalidOperationException("The authenticated MCP request is unavailable.");
+
+    public int GetUserId()
+    {
+        var subject = Principal.FindFirstValue(OpenIddictConstants.Claims.Subject)
+            ?? Principal.FindFirstValue(ClaimTypes.NameIdentifier);
+        return int.TryParse(subject, out var userId)
+            ? userId
+            : throw new InvalidOperationException("The authenticated MCP identity has no valid user id.");
+    }
+}

--- a/code/FinanceManager.Api/Mcp/ReferenceDataTools.cs
+++ b/code/FinanceManager.Api/Mcp/ReferenceDataTools.cs
@@ -1,0 +1,29 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.Labels.Repositories;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace FinanceManager.Api.Mcp;
+
+[McpServerToolType]
+public sealed class ReferenceDataTools(
+    McpUserContext userContext,
+    ICurrencyRepository currencies,
+    IFinancialLabelsRepository labels)
+{
+    [McpServerTool(Name = "list_reference_data", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [Description("List safe currency and financial-label reference data available to the authenticated user.")]
+    public async Task<McpReferenceData> ListReferenceData(CancellationToken cancellationToken = default)
+    {
+        _ = userContext.GetUserId();
+        var currencyModels = await currencies.GetCurrencies(cancellationToken)
+            .OrderBy(currency => currency.ShortName)
+            .Select(McpResponseMapper.Currency)
+            .ToListAsync(cancellationToken);
+        var labelModels = await labels.GetLabels(cancellationToken)
+            .OrderBy(label => label.Name)
+            .Select(McpResponseMapper.Label)
+            .ToListAsync(cancellationToken);
+        return new McpReferenceData(currencyModels, labelModels);
+    }
+}

--- a/code/FinanceManager.Api/Mcp/TransactionTools.cs
+++ b/code/FinanceManager.Api/Mcp/TransactionTools.cs
@@ -1,0 +1,146 @@
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace FinanceManager.Api.Mcp;
+
+[McpServerToolType]
+public sealed class TransactionTools(
+    McpUserContext userContext,
+    ICurrencyAccountRepository<CurrencyAccount> currencyAccounts,
+    IAccountRepository<BondAccount> bondAccounts,
+    IAccountRepository<InvestmentAccount> investmentAccounts,
+    IAccountEntryRepository<CurrencyAccountEntry> currencyEntries,
+    IBondAccountEntryRepository<BondAccountEntry> bondEntries,
+    IInvestmentTransactionRepository investmentTransactions,
+    IBondDetailsRepository bondDetails)
+{
+    [McpServerTool(Name = "list_transactions", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [Description("List the authenticated user's transactions with optional date, account, label, text, and paging filters. Defaults to the last 90 days.")]
+    public async Task<McpTransactionPage> ListTransactions(
+        [Description("Inclusive start date. Defaults to 90 days before endDate.")] DateOnly? startDate = null,
+        [Description("Inclusive end date. Defaults to today.")] DateOnly? endDate = null,
+        [Description("Optional owned account id.")] int? accountId = null,
+        [Description("Optional exact label/category name, case-insensitive.")] string? label = null,
+        [Description("Optional text contained in description, account name, or ticker.")] string? query = null,
+        [Description("Number of matching rows to skip, from 0.")] int offset = 0,
+        [Description("Page size from 1 to 100.")] int limit = 50,
+        CancellationToken cancellationToken = default)
+    {
+        if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset), "Offset cannot be negative.");
+        if (limit is < 1 or > 100) throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be between 1 and 100.");
+
+        var end = endDate ?? DateOnly.FromDateTime(DateTime.UtcNow);
+        var start = startDate ?? end.AddDays(-90);
+        if (start > end) throw new ArgumentException("Start date cannot be after end date.");
+
+        var userId = userContext.GetUserId();
+        var currencyAccountMap = (await currencyAccounts.GetAll(userId)).Where(account => account.UserId == userId).ToDictionary(account => account.AccountId);
+        var bondAccountMap = (await bondAccounts.GetAll(userId)).Where(account => account.UserId == userId).ToDictionary(account => account.AccountId);
+        var investmentAccountMap = (await investmentAccounts.GetAll(userId)).Where(account => account.UserId == userId).ToDictionary(account => account.AccountId);
+        var ownedAccountIds = currencyAccountMap.Keys.Concat(bondAccountMap.Keys).Concat(investmentAccountMap.Keys).ToHashSet();
+        if (accountId is not null && !ownedAccountIds.Contains(accountId.Value))
+            return new McpTransactionPage([], offset, limit, false);
+
+        List<McpTransaction> transactions = [];
+        var rangeStart = start.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var rangeEnd = end.ToDateTime(TimeOnly.MaxValue, DateTimeKind.Utc);
+        var currencyIds = SelectedIds(currencyAccountMap.Keys, accountId);
+        if (currencyIds.Count != 0)
+        {
+            transactions.AddRange((await currencyEntries.GetRange(currencyIds, rangeStart, rangeEnd))
+                .Where(entry => currencyAccountMap.ContainsKey(entry.AccountId))
+                .Select(entry => McpResponseMapper.Transaction(entry, currencyAccountMap[entry.AccountId].Name)));
+        }
+
+        var bondIds = SelectedIds(bondAccountMap.Keys, accountId);
+        if (bondIds.Count != 0)
+        {
+            var bondNames = new Dictionary<int, string>();
+            foreach (var entry in await bondEntries.GetRange(bondIds, rangeStart, rangeEnd))
+            {
+                if (!bondAccountMap.ContainsKey(entry.AccountId)) continue;
+                if (!bondNames.TryGetValue(entry.BondDetailsId, out var bondName))
+                {
+                    bondName = (await bondDetails.GetByIdAsync(entry.BondDetailsId, cancellationToken))?.Name ?? "Bond";
+                    bondNames[entry.BondDetailsId] = bondName;
+                }
+                transactions.Add(McpResponseMapper.Transaction(entry, bondAccountMap[entry.AccountId].Name, bondName));
+            }
+        }
+
+        var investments = await investmentTransactions.GetByUser(userId, start, end, cancellationToken);
+        transactions.AddRange(investments
+            .Where(transaction => transaction.UserId == userId)
+            .Where(transaction => accountId is null || transaction.AccountId == accountId)
+            .Where(transaction => investmentAccountMap.ContainsKey(transaction.AccountId))
+            .Select(transaction => McpResponseMapper.Transaction(transaction, investmentAccountMap[transaction.AccountId].Name)));
+
+        var filtered = transactions
+            .Where(transaction => string.IsNullOrWhiteSpace(label) || transaction.Labels.Contains(label, StringComparer.OrdinalIgnoreCase))
+            .Where(transaction => MatchesQuery(transaction, query))
+            .OrderByDescending(transaction => transaction.Date)
+            .ThenByDescending(transaction => transaction.TransactionId)
+            .ToList();
+        var page = filtered.Skip(offset).Take(limit).ToList();
+        return new McpTransactionPage(page, offset, limit, filtered.Count > offset + page.Count);
+    }
+
+    [McpServerTool(Name = "get_transaction", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [Description("Get transaction details only when the account and transaction belong to the authenticated user. Returns null for missing or foreign data.")]
+    public async Task<McpTransaction?> GetTransaction(
+        [Description("Account type: currency, bond, or investment.")] string accountType,
+        [Description("Owned account id.")] int accountId,
+        [Description("Transaction id returned by list_transactions.")] long transactionId,
+        CancellationToken cancellationToken = default)
+    {
+        var userId = userContext.GetUserId();
+        switch (accountType.Trim().ToLowerInvariant())
+        {
+            case "currency":
+                {
+                    var account = (await currencyAccounts.GetAll(userId)).SingleOrDefault(item => item.UserId == userId && item.AccountId == accountId);
+                    if (account is null || transactionId is < int.MinValue or > int.MaxValue) return null;
+                    var entry = await currencyEntries.Get(accountId, (int)transactionId);
+                    return entry is null || entry.AccountId != accountId
+                        ? null
+                        : McpResponseMapper.Transaction(entry, account.Name);
+                }
+            case "bond":
+                {
+                    var account = (await bondAccounts.GetAll(userId)).SingleOrDefault(item => item.UserId == userId && item.AccountId == accountId);
+                    if (account is null || transactionId is < int.MinValue or > int.MaxValue) return null;
+                    var entry = await bondEntries.Get(accountId, (int)transactionId);
+                    if (entry is null || entry.AccountId != accountId) return null;
+                    var name = (await bondDetails.GetByIdAsync(entry.BondDetailsId, cancellationToken))?.Name ?? "Bond";
+                    return McpResponseMapper.Transaction(entry, account.Name, name);
+                }
+            case "investment":
+                {
+                    var account = (await investmentAccounts.GetAll(userId)).SingleOrDefault(item => item.UserId == userId && item.AccountId == accountId);
+                    if (account is null) return null;
+                    var transaction = await investmentTransactions.Get(transactionId, cancellationToken);
+                    return transaction is null || transaction.UserId != userId || transaction.AccountId != accountId
+                        ? null
+                        : McpResponseMapper.Transaction(transaction, account.Name);
+                }
+            default:
+                throw new ArgumentException("Account type must be currency, bond, or investment.", nameof(accountType));
+        }
+    }
+
+    private static IReadOnlyCollection<int> SelectedIds(IEnumerable<int> accountIds, int? selectedAccountId) =>
+        [.. accountIds.Where(id => selectedAccountId is null || id == selectedAccountId)];
+
+    private static bool MatchesQuery(McpTransaction transaction, string? query) =>
+        string.IsNullOrWhiteSpace(query) ||
+        transaction.Description.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+        transaction.AccountName.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+        transaction.Labels.Any(label => label.Contains(query, StringComparison.OrdinalIgnoreCase));
+}

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
@@ -155,6 +155,7 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
 
     public async Task<BondAccountEntry?> Get(int accountId, int entryId) => await context.BondEntries
             .AsNoTracking()
+            .Include(entry => entry.Labels)
             .FirstOrDefaultAsync(x => x.AccountId == accountId && x.EntryId == entryId);
 
     public async Task<int> GetCount(int accountId) => await context.BondEntries.AsNoTracking().CountAsync(x => x.AccountId == accountId);

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryRepository.cs
@@ -172,6 +172,7 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
 
     public async Task<CurrencyAccountEntry?> Get(int accountId, int entryId) => await context.CurrencyEntries
             .AsNoTracking()
+            .Include(entry => entry.Labels)
             .FirstOrDefaultAsync(x => x.AccountId == accountId && x.EntryId == entryId);
 
     public async Task<int> GetCount(int accountId) => await context.CurrencyEntries.AsNoTracking().CountAsync(x => x.AccountId == accountId);

--- a/code/FinanceManager.Tests.Integration/Mcp/McpEndpointTests.cs
+++ b/code/FinanceManager.Tests.Integration/Mcp/McpEndpointTests.cs
@@ -1,7 +1,19 @@
 using FinanceManager.Api.Controllers;
 using FinanceManager.Api.Services;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Services;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
 using FinanceManager.Domain.Identity.Entities;
 using FinanceManager.Domain.Identity.Repositories;
+using FinanceManager.Domain.Labels.Repositories;
 using FinanceManager.Infrastructure.Contexts;
 using FinanceManager.Infrastructure.OAuth;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -39,10 +51,81 @@ public sealed class McpEndpointTests : IDisposable
         };
         var users = new Mock<IUserRepository>();
         users.Setup(repository => repository.GetUser(_userId)).ReturnsAsync(user);
+        var currencyAccounts = new Mock<ICurrencyAccountRepository<CurrencyAccount>>();
+        currencyAccounts.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([
+            new CurrencyAccount(_userId, 11, "MCP cash", AccountLabel.Cash),
+            new CurrencyAccount(999, 12, "Foreign cash", AccountLabel.Cash)
+        ]);
+        var bondAccounts = new Mock<IAccountRepository<BondAccount>>();
+        bondAccounts.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([]);
+        var investmentAccounts = new Mock<IAccountRepository<InvestmentAccount>>();
+        investmentAccounts.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([
+            new InvestmentAccount(_userId, 21, "MCP broker"),
+            new InvestmentAccount(999, 22, "Foreign broker")
+        ]);
+        var currencyEntries = new Mock<IAccountEntryRepository<CurrencyAccountEntry>>();
+        var currencyEntry = new CurrencyAccountEntry(11, 301, DateTime.UtcNow, 100, -20)
+        {
+            Description = "MCP lunch",
+            ContractorDetails = "internal counterparty"
+        };
+        currencyEntries.Setup(repository => repository.GetRange(
+                It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync([currencyEntry]);
+        currencyEntries.Setup(repository => repository.Get(11, 301)).ReturnsAsync(currencyEntry);
+        var bondEntries = new Mock<IBondAccountEntryRepository<BondAccountEntry>>();
+        var investmentTransactions = new Mock<IInvestmentTransactionRepository>();
+        investmentTransactions.Setup(repository => repository.GetByUser(
+                _userId, It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                InvestmentTransaction(_userId, 21, 401, "MCP", 2),
+                InvestmentTransaction(999, 22, 402, "FOREIGN", 9)
+            ]);
+        var bondDetails = new Mock<IBondDetailsRepository>();
+        var valuation = new Mock<IInvestmentValuationService>();
+        valuation.Setup(service => service.GetAccountValueAsync(
+                It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, decimal> { [21] = 1234m, [22] = 9999m });
+        valuation.Setup(service => service.GetHoldingsAsOfAsync(
+                21, It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<long, decimal> { [401] = 2 });
+        var assetListings = new Mock<IAssetListingRepository>();
+        assetListings.Setup(repository => repository.Get(401, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(InvestmentTransaction(_userId, 21, 401, "MCP", 2).AssetListing);
+        var currencies = new Mock<ICurrencyRepository>();
+        currencies.Setup(repository => repository.GetByCode("PLN", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DefaultCurrency.PLN);
+        currencies.Setup(repository => repository.GetCurrencies(It.IsAny<CancellationToken>()))
+            .Returns(new[] { DefaultCurrency.PLN }.ToAsyncEnumerable());
+        var labels = new Mock<IFinancialLabelsRepository>();
+        labels.Setup(repository => repository.GetLabels(It.IsAny<CancellationToken>()))
+            .Returns(new[] { new FinancialLabel { Id = 51, Name = "MCP category" } }.ToAsyncEnumerable());
         _app = new FinanceManagerApiTestApp(services =>
         {
             services.RemoveAll<IUserRepository>();
             services.AddSingleton(users.Object);
+            services.RemoveAll<ICurrencyAccountRepository<CurrencyAccount>>();
+            services.AddSingleton(currencyAccounts.Object);
+            services.RemoveAll<IAccountRepository<BondAccount>>();
+            services.AddSingleton(bondAccounts.Object);
+            services.RemoveAll<IAccountRepository<InvestmentAccount>>();
+            services.AddSingleton(investmentAccounts.Object);
+            services.RemoveAll<IAccountEntryRepository<CurrencyAccountEntry>>();
+            services.AddSingleton(currencyEntries.Object);
+            services.RemoveAll<IBondAccountEntryRepository<BondAccountEntry>>();
+            services.AddSingleton(bondEntries.Object);
+            services.RemoveAll<IInvestmentTransactionRepository>();
+            services.AddSingleton(investmentTransactions.Object);
+            services.RemoveAll<IBondDetailsRepository>();
+            services.AddSingleton(bondDetails.Object);
+            services.RemoveAll<IInvestmentValuationService>();
+            services.AddSingleton(valuation.Object);
+            services.RemoveAll<IAssetListingRepository>();
+            services.AddSingleton(assetListings.Object);
+            services.RemoveAll<ICurrencyRepository>();
+            services.AddSingleton(currencies.Object);
+            services.RemoveAll<IFinancialLabelsRepository>();
+            services.AddSingleton(labels.Object);
         });
 
         using var scope = _app.Services.CreateScope();
@@ -144,6 +227,91 @@ public sealed class McpEndpointTests : IDisposable
         Assert.Contains(_userId.ToString(), resultText, StringComparison.Ordinal);
         Assert.Contains(_userLogin, resultText, StringComparison.Ordinal);
         Assert.Contains("User", resultText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AuthenticatedClient_CallsEveryReadOnlyToolGroupWithoutCrossUserLeakage()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = CreateBrowser();
+        var accessToken = await GetAccessToken(client, cancellationToken);
+
+        using var listRequest = McpRequest("tools/list", 1, new { }, accessToken);
+        listRequest.Headers.TryAddWithoutValidation("MCP-Protocol-Version", "2025-06-18");
+        var listResponse = await client.SendAsync(listRequest, cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        var listJson = await ReadMcpJson(listResponse, cancellationToken);
+        var advertisedTools = listJson.GetProperty("result").GetProperty("tools").EnumerateArray().ToArray();
+        var toolNames = advertisedTools
+            .Select(tool => tool.GetProperty("name").GetString())
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.True(new[]
+        {
+            "list_financial_accounts",
+            "get_financial_account",
+            "list_transactions",
+            "get_transaction",
+            "get_investment_portfolio",
+            "list_reference_data"
+        }.All(toolNames.Contains));
+        Assert.All(advertisedTools, tool => Assert.True(
+            tool.GetProperty("annotations").GetProperty("readOnlyHint").GetBoolean()));
+        var portfolioTool = Assert.Single(advertisedTools, tool =>
+            tool.GetProperty("name").GetString() == "get_investment_portfolio");
+        Assert.True(portfolioTool.GetProperty("annotations").GetProperty("openWorldHint").GetBoolean());
+
+        var accounts = await CallTool(client, accessToken, 2, "list_financial_accounts", new { }, cancellationToken);
+        Assert.Contains("MCP cash", accounts, StringComparison.Ordinal);
+        Assert.Contains("MCP broker", accounts, StringComparison.Ordinal);
+        Assert.DoesNotContain("Foreign", accounts, StringComparison.OrdinalIgnoreCase);
+
+        var account = await CallTool(client, accessToken, 3, "get_financial_account", new { accountId = 11 }, cancellationToken);
+        Assert.Contains("MCP cash", account, StringComparison.Ordinal);
+
+        var transactions = await CallTool(client, accessToken, 4, "list_transactions", new
+        {
+            startDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1),
+            endDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(1)
+        }, cancellationToken);
+        Assert.Contains("MCP lunch", transactions, StringComparison.Ordinal);
+        Assert.Contains("MCP broker", transactions, StringComparison.Ordinal);
+        Assert.DoesNotContain("FOREIGN", transactions, StringComparison.Ordinal);
+        Assert.DoesNotContain("internal counterparty", transactions, StringComparison.Ordinal);
+
+        var transaction = await CallTool(client, accessToken, 5, "get_transaction", new
+        {
+            accountType = "currency",
+            accountId = 11,
+            transactionId = 301
+        }, cancellationToken);
+        Assert.Contains("MCP lunch", transaction, StringComparison.Ordinal);
+
+        var foreignTransaction = await CallTool(client, accessToken, 6, "get_transaction", new
+        {
+            accountType = "currency",
+            accountId = 12,
+            transactionId = 777
+        }, cancellationToken);
+        Assert.DoesNotContain("Foreign", foreignTransaction, StringComparison.OrdinalIgnoreCase);
+
+        var portfolio = await CallTool(client, accessToken, 7, "get_investment_portfolio", new
+        {
+            asOfDate = DateOnly.FromDateTime(DateTime.UtcNow)
+        }, cancellationToken);
+        Assert.Contains("MCP broker", portfolio, StringComparison.Ordinal);
+        Assert.Contains("1234", portfolio, StringComparison.Ordinal);
+        Assert.DoesNotContain("FOREIGN", portfolio, StringComparison.Ordinal);
+        Assert.DoesNotContain("9999", portfolio, StringComparison.Ordinal);
+
+        var referenceData = await CallTool(client, accessToken, 8, "list_reference_data", new { }, cancellationToken);
+        Assert.Contains("PLN", referenceData, StringComparison.Ordinal);
+        Assert.Contains("MCP category", referenceData, StringComparison.Ordinal);
+
+        foreach (var response in new[] { accounts, account, transactions, transaction, foreignTransaction, portfolio, referenceData })
+        {
+            Assert.DoesNotContain("userId", response, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("createdAt", response, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     [Fact]
@@ -264,4 +432,47 @@ public sealed class McpEndpointTests : IDisposable
         }
         return JsonDocument.Parse(body).RootElement.Clone();
     }
+
+    private static async Task<string> CallTool(
+        HttpClient client,
+        string accessToken,
+        int id,
+        string name,
+        object arguments,
+        CancellationToken cancellationToken)
+    {
+        using var request = McpRequest("tools/call", id, new { name, arguments }, accessToken);
+        request.Headers.TryAddWithoutValidation("MCP-Protocol-Version", "2025-06-18");
+        var response = await client.SendAsync(request, cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = (await ReadMcpJson(response, cancellationToken)).GetProperty("result");
+        Assert.False(result.TryGetProperty("isError", out var isError) && isError.GetBoolean());
+        return result.GetRawText();
+    }
+
+    private static InvestmentTransaction InvestmentTransaction(
+        int userId,
+        int accountId,
+        long listingId,
+        string ticker,
+        decimal quantity) => new()
+        {
+            Id = listingId,
+            UserId = userId,
+            AccountId = accountId,
+            AssetListingId = listingId,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = quantity,
+            UnitPrice = 100,
+            Currency = "USD",
+            TradeDate = DateOnly.FromDateTime(DateTime.UtcNow),
+            AssetListing = new AssetListing
+            {
+                Id = listingId,
+                Ticker = ticker,
+                ExchangeMic = "XNYS",
+                ExchangeName = "New York Stock Exchange",
+                TradingCurrency = "USD"
+            }
+        };
 }

--- a/code/FinanceManager.Tests.Unit/Api/Mcp/McpToolsTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Mcp/McpToolsTests.cs
@@ -1,0 +1,283 @@
+using FinanceManager.Api.Mcp;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Services;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using FinanceManager.Domain.Labels.Repositories;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using OpenIddict.Abstractions;
+using System.Security.Claims;
+using System.Text.Json;
+using Xunit;
+
+namespace FinanceManager.Tests.Unit.Api.Mcp;
+
+public sealed class McpToolsTests
+{
+    private const int _userId = 73;
+
+    [Fact]
+    public void UserContextAndIdentity_UseValidatedOAuthSubject()
+    {
+        var context = UserContext(
+            new Claim(OpenIddictConstants.Claims.Subject, _userId.ToString()),
+            new Claim(ClaimTypes.NameIdentifier, "999"),
+            new Claim(OpenIddictConstants.Claims.Name, "mcp-user"),
+            new Claim(OpenIddictConstants.Claims.Role, "User"));
+
+        var identity = new IdentityTools(context).WhoAmI();
+
+        Assert.Equal(_userId, context.GetUserId());
+        Assert.Equal(_userId.ToString(), identity.UserId);
+        Assert.Equal("mcp-user", identity.Login);
+        Assert.Equal(["User"], identity.Roles);
+    }
+
+    [Fact]
+    public void UserContext_RejectsMissingOrInvalidSubject()
+    {
+        Assert.Throws<InvalidOperationException>(() => UserContext().GetUserId());
+        Assert.Throws<InvalidOperationException>(() =>
+            UserContext(new Claim(OpenIddictConstants.Claims.Subject, "not-a-user-id")).GetUserId());
+    }
+
+    [Fact]
+    public async Task FinancialAccounts_UseSubjectAndFilterForeignRepositoryRows()
+    {
+        var currencies = new Mock<ICurrencyAccountRepository<CurrencyAccount>>();
+        var bonds = new Mock<IAccountRepository<BondAccount>>();
+        var investments = new Mock<IAccountRepository<InvestmentAccount>>();
+        currencies.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([
+            new CurrencyAccount(_userId, 1, "Cash", AccountLabel.Cash),
+            new CurrencyAccount(999, 2, "Foreign cash", AccountLabel.Cash)
+        ]);
+        bonds.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([]);
+        investments.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([]);
+        var tools = new FinancialAccountTools(UserContext(Subject()), currencies.Object, bonds.Object, investments.Object);
+
+        var result = await tools.ListFinancialAccounts();
+
+        var account = Assert.Single(result);
+        Assert.Equal(1, account.AccountId);
+        Assert.Equal("Cash", account.Name);
+        Assert.Equal("currency", account.Type);
+        currencies.Verify(repository => repository.GetAll(_userId), Times.Once);
+        bonds.Verify(repository => repository.GetAll(_userId), Times.Once);
+        investments.Verify(repository => repository.GetAll(_userId), Times.Once);
+    }
+
+    [Fact]
+    public async Task Transactions_ReturnEmptyForForeignAccountWithoutReadingItsEntries()
+    {
+        var currencies = new Mock<ICurrencyAccountRepository<CurrencyAccount>>();
+        var bonds = new Mock<IAccountRepository<BondAccount>>();
+        var investments = new Mock<IAccountRepository<InvestmentAccount>>();
+        var currencyEntries = new Mock<IAccountEntryRepository<CurrencyAccountEntry>>();
+        var bondEntries = new Mock<IBondAccountEntryRepository<BondAccountEntry>>();
+        var investmentTransactions = new Mock<IInvestmentTransactionRepository>();
+        var bondDetails = new Mock<IBondDetailsRepository>();
+        currencies.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([
+            new CurrencyAccount(_userId, 1, "Cash", AccountLabel.Cash)
+        ]);
+        bonds.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([]);
+        investments.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([]);
+        var tools = new TransactionTools(
+            UserContext(Subject()), currencies.Object, bonds.Object, investments.Object,
+            currencyEntries.Object, bondEntries.Object, investmentTransactions.Object, bondDetails.Object);
+
+        var result = await tools.ListTransactions(
+            accountId: 999,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Empty(result.Transactions);
+        currencyEntries.Verify(repository => repository.GetRange(
+            It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.Never);
+        bondEntries.Verify(repository => repository.GetRange(
+            It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.Never);
+        investmentTransactions.Verify(repository => repository.GetByUser(
+            It.IsAny<long>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Transactions_DiscardForeignRowsReturnedByRepository()
+    {
+        var currencies = new Mock<ICurrencyAccountRepository<CurrencyAccount>>();
+        var bonds = new Mock<IAccountRepository<BondAccount>>();
+        var investments = new Mock<IAccountRepository<InvestmentAccount>>();
+        var currencyEntries = new Mock<IAccountEntryRepository<CurrencyAccountEntry>>();
+        var bondEntries = new Mock<IBondAccountEntryRepository<BondAccountEntry>>();
+        var investmentTransactions = new Mock<IInvestmentTransactionRepository>();
+        var bondDetails = new Mock<IBondDetailsRepository>();
+        currencies.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([
+            new CurrencyAccount(_userId, 1, "Cash", AccountLabel.Cash)
+        ]);
+        bonds.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([]);
+        investments.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([]);
+        currencyEntries.Setup(repository => repository.GetRange(
+                It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .ReturnsAsync([new CurrencyAccountEntry(999, 17, DateTime.UtcNow, 10, -10)]);
+        investmentTransactions.Setup(repository => repository.GetByUser(
+                _userId, It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        var tools = new TransactionTools(
+            UserContext(Subject()), currencies.Object, bonds.Object, investments.Object,
+            currencyEntries.Object, bondEntries.Object, investmentTransactions.Object, bondDetails.Object);
+
+        var result = await tools.ListTransactions(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Empty(result.Transactions);
+    }
+
+    [Fact]
+    public async Task InvestmentPortfolio_UsesSubjectAndFiltersForeignRows()
+    {
+        var accounts = new Mock<IAccountRepository<InvestmentAccount>>();
+        var valuation = new Mock<IInvestmentValuationService>();
+        var currencies = new Mock<ICurrencyRepository>();
+        var listings = new Mock<IAssetListingRepository>();
+        accounts.Setup(repository => repository.GetAll(_userId)).ReturnsAsync([
+            new InvestmentAccount(_userId, 10, "Broker"),
+            new InvestmentAccount(999, 20, "Foreign broker")
+        ]);
+        currencies.Setup(repository => repository.GetByCode("PLN", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DefaultCurrency.PLN);
+        valuation.Setup(service => service.GetAccountValueAsync(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.SequenceEqual(new[] { 10 })),
+                DefaultCurrency.PLN,
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, decimal> { [10] = 1200m });
+        valuation.Setup(service => service.GetHoldingsAsOfAsync(
+                10, new DateOnly(2026, 7, 21), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<long, decimal> { [100] = 3 });
+        listings.Setup(repository => repository.Get(100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AssetListing(100, "OWN"));
+        var tools = new InvestmentTools(UserContext(Subject()), accounts.Object, valuation.Object, currencies.Object, listings.Object);
+
+        var result = await tools.GetInvestmentPortfolio(
+            new DateOnly(2026, 7, 21),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(1200m, result.TotalValue);
+        Assert.Equal(10, Assert.Single(result.Accounts).AccountId);
+        var position = Assert.Single(result.Positions);
+        Assert.Equal("OWN", position.Ticker);
+        Assert.Equal(3, position.Quantity);
+        valuation.Verify(service => service.GetHoldingsAsOfAsync(
+            10, new DateOnly(2026, 7, 21), It.IsAny<CancellationToken>()), Times.Once);
+        valuation.Verify(service => service.GetHoldingsAsOfAsync(
+            20, It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReferenceData_RequiresIdentityAndMapsOnlySafeFields()
+    {
+        var currencies = new Mock<ICurrencyRepository>();
+        var labels = new Mock<IFinancialLabelsRepository>();
+        currencies.Setup(repository => repository.GetCurrencies(It.IsAny<CancellationToken>()))
+            .Returns(new[] { DefaultCurrency.USD }.ToAsyncEnumerable());
+        labels.Setup(repository => repository.GetLabels(It.IsAny<CancellationToken>()))
+            .Returns(new[]
+            {
+                new FinancialLabel
+                {
+                    Id = 4,
+                    Name = "Salary",
+                    Classifications = [new FinancialLabelClassification { Id = 88, LabelId = 4, Kind = "income", Value = "salary" }]
+                }
+            }.ToAsyncEnumerable());
+        var tools = new ReferenceDataTools(UserContext(Subject()), currencies.Object, labels.Object);
+
+        var result = await tools.ListReferenceData(TestContext.Current.CancellationToken);
+
+        Assert.Equal("USD", Assert.Single(result.Currencies).Code);
+        var label = Assert.Single(result.Labels);
+        Assert.Equal("Salary", label.Name);
+        var classification = Assert.Single(label.Classifications);
+        Assert.Equal("income", classification.Kind);
+        Assert.Null(classification.GetType().GetProperty("Id"));
+        Assert.Null(classification.GetType().GetProperty("LabelId"));
+    }
+
+    [Fact]
+    public void ResponseMappings_OmitOwnershipAndInternalPersistenceFields()
+    {
+        var label = new FinancialLabel { Id = 4, Name = "Food" };
+        var currencyEntry = new CurrencyAccountEntry(1, 5, DateTime.UtcNow, 100, -20)
+        {
+            Description = "Lunch",
+            ContractorDetails = "private raw counterparty",
+            Labels = [label]
+        };
+        var investment = InvestmentTransaction(_userId, 10, 100, "SAFE", 2);
+        investment.Notes = "private note";
+        investment.CreatedAt = DateTimeOffset.UtcNow;
+        investment.AssetListing.MarketDataSymbols = [new MarketDataSymbol { Symbol = "provider-secret" }];
+        var payload = new object[]
+        {
+            McpResponseMapper.Account(new CurrencyAccount(_userId, 1, "Cash", AccountLabel.Cash)),
+            McpResponseMapper.Transaction(currencyEntry, "Cash"),
+            McpResponseMapper.Transaction(new CurrencyAccountEntry(1, 6, DateTime.UtcNow, 100, -20)
+            {
+                ContractorDetails = "fallback-sensitive counterparty"
+            }, "Cash"),
+            McpResponseMapper.InvestmentPosition(10, "Broker", investment.AssetListing, 2),
+            McpResponseMapper.Currency(DefaultCurrency.USD),
+            McpResponseMapper.Label(label)
+        };
+
+        var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.Contains("Lunch", json, StringComparison.Ordinal);
+        Assert.Contains("SAFE", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("userId", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("contractorDetails", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("private raw counterparty", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("fallback-sensitive counterparty", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("private note", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("createdAt", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("provider-secret", json, StringComparison.Ordinal);
+    }
+
+    private static McpUserContext UserContext(params Claim[] claims)
+    {
+        var httpContext = new DefaultHttpContext
+        {
+            User = new ClaimsPrincipal(new ClaimsIdentity(claims, "McpOAuth"))
+        };
+        return new McpUserContext(new HttpContextAccessor { HttpContext = httpContext });
+    }
+
+    private static Claim Subject() => new(OpenIddictConstants.Claims.Subject, _userId.ToString());
+
+    private static AssetListing AssetListing(long id, string ticker) => new()
+    {
+        Id = id,
+        Ticker = ticker,
+        ExchangeMic = "XNYS",
+        ExchangeName = "New York Stock Exchange",
+        TradingCurrency = "USD"
+    };
+
+    private static InvestmentTransaction InvestmentTransaction(int userId, int accountId, long listingId, string ticker, decimal quantity) => new()
+    {
+        Id = listingId,
+        UserId = userId,
+        AccountId = accountId,
+        AssetListingId = listingId,
+        Type = InvestmentTransactionType.Buy,
+        Quantity = quantity,
+        UnitPrice = 100,
+        Currency = "USD",
+        TradeDate = new DateOnly(2026, 1, 1),
+        AssetListing = AssetListing(listingId, ticker)
+    };
+}

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/EntryRepositoryGetTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/EntryRepositoryGetTests.cs
@@ -1,0 +1,48 @@
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+using FinanceManager.Infrastructure.Contexts;
+using FinanceManager.Infrastructure.Repositories.Account.Entry;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Tests.Unit.Infrastructure.Repositories;
+
+[Collection("Infrastructure")]
+[Trait("Category", "Unit")]
+public sealed class EntryRepositoryGetTests
+{
+    [Fact]
+    public async Task CurrencyGet_IncludesLabels()
+    {
+        await using var context = CreateContext();
+        var label = new FinancialLabel { Name = "Groceries" };
+        var entry = new CurrencyAccountEntry(1, 10, DateTime.UtcNow, 100, -25) { Labels = [label] };
+        context.CurrencyEntries.Add(entry);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        context.ChangeTracker.Clear();
+
+        var result = await new CurrencyEntryRepository(context).Get(1, 10);
+
+        Assert.Equal("Groceries", Assert.Single(Assert.IsType<CurrencyAccountEntry>(result).Labels).Name);
+    }
+
+    [Fact]
+    public async Task BondGet_IncludesLabels()
+    {
+        await using var context = CreateContext();
+        var label = new FinancialLabel { Name = "Interest" };
+        var entry = new BondAccountEntry(2, 20, DateTime.UtcNow, 100, 5, 7) { Labels = [label] };
+        context.BondEntries.Add(entry);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        context.ChangeTracker.Clear();
+
+        var result = await new BondEntryRepository(context).Get(2, 20);
+
+        Assert.Equal("Interest", Assert.Single(Assert.IsType<BondAccountEntry>(result).Labels).Name);
+    }
+
+    private static AppDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+}


### PR DESCRIPTION
## Summary

- add authenticated read-only MCP tools for financial accounts, transactions, investments, currencies, and financial labels
- derive ownership exclusively from the validated OAuth principal and return dedicated safe response models
- reuse repository and valuation services, including provider-aware investment valuation
- add unit, EF repository, and authenticated MCP transport coverage for response mapping and cross-user isolation

## Validation

- `dotnet build FinanceManager.slnx --no-restore`
- `dotnet format FinanceManager.slnx --verify-no-changes --no-restore`
- 605 unit tests
- 9 architecture tests
- 283 integration tests
- independent GPT-5.6-Sol review: no remaining findings

Closes #590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only financial account, transaction, investment portfolio, and reference data tools.
  * Added filtering, searching, pagination, valuation currency, and date-range options.
  * Responses now provide structured account, transaction, investment, currency, and label data.
* **Bug Fixes**
  * Financial transaction labels are now included when retrieving entries.
  * Access is restricted to the authenticated user’s data, preventing cross-user data exposure.
* **Tests**
  * Added comprehensive coverage for tool access, response privacy, filtering, identity validation, and label loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->