### PR TITLE
Complete MCP security coverage and operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- MCP access tokens and grants can now be revoked server-side, and deployment guidance covers secure certificate configuration and rotation. #584
 - Investment accounts now show asset appreciation based on current holdings value minus the remaining buy cost, with transaction-date currency conversion. #578
 - The **Investment rate** chart is now interactive: selecting a month highlights its bar and shows that month's salary and invested amount, while the average line displays its value. #576
 - The dashboard date picker has been redesigned into a compact pill: the active preset (This month / This quarter / This year) is now highlighted, and the custom range opens in a calendar dialog — consistent with the account details pages — showing the selected dates next to the presets. #559

--- a/code/FinanceManager.Api/ApiConfigurationExtensions.cs
+++ b/code/FinanceManager.Api/ApiConfigurationExtensions.cs
@@ -274,6 +274,7 @@ public static class ApiConfigurationExtensions
                         .SetTokenEndpointUris("/connect/token")
                         .AllowAuthorizationCodeFlow()
                         .AllowRefreshTokenFlow()
+                        .UseReferenceAccessTokens()
                         .RegisterScopes("mcp")
                         .RegisterResources(mcpOAuth.Resource)
                         .SetAuthorizationCodeLifetime(mcpOAuth.AuthorizationCodeLifetime)
@@ -306,6 +307,7 @@ public static class ApiConfigurationExtensions
                 .AddValidation(options =>
                 {
                     options.UseLocalServer();
+                    options.EnableAuthorizationEntryValidation();
                     options.EnableTokenEntryValidation();
                     options.UseAspNetCore();
                 });

--- a/code/FinanceManager.Api/Mcp/McpClientRevocationCommand.cs
+++ b/code/FinanceManager.Api/Mcp/McpClientRevocationCommand.cs
@@ -1,0 +1,46 @@
+using FinanceManager.Infrastructure.OAuth;
+
+namespace FinanceManager.Api.Mcp;
+
+internal static class McpClientRevocationCommand
+{
+    private const string _argument = "--revoke-mcp-client";
+
+    public static bool IsRequested(string[] args) => Array.IndexOf(args, _argument) >= 0;
+
+    public static Task<int> RunAsync(string[] args, IServiceProvider services) =>
+        RunAsync(
+            args,
+            async clientId =>
+            {
+                using var scope = services.CreateScope();
+                return await scope.ServiceProvider.GetRequiredService<McpOAuthGrantRevoker>()
+                    .RevokeClientAsync(clientId);
+            },
+            Console.Out,
+            Console.Error);
+
+    internal static async Task<int> RunAsync(
+        string[] args,
+        Func<string, Task<McpOAuthRevocationResult?>> revokeClient,
+        TextWriter output,
+        TextWriter error)
+    {
+        if (args.Length != 2 || args[0] != _argument || string.IsNullOrWhiteSpace(args[1]))
+        {
+            await error.WriteLineAsync("Usage: FinanceManager.Api --revoke-mcp-client <client-id>");
+            return 2;
+        }
+
+        var result = await revokeClient(args[1]);
+        if (result is null)
+        {
+            await error.WriteLineAsync($"MCP OAuth client '{args[1]}' was not found.");
+            return 3;
+        }
+
+        await output.WriteLineAsync(
+            $"Revoked {result.Authorizations} authorization(s) and {result.Tokens} token(s) for MCP OAuth client '{args[1]}'.");
+        return 0;
+    }
+}

--- a/code/FinanceManager.Api/Program.cs
+++ b/code/FinanceManager.Api/Program.cs
@@ -132,28 +132,9 @@ app.MapHub<FinanceManager.Api.Hubs.LabelSetterProgressHub>("/hubs/label-setter-p
 app.MapHub<FinanceManager.Api.Hubs.AdminLogsHub>("/hubs/admin-logs");
 app.MapFallbackToFile("index.html");
 
-var revokeClientArgument = Array.IndexOf(args, "--revoke-mcp-client");
-if (revokeClientArgument >= 0)
+if (McpClientRevocationCommand.IsRequested(args))
 {
-    if (args.Length != 2 || revokeClientArgument != 0 || string.IsNullOrWhiteSpace(args[1]))
-    {
-        Console.Error.WriteLine("Usage: FinanceManager.Api --revoke-mcp-client <client-id>");
-        Environment.ExitCode = 2;
-        return;
-    }
-
-    using var scope = app.Services.CreateScope();
-    var result = await scope.ServiceProvider.GetRequiredService<McpOAuthGrantRevoker>()
-        .RevokeClientAsync(args[1]);
-    if (result is null)
-    {
-        Console.Error.WriteLine($"MCP OAuth client '{args[1]}' was not found.");
-        Environment.ExitCode = 3;
-        return;
-    }
-
-    Console.WriteLine(
-        $"Revoked {result.Authorizations} authorization(s) and {result.Tokens} token(s) for MCP OAuth client '{args[1]}'.");
+    Environment.ExitCode = await McpClientRevocationCommand.RunAsync(args, app.Services);
     return;
 }
 

--- a/code/FinanceManager.Api/Program.cs
+++ b/code/FinanceManager.Api/Program.cs
@@ -6,6 +6,7 @@ using FinanceManager.Application;
 using FinanceManager.Application.Shared.Diagnostics;
 using FinanceManager.Application.Shared.Options;
 using FinanceManager.Infrastructure;
+using FinanceManager.Infrastructure.OAuth;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
@@ -130,4 +131,30 @@ app.MapHub<FinanceManager.Api.Hubs.CurrencyImportHub>("/hubs/currency-import");
 app.MapHub<FinanceManager.Api.Hubs.LabelSetterProgressHub>("/hubs/label-setter-progress");
 app.MapHub<FinanceManager.Api.Hubs.AdminLogsHub>("/hubs/admin-logs");
 app.MapFallbackToFile("index.html");
+
+var revokeClientArgument = Array.IndexOf(args, "--revoke-mcp-client");
+if (revokeClientArgument >= 0)
+{
+    if (args.Length != 2 || revokeClientArgument != 0 || string.IsNullOrWhiteSpace(args[1]))
+    {
+        Console.Error.WriteLine("Usage: FinanceManager.Api --revoke-mcp-client <client-id>");
+        Environment.ExitCode = 2;
+        return;
+    }
+
+    using var scope = app.Services.CreateScope();
+    var result = await scope.ServiceProvider.GetRequiredService<McpOAuthGrantRevoker>()
+        .RevokeClientAsync(args[1]);
+    if (result is null)
+    {
+        Console.Error.WriteLine($"MCP OAuth client '{args[1]}' was not found.");
+        Environment.ExitCode = 3;
+        return;
+    }
+
+    Console.WriteLine(
+        $"Revoked {result.Authorizations} authorization(s) and {result.Tokens} token(s) for MCP OAuth client '{args[1]}'.");
+    return;
+}
+
 app.Run();

--- a/code/FinanceManager.Infrastructure/OAuth/McpOAuthGrantRevoker.cs
+++ b/code/FinanceManager.Infrastructure/OAuth/McpOAuthGrantRevoker.cs
@@ -1,0 +1,27 @@
+using OpenIddict.Abstractions;
+
+namespace FinanceManager.Infrastructure.OAuth;
+
+public sealed class McpOAuthGrantRevoker(
+    IOpenIddictApplicationManager applications,
+    IOpenIddictAuthorizationManager authorizations,
+    IOpenIddictTokenManager tokens)
+{
+    public async Task<McpOAuthRevocationResult?> RevokeClientAsync(
+        string clientId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        var application = await applications.FindByClientIdAsync(clientId, cancellationToken);
+        if (application is null) return null;
+        var applicationId = await applications.GetIdAsync(application, cancellationToken)
+            ?? throw new InvalidOperationException($"OpenIddict application '{clientId}' has no id.");
+
+        var revokedAuthorizations = await authorizations.RevokeByApplicationIdAsync(applicationId, cancellationToken);
+        var revokedTokens = await tokens.RevokeByApplicationIdAsync(applicationId, cancellationToken);
+
+        return new McpOAuthRevocationResult(revokedAuthorizations, revokedTokens);
+    }
+}
+
+public sealed record McpOAuthRevocationResult(long Authorizations, long Tokens);

--- a/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
@@ -144,6 +144,7 @@ public static class ServiceCollectionExtension
         services.AddOpenIddict()
             .AddCore(options => options.UseEntityFrameworkCore().UseDbContext<AppDbContext>());
         services.AddScoped<McpOAuthConfigurationReconciler>();
+        services.AddScoped<McpOAuthGrantRevoker>();
 
         // The cleanup service builds standalone AppDbContexts to drop expired guest sandboxes; without a shared
         // root, EF Core's InMemory provider uses a per-internal-provider singleton, so the standalone context

--- a/code/FinanceManager.Tests.Integration/Mcp/McpEndpointTests.cs
+++ b/code/FinanceManager.Tests.Integration/Mcp/McpEndpointTests.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Moq;
+using OpenIddict.Abstractions;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -188,6 +189,118 @@ public sealed class McpEndpointTests : IDisposable
     }
 
     [Fact]
+    public async Task McpWithTokenMissingMcpScope_IsForbidden()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = CreateBrowser();
+        var tokens = await GetTokenResponse(client, cancellationToken);
+        var refreshToken = tokens.GetProperty("refresh_token").GetString();
+        var refreshResponse = await client.PostAsync("/connect/token", new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["grant_type"] = "refresh_token",
+            ["client_id"] = "finance-manager-mcp-test",
+            ["refresh_token"] = refreshToken!,
+            ["scope"] = "offline_access"
+        }), cancellationToken);
+        Assert.Equal(HttpStatusCode.OK, refreshResponse.StatusCode);
+        var refreshed = await refreshResponse.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
+        Assert.False(refreshed.TryGetProperty("scope", out var scope) &&
+            scope.GetString()!.Split(' ').Contains("mcp", StringComparer.Ordinal));
+
+        using var request = McpRequest(
+            "tools/list", 1, new { }, refreshed.GetProperty("access_token").GetString());
+        var response = await client.SendAsync(request, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task McpWithRevokedAuthorization_IsUnauthorized()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = CreateBrowser();
+        var accessToken = await GetAccessToken(client, cancellationToken);
+        using (var scope = _app.Services.CreateScope())
+        {
+            var authorizationManager = scope.ServiceProvider.GetRequiredService<IOpenIddictAuthorizationManager>();
+            var revoked = 0;
+            await foreach (var authorization in authorizationManager.FindBySubjectAsync(
+                               _userId.ToString(), cancellationToken))
+            {
+                Assert.True(await authorizationManager.TryRevokeAsync(authorization, cancellationToken));
+                revoked++;
+            }
+            Assert.True(revoked > 0);
+        }
+
+        using var request = McpRequest("tools/list", 1, new { }, accessToken);
+        var response = await client.SendAsync(request, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task McpWithRevokedAccessToken_IsUnauthorized()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        using var client = CreateBrowser();
+        var accessToken = await GetAccessToken(client, cancellationToken);
+        using (var scope = _app.Services.CreateScope())
+        {
+            var tokenManager = scope.ServiceProvider.GetRequiredService<IOpenIddictTokenManager>();
+            var token = await tokenManager.FindByReferenceIdAsync(accessToken, cancellationToken);
+            Assert.NotNull(token);
+            Assert.True(await tokenManager.TryRevokeAsync(token, cancellationToken));
+        }
+
+        using var request = McpRequest("tools/list", 1, new { }, accessToken);
+        var response = await client.SendAsync(request, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task McpWithExpiredAccessToken_IsUnauthorized()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var users = new Mock<IUserRepository>();
+        users.Setup(repository => repository.GetUser(_userId)).ReturnsAsync(new User
+        {
+            UserId = _userId,
+            Login = _userLogin,
+            UserRole = UserRole.User,
+            CreationDate = DateTime.UtcNow
+        });
+        using var app = new FinanceManagerApiTestApp(services =>
+        {
+            services.RemoveAll<IUserRepository>();
+            services.AddSingleton(users.Object);
+        }, hostSettings: new Dictionary<string, string?>
+        {
+            ["McpOAuth:AccessTokenLifetime"] = "00:00:01"
+        });
+        using (var scope = app.Services.CreateScope())
+        {
+            scope.ServiceProvider.GetRequiredService<AppDbContext>().Database.EnsureCreated();
+            var options = scope.ServiceProvider.GetRequiredService<IOptions<McpOAuthOptions>>().Value;
+            await scope.ServiceProvider.GetRequiredService<McpOAuthConfigurationReconciler>()
+                .ReconcileAsync(options, cancellationToken);
+        }
+        using var client = app.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            BaseAddress = new Uri("http://localhost/")
+        });
+        var accessToken = await GetAccessToken(client, cancellationToken, app);
+        await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+
+        using var request = McpRequest("tools/list", 1, new { }, accessToken);
+        var response = await client.SendAsync(request, cancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
     public async Task AuthenticatedClient_CanInitializeListToolsAndCallWhoAmI()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -351,7 +464,16 @@ public sealed class McpEndpointTests : IDisposable
         BaseAddress = new Uri("http://localhost/")
     });
 
-    private async Task<string> GetAccessToken(HttpClient client, CancellationToken cancellationToken)
+    private async Task<string> GetAccessToken(
+        HttpClient client,
+        CancellationToken cancellationToken,
+        FinanceManagerApiTestApp? app = null) =>
+        (await GetTokenResponse(client, cancellationToken, app)).GetProperty("access_token").GetString()!;
+
+    private async Task<JsonElement> GetTokenResponse(
+        HttpClient client,
+        CancellationToken cancellationToken,
+        FinanceManagerApiTestApp? app = null)
     {
         var verifier = WebEncoders.Base64UrlEncode(RandomNumberGenerator.GetBytes(32));
         var challenge = WebEncoders.Base64UrlEncode(SHA256.HashData(Encoding.ASCII.GetBytes(verifier)));
@@ -369,7 +491,7 @@ public sealed class McpEndpointTests : IDisposable
         var csrfToken = await BootstrapCsrfToken(client, cancellationToken);
         var bridge = await client.PostAsync("/api/Auth/oauth-bridge", new FormUrlEncodedContent(new Dictionary<string, string>
         {
-            ["token"] = IssueJwt(),
+            ["token"] = IssueJwt(app),
             ["returnUrl"] = "http://localhost" + authorizationUrl,
             ["__RequestVerificationToken"] = csrfToken
         }), cancellationToken);
@@ -388,13 +510,12 @@ public sealed class McpEndpointTests : IDisposable
             ["code_verifier"] = verifier
         }), cancellationToken);
         Assert.Equal(HttpStatusCode.OK, tokenResponse.StatusCode);
-        var token = await tokenResponse.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
-        return token.GetProperty("access_token").GetString()!;
+        return await tokenResponse.Content.ReadFromJsonAsync<JsonElement>(cancellationToken);
     }
 
-    private string IssueJwt()
+    private string IssueJwt(FinanceManagerApiTestApp? app = null)
     {
-        using var scope = _app.Services.CreateScope();
+        using var scope = (app ?? _app).Services.CreateScope();
         return scope.ServiceProvider.GetRequiredService<JwtTokenGenerator>()
             .GenerateToken(_userLogin, _userId, UserRole.User, false)
             .AccessToken;

--- a/code/FinanceManager.Tests.Unit/Api/Mcp/McpClientRevocationCommandTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Mcp/McpClientRevocationCommandTests.cs
@@ -1,0 +1,62 @@
+using FinanceManager.Api.Mcp;
+using FinanceManager.Infrastructure.OAuth;
+
+namespace FinanceManager.Tests.Unit.Api.Mcp;
+
+public sealed class McpClientRevocationCommandTests
+{
+    [Fact]
+    public async Task RunAsync_ReturnsUsageErrorForInvalidArguments()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exitCode = await McpClientRevocationCommand.RunAsync(
+            ["--revoke-mcp-client"],
+            _ => throw new InvalidOperationException("Revocation should not run."),
+            output,
+            error);
+
+        Assert.Equal(2, exitCode);
+        Assert.Contains("Usage:", error.ToString());
+        Assert.Empty(output.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsNotFoundForUnknownClient()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exitCode = await McpClientRevocationCommand.RunAsync(
+            ["--revoke-mcp-client", "missing"],
+            _ => Task.FromResult<McpOAuthRevocationResult?>(null),
+            output,
+            error);
+
+        Assert.Equal(3, exitCode);
+        Assert.Contains("'missing' was not found", error.ToString());
+        Assert.Empty(output.ToString());
+    }
+
+    [Fact]
+    public async Task RunAsync_ReturnsSuccessAndReportsRevocationCounts()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exitCode = await McpClientRevocationCommand.RunAsync(
+            ["--revoke-mcp-client", "mcp-client"],
+            clientId =>
+            {
+                Assert.Equal("mcp-client", clientId);
+                return Task.FromResult<McpOAuthRevocationResult?>(new(2, 3));
+            },
+            output,
+            error);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Revoked 2 authorization(s) and 3 token(s)", output.ToString());
+        Assert.Empty(error.ToString());
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Infrastructure/OAuth/McpOAuthGrantRevokerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/OAuth/McpOAuthGrantRevokerTests.cs
@@ -1,0 +1,51 @@
+using FinanceManager.Infrastructure.OAuth;
+using Moq;
+using OpenIddict.Abstractions;
+
+namespace FinanceManager.Tests.Unit.Infrastructure.OAuth;
+
+public sealed class McpOAuthGrantRevokerTests
+{
+    [Fact]
+    public async Task RevokeClientAsync_UsesBulkOpenIddictRevocation()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var application = new object();
+        var applications = new Mock<IOpenIddictApplicationManager>();
+        var authorizations = new Mock<IOpenIddictAuthorizationManager>();
+        var tokens = new Mock<IOpenIddictTokenManager>();
+        applications.Setup(manager => manager.FindByClientIdAsync("mcp-client", cancellationToken))
+            .ReturnsAsync(application);
+        applications.Setup(manager => manager.GetIdAsync(application, cancellationToken))
+            .ReturnsAsync("application-id");
+        authorizations.Setup(manager => manager.RevokeByApplicationIdAsync("application-id", cancellationToken))
+            .ReturnsAsync(2);
+        tokens.Setup(manager => manager.RevokeByApplicationIdAsync("application-id", cancellationToken))
+            .ReturnsAsync(3);
+        var revoker = new McpOAuthGrantRevoker(applications.Object, authorizations.Object, tokens.Object);
+
+        var result = await revoker.RevokeClientAsync("mcp-client", cancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Authorizations);
+        Assert.Equal(3, result.Tokens);
+    }
+
+    [Fact]
+    public async Task RevokeClientAsync_ReturnsNullForUnknownClient()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var applications = new Mock<IOpenIddictApplicationManager>();
+        var authorizations = new Mock<IOpenIddictAuthorizationManager>();
+        var tokens = new Mock<IOpenIddictTokenManager>();
+        applications.Setup(manager => manager.FindByClientIdAsync("missing", cancellationToken))
+            .ReturnsAsync((object?)null);
+        var revoker = new McpOAuthGrantRevoker(applications.Object, authorizations.Object, tokens.Object);
+
+        var result = await revoker.RevokeClientAsync("missing", cancellationToken);
+
+        Assert.Null(result);
+        authorizations.VerifyNoOtherCalls();
+        tokens.VerifyNoOtherCalls();
+    }
+}

--- a/docs/codebase/INTEGRATIONS.md
+++ b/docs/codebase/INTEGRATIONS.md
@@ -14,6 +14,7 @@
 | GitHub Models via Copilot SDK | External AI service | Alternate AI provider in configured fallback chain | Copilot SDK session auth `[TODO]` | Medium | `code\FinanceManager.Infrastructure\Services\Ai\CopilotChatClient.cs`, `code\FinanceManager.Api\appsettings.json` |
 | Ollama | Local/remote AI endpoint | Final AI fallback provider | No auth detected in code | Medium | `code\FinanceManager.Infrastructure\Services\Ai\OllamaChatClient.cs`, `code\FinanceManager.Api\appsettings.json` |
 | SignalR hub (`/hubs/currency-import`) | Realtime transport | Import job progress/events between API and browser | JWT via query-string token handling | Medium | `code\FinanceManager.Api\Program.cs` |
+| MCP/OAuth (`/mcp`, `/connect/*`) | Stateless MCP transport and OAuth authorization server | Gives configured AI clients owner-isolated read access to Finance Manager data | OpenIddict authorization code, refresh token, resource, and `mcp` scope validation | High | `code\FinanceManager.Api\Mcp`, `code\FinanceManager.Api\Controllers\McpOAuthController.cs`, `docs\deployment.md` |
 | Browser local/session storage | Browser-side storage | Persist user session and login state | Same-origin browser storage | Medium | `code\FinanceManager\Program.cs`, `code\FinanceManager.Components\Services\LoginService.cs` |
 
 ### 2) Data Stores
@@ -22,6 +23,7 @@
 |-------|------|--------------|----------|----------|
 | EF Core relational database (`AppDbContext`) | System-of-record for users, accounts, entries, prices, labels, imports | `FinanceManager.Infrastructure\Repositories\*` via `AppDbContext` | Database-provider drift between SQL Server and PostgreSQL setups | `code\FinanceManager.Infrastructure\Contexts\AppDbContext.cs`, `code\FinanceManager.Infrastructure\ServiceCollectionExtension.cs` |
 | In-memory EF Core database | Test-only persistence for integration tests | `FinanceManager.Tests.Integration\TestDatabase.cs` | Divergence from relational behavior in production | `code\FinanceManager.Tests.Integration\TestDatabase.cs`, `code\FinanceManager.Tests.Integration\FinanceManagerApiTestApp.cs` |
+| OpenIddict entities in `AppDbContext` | MCP OAuth clients, authorizations, scopes, and refresh/token state | OpenIddict EF Core stores and startup reconciliation | Grant revocation and persistent encryption keys must remain operational across deployments | `code\FinanceManager.Infrastructure\Contexts\AppDbContext.cs`, `code\FinanceManager.Infrastructure\OAuth`, `docs\deployment.md` |
 | `IMemoryCache` | Client caches and stock-price memoization | `FinanceManager.Components` and `FinanceManager.Application\Providers` | Cache scope is per process/browser and not shared across instances | `code\FinanceManager.Components\ServiceCollectionExtension.cs`, `code\FinanceManager.Application\Providers\StockPriceProvider.cs` |
 | Browser local/session storage | User session persistence in the frontend | `LoginService` | Token/session handling depends on browser storage state | `code\FinanceManager.Components\Services\LoginService.cs` |
 
@@ -29,7 +31,7 @@
 
 - Credential sources: appsettings files, environment variables (notably `FINANCE_MANAGER_DB_KEY` and optional OTLP endpoint), ASP.NET User Secrets (`UserSecretsId`), and runtime options sections
 - Hardcoding checks: development/test JWT signing keys and a development SQL Server connection string are committed in `appsettings.*`; external AI/stock API keys are present as config slots but blank in the checked-in config
-- Rotation or lifecycle notes: `[TODO]` no documented secret-rotation process was found in the repository
+- Rotation or lifecycle notes: MCP OAuth signing/encryption certificate storage and disruptive rotation are documented in `docs\deployment.md`; a general rotation runbook for the other application secrets is still `[TODO]`
 
 ### 4) Reliability and Failure Behavior
 
@@ -53,4 +55,3 @@
 - `code\FinanceManager.Api\appsettings.Development.json`
 - `code\ServiceDefaults\Extensions.cs`
 - `code\AppHost\AppHost.cs`
-

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,6 +25,58 @@ A merge to `develop` triggers build → unit tests → code-quality → security
 
 After step 3 is done, the next merge into `develop` will deploy automatically. Validate at `https://FinanceManagerApi-dev.azurewebsites.net`.
 
+## MCP OAuth production configuration
+
+The MCP endpoint is disabled unless `McpOAuth:Enabled` is `true`. Production and hosted development environments must use their public HTTPS origin consistently; internal App Service or container URLs must not appear in OAuth metadata.
+
+Configure these settings through the platform secret/configuration store (Azure App Settings use `__` in place of `:`):
+
+| Setting | Production requirement |
+|---------|------------------------|
+| `McpOAuth__Enabled` | `true` to publish `/mcp`, OAuth endpoints, and discovery metadata. |
+| `McpOAuth__Issuer` | Public HTTPS origin with trailing slash, for example `https://finance.example.com/`. |
+| `McpOAuth__Resource` | Exact public MCP URL, normally the issuer origin plus `/mcp`. |
+| `McpOAuth__LoginUrl` | Public HTTPS Blazor login URL. |
+| `McpOAuth__Clients__0__ClientId` | Public client identifier advertised to the MCP client. It is not a secret. |
+| `McpOAuth__Clients__0__DisplayName` | Non-empty operator-facing name for the client; startup validation requires it. |
+| `McpOAuth__Clients__0__RedirectUris__0` | Exact redirect URI registered by ChatGPT, Claude, or another client. Add array entries for every supported URI; matching is strict. |
+| `McpOAuth__Clients__0__RequirePkce` | `true` unless that specific client is known not to support PKCE. Do not disable PKCE globally. |
+| `McpOAuth__SigningCertificatePath` / `McpOAuth__EncryptionCertificatePath` | Absolute paths to persistent PKCS#12 (`.pfx`) files mounted outside the application content directory. |
+| `McpOAuth__SigningCertificatePassword` / `McpOAuth__EncryptionCertificatePassword` | Passwords supplied only through the secret store. |
+
+Use separate MCP client entries when clients require different redirect URIs or PKCE behavior. On startup Finance Manager reconciles configured client redirect URIs, permissions, and PKCE requirements with OpenIddict, removing stale configuration. A removed redirect URI therefore stops working after the next successful startup.
+
+### Reverse proxy and discovery URLs
+
+The TLS-terminating proxy must forward the original scheme and client address. Set `ReverseProxy__KnownProxies` or `ReverseProxy__KnownNetworks` to only the actual proxy IPs/CIDR ranges; the application refuses to start outside Development when neither is configured. Never trust forwarded headers from arbitrary sources.
+
+After deployment, verify all returned URLs use the public HTTPS origin:
+
+- `/.well-known/openid-configuration`
+- `/.well-known/oauth-authorization-server`
+- `/.well-known/oauth-protected-resource/mcp`
+- `/.well-known/mcp.json`
+- `/connect/mcp`
+
+Also complete one authorization-code flow through the real proxy and confirm that an unauthenticated `/mcp` request returns `401` with resource-metadata discovery. Do not put access tokens or authorization codes in command lines, logs, screenshots, or support tickets.
+
+### Signing and encryption key lifecycle
+
+Development certificates are used only in the local Development environment. Test uses ephemeral keys. Every other environment fails startup unless persistent signing and encryption certificates are configured; production never writes development certificates to the host certificate store.
+
+Store the `.pfx` files in a managed secret/certificate service or a read-only protected mount. Restrict file and secret access to the application identity, back up the certificates according to the service recovery policy, and monitor their expiry dates.
+
+The current configuration supports one active signing certificate and one active encryption certificate, so rotation is deliberately disruptive rather than seamless. Use this runbook:
+
+1. Generate new signing and encryption certificates and stage their `.pfx` files and passwords without replacing the active files.
+2. Schedule a reconnect window. Stop or drain all application instances so two different key sets cannot issue tokens concurrently.
+3. From a one-off process with the current deployed configuration and database access, run `dotnet FinanceManager.Api.dll --revoke-mcp-client <client-id>`. The command revokes that client's authorizations and tokens through OpenIddict, prints only counts, and exits. A missing client returns exit code `3`; invalid arguments return `2`. Existing SPA JWT and refresh-token records are separate and are not touched.
+4. Atomically change all four certificate path/password settings to the new pair, then restart every instance.
+5. Verify discovery, complete a new OAuth connection, refresh it once, and call `who_am_i` before restoring traffic.
+6. Retain the old certificates only for the audited recovery period, then destroy them through the secret store. Never commit either certificate or password to the repository.
+
+Because old encrypted refresh tokens cannot be used after the key change, connected MCP clients must authorize again. Normal Finance Manager logout ends the browser/SPA session but does not revoke an independent MCP grant; users disconnect in their AI client, while operators revoke compromised MCP grants in the OpenIddict store.
+
 ## Health probes
 
 The API exposes three health endpoints (mapped in every environment, including production):


### PR DESCRIPTION
## Summary

- make MCP access tokens reference tokens and enforce both authorization-entry and token-entry revocation
- add a supported `--revoke-mcp-client` operations command backed by OpenIddict bulk revocation APIs
- cover missing-scope, revoked-grant, revoked-token, and expired-token rejection at the real `/mcp` boundary
- document production issuer/resource/client configuration, trusted proxy requirements, persistent certificates, and disruptive key rotation
- update the integration inventory for MCP/OpenIddict

## Parent acceptance audit

This closes the remaining security-test and deployment-documentation gaps after #587, #588, #589, and #590. The complete feature now includes persisted/reconciled OpenIddict configuration, OAuth and first-party bridge flows, protected stateless MCP transport, onboarding/discovery, owner-isolated read-only tools, and operational key/grant lifecycle guidance.

## Validation

- `dotnet build FinanceManager.slnx --no-restore`
- `dotnet format FinanceManager.slnx --verify-no-changes --no-restore`
- 607 unit tests
- 9 architecture tests
- 287 integration tests
- independent GPT-5.6-Sol review and two fix/re-review cycles: no remaining findings

Closes #584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line option to revoke all OAuth authorizations and access tokens for a specified MCP client.
  - The command reports the number of revoked authorizations and tokens and clearly indicates when a client cannot be found.

- **Security Improvements**
  - MCP OAuth access tokens now support server-side reference validation.
  - Revoked authorizations, revoked tokens, expired tokens, and missing scopes are consistently rejected during MCP access checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->