### PR TITLE
fix: resolve #596 - Show purchase-day value, current valuation, and gain/loss in transaction details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Expanding an investment purchase now shows its value on the purchase date, the current market price and valuation, and the gain/loss in both amount and percentage — converted to your preferred currency using the historical rate for the purchase and the latest rate for the current value, or shown in the instrument's own currency when no rate is available. #596
 - Connected AI clients can now read the signed-in user's financial accounts, filtered transaction history, investment positions and valuations, currencies, and financial labels through owner-isolated MCP tools. #590
 - AI clients can now connect to a protected MCP endpoint, discover its OAuth settings automatically, verify the signed-in identity, and follow a responsive setup guide with copyable and downloadable configuration. #589
 - MCP clients can now securely sign in through Finance Manager and receive scoped, refreshable access tokens. #588

--- a/code/FinanceManager.Api/Controllers/Accounts/InvestmentValuationController.cs
+++ b/code/FinanceManager.Api/Controllers/Accounts/InvestmentValuationController.cs
@@ -1,5 +1,6 @@
 using FinanceManager.Api.Helpers;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Services;
 using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
@@ -15,6 +16,7 @@ namespace FinanceManager.Api.Controllers.Accounts;
 public class InvestmentValuationController(
     IAccountRepository<InvestmentAccount> accountRepository,
     IInvestmentValuationService valuationService,
+    IInvestmentTransactionValuationService transactionValuationService,
     ICurrencyRepository currencyRepository) : ControllerBase
 {
     [HttpGet("Holdings/{accountId:int}/{date:DateTime}")]
@@ -66,5 +68,22 @@ public class InvestmentValuationController(
 
         var series = await valuationService.GetAccountValueSeriesAsync(accountId, currency, startDate, endDate, cancellationToken);
         return Ok(series);
+    }
+
+    [HttpGet("TransactionValuations/{accountId:int}/{currencyId:int}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IReadOnlyList<InvestmentTransactionValuationDto>))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetTransactionValuations(int accountId, int currencyId, CancellationToken cancellationToken = default)
+    {
+        var account = await accountRepository.Get(accountId);
+        if (account is null) return NotFound();
+        if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
+
+        var currency = await currencyRepository.GetCurrency(currencyId, cancellationToken);
+        if (currency is null) return NotFound("Currency not found.");
+
+        var valuations = await transactionValuationService.GetForAccountAsync(accountId, currency, cancellationToken);
+        return Ok(valuations);
     }
 }

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentTransactionValuationService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentTransactionValuationService.cs
@@ -1,0 +1,107 @@
+using FinanceManager.Domain.Assets.Services;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Services;
+
+namespace FinanceManager.Application.FinancialAccounts.Investments.Valuation;
+
+/// <summary>
+/// Values individual Buy transactions for the transaction detail view. Mirrors the currency and
+/// fallback conventions of <c>AssetsServiceInvestment.GetUnrealizedGainLossPerInstrument</c> but at
+/// the granularity of a single transaction: the purchase-day value is converted at the trade-date
+/// exchange rate, the current valuation at the latest rate, and when no rate is available the figures
+/// stay in the transaction currency so amounts in different currencies are never mixed.
+/// </summary>
+internal class InvestmentTransactionValuationService(
+    IInvestmentTransactionRepository transactionRepository,
+    IInvestmentPriceProvider priceProvider,
+    ICurrencyExchangeService currencyExchangeService) : IInvestmentTransactionValuationService
+{
+    public async Task<IReadOnlyList<InvestmentTransactionValuationDto>> GetForAccountAsync(
+        int accountId,
+        Currency targetCurrency,
+        CancellationToken cancellationToken = default)
+    {
+        var transactions = await transactionRepository.GetByAccount(accountId, cancellationToken);
+
+        var now = DateTime.UtcNow;
+        // Memoise the two external lookups so an account with many trades in the same instrument
+        // and currency issues one price call per (listing, display currency) and one FX call per
+        // (currency, trade date) instead of one per transaction.
+        var currentPriceByKey = new Dictionary<(long ListingId, string Currency), decimal>();
+        var purchaseRateByKey = new Dictionary<(string Currency, DateOnly TradeDate), decimal?>();
+
+        var results = new List<InvestmentTransactionValuationDto>();
+        foreach (var transaction in transactions.Where(t => t.Type == InvestmentTransactionType.Buy))
+        {
+            var purchaseValueInTradeCurrency = transaction.Quantity * transaction.UnitPrice;
+            var sameAsTarget = string.Equals(transaction.Currency, targetCurrency.ShortName, StringComparison.OrdinalIgnoreCase);
+
+            var purchaseRate = sameAsTarget
+                ? 1m
+                : await GetPurchaseRateAsync(transaction, targetCurrency, purchaseRateByKey);
+
+            // Convert into the user's default currency only when the trade-date rate is known;
+            // otherwise present the whole row in the transaction's own currency.
+            var converted = purchaseRate is decimal rate && rate > 0m;
+            var displayCurrency = converted ? targetCurrency : new Currency { ShortName = transaction.Currency, Symbol = transaction.Currency };
+
+            var purchaseValue = converted ? purchaseValueInTradeCurrency * purchaseRate!.Value : purchaseValueInTradeCurrency;
+
+            // Current price is fetched already denominated in the display currency: the provider
+            // applies the latest exchange rate for us, matching "latest rate for current valuation".
+            var currentPrice = await GetCurrentPriceAsync(transaction.AssetListingId, displayCurrency, now, currentPriceByKey, cancellationToken);
+            var hasCurrentPrice = currentPrice > 0m;
+            var currentValuation = hasCurrentPrice ? transaction.Quantity * currentPrice : 0m;
+
+            var gainLoss = hasCurrentPrice ? currentValuation - purchaseValue : 0m;
+            var gainLossPercent = hasCurrentPrice && purchaseValue != 0m ? (currentValuation / purchaseValue - 1m) * 100m : 0m;
+
+            results.Add(new InvestmentTransactionValuationDto(
+                transaction.Id,
+                purchaseValue,
+                currentPrice,
+                currentValuation,
+                gainLoss,
+                gainLossPercent,
+                displayCurrency.ShortName,
+                converted,
+                hasCurrentPrice));
+        }
+
+        return results;
+    }
+
+    private async Task<decimal?> GetPurchaseRateAsync(
+        InvestmentTransaction transaction,
+        Currency targetCurrency,
+        Dictionary<(string Currency, DateOnly TradeDate), decimal?> cache)
+    {
+        var key = (transaction.Currency, transaction.TradeDate);
+        if (cache.TryGetValue(key, out var cached)) return cached;
+
+        var sourceCurrency = new Currency { ShortName = transaction.Currency, Symbol = transaction.Currency };
+        var rate = await currencyExchangeService.GetExchangeRateAsync(
+            sourceCurrency, targetCurrency, transaction.TradeDate.ToDateTime(TimeOnly.MinValue));
+        cache[key] = rate;
+        return rate;
+    }
+
+    private async Task<decimal> GetCurrentPriceAsync(
+        long listingId,
+        Currency displayCurrency,
+        DateTime asOf,
+        Dictionary<(long ListingId, string Currency), decimal> cache,
+        CancellationToken cancellationToken)
+    {
+        var key = (listingId, displayCurrency.ShortName);
+        if (cache.TryGetValue(key, out var cached)) return cached;
+
+        var price = await priceProvider.GetPricePerUnitAsync(listingId, displayCurrency, asOf, cancellationToken);
+        cache[key] = price;
+        return price;
+    }
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Registration.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Registration.cs
@@ -70,6 +70,7 @@ internal static class Registration
                 .AddScoped<IInvestmentPriceProvider, InvestmentPriceProvider>()
                 .AddScoped<IInvestmentPriceBackfillService, InvestmentPriceBackfillService>()
                 .AddScoped<IInvestmentValuationService, InvestmentValuationService>()
+                .AddScoped<IInvestmentTransactionValuationService, InvestmentTransactionValuationService>()
                 .AddScoped<IInvestmentInstrumentDiscoveryService, InvestmentInstrumentDiscoveryService>()
                 .AddScoped<IInstrumentImportService, InstrumentImportService>()
                 .AddScoped<IBondUnrealizedGainLossCalculator, BondUnrealizedGainLossCalculator>()

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
@@ -56,7 +56,7 @@ else
                     @foreach (var group in dayGroups)
                     {
                         <InvestmentDayGroupCard Day="@group.Key" Transactions="@group" Currency="@_currency.ShortName"
-                                                IsMobile="@_isMobile" OnEdit="ShowEdit" OnDelete="DeleteAsync" />
+                                                Valuations="@_valuations" IsMobile="@_isMobile" OnEdit="ShowEdit" OnDelete="DeleteAsync" />
                     }
                 }
             </MudItem>

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -36,6 +36,8 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
     private readonly string _accountTypeLabel = "Investment account";
     private Currency _currency = DefaultCurrency.USD;
     private List<InvestmentTransactionDto> _transactions = [];
+    private IReadOnlyDictionary<long, InvestmentTransactionValuationDto> _valuations =
+        new Dictionary<long, InvestmentTransactionValuationDto>();
     private List<HoldingRow> _holdings = [];
 
     // Range / chart state.
@@ -111,6 +113,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
             if (initialLoad)
                 ApplyAutomaticCustomRange();
 
+            await LoadValuationsAsync();
             await UpdateInfo();
         }
         catch (Exception ex)
@@ -121,6 +124,23 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
         finally
         {
             _isLoading = false;
+        }
+    }
+
+    // Per-transaction purchase value / current valuation / gain-loss is priced server-side (needs
+    // market prices + FX). It only enriches the detail rows, so a failure here must not hide the
+    // transaction list itself.
+    private async Task LoadValuationsAsync()
+    {
+        try
+        {
+            _valuations = (await ValuationHttpClient.GetTransactionValuationsAsync(AccountId, _currency.Id))
+                .ToDictionary(v => v.TransactionId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to load transaction valuations for account {AccountId}", AccountId);
+            _valuations = new Dictionary<long, InvestmentTransactionValuationDto>();
         }
     }
 

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentDayGroupCard.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentDayGroupCard.razor
@@ -1,6 +1,7 @@
 @namespace FinanceManager.Components.Components.Features.FinancialAccounts.InvestmentAccountComponents.TransactionHistory
 @using FinanceManager.Domain.FinancialAccounts.Investments.Dtos
 @using FinanceManager.Domain.FinancialAccounts.Investments.Entities
+@using System.Collections.Generic
 
 <MudCard Outlined="true" Class="mb-3" Style="background-color: transparent;">
     <MudCardHeader Class="py-1 px-4">
@@ -31,7 +32,8 @@
         <MudStack Spacing="0">
             @foreach (var transaction in TransactionList)
             {
-                <InvestmentTransactionRow @key="transaction.Id" Transaction="transaction" IsMobile="@IsMobile" OnEdit="OnEdit" OnDelete="OnDelete" />
+                <InvestmentTransactionRow @key="transaction.Id" Transaction="transaction" IsMobile="@IsMobile"
+                                          Valuation="@GetValuation(transaction.Id)" OnEdit="OnEdit" OnDelete="OnDelete" />
                 <MudDivider />
             }
         </MudStack>
@@ -43,10 +45,16 @@
     [Parameter] public required IEnumerable<InvestmentTransactionDto> Transactions { get; set; }
     [Parameter] public required string Currency { get; set; }
     [Parameter] public bool IsMobile { get; set; }
+
+    /// <summary>Per-transaction valuation figures keyed by transaction id; null/absent entries render without them.</summary>
+    [Parameter] public IReadOnlyDictionary<long, InvestmentTransactionValuationDto>? Valuations { get; set; }
     [Parameter] public EventCallback<InvestmentTransactionDto> OnEdit { get; set; }
     [Parameter] public EventCallback<InvestmentTransactionDto> OnDelete { get; set; }
 
     private List<InvestmentTransactionDto> TransactionList => Transactions as List<InvestmentTransactionDto> ?? Transactions.ToList();
+
+    private InvestmentTransactionValuationDto? GetValuation(long transactionId) =>
+        Valuations is not null && Valuations.TryGetValue(transactionId, out var valuation) ? valuation : null;
 
     private DateTime DayDateTime => Day.ToDateTime(TimeOnly.MinValue);
 

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentTransactionRow.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentTransactionRow.razor
@@ -91,6 +91,53 @@
                 <MudText Typo="Typo.overline" Color="Color.Default">Currency</MudText>
                 <MudText Typo="Typo.body2">@Transaction.Currency</MudText>
             </MudItem>
+            @if (ShowValuation)
+            {
+                <MudItem xs="12">
+                    <MudDivider Class="my-1" Style="border-style: dashed;" />
+                </MudItem>
+                <MudItem xs="6" sm="6">
+                    <MudText Typo="Typo.overline" Color="Color.Default">Purchase value</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular">@Valuation!.PurchaseValue.ToString("N2") @Valuation.Currency</MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6">
+                    <MudText Typo="Typo.overline" Color="Color.Default">Current price</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular">
+                        @(Valuation!.HasCurrentPrice ? $"{Valuation.CurrentPrice:N2} {Valuation.Currency}" : "—")
+                    </MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6">
+                    <MudText Typo="Typo.overline" Color="Color.Default">Current valuation</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular">
+                        @(Valuation!.HasCurrentPrice ? $"{Valuation.CurrentValuation:N2} {Valuation.Currency}" : "—")
+                    </MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6">
+                    <MudText Typo="Typo.overline" Color="Color.Default">Gain / loss</MudText>
+                    @if (Valuation!.HasCurrentPrice)
+                    {
+                        <MudText Typo="Typo.body2" Class="fm-tabular"
+                                 Color="@(Valuation.GainLoss >= 0 ? Color.Success : Color.Error)">
+                            @(Valuation.GainLoss >= 0 ? "+" : "")@Valuation.GainLoss.ToString("N2") @Valuation.Currency
+                            (@(Valuation.GainLoss >= 0 ? "+" : "")@Valuation.GainLossPercent.ToString("N2")%)
+                        </MudText>
+                    }
+                    else
+                    {
+                        <MudTooltip Text="No current market price is available for this instrument.">
+                            <MudText Typo="Typo.body2" Color="Color.Default">Price unavailable</MudText>
+                        </MudTooltip>
+                    }
+                </MudItem>
+                @if (!Valuation!.IsConverted)
+                {
+                    <MudItem xs="12">
+                        <MudText Typo="Typo.caption" Color="Color.Default">
+                            Shown in @Valuation.Currency — no conversion to your default currency was available.
+                        </MudText>
+                    </MudItem>
+                }
+            }
             @if (!string.IsNullOrWhiteSpace(Transaction.Notes))
             {
                 <MudItem xs="12">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentTransactionRow.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentTransactionRow.razor.cs
@@ -10,6 +10,9 @@ public partial class InvestmentTransactionRow
 {
     [Parameter] public required InvestmentTransactionDto Transaction { get; set; }
     [Parameter] public bool IsMobile { get; set; }
+
+    /// <summary>Valuation/performance figures for this transaction (Buy only); null when not available.</summary>
+    [Parameter] public InvestmentTransactionValuationDto? Valuation { get; set; }
     [Parameter] public EventCallback<InvestmentTransactionDto> OnEdit { get; set; }
     [Parameter] public EventCallback<InvestmentTransactionDto> OnDelete { get; set; }
 
@@ -19,6 +22,9 @@ public partial class InvestmentTransactionRow
     private Color TypeColor => Transaction.Type == InvestmentTransactionType.Sell ? Color.Error : Color.Success;
 
     private decimal GrossValue => Transaction.Quantity * Transaction.UnitPrice;
+
+    // Performance tiles apply to purchases only, and only once the server has priced the position.
+    private bool ShowValuation => Transaction.Type == InvestmentTransactionType.Buy && Valuation is not null;
 
     // Buy is a cash outflow (negative), sell is a cash inflow (positive). Fees always reduce the cash impact.
     private decimal CashImpact => Transaction.Type == InvestmentTransactionType.Sell

--- a/code/FinanceManager.Components/HttpClients/InvestmentValuationHttpClient.cs
+++ b/code/FinanceManager.Components/HttpClients/InvestmentValuationHttpClient.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using System.Globalization;
 using System.Net.Http.Json;
 
@@ -5,6 +6,14 @@ namespace FinanceManager.Components.HttpClients;
 
 public class InvestmentValuationHttpClient(HttpClient httpClient)
 {
+    public async Task<IReadOnlyList<InvestmentTransactionValuationDto>> GetTransactionValuationsAsync(int accountId, int currencyId)
+    {
+        using var response = await httpClient.GetAsync(
+            $"{httpClient.BaseAddress}api/InvestmentValuation/TransactionValuations/{accountId}/{currencyId}");
+        if (!response.IsSuccessStatusCode) return [];
+        return await response.Content.ReadFromJsonAsync<IReadOnlyList<InvestmentTransactionValuationDto>>() ?? [];
+    }
+
     public async Task<IReadOnlyDictionary<long, decimal>> GetHoldingsAsync(int accountId, DateTime date)
     {
         using var response = await httpClient.GetAsync(

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionValuationDto.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionValuationDto.cs
@@ -1,0 +1,18 @@
+namespace FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+
+/// <summary>
+/// Valuation and performance figures for a single <see cref="Entities.InvestmentTransaction"/> Buy,
+/// used by the transaction detail view. All monetary figures are expressed in <see cref="Currency"/>:
+/// the user's default currency when <see cref="IsConverted"/> is <c>true</c>, otherwise the
+/// instrument/transaction currency (values are never mixed across currencies).
+/// </summary>
+public record InvestmentTransactionValuationDto(
+    long TransactionId,
+    decimal PurchaseValue,
+    decimal CurrentPrice,
+    decimal CurrentValuation,
+    decimal GainLoss,
+    decimal GainLossPercent,
+    string Currency,
+    bool IsConverted,
+    bool HasCurrentPrice);

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Services/IInvestmentTransactionValuationService.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Services/IInvestmentTransactionValuationService.cs
@@ -1,0 +1,23 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+
+namespace FinanceManager.Domain.FinancialAccounts.Investments.Services;
+
+/// <summary>
+/// Computes per-transaction valuation and performance figures (purchase-day value, current
+/// valuation and gain/loss) for the transaction detail view. Buy transactions are priced through
+/// <see cref="IInvestmentPriceProvider"/> and converted to a target currency using the historical
+/// exchange rate on the trade date for the purchase value and the latest rate for the current
+/// valuation. When conversion is unavailable the figures fall back to the transaction currency.
+/// </summary>
+public interface IInvestmentTransactionValuationService
+{
+    /// <summary>
+    /// Valuation figures keyed by transaction id for every Buy transaction of the account.
+    /// Sell transactions are omitted. Returns an empty list for an account with no Buy transactions.
+    /// </summary>
+    Task<IReadOnlyList<InvestmentTransactionValuationDto>> GetForAccountAsync(
+        int accountId,
+        Currency targetCurrency,
+        CancellationToken cancellationToken = default);
+}

--- a/code/FinanceManager.Tests.Integration/Controllers/InvestmentValuationControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/InvestmentValuationControllerTests.cs
@@ -154,6 +154,38 @@ public class InvestmentValuationControllerTests(OptionsProvider optionsProvider)
     }
 
     [Fact]
+    public async Task GetTransactionValuations_ReturnsBuyPerformance()
+    {
+        await SeedHoldingsWithPrice();
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentValuationHttpClient(Client);
+
+        var valuations = await client.GetTransactionValuationsAsync(_testAccountId, _usdCurrencyId);
+
+        // Only the Buy (5 @ 90 USD) is valued; latest quote is 100 USD.
+        var valuation = Assert.Single(valuations);
+        Assert.True(valuation.IsConverted);
+        Assert.Equal("USD", valuation.Currency);
+        Assert.True(valuation.HasCurrentPrice);
+        Assert.Equal(450m, valuation.PurchaseValue);    // 5 * 90
+        Assert.Equal(100m, valuation.CurrentPrice);
+        Assert.Equal(500m, valuation.CurrentValuation); // 5 * 100
+        Assert.Equal(50m, valuation.GainLoss);
+    }
+
+    [Fact]
+    public async Task GetTransactionValuations_ForOtherUsersAccount_ReturnsForbidden()
+    {
+        await SeedHoldingsWithPrice();
+        Authorize("otheruser", _testUserId + 1, UserRole.User);
+
+        var response = await Client.GetAsync(
+            $"api/InvestmentValuation/TransactionValuations/{_testAccountId}/{_usdCurrencyId}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
     public async Task GetHoldings_ForUnknownAccount_ReturnsNotFound()
     {
         await SeedAccount();

--- a/code/FinanceManager.Tests.Unit/Application/Services/InvestmentTransactionValuationServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/InvestmentTransactionValuationServiceTests.cs
@@ -1,0 +1,157 @@
+using FinanceManager.Application.FinancialAccounts.Investments.Valuation;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Services;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class InvestmentTransactionValuationServiceTests
+{
+    private const int _accountId = 5;
+    private const long _listingId = 11;
+    private static readonly AssetListing _listing = new() { Id = _listingId, Ticker = "CSPX" };
+
+    private static InvestmentTransaction Buy(decimal quantity, decimal unitPrice, string currency, DateOnly tradeDate, long id = 1) => new()
+    {
+        Id = id,
+        AccountId = _accountId,
+        AssetListingId = _listingId,
+        AssetListing = _listing,
+        Type = InvestmentTransactionType.Buy,
+        Quantity = quantity,
+        UnitPrice = unitPrice,
+        Currency = currency,
+        TradeDate = tradeDate,
+    };
+
+    private static (Mock<IInvestmentTransactionRepository> Repo, Mock<IInvestmentPriceProvider> Price, Mock<ICurrencyExchangeService> Fx) Mocks(
+        params InvestmentTransaction[] transactions)
+    {
+        var repo = new Mock<IInvestmentTransactionRepository>();
+        repo.Setup(x => x.GetByAccount(_accountId, It.IsAny<CancellationToken>())).ReturnsAsync(transactions);
+        return (repo, new Mock<IInvestmentPriceProvider>(), new Mock<ICurrencyExchangeService>());
+    }
+
+    private static InvestmentTransactionValuationService Build(
+        Mock<IInvestmentTransactionRepository> repo, Mock<IInvestmentPriceProvider> price, Mock<ICurrencyExchangeService> fx) =>
+        new(repo.Object, price.Object, fx.Object);
+
+    [Fact]
+    public async Task Converts_PurchaseAtTradeDateRate_And_CurrentAtLatestPrice()
+    {
+        var tradeDate = new DateOnly(2026, 1, 10);
+        var (repo, price, fx) = Mocks(Buy(10m, 100m, "USD", tradeDate));
+
+        // Purchase value converts at the trade-date rate; current price comes back already in PLN.
+        fx.Setup(x => x.GetExchangeRateAsync(It.Is<Currency>(c => c.ShortName == "USD"), DefaultCurrency.PLN,
+                tradeDate.ToDateTime(TimeOnly.MinValue)))
+            .ReturnsAsync(4m);
+        price.Setup(x => x.GetPricePerUnitAsync(_listingId, DefaultCurrency.PLN, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(500m);
+
+        var result = Assert.Single(await Build(repo, price, fx).GetForAccountAsync(_accountId, DefaultCurrency.PLN, TestContext.Current.CancellationToken));
+
+        Assert.True(result.IsConverted);
+        Assert.Equal("PLN", result.Currency);
+        Assert.True(result.HasCurrentPrice);
+        Assert.Equal(4000m, result.PurchaseValue);   // 10 * 100 * 4
+        Assert.Equal(500m, result.CurrentPrice);
+        Assert.Equal(5000m, result.CurrentValuation); // 10 * 500
+        Assert.Equal(1000m, result.GainLoss);
+        Assert.Equal(25m, result.GainLossPercent);    // (5000/4000 - 1) * 100
+    }
+
+    [Fact]
+    public async Task FallsBackToTransactionCurrency_WhenTradeDateRateMissing()
+    {
+        var tradeDate = new DateOnly(2026, 1, 10);
+        var (repo, price, fx) = Mocks(Buy(2m, 50m, "EUR", tradeDate));
+
+        fx.Setup(x => x.GetExchangeRateAsync(It.Is<Currency>(c => c.ShortName == "EUR"), DefaultCurrency.PLN, It.IsAny<DateTime>()))
+            .ReturnsAsync((decimal?)null);
+        // With no conversion, the current price is requested in the transaction currency instead.
+        price.Setup(x => x.GetPricePerUnitAsync(_listingId, It.Is<Currency>(c => c.ShortName == "EUR"), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(60m);
+
+        var result = Assert.Single(await Build(repo, price, fx).GetForAccountAsync(_accountId, DefaultCurrency.PLN, TestContext.Current.CancellationToken));
+
+        Assert.False(result.IsConverted);
+        Assert.Equal("EUR", result.Currency);
+        Assert.Equal(100m, result.PurchaseValue);     // 2 * 50, unconverted
+        Assert.Equal(120m, result.CurrentValuation);  // 2 * 60
+        Assert.Equal(20m, result.GainLoss);
+        Assert.Equal(20m, result.GainLossPercent);
+    }
+
+    [Fact]
+    public async Task MissingCurrentPrice_IsFlagged_WithoutMisleadingLoss()
+    {
+        var (repo, price, fx) = Mocks(Buy(3m, 100m, "USD", new DateOnly(2026, 1, 10)));
+        price.Setup(x => x.GetPricePerUnitAsync(_listingId, It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0m);
+
+        var result = Assert.Single(await Build(repo, price, fx).GetForAccountAsync(_accountId, DefaultCurrency.USD, TestContext.Current.CancellationToken));
+
+        Assert.False(result.HasCurrentPrice);
+        Assert.Equal(300m, result.PurchaseValue);
+        Assert.Equal(0m, result.CurrentValuation);
+        Assert.Equal(0m, result.GainLoss);
+        Assert.Equal(0m, result.GainLossPercent);
+    }
+
+    [Fact]
+    public async Task SameCurrencyAsTarget_SkipsExchangeLookup()
+    {
+        var (repo, price, fx) = Mocks(Buy(4m, 25m, "USD", new DateOnly(2026, 1, 10)));
+        price.Setup(x => x.GetPricePerUnitAsync(_listingId, DefaultCurrency.USD, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(30m);
+
+        var result = Assert.Single(await Build(repo, price, fx).GetForAccountAsync(_accountId, DefaultCurrency.USD, TestContext.Current.CancellationToken));
+
+        Assert.True(result.IsConverted);
+        Assert.Equal("USD", result.Currency);
+        Assert.Equal(100m, result.PurchaseValue);
+        Assert.Equal(120m, result.CurrentValuation);
+        fx.Verify(x => x.GetExchangeRateAsync(It.IsAny<Currency>(), It.IsAny<Currency>(), It.IsAny<DateTime>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task OmitsSellTransactions()
+    {
+        var tradeDate = new DateOnly(2026, 1, 10);
+        var sell = Buy(1m, 100m, "USD", tradeDate, id: 2);
+        sell.Type = InvestmentTransactionType.Sell;
+        var (repo, price, fx) = Mocks(Buy(1m, 100m, "USD", tradeDate, id: 1), sell);
+        price.Setup(x => x.GetPricePerUnitAsync(_listingId, DefaultCurrency.USD, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(110m);
+
+        var results = await Build(repo, price, fx).GetForAccountAsync(_accountId, DefaultCurrency.USD, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1L, Assert.Single(results).TransactionId);
+    }
+
+    [Fact]
+    public async Task MemoisesPriceAndRateLookups_AcrossTradesInSameListingAndDate()
+    {
+        var tradeDate = new DateOnly(2026, 1, 10);
+        var (repo, price, fx) = Mocks(
+            Buy(1m, 100m, "USD", tradeDate, id: 1),
+            Buy(2m, 100m, "USD", tradeDate, id: 2));
+        fx.Setup(x => x.GetExchangeRateAsync(It.Is<Currency>(c => c.ShortName == "USD"), DefaultCurrency.PLN, It.IsAny<DateTime>()))
+            .ReturnsAsync(4m);
+        price.Setup(x => x.GetPricePerUnitAsync(_listingId, DefaultCurrency.PLN, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(500m);
+
+        var results = await Build(repo, price, fx).GetForAccountAsync(_accountId, DefaultCurrency.PLN, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, results.Count);
+        price.Verify(x => x.GetPricePerUnitAsync(_listingId, DefaultCurrency.PLN, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()), Times.Once);
+        fx.Verify(x => x.GetExchangeRateAsync(It.Is<Currency>(c => c.ShortName == "USD"), DefaultCurrency.PLN, It.IsAny<DateTime>()), Times.Once);
+    }
+}


### PR DESCRIPTION
Closes #596

## Summary

Expanding an investment **purchase** in the transaction detail view now shows its valuation and performance:

- **Purchase value** — quantity × unit price
- **Current price** — latest available market price per unit
- **Current valuation** — quantity × current price
- **Gain / loss** — amount and percentage, with the existing green/red (`Color.Success`/`Color.Error`) convention

### Currency handling
- Values are converted to the user's **default currency** using the **historical** exchange rate on the trade date for the purchase value and the **latest** rate for the current valuation (mirroring `AssetsServiceInvestment.GetUnrealizedGainLossPerInstrument`).
- When no suitable rate is available, the whole row falls back to the transaction/instrument currency — currencies are never mixed — and a caption notes the fallback.
- A missing market price is surfaced explicitly ("Price unavailable") instead of a misleading −100% loss.

Sells are unaffected (the tiles are Buy-only).

## Changes
- **Domain**: `InvestmentTransactionValuationDto` + `IInvestmentTransactionValuationService`.
- **Application**: `InvestmentTransactionValuationService` — Buy-only, reuses `IInvestmentPriceProvider` and `ICurrencyExchangeService`, memoises price/FX lookups per listing/currency/date.
- **Api**: `GET api/InvestmentValuation/TransactionValuations/{accountId}/{currencyId}` (owner-authorized).
- **Components**: `InvestmentValuationHttpClient.GetTransactionValuationsAsync`, threaded `InvestmentAccountDetailsPageContent → InvestmentDayGroupCard → InvestmentTransactionRow`, new detail tiles.
- **Changelog**: `Added` entry under `[Unreleased]`.

## Testing
- `dotnet build` — clean (0 warnings, warnings-as-errors).
- `dotnet format --verify-no-changes` — clean.
- Unit tests: **616 passed** (6 new — conversion at historical vs latest FX, fallback to instrument currency, missing-price handling, same-currency short-circuit, sells omitted, lookup memoisation).
- Integration tests: **289 passed** (2 new — endpoint happy path + forbidden for another user's account).
- Rendered on the guest demo account (CSPX/USD → PLN) and screenshotted on mobile (430px) and desktop (1280px); both positive (green) and negative (red) gain/loss verified. Purchase value ≈ 1,867 PLN, current valuation ≈ 1,636 PLN, gain/loss −231.43 PLN (−12.40%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added investment transaction valuation details for buy transactions, including purchase value, current price, current valuation, and gain/loss.
  * Valuations can be converted to the selected currency using historical exchange rates.
  * Added indicators for unavailable prices and values that remain in the transaction’s original currency.
  * Sell transactions are excluded from valuation summaries.

* **Bug Fixes**
  * Valuation failures no longer prevent investment transaction history from loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->