### PR TITLE
Add startup backfill pipeline for stock prices and currency rates #597

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- The API now backfills historical stock closing prices and currency exchange rates in the background each time it starts, filling in any missing daily points from Alpha Vantage so charts and valuations stay complete without waiting for the weekly schedule. Runs are idempotent (existing rows are never overwritten or duplicated), skip instruments and currency pairs that are already up to date, avoid needless calls over weekends or on restarts the same day, and stop gracefully when the provider's rate limit is reached — resuming on the next start. Startup backfill can be turned off or tuned per dataset via the `Backfill` configuration section. #597
 - Expanding an investment purchase now shows its value on the purchase date, the current market price and valuation, and the gain/loss in both amount and percentage — converted to your preferred currency using the historical rate for the purchase and the latest rate for the current value, or shown in the instrument's own currency when no rate is available. #596
 - Connected AI clients can now read the signed-in user's financial accounts, filtered transaction history, investment positions and valuations, currencies, and financial labels through owner-isolated MCP tools. #590
 - AI clients can now connect to a protected MCP endpoint, discover its OAuth settings automatically, verify the signed-in identity, and follow a responsive setup guide with copyable and downloadable configuration. #589

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,7 @@ Integration tests use the EF Core **InMemory** provider. They also remove `Datab
 - Latest C# features allowed by the configured `LangVersion` are fair game.
 - Private/internal fields: `_camelCase`. Interfaces: `IPascalCase`. Files and types: `PascalCase`.
 - Namespaces must match folder paths (`dotnet_style_namespace_match_folder = true` in `.editorconfig`).
+- **One top-level type per file**, and the file is named after that type. Do not co-locate a supporting type (a result record, enum, DTO, etc.) in another type's file — e.g. a `FooResult` record belongs in `FooResult.cs`, not alongside `IFoo` in `IFoo.cs`. Nested/private helper types declared *inside* another type are exempt.
 
 ## Razor / DI Injection
 

--- a/code/FinanceManager.Api/ApiConfigurationExtensions.cs
+++ b/code/FinanceManager.Api/ApiConfigurationExtensions.cs
@@ -78,6 +78,7 @@ public static class ApiConfigurationExtensions
             .ValidateOnStart();
         services.Configure<AiProviderOptions>(configuration.GetSection("AiProvider"));
         services.Configure<MaintenanceOptions>(configuration.GetSection(MaintenanceOptions.SectionName));
+        services.Configure<BackfillOptions>(configuration.GetSection(BackfillOptions.SectionName));
         services.Configure<List<AiProviderFallbackStrategyOption>>(configuration.GetSection("AIProviderFallbackStrategies"));
 
         return services;
@@ -394,6 +395,7 @@ public static class ApiConfigurationExtensions
         services.AddHostedService<CurrencyImportBackgroundService>();
         services.AddSingleton<IPriceBackfillJobChannel, PriceBackfillJobChannel>();
         services.AddHostedService<PriceBackfillBackgroundService>();
+        services.AddHostedService<StartupBackfillBackgroundService>();
 
         services.Configure<LogRetentionOptions>(configuration.GetSection(LogRetentionOptions.SectionName));
         services.AddSingleton<ILogEntryQueue, LogEntryQueue>();

--- a/code/FinanceManager.Api/Services/StartupBackfillBackgroundService.cs
+++ b/code/FinanceManager.Api/Services/StartupBackfillBackgroundService.cs
@@ -1,0 +1,83 @@
+using FinanceManager.Application.Backfill;
+using FinanceManager.Application.Shared.Options;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
+
+namespace FinanceManager.Api.Services;
+
+/// <summary>
+/// Runs every registered <see cref="IBackfillService"/> once, in the background, after the API starts.
+/// It does not block API readiness, isolates each service's failures so one bad run cannot stop the
+/// rest, and executes them sequentially in deterministic order because the underlying providers
+/// (Alpha Vantage free tier) are heavily rate-limited.
+/// </summary>
+public sealed class StartupBackfillBackgroundService(
+    IServiceScopeFactory scopeFactory,
+    IOptions<BackfillOptions> options,
+    ILogger<StartupBackfillBackgroundService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!options.Value.RunOnStartup)
+        {
+            logger.LogInformation("Startup backfill is disabled (Backfill:RunOnStartup=false); nothing to run.");
+            return;
+        }
+
+        // Yield so host startup completes and the API is ready before any provider work begins.
+        await Task.Yield();
+
+        using var scope = scopeFactory.CreateScope();
+        var services = scope.ServiceProvider
+            .GetServices<IBackfillService>()
+            .OrderBy(s => s.Order)
+            .ThenBy(s => s.Name, StringComparer.Ordinal)
+            .ToList();
+
+        if (services.Count == 0)
+        {
+            logger.LogInformation("Startup backfill found no registered backfill services.");
+            return;
+        }
+
+        logger.LogInformation("Startup backfill running {Count} service(s).", services.Count);
+
+        foreach (var service in services)
+        {
+            if (stoppingToken.IsCancellationRequested)
+            {
+                logger.LogInformation("Startup backfill cancelled before running {Service}.", service.Name);
+                break;
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            logger.LogInformation("Startup backfill starting {Service}.", service.Name);
+
+            try
+            {
+                var result = await service.BackfillAsync(stoppingToken);
+                stopwatch.Stop();
+
+                logger.LogInformation(
+                    "Startup backfill finished {Service} in {ElapsedMs} ms: {Inspected} inspected, " +
+                    "{Requests} requests, {Inserted} inserted, {Skipped} skipped, {Failures} failures, rate-limited: {RateLimited}.",
+                    service.Name, stopwatch.ElapsedMilliseconds, result.TargetsInspected, result.ProviderRequests,
+                    result.RowsInserted, result.RowsSkipped, result.Failures, result.RateLimited);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // Host is shutting down: stop cleanly without treating it as a service failure.
+                logger.LogInformation("Startup backfill cancelled during {Service}.", service.Name);
+                break;
+            }
+            catch (Exception ex)
+            {
+                // Isolate failures: a thrown service must not stop the remaining services from running.
+                stopwatch.Stop();
+                logger.LogError(ex, "Startup backfill service {Service} failed after {ElapsedMs} ms.", service.Name, stopwatch.ElapsedMilliseconds);
+            }
+        }
+
+        logger.LogInformation("Startup backfill run complete.");
+    }
+}

--- a/code/FinanceManager.Api/appsettings.Development.json
+++ b/code/FinanceManager.Api/appsettings.Development.json
@@ -52,5 +52,12 @@
   "CurrencyExchangeRates": {
     "CsvDirectory": "../../resources/CurrencyExchangeRates"
   },
+  "Backfill": {
+    "RunOnStartup": false,
+    "StockPricesEnabled": true,
+    "CurrencyRatesEnabled": true,
+    "StockLookbackDays": 30,
+    "CurrencyLookbackDays": 30
+  },
   "AllowedHosts": "*"
 }

--- a/code/FinanceManager.Api/appsettings.Production.json
+++ b/code/FinanceManager.Api/appsettings.Production.json
@@ -88,6 +88,13 @@
     "BaseUrl": "https://www.alphavantage.co/query",
     "OutputSize": "full"
   },
+  "Backfill": {
+    "RunOnStartup": true,
+    "StockPricesEnabled": true,
+    "CurrencyRatesEnabled": true,
+    "StockLookbackDays": 30,
+    "CurrencyLookbackDays": 30
+  },
   "HttpClientResilience": {
     "AttemptTimeoutSeconds": 30,
     "TotalRequestTimeoutSeconds": 90,

--- a/code/FinanceManager.Application/Backfill/BackfillResult.cs
+++ b/code/FinanceManager.Application/Backfill/BackfillResult.cs
@@ -1,0 +1,22 @@
+namespace FinanceManager.Application.Backfill;
+
+/// <summary>
+/// Structured outcome of one backfill run, sized for a single summary log line.
+/// </summary>
+/// <param name="TargetsInspected">Distinct targets (listings, currency pairs) the run looked at.</param>
+/// <param name="ProviderRequests">External provider calls actually made (fresh targets are skipped).</param>
+/// <param name="RowsInserted">New rows written to the database.</param>
+/// <param name="RowsSkipped">Rows already present that were left untouched.</param>
+/// <param name="Failures">Targets that failed (no symbol, provider error) without corrupting others.</param>
+/// <param name="RateLimited">True when a provider quota/rate-limit stopped the run early; the next start resumes.</param>
+public readonly record struct BackfillResult(
+    int TargetsInspected,
+    int ProviderRequests,
+    int RowsInserted,
+    int RowsSkipped,
+    int Failures,
+    bool RateLimited = false)
+{
+    /// <summary>A run that did nothing (e.g. the service is disabled by configuration).</summary>
+    public static BackfillResult Empty => new(0, 0, 0, 0, 0);
+}

--- a/code/FinanceManager.Application/Backfill/Currencies/CurrencyPair.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/CurrencyPair.cs
@@ -1,0 +1,4 @@
+namespace FinanceManager.Application.Backfill.Currencies;
+
+/// <summary>A normalized, upper-cased currency pair to backfill (<see cref="From"/> → <see cref="To"/>).</summary>
+public readonly record struct CurrencyPair(string From, string To);

--- a/code/FinanceManager.Application/Backfill/Currencies/CurrencyPairDiscoveryService.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/CurrencyPairDiscoveryService.cs
@@ -1,0 +1,88 @@
+using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.Identity.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Application.Backfill.Currencies;
+
+/// <summary>
+/// Builds the backfill's currency-pair set from two concrete sources the domain already exposes:
+/// the trading currencies of every held listing (reusing the same distinct-listing query the stock
+/// backfill uses) and every distinct user preferred currency. Portfolio valuation converts the
+/// former into the latter, so their cross-product is the set of rates the app must be able to serve.
+/// </summary>
+public sealed class CurrencyPairDiscoveryService(
+    IInvestmentTransactionRepository transactionRepository,
+    IAssetListingRepository listingRepository,
+    IUserRepository userRepository,
+    ICurrencyRepository currencyRepository,
+    ILogger<CurrencyPairDiscoveryService> logger) : ICurrencyPairDiscoveryService
+{
+    public async Task<IReadOnlyList<CurrencyPair>> GetPairsAsync(CancellationToken cancellationToken = default)
+    {
+        var sources = await GetSourceCurrenciesAsync(cancellationToken);
+        var targets = await GetTargetCurrenciesAsync(cancellationToken);
+
+        var pairs = new HashSet<CurrencyPair>();
+        foreach (var from in sources)
+        {
+            foreach (var to in targets)
+            {
+                if (!string.Equals(from, to, StringComparison.Ordinal))
+                    pairs.Add(new CurrencyPair(from, to));
+            }
+        }
+
+        logger.LogInformation(
+            "Currency backfill discovered {PairCount} pairs from {SourceCount} traded currencies and {TargetCount} preferred currencies.",
+            pairs.Count, sources.Count, targets.Count);
+
+        return pairs.ToList();
+    }
+
+    private async Task<IReadOnlyCollection<string>> GetSourceCurrenciesAsync(CancellationToken ct)
+    {
+        var listingIds = await transactionRepository.GetDistinctAssetListingIds(ct);
+        var currencies = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var listingId in listingIds)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var listing = await listingRepository.Get(listingId, ct);
+            if (listing is null || string.IsNullOrWhiteSpace(listing.TradingCurrency)) continue;
+
+            currencies.Add(Normalize(listing.TradingCurrency));
+        }
+
+        return currencies;
+    }
+
+    private async Task<IReadOnlyCollection<string>> GetTargetCurrenciesAsync(CancellationToken ct)
+    {
+        var currencyIds = await userRepository.GetDistinctPreferredCurrencyIds(ct);
+        var currencies = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var currencyId in currencyIds)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var currency = await currencyRepository.GetCurrency(currencyId, ct);
+            if (currency is null || string.IsNullOrWhiteSpace(currency.ShortName)) continue;
+
+            currencies.Add(Normalize(currency.ShortName));
+        }
+
+        return currencies;
+    }
+
+    // Match the persistence layer's normalisation (trim + upper) and collapse pence-style minor
+    // units (GBX → GBP) so a listing quoted in GBX resolves rates the FX provider actually knows.
+    private static string Normalize(string currency)
+    {
+        var trimmed = currency.Trim().ToUpperInvariant();
+        return DefaultCurrency.MinorQuoteUnits.TryGetValue(trimmed, out var major) ? major : trimmed;
+    }
+}

--- a/code/FinanceManager.Application/Backfill/Currencies/CurrencyRateBackfillService.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/CurrencyRateBackfillService.cs
@@ -1,0 +1,135 @@
+using FinanceManager.Application.Shared.Options;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinanceManager.Application.Backfill.Currencies;
+
+/// <summary>
+/// Startup currency exchange-rate backfill. For each discovered pair it skips already-fresh pairs,
+/// calls Alpha Vantage <c>FX_DAILY</c> once for stale pairs, and inserts only the dates missing from
+/// the database. Provider calls are sequential (free-tier rate limits); a quota response stops the
+/// run early while every row inserted so far stays committed for the next startup to resume from.
+/// </summary>
+public sealed class CurrencyRateBackfillService(
+    ICurrencyPairDiscoveryService pairDiscovery,
+    IFxDailySource fxSource,
+    IExchangeRateRepository exchangeRateRepository,
+    IOptions<BackfillOptions> options,
+    ILogger<CurrencyRateBackfillService> logger) : IBackfillService
+{
+    public string Name => "CurrencyRates";
+
+    public int Order => 20;
+
+    public async Task<BackfillResult> BackfillAsync(CancellationToken cancellationToken)
+    {
+        if (!options.Value.CurrencyRatesEnabled)
+        {
+            logger.LogInformation("Currency-rate backfill is disabled by configuration; skipping.");
+            return BackfillResult.Empty;
+        }
+
+        var lookback = Math.Max(1, options.Value.CurrencyLookbackDays);
+        var nowUtc = DateTime.UtcNow;
+        var expectedLatest = LastMarketDay(nowUtc);
+        var windowStart = nowUtc.Date.AddDays(-lookback);
+
+        var pairs = await pairDiscovery.GetPairsAsync(cancellationToken);
+
+        var inspected = 0;
+        var requests = 0;
+        var inserted = 0;
+        var skipped = 0;
+        var failures = 0;
+        var rateLimited = false;
+
+        foreach (var pair in pairs)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            inspected++;
+
+            // Freshness gate: if the newest stored point is already the last closed market day we make
+            // no call. This also stops weekend and same-UTC-day restarts from re-hitting the provider,
+            // since the newest stored date won't advance until a new market day closes.
+            var latestStored = await exchangeRateRepository.GetLatestDate(pair.From, pair.To, cancellationToken);
+            if (latestStored is DateTime latest && latest.Date >= expectedLatest)
+            {
+                skipped++;
+                continue;
+            }
+
+            requests++;
+            var result = await fxSource.GetDailyRatesAsync(pair.From, pair.To, cancellationToken);
+
+            if (result.Status == FxDailyStatus.RateLimited)
+            {
+                // Quota exhausted. Stop calling the provider for the rest of this run; already-inserted
+                // rows remain committed and the next startup continues idempotently from here.
+                rateLimited = true;
+                logger.LogWarning(
+                    "Currency backfill hit the Alpha Vantage rate limit at pair {From}->{To}; stopping this run. " +
+                    "Inserted {Inserted} rows so far; remaining pairs resume on next start.",
+                    pair.From, pair.To, inserted);
+                break;
+            }
+
+            if (result.Status != FxDailyStatus.Ok || result.Points.Count == 0)
+            {
+                if (result.Status == FxDailyStatus.Error) failures++;
+                continue;
+            }
+
+            // Only keep points inside the lookback window; older history isn't needed on startup.
+            var windowPoints = result.Points
+                .Where(p => p.Key.Date >= windowStart && p.Value > 0)
+                .Select(p => (Date: p.Key, Rate: p.Value))
+                .ToList();
+
+            if (windowPoints.Count == 0)
+                continue;
+
+            var minDate = windowPoints.Min(p => p.Date);
+            var maxDate = windowPoints.Max(p => p.Date);
+            var existingDates = (await exchangeRateRepository.GetExistingDates(pair.From, pair.To, minDate, maxDate, cancellationToken))
+                .Select(d => d.Date)
+                .ToHashSet();
+
+            var missing = windowPoints.Where(p => !existingDates.Contains(p.Date.Date)).ToList();
+            skipped += windowPoints.Count - missing.Count;
+
+            if (missing.Count == 0)
+                continue;
+
+            try
+            {
+                var written = await exchangeRateRepository.AddRange(pair.From, pair.To, missing, cancellationToken);
+                inserted += written;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                failures++;
+                logger.LogError(ex, "Currency backfill failed to persist rates for pair {From}->{To}.", pair.From, pair.To);
+            }
+        }
+
+        logger.LogInformation(
+            "Currency-rate backfill finished: {Inspected} pairs inspected, {Requests} provider requests, " +
+            "{Inserted} rows inserted, {Skipped} rows skipped, {Failures} failures, rate-limited: {RateLimited}.",
+            inspected, requests, inserted, skipped, failures, rateLimited);
+
+        return new BackfillResult(inspected, requests, inserted, skipped, failures, rateLimited);
+    }
+
+    // The most recent weekday at or before now (UTC). FX markets are closed on weekends, so a
+    // Saturday/Sunday restart expects nothing newer than Friday — treating Friday as "latest" keeps
+    // weekend restarts from re-requesting a pair that is already up to date.
+    private static DateTime LastMarketDay(DateTime nowUtc)
+    {
+        var date = nowUtc.Date;
+        while (date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
+            date = date.AddDays(-1);
+
+        return date;
+    }
+}

--- a/code/FinanceManager.Application/Backfill/Currencies/FxDailyResult.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/FxDailyResult.cs
@@ -1,0 +1,15 @@
+namespace FinanceManager.Application.Backfill.Currencies;
+
+/// <summary>
+/// Outcome of one <see cref="IFxDailySource.GetDailyRatesAsync"/> call.
+/// <see cref="Points"/> is keyed by UTC date (day start) to the closing rate.
+/// </summary>
+/// <param name="Status">Terminal status of the request.</param>
+/// <param name="Points">Returned daily closing rates; empty unless <see cref="Status"/> is <see cref="FxDailyStatus.Ok"/>.</param>
+public readonly record struct FxDailyResult(FxDailyStatus Status, IReadOnlyDictionary<DateTime, decimal> Points)
+{
+    public static FxDailyResult Empty { get; } = new(FxDailyStatus.Empty, new Dictionary<DateTime, decimal>());
+    public static FxDailyResult RateLimited { get; } = new(FxDailyStatus.RateLimited, new Dictionary<DateTime, decimal>());
+    public static FxDailyResult Failed { get; } = new(FxDailyStatus.Error, new Dictionary<DateTime, decimal>());
+    public static FxDailyResult Success(IReadOnlyDictionary<DateTime, decimal> points) => new(FxDailyStatus.Ok, points);
+}

--- a/code/FinanceManager.Application/Backfill/Currencies/FxDailyStatus.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/FxDailyStatus.cs
@@ -1,0 +1,17 @@
+namespace FinanceManager.Application.Backfill.Currencies;
+
+/// <summary>How an <see cref="IFxDailySource"/> request ended.</summary>
+public enum FxDailyStatus
+{
+    /// <summary>Points were returned (see <see cref="FxDailyResult.Points"/>).</summary>
+    Ok,
+
+    /// <summary>The provider responded but had no data for the pair (unknown pair, unconfigured key).</summary>
+    Empty,
+
+    /// <summary>The provider's daily quota / rate limit is exhausted; stop making further calls this run.</summary>
+    RateLimited,
+
+    /// <summary>An unexpected error occurred for this pair; other pairs may still be attempted.</summary>
+    Error
+}

--- a/code/FinanceManager.Application/Backfill/Currencies/ICurrencyPairDiscoveryService.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/ICurrencyPairDiscoveryService.cs
@@ -1,8 +1,5 @@
 namespace FinanceManager.Application.Backfill.Currencies;
 
-/// <summary>A normalized, upper-cased currency pair to backfill (<see cref="From"/> → <see cref="To"/>).</summary>
-public readonly record struct CurrencyPair(string From, string To);
-
 /// <summary>
 /// Discovers the distinct currency pairs the system needs exchange rates for: every currency an
 /// instrument trades in, valued into every currency a user has chosen to see their portfolio in.

--- a/code/FinanceManager.Application/Backfill/Currencies/ICurrencyPairDiscoveryService.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/ICurrencyPairDiscoveryService.cs
@@ -1,0 +1,17 @@
+namespace FinanceManager.Application.Backfill.Currencies;
+
+/// <summary>A normalized, upper-cased currency pair to backfill (<see cref="From"/> → <see cref="To"/>).</summary>
+public readonly record struct CurrencyPair(string From, string To);
+
+/// <summary>
+/// Discovers the distinct currency pairs the system needs exchange rates for: every currency an
+/// instrument trades in, valued into every currency a user has chosen to see their portfolio in.
+/// </summary>
+public interface ICurrencyPairDiscoveryService
+{
+    /// <summary>
+    /// Distinct source → target pairs, normalized (trimmed, upper-cased, pence-style minor units
+    /// collapsed to their major currency) and de-duplicated, excluding same-currency pairs.
+    /// </summary>
+    Task<IReadOnlyList<CurrencyPair>> GetPairsAsync(CancellationToken cancellationToken = default);
+}

--- a/code/FinanceManager.Application/Backfill/Currencies/IFxDailySource.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/IFxDailySource.cs
@@ -1,0 +1,47 @@
+namespace FinanceManager.Application.Backfill.Currencies;
+
+/// <summary>How an <see cref="IFxDailySource"/> request ended.</summary>
+public enum FxDailyStatus
+{
+    /// <summary>Points were returned (see <see cref="FxDailyResult.Points"/>).</summary>
+    Ok,
+
+    /// <summary>The provider responded but had no data for the pair (unknown pair, unconfigured key).</summary>
+    Empty,
+
+    /// <summary>The provider's daily quota / rate limit is exhausted; stop making further calls this run.</summary>
+    RateLimited,
+
+    /// <summary>An unexpected error occurred for this pair; other pairs may still be attempted.</summary>
+    Error
+}
+
+/// <summary>
+/// Outcome of one <see cref="IFxDailySource.GetDailyRatesAsync"/> call.
+/// <see cref="Points"/> is keyed by UTC date (day start) to the closing rate.
+/// </summary>
+/// <param name="Status">Terminal status of the request.</param>
+/// <param name="Points">Returned daily closing rates; empty unless <see cref="Status"/> is <see cref="FxDailyStatus.Ok"/>.</param>
+public readonly record struct FxDailyResult(FxDailyStatus Status, IReadOnlyDictionary<DateTime, decimal> Points)
+{
+    public static FxDailyResult Empty { get; } = new(FxDailyStatus.Empty, new Dictionary<DateTime, decimal>());
+    public static FxDailyResult RateLimited { get; } = new(FxDailyStatus.RateLimited, new Dictionary<DateTime, decimal>());
+    public static FxDailyResult Failed { get; } = new(FxDailyStatus.Error, new Dictionary<DateTime, decimal>());
+    public static FxDailyResult Success(IReadOnlyDictionary<DateTime, decimal> points) => new(FxDailyStatus.Ok, points);
+}
+
+/// <summary>
+/// Fetches Alpha Vantage <c>FX_DAILY</c> series for a single currency pair. Separate from the
+/// generic exchange-rate providers because the startup backfill needs the whole date-keyed series
+/// in one call plus an explicit rate-limit signal, neither of which the per-date provider surface
+/// exposes.
+/// </summary>
+public interface IFxDailySource
+{
+    /// <summary>
+    /// One <c>FX_DAILY</c> request for <paramref name="fromCurrency"/> → <paramref name="toCurrency"/>.
+    /// Never throws for provider-side failures; those come back as a non-<see cref="FxDailyStatus.Ok"/>
+    /// status so the caller can decide whether to continue.
+    /// </summary>
+    Task<FxDailyResult> GetDailyRatesAsync(string fromCurrency, string toCurrency, CancellationToken cancellationToken = default);
+}

--- a/code/FinanceManager.Application/Backfill/Currencies/IFxDailySource.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/IFxDailySource.cs
@@ -1,35 +1,5 @@
 namespace FinanceManager.Application.Backfill.Currencies;
 
-/// <summary>How an <see cref="IFxDailySource"/> request ended.</summary>
-public enum FxDailyStatus
-{
-    /// <summary>Points were returned (see <see cref="FxDailyResult.Points"/>).</summary>
-    Ok,
-
-    /// <summary>The provider responded but had no data for the pair (unknown pair, unconfigured key).</summary>
-    Empty,
-
-    /// <summary>The provider's daily quota / rate limit is exhausted; stop making further calls this run.</summary>
-    RateLimited,
-
-    /// <summary>An unexpected error occurred for this pair; other pairs may still be attempted.</summary>
-    Error
-}
-
-/// <summary>
-/// Outcome of one <see cref="IFxDailySource.GetDailyRatesAsync"/> call.
-/// <see cref="Points"/> is keyed by UTC date (day start) to the closing rate.
-/// </summary>
-/// <param name="Status">Terminal status of the request.</param>
-/// <param name="Points">Returned daily closing rates; empty unless <see cref="Status"/> is <see cref="FxDailyStatus.Ok"/>.</param>
-public readonly record struct FxDailyResult(FxDailyStatus Status, IReadOnlyDictionary<DateTime, decimal> Points)
-{
-    public static FxDailyResult Empty { get; } = new(FxDailyStatus.Empty, new Dictionary<DateTime, decimal>());
-    public static FxDailyResult RateLimited { get; } = new(FxDailyStatus.RateLimited, new Dictionary<DateTime, decimal>());
-    public static FxDailyResult Failed { get; } = new(FxDailyStatus.Error, new Dictionary<DateTime, decimal>());
-    public static FxDailyResult Success(IReadOnlyDictionary<DateTime, decimal> points) => new(FxDailyStatus.Ok, points);
-}
-
 /// <summary>
 /// Fetches Alpha Vantage <c>FX_DAILY</c> series for a single currency pair. Separate from the
 /// generic exchange-rate providers because the startup backfill needs the whole date-keyed series

--- a/code/FinanceManager.Application/Backfill/IBackfillService.cs
+++ b/code/FinanceManager.Application/Backfill/IBackfillService.cs
@@ -20,24 +20,3 @@ public interface IBackfillService
     /// </summary>
     Task<BackfillResult> BackfillAsync(CancellationToken cancellationToken);
 }
-
-/// <summary>
-/// Structured outcome of one backfill run, sized for a single summary log line.
-/// </summary>
-/// <param name="TargetsInspected">Distinct targets (listings, currency pairs) the run looked at.</param>
-/// <param name="ProviderRequests">External provider calls actually made (fresh targets are skipped).</param>
-/// <param name="RowsInserted">New rows written to the database.</param>
-/// <param name="RowsSkipped">Rows already present that were left untouched.</param>
-/// <param name="Failures">Targets that failed (no symbol, provider error) without corrupting others.</param>
-/// <param name="RateLimited">True when a provider quota/rate-limit stopped the run early; the next start resumes.</param>
-public readonly record struct BackfillResult(
-    int TargetsInspected,
-    int ProviderRequests,
-    int RowsInserted,
-    int RowsSkipped,
-    int Failures,
-    bool RateLimited = false)
-{
-    /// <summary>A run that did nothing (e.g. the service is disabled by configuration).</summary>
-    public static BackfillResult Empty => new(0, 0, 0, 0, 0);
-}

--- a/code/FinanceManager.Application/Backfill/IBackfillService.cs
+++ b/code/FinanceManager.Application/Backfill/IBackfillService.cs
@@ -1,0 +1,43 @@
+namespace FinanceManager.Application.Backfill;
+
+/// <summary>
+/// One startup-backfill unit of work (stock prices, currency rates, …). Implementations are
+/// resolved as a group and run sequentially by the startup orchestrator; sequential execution is
+/// intentional because the underlying providers (Alpha Vantage free tier) are heavily rate-limited.
+/// </summary>
+public interface IBackfillService
+{
+    /// <summary>Short human-readable name used in structured logs (e.g. "StockPrices").</summary>
+    string Name { get; }
+
+    /// <summary>Deterministic run order; lower runs first. Ties break on <see cref="Name"/>.</summary>
+    int Order { get; }
+
+    /// <summary>
+    /// Run the backfill once. Must be safe to call repeatedly (idempotent) and must not throw for
+    /// per-target provider failures — those belong in <see cref="BackfillResult.Failures"/> so one
+    /// bad target never aborts the rest of the run.
+    /// </summary>
+    Task<BackfillResult> BackfillAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Structured outcome of one backfill run, sized for a single summary log line.
+/// </summary>
+/// <param name="TargetsInspected">Distinct targets (listings, currency pairs) the run looked at.</param>
+/// <param name="ProviderRequests">External provider calls actually made (fresh targets are skipped).</param>
+/// <param name="RowsInserted">New rows written to the database.</param>
+/// <param name="RowsSkipped">Rows already present that were left untouched.</param>
+/// <param name="Failures">Targets that failed (no symbol, provider error) without corrupting others.</param>
+/// <param name="RateLimited">True when a provider quota/rate-limit stopped the run early; the next start resumes.</param>
+public readonly record struct BackfillResult(
+    int TargetsInspected,
+    int ProviderRequests,
+    int RowsInserted,
+    int RowsSkipped,
+    int Failures,
+    bool RateLimited = false)
+{
+    /// <summary>A run that did nothing (e.g. the service is disabled by configuration).</summary>
+    public static BackfillResult Empty => new(0, 0, 0, 0, 0);
+}

--- a/code/FinanceManager.Application/Backfill/StockPriceBackfillService.cs
+++ b/code/FinanceManager.Application/Backfill/StockPriceBackfillService.cs
@@ -1,0 +1,52 @@
+using FinanceManager.Application.Assets.Pricing;
+using FinanceManager.Application.Shared.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinanceManager.Application.Backfill;
+
+/// <summary>
+/// Startup stock-price backfill. Deliberately a thin adapter over the existing
+/// <see cref="IInvestmentPriceBackfillService"/> so the discovery, rate-limited provider chain,
+/// freshness check and idempotent upsert all stay in one place and are not duplicated here.
+/// </summary>
+public sealed class StockPriceBackfillService(
+    IInvestmentPriceBackfillService backfillService,
+    IOptions<BackfillOptions> options,
+    ILogger<StockPriceBackfillService> logger) : IBackfillService
+{
+    public string Name => "StockPrices";
+
+    public int Order => 10;
+
+    public async Task<BackfillResult> BackfillAsync(CancellationToken cancellationToken)
+    {
+        if (!options.Value.StockPricesEnabled)
+        {
+            logger.LogInformation("Stock-price backfill is disabled by configuration; skipping.");
+            return BackfillResult.Empty;
+        }
+
+        var lookback = Math.Max(1, options.Value.StockLookbackDays);
+        var end = DateTime.UtcNow.Date;
+        var start = end.AddDays(-lookback);
+
+        // The wrapped service gathers every distinct held listing and runs each through
+        // EnsureQuotesAsync, which already skips already-covered listings, calls the provider at
+        // most once per listing, and upserts only missing dates — exactly the startup behaviour
+        // required here. It reports coverage per listing rather than row-level insert/skip counts,
+        // so those fields stay 0; inspected maps to listings and failures to uncovered listings.
+        var result = await backfillService.BackfillAsync(start, end, cancellationToken);
+
+        logger.LogInformation(
+            "Stock-price backfill covered {Covered}/{Listings} listings over {Start:yyyy-MM-dd}..{End:yyyy-MM-dd}.",
+            result.Covered, result.Listings, start, end);
+
+        return new BackfillResult(
+            TargetsInspected: result.Listings,
+            ProviderRequests: 0,
+            RowsInserted: 0,
+            RowsSkipped: 0,
+            Failures: result.Uncovered);
+    }
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Registration.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Registration.cs
@@ -1,4 +1,6 @@
 using FinanceManager.Application.Assets.Pricing;
+using FinanceManager.Application.Backfill;
+using FinanceManager.Application.Backfill.Currencies;
 using FinanceManager.Application.FinancialAccounts.Bond;
 using FinanceManager.Application.FinancialAccounts.Bond.Assets;
 using FinanceManager.Application.FinancialAccounts.Bond.Balance;
@@ -69,6 +71,9 @@ internal static class Registration
                 .AddScoped<IAccountCsvExportService<BondAccountExportDto>, BondAccountCsvExportService>()
                 .AddScoped<IInvestmentPriceProvider, InvestmentPriceProvider>()
                 .AddScoped<IInvestmentPriceBackfillService, InvestmentPriceBackfillService>()
+                .AddScoped<ICurrencyPairDiscoveryService, CurrencyPairDiscoveryService>()
+                .AddScoped<IBackfillService, StockPriceBackfillService>()
+                .AddScoped<IBackfillService, CurrencyRateBackfillService>()
                 .AddScoped<IInvestmentValuationService, InvestmentValuationService>()
                 .AddScoped<IInvestmentTransactionValuationService, InvestmentTransactionValuationService>()
                 .AddScoped<IInvestmentInstrumentDiscoveryService, InvestmentInstrumentDiscoveryService>()

--- a/code/FinanceManager.Application/Shared/Options/BackfillOptions.cs
+++ b/code/FinanceManager.Application/Shared/Options/BackfillOptions.cs
@@ -1,0 +1,32 @@
+namespace FinanceManager.Application.Shared.Options;
+
+/// <summary>
+/// Controls the startup backfill pipeline. Disable <see cref="RunOnStartup"/> for tests, migrations,
+/// or environments where an external scheduler owns the process; toggle individual datasets with the
+/// per-service flags.
+/// </summary>
+public sealed class BackfillOptions
+{
+    public const string SectionName = "Backfill";
+
+    /// <summary>Master switch: when false the startup orchestrator does nothing.</summary>
+    public bool RunOnStartup { get; set; }
+
+    /// <summary>Whether the stock-price backfill service runs.</summary>
+    public bool StockPricesEnabled { get; set; } = true;
+
+    /// <summary>Whether the currency exchange-rate backfill service runs.</summary>
+    public bool CurrencyRatesEnabled { get; set; } = true;
+
+    /// <summary>
+    /// How many days of history the stock backfill covers on each run. The rolling window is
+    /// [today − LookbackDays, today]; the provider chain skips listings already covered in it.
+    /// </summary>
+    public int StockLookbackDays { get; set; } = 30;
+
+    /// <summary>
+    /// How many days of history the currency backfill requests per pair when a refresh is needed.
+    /// Only the dates missing from the database are actually inserted.
+    /// </summary>
+    public int CurrencyLookbackDays { get; set; } = 30;
+}

--- a/code/FinanceManager.Domain/FinancialAccounts/Currencies/Repositories/IExchangeRateRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Currencies/Repositories/IExchangeRateRepository.cs
@@ -5,4 +5,24 @@ public interface IExchangeRateRepository
     public Task<decimal?> Get(string fromCurrency, string toCurrency, DateTime date, CancellationToken ct = default);
     public Task Add(string fromCurrency, string toCurrency, DateTime date, decimal rate, CancellationToken ct = default);
     public Task<IReadOnlyDictionary<(string From, string To, DateTime Date), decimal>> GetRange(string fromCurrency, string toCurrency, DateTime dateStart, DateTime dateEnd, CancellationToken ct = default);
+
+    /// <summary>
+    /// The most recent stored date for a direct (from → to) pair, or <c>null</c> when none exists.
+    /// Lets a backfill decide whether a pair is fresh in a single query instead of scanning a range.
+    /// </summary>
+    public Task<DateTime?> GetLatestDate(string fromCurrency, string toCurrency, CancellationToken ct = default);
+
+    /// <summary>
+    /// The distinct stored dates for a direct (from → to) pair within [start, end]. Used to filter a
+    /// provider's returned points down to the ones missing from the database before a bulk insert.
+    /// </summary>
+    public Task<IReadOnlyCollection<DateTime>> GetExistingDates(string fromCurrency, string toCurrency, DateTime dateStart, DateTime dateEnd, CancellationToken ct = default);
+
+    /// <summary>
+    /// Inserts many daily rates for a direct (from → to) pair in one transaction, skipping any date
+    /// already present. Returns the number of rows actually inserted. Safe to run concurrently: the
+    /// unique (from, to, date) index is the final guard and a conflicting insert is treated as a
+    /// no-op rather than an error.
+    /// </summary>
+    public Task<int> AddRange(string fromCurrency, string toCurrency, IReadOnlyCollection<(DateTime Date, decimal Rate)> rates, CancellationToken ct = default);
 }

--- a/code/FinanceManager.Domain/Identity/Repositories/IUserRepository.cs
+++ b/code/FinanceManager.Domain/Identity/Repositories/IUserRepository.cs
@@ -51,4 +51,11 @@ public interface IUserRepository
     Task<bool> AddUserWithId(int userId, string login, string password, PricingLevel pricingLevel, UserRole userRole, string? firstName = null, string? lastName = null);
 
     Task<bool> RemoveUser(int userId);
+
+    /// <summary>
+    /// The distinct preferred-currency ids across all users, resolved in a single grouped query.
+    /// Feeds the startup currency backfill, which must cover every currency a portfolio is valued in
+    /// without enumerating users one by one.
+    /// </summary>
+    Task<IReadOnlyList<int>> GetDistinctPreferredCurrencyIds(CancellationToken ct = default);
 }

--- a/code/FinanceManager.Infrastructure/Repositories/ExchangeRateRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/ExchangeRateRepository.cs
@@ -120,6 +120,128 @@ public class ExchangeRateRepository(AppDbContext context) : IExchangeRateReposit
         }
     }
 
+    public async Task<DateTime?> GetLatestDate(string fromCurrency, string toCurrency, CancellationToken ct = default)
+    {
+        var from = Normalize(fromCurrency);
+        var to = Normalize(toCurrency);
+
+        await _contextLock.WaitAsync(ct);
+        try
+        {
+            var dates = context.ExchangeRates
+                .AsNoTracking()
+                .Where(x => x.FromCurrency == from && x.ToCurrency == to)
+                .Select(x => x.Date);
+
+            // MaxAsync throws on an empty sequence; project to nullable and use a scalar aggregate so
+            // an unseen pair returns null instead of blowing up.
+            return await dates.MaxAsync(d => (DateTime?)d, ct);
+        }
+        finally
+        {
+            _contextLock.Release();
+        }
+    }
+
+    public async Task<IReadOnlyCollection<DateTime>> GetExistingDates(string fromCurrency, string toCurrency, DateTime dateStart, DateTime dateEnd, CancellationToken ct = default)
+    {
+        var from = Normalize(fromCurrency);
+        var to = Normalize(toCurrency);
+        var startDay = NormalizeDate(dateStart);
+        var endDay = NormalizeDate(dateEnd);
+
+        if (startDay > endDay)
+            (startDay, endDay) = (endDay, startDay);
+
+        await _contextLock.WaitAsync(ct);
+        try
+        {
+            return await context.ExchangeRates
+                .AsNoTracking()
+                .Where(x => x.FromCurrency == from && x.ToCurrency == to && x.Date >= startDay && x.Date <= endDay)
+                .Select(x => x.Date)
+                .ToListAsync(ct);
+        }
+        finally
+        {
+            _contextLock.Release();
+        }
+    }
+
+    public async Task<int> AddRange(string fromCurrency, string toCurrency, IReadOnlyCollection<(DateTime Date, decimal Rate)> rates, CancellationToken ct = default)
+    {
+        if (rates.Count == 0) return 0;
+
+        var from = Normalize(fromCurrency);
+        var to = Normalize(toCurrency);
+
+        // Collapse duplicate dates in the incoming batch (last wins) and normalise the kind so the
+        // in-memory existence check matches what the database stores.
+        var byDate = new Dictionary<DateTime, decimal>();
+        foreach (var (date, rate) in rates)
+            byDate[NormalizeDate(date)] = rate;
+
+        await _contextLock.WaitAsync(ct);
+        try
+        {
+            var minDay = byDate.Keys.Min();
+            var maxDay = byDate.Keys.Max();
+
+            var existing = await context.ExchangeRates
+                .AsNoTracking()
+                .Where(x => x.FromCurrency == from && x.ToCurrency == to && x.Date >= minDay && x.Date <= maxDay)
+                .Select(x => x.Date)
+                .ToListAsync(ct);
+
+            var existingDates = existing.ToHashSet();
+
+            var toInsert = byDate
+                .Where(kvp => !existingDates.Contains(kvp.Key))
+                .Select(kvp => new ExchangeRate
+                {
+                    FromCurrency = from,
+                    ToCurrency = to,
+                    Date = kvp.Key,
+                    Rate = kvp.Value
+                })
+                .ToList();
+
+            if (toInsert.Count == 0) return 0;
+
+            context.ExchangeRates.AddRange(toInsert);
+            try
+            {
+                await context.SaveChangesAsync(ct);
+                return toInsert.Count;
+            }
+            catch (DbUpdateException)
+            {
+                // A concurrent backfill inserted overlapping dates between the read above and this
+                // save. Drop this context's pending inserts, then re-insert only the dates that are
+                // still missing so completed rows stay committed and the run remains idempotent.
+                context.ChangeTracker.Clear();
+
+                var nowExisting = (await context.ExchangeRates
+                        .AsNoTracking()
+                        .Where(x => x.FromCurrency == from && x.ToCurrency == to && x.Date >= minDay && x.Date <= maxDay)
+                        .Select(x => x.Date)
+                        .ToListAsync(ct))
+                    .ToHashSet();
+
+                var retry = toInsert.Where(r => !nowExisting.Contains(r.Date)).ToList();
+                if (retry.Count == 0) return 0;
+
+                context.ExchangeRates.AddRange(retry);
+                await context.SaveChangesAsync(ct);
+                return retry.Count;
+            }
+        }
+        finally
+        {
+            _contextLock.Release();
+        }
+    }
+
     private static string Normalize(string currency) => currency.Trim().ToUpperInvariant();
 
     // Rates are daily; store the UTC day start so lookups are exact and PostgreSQL accepts the value.

--- a/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/UserRepository.cs
@@ -235,4 +235,11 @@ public class UserRepository(AppDbContext context) : IUserRepository
 
         return true;
     }
+
+    public async Task<IReadOnlyList<int>> GetDistinctPreferredCurrencyIds(CancellationToken ct = default) =>
+        await context.Users
+            .AsNoTracking()
+            .Select(x => x.PreferredCurrencyId)
+            .Distinct()
+            .ToListAsync(ct);
 }

--- a/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
@@ -1,4 +1,5 @@
-﻿using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+﻿using FinanceManager.Application.Backfill.Currencies;
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
 using FinanceManager.Application.FinancialAccounts.Stock.Resolution;
 using FinanceManager.Application.Insights.Generation;
 using FinanceManager.Application.Labels.Setter;
@@ -68,6 +69,7 @@ public static class ServiceCollectionExtension
         services.AddHttpClient<OpenFigiClient>();
         services.AddScoped<IOpenFigiClient>(sp => sp.GetRequiredService<OpenFigiClient>());
         services.AddHttpClient<ICurrencyExchangeRateProvider, FawazAhmedCurrencyApiClient>();
+        services.AddHttpClient<IFxDailySource, AlphaVantageFxClient>();
 
         services.AddAI();
 

--- a/code/FinanceManager.Infrastructure/Services/Currencies/AlphaVantageFxClient.cs
+++ b/code/FinanceManager.Infrastructure/Services/Currencies/AlphaVantageFxClient.cs
@@ -1,0 +1,137 @@
+using FinanceManager.Application.Backfill.Currencies;
+using FinanceManager.Application.Shared.ExternalServices;
+using Microsoft.Extensions.Logging;
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FinanceManager.Infrastructure.Services.Currencies;
+
+/// <summary>
+/// Fetches Alpha Vantage <c>FX_DAILY</c> series for the startup currency backfill. Reuses the shared
+/// Alpha Vantage service configuration (base URL + API key) so it honours the same throttling and
+/// key management as the stock client, and reports quota exhaustion distinctly so the backfill can
+/// stop calling for the rest of the run.
+/// </summary>
+internal sealed class AlphaVantageFxClient(
+    HttpClient httpClient,
+    ILogger<AlphaVantageFxClient> logger,
+    IExternalServiceConfigService configService) : IFxDailySource
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public async Task<FxDailyResult> GetDailyRatesAsync(string fromCurrency, string toCurrency, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(fromCurrency) || string.IsNullOrWhiteSpace(toCurrency))
+            return FxDailyResult.Empty;
+
+        var config = await configService.GetServiceAsync("AlphaVantage", cancellationToken);
+        var apiKey = config.ApiKey;
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            logger.LogWarning("Alpha Vantage API key is missing; cannot backfill FX pair {From}->{To}.", fromCurrency, toCurrency);
+            return FxDailyResult.Empty;
+        }
+
+        var url = BuildUrl(
+            $"function=FX_DAILY&from_symbol={Uri.EscapeDataString(fromCurrency)}&to_symbol={Uri.EscapeDataString(toCurrency)}&outputsize=compact&apikey={apiKey}",
+            config.BaseUrl);
+
+        try
+        {
+            using var response = await httpClient.GetAsync(url, cancellationToken);
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                return FxDailyResult.RateLimited;
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogWarning("Alpha Vantage FX_DAILY failed with status {StatusCode} for {From}->{To}.", response.StatusCode, fromCurrency, toCurrency);
+                return FxDailyResult.Failed;
+            }
+
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            var parsed = JsonSerializer.Deserialize<AlphaVantageFxResponse>(content, _jsonOptions);
+
+            // Alpha Vantage returns HTTP 200 with a "Note"/"Information" body when the free-tier quota
+            // is exhausted; detect that so the backfill can stop instead of hammering the endpoint.
+            if (IsRateLimit(parsed))
+            {
+                logger.LogWarning("Alpha Vantage FX_DAILY reported a rate limit for {From}->{To}.", fromCurrency, toCurrency);
+                return FxDailyResult.RateLimited;
+            }
+
+            if (parsed?.Series is null || parsed.Series.Count == 0)
+                return FxDailyResult.Empty;
+
+            var points = new Dictionary<DateTime, decimal>(parsed.Series.Count);
+            foreach (var entry in parsed.Series)
+            {
+                if (!TryParseDate(entry.Key, out var date)) continue;
+
+                var close = ParseDecimal(entry.Value?.Close);
+                if (close <= 0) continue;
+
+                points[date] = close;
+            }
+
+            return points.Count == 0 ? FxDailyResult.Empty : FxDailyResult.Success(points);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Alpha Vantage FX_DAILY threw for {From}->{To}.", fromCurrency, toCurrency);
+            return FxDailyResult.Failed;
+        }
+    }
+
+    private static bool IsRateLimit(AlphaVantageFxResponse? response)
+    {
+        var message = response?.Note ?? response?.Information;
+        if (string.IsNullOrWhiteSpace(message)) return false;
+
+        return message.Contains("rate limit", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("call frequency", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("premium", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string BuildUrl(string query, string baseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl)) return query;
+        return baseUrl.Contains('?') ? $"{baseUrl}&{query}" : $"{baseUrl}?{query}";
+    }
+
+    private static bool TryParseDate(string value, out DateTime date)
+    {
+        var ok = DateTime.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsed);
+        date = DateTime.SpecifyKind(parsed.Date, DateTimeKind.Utc);
+        return ok;
+    }
+
+    private static decimal ParseDecimal(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return 0m;
+        return decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed) ? parsed : 0m;
+    }
+
+    private sealed class AlphaVantageFxResponse
+    {
+        public string? Information { get; set; }
+        public string? Note { get; set; }
+
+        [JsonPropertyName("Time Series FX (Daily)")]
+        public Dictionary<string, AlphaVantageFxEntry>? Series { get; set; }
+    }
+
+    private sealed class AlphaVantageFxEntry
+    {
+        [JsonPropertyName("4. close")]
+        public string? Close { get; set; }
+    }
+}

--- a/code/FinanceManager.Tests.Integration/FinanceManagerApiTestApp.cs
+++ b/code/FinanceManager.Tests.Integration/FinanceManagerApiTestApp.cs
@@ -86,6 +86,9 @@ internal sealed class FinanceManagerApiTestApp : WebApplicationFactory<ApiEntryP
                 // appsettings.json restricts AllowedHosts to the production hostname; the test host serves
                 // requests over http://localhost, so relax host filtering here or every request 400s.
                 ["AllowedHosts"] = "*",
+                // The startup backfill reaches out to Alpha Vantage; keep it off in tests so the host
+                // starts deterministically without external calls or DB races on the in-memory context.
+                ["Backfill:RunOnStartup"] = "false",
             };
 
             config.AddInMemoryCollection(settings);

--- a/code/FinanceManager.Tests.Unit/Api/Services/StartupBackfillBackgroundServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Services/StartupBackfillBackgroundServiceTests.cs
@@ -1,0 +1,129 @@
+using FinanceManager.Api.Services;
+using FinanceManager.Application.Backfill;
+using FinanceManager.Application.Shared.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System.Reflection;
+
+namespace FinanceManager.Tests.Unit.Api.Services;
+
+[Trait("Category", "Unit")]
+public class StartupBackfillBackgroundServiceTests
+{
+    [Fact]
+    public async Task RunsAllRegisteredServicesInDeterministicOrder()
+    {
+        var log = new List<string>();
+        var services = new List<IBackfillService>
+        {
+            new FakeBackfillService("c", 30, log),
+            new FakeBackfillService("a", 10, log),
+            new FakeBackfillService("b", 20, log),
+        };
+
+        await RunAsync(services, CancellationToken.None);
+
+        Assert.Equal(["a", "b", "c"], log);
+    }
+
+    [Fact]
+    public async Task ContinuesAfterOneServiceThrows()
+    {
+        var log = new List<string>();
+        var services = new List<IBackfillService>
+        {
+            new FakeBackfillService("first", 10, log),
+            new FakeBackfillService("boom", 20, log, throwOnRun: new InvalidOperationException("boom")),
+            new FakeBackfillService("third", 30, log),
+        };
+
+        await RunAsync(services, CancellationToken.None);
+
+        // All three ran even though the middle one threw: failures are isolated.
+        Assert.Equal(["first", "boom", "third"], log);
+    }
+
+    [Fact]
+    public async Task PreCancelledToken_RunsNoServices()
+    {
+        var log = new List<string>();
+        var services = new List<IBackfillService>
+        {
+            new FakeBackfillService("a", 10, log),
+            new FakeBackfillService("b", 20, log),
+        };
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await RunAsync(services, cts.Token);
+
+        Assert.Empty(log);
+    }
+
+    [Fact]
+    public async Task CancellationMidRun_StopsRemainingServices()
+    {
+        var log = new List<string>();
+        using var cts = new CancellationTokenSource();
+        var services = new List<IBackfillService>
+        {
+            new FakeBackfillService("first", 10, log, onRun: cts.Cancel),
+            new FakeBackfillService("second", 20, log),
+        };
+
+        await RunAsync(services, cts.Token);
+
+        // The first service cancels the token; the orchestrator must stop before the second.
+        Assert.Equal(["first"], log);
+    }
+
+    [Fact]
+    public async Task RunOnStartupFalse_RunsNothing()
+    {
+        var log = new List<string>();
+        var services = new List<IBackfillService> { new FakeBackfillService("a", 10, log) };
+
+        await RunAsync(services, CancellationToken.None, runOnStartup: false);
+
+        Assert.Empty(log);
+    }
+
+    private static async Task RunAsync(IEnumerable<IBackfillService> services, CancellationToken token, bool runOnStartup = true)
+    {
+        var collection = new ServiceCollection();
+        foreach (var service in services)
+            collection.AddSingleton(service);
+
+        using var provider = collection.BuildServiceProvider();
+
+        var sut = new StartupBackfillBackgroundService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            Options.Create(new BackfillOptions { RunOnStartup = runOnStartup }),
+            NullLogger<StartupBackfillBackgroundService>.Instance);
+
+        // ExecuteAsync is protected; invoke it directly so the test controls the stopping token.
+        var execute = typeof(StartupBackfillBackgroundService)
+            .GetMethod("ExecuteAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        await (Task)execute.Invoke(sut, [token])!;
+    }
+
+    private sealed class FakeBackfillService(string name, int order, List<string> log, Exception? throwOnRun = null, Action? onRun = null) : IBackfillService
+    {
+        public string Name => name;
+        public int Order => order;
+
+        public Task<BackfillResult> BackfillAsync(CancellationToken cancellationToken)
+        {
+            onRun?.Invoke();
+            log.Add(name);
+
+            if (throwOnRun is not null)
+                throw throwOnRun;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(BackfillResult.Empty);
+        }
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Api/Services/StartupBackfillBackgroundServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Services/StartupBackfillBackgroundServiceTests.cs
@@ -28,6 +28,23 @@ public class StartupBackfillBackgroundServiceTests
     }
 
     [Fact]
+    public async Task EqualOrder_BreaksTieByNameAscending()
+    {
+        var log = new List<string>();
+        // Same Order, registered in reverse-alphabetical order: the ThenBy(Name) tie-break must still
+        // run them alphabetically.
+        var services = new List<IBackfillService>
+        {
+            new FakeBackfillService("zeta", 10, log),
+            new FakeBackfillService("alpha", 10, log),
+        };
+
+        await RunAsync(services, CancellationToken.None);
+
+        Assert.Equal(["alpha", "zeta"], log);
+    }
+
+    [Fact]
     public async Task ContinuesAfterOneServiceThrows()
     {
         var log = new List<string>();

--- a/code/FinanceManager.Tests.Unit/Application/Backfill/CurrencyPairDiscoveryServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Backfill/CurrencyPairDiscoveryServiceTests.cs
@@ -1,0 +1,63 @@
+using FinanceManager.Application.Backfill.Currencies;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.Identity.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Backfill;
+
+[Trait("Category", "Unit")]
+public class CurrencyPairDiscoveryServiceTests
+{
+    private readonly Mock<IInvestmentTransactionRepository> _transactions = new();
+    private readonly Mock<IAssetListingRepository> _listings = new();
+    private readonly Mock<IUserRepository> _users = new();
+    private readonly Mock<ICurrencyRepository> _currencies = new();
+
+    private CurrencyPairDiscoveryService CreateSut() => new(
+        _transactions.Object,
+        _listings.Object,
+        _users.Object,
+        _currencies.Object,
+        NullLogger<CurrencyPairDiscoveryService>.Instance);
+
+    [Fact]
+    public async Task BuildsNormalizedCrossProductOfTradedAndPreferredCurrencies()
+    {
+        _transactions.Setup(x => x.GetDistinctAssetListingIds(It.IsAny<CancellationToken>())).ReturnsAsync([1L, 2L]);
+        // GBX normalises to GBP; "usd" normalises to USD.
+        _listings.Setup(x => x.Get(1L, It.IsAny<CancellationToken>())).ReturnsAsync(new AssetListing { TradingCurrency = "GBX" });
+        _listings.Setup(x => x.Get(2L, It.IsAny<CancellationToken>())).ReturnsAsync(new AssetListing { TradingCurrency = "usd" });
+
+        _users.Setup(x => x.GetDistinctPreferredCurrencyIds(It.IsAny<CancellationToken>())).ReturnsAsync([0, 1]);
+        _currencies.Setup(x => x.GetCurrency(0, It.IsAny<CancellationToken>())).ReturnsAsync(DefaultCurrency.PLN);
+        _currencies.Setup(x => x.GetCurrency(1, It.IsAny<CancellationToken>())).ReturnsAsync(DefaultCurrency.USD);
+
+        var pairs = await CreateSut().GetPairsAsync(TestContext.Current.CancellationToken);
+
+        // Sources {GBP, USD} × targets {PLN, USD}, excluding USD→USD.
+        Assert.Equal(
+            new HashSet<CurrencyPair>
+            {
+                new("GBP", "PLN"),
+                new("GBP", "USD"),
+                new("USD", "PLN"),
+            },
+            pairs.ToHashSet());
+    }
+
+    [Fact]
+    public async Task NoListingsOrUsers_ReturnsNoPairs()
+    {
+        _transactions.Setup(x => x.GetDistinctAssetListingIds(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+        _users.Setup(x => x.GetDistinctPreferredCurrencyIds(It.IsAny<CancellationToken>())).ReturnsAsync([]);
+
+        var pairs = await CreateSut().GetPairsAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(pairs);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Backfill/CurrencyRateBackfillServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Backfill/CurrencyRateBackfillServiceTests.cs
@@ -1,0 +1,147 @@
+using FinanceManager.Application.Backfill;
+using FinanceManager.Application.Backfill.Currencies;
+using FinanceManager.Application.Shared.Options;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Backfill;
+
+[Trait("Category", "Unit")]
+public class CurrencyRateBackfillServiceTests
+{
+    private readonly Mock<ICurrencyPairDiscoveryService> _discovery = new();
+    private readonly Mock<IFxDailySource> _fxSource = new();
+    private readonly Mock<IExchangeRateRepository> _exchangeRates = new();
+    private readonly BackfillOptions _options = new() { CurrencyRatesEnabled = true, CurrencyLookbackDays = 30 };
+
+    private CurrencyRateBackfillService CreateSut() => new(
+        _discovery.Object,
+        _fxSource.Object,
+        _exchangeRates.Object,
+        Options.Create(_options),
+        NullLogger<CurrencyRateBackfillService>.Instance);
+
+    [Fact]
+    public async Task Disabled_DoesNothing()
+    {
+        _options.CurrencyRatesEnabled = false;
+
+        var result = await CreateSut().BackfillAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(BackfillResult.Empty, result);
+        _discovery.Verify(x => x.GetPairsAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _fxSource.Verify(x => x.GetDailyRatesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task FreshPair_SkipsProviderCall()
+    {
+        SetupPairs(("USD", "PLN"));
+        // The newest stored date is today, so it is already at least the last closed market day.
+        _exchangeRates
+            .Setup(x => x.GetLatestDate("USD", "PLN", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DateTime.UtcNow.Date);
+
+        var result = await CreateSut().BackfillAsync(TestContext.Current.CancellationToken);
+
+        _fxSource.Verify(x => x.GetDailyRatesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        Assert.Equal(1, result.TargetsInspected);
+        Assert.Equal(0, result.ProviderRequests);
+        Assert.Equal(1, result.RowsSkipped);
+        Assert.Equal(0, result.RowsInserted);
+    }
+
+    [Fact]
+    public async Task StalePair_ImportsOnlyMissingDates()
+    {
+        var d1 = DateTime.UtcNow.Date.AddDays(-3);
+        var d2 = DateTime.UtcNow.Date.AddDays(-2);
+        var d3 = DateTime.UtcNow.Date.AddDays(-1);
+
+        SetupPairs(("USD", "PLN"));
+        _exchangeRates
+            .Setup(x => x.GetLatestDate("USD", "PLN", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
+        _fxSource
+            .Setup(x => x.GetDailyRatesAsync("USD", "PLN", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FxDailyResult.Success(new Dictionary<DateTime, decimal>
+            {
+                [d1] = 3.9m,
+                [d2] = 4.0m,
+                [d3] = 4.1m,
+            }));
+        // d2 is already stored; only d1 and d3 should be inserted.
+        _exchangeRates
+            .Setup(x => x.GetExistingDates("USD", "PLN", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([d2]);
+
+        IReadOnlyCollection<(DateTime Date, decimal Rate)>? inserted = null;
+        _exchangeRates
+            .Setup(x => x.AddRange("USD", "PLN", It.IsAny<IReadOnlyCollection<(DateTime, decimal)>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, IReadOnlyCollection<(DateTime, decimal)>, CancellationToken>((_, _, rows, _) => inserted = rows)
+            .ReturnsAsync((string _, string _, IReadOnlyCollection<(DateTime, decimal)> rows, CancellationToken _) => rows.Count);
+
+        var result = await CreateSut().BackfillAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(inserted);
+        Assert.Equal([d1, d3], inserted!.Select(r => r.Date).OrderBy(d => d));
+        Assert.Equal(2, result.RowsInserted);
+        Assert.Equal(1, result.RowsSkipped);
+        Assert.Equal(1, result.ProviderRequests);
+        Assert.Equal(1, result.TargetsInspected);
+    }
+
+    [Fact]
+    public async Task AllReturnedDatesAlreadyStored_InsertsNothing()
+    {
+        var d1 = DateTime.UtcNow.Date.AddDays(-2);
+        var d2 = DateTime.UtcNow.Date.AddDays(-1);
+
+        SetupPairs(("EUR", "PLN"));
+        _exchangeRates
+            .Setup(x => x.GetLatestDate("EUR", "PLN", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
+        _fxSource
+            .Setup(x => x.GetDailyRatesAsync("EUR", "PLN", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FxDailyResult.Success(new Dictionary<DateTime, decimal> { [d1] = 4.2m, [d2] = 4.3m }));
+        _exchangeRates
+            .Setup(x => x.GetExistingDates("EUR", "PLN", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([d1, d2]);
+
+        var result = await CreateSut().BackfillAsync(TestContext.Current.CancellationToken);
+
+        _exchangeRates.Verify(
+            x => x.AddRange(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyCollection<(DateTime, decimal)>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        Assert.Equal(0, result.RowsInserted);
+        Assert.Equal(2, result.RowsSkipped);
+    }
+
+    [Fact]
+    public async Task RateLimitResponse_StopsFurtherProviderCalls()
+    {
+        SetupPairs(("USD", "PLN"), ("EUR", "PLN"));
+        _exchangeRates
+            .Setup(x => x.GetLatestDate(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DateTime?)null);
+        _fxSource
+            .Setup(x => x.GetDailyRatesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FxDailyResult.RateLimited);
+
+        var result = await CreateSut().BackfillAsync(TestContext.Current.CancellationToken);
+
+        // Two stale pairs, but the run stops after the first rate-limited response.
+        _fxSource.Verify(x => x.GetDailyRatesAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _exchangeRates.Verify(
+            x => x.AddRange(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyCollection<(DateTime, decimal)>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        Assert.True(result.RateLimited);
+    }
+
+    private void SetupPairs(params (string From, string To)[] pairs) =>
+        _discovery
+            .Setup(x => x.GetPairsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pairs.Select(p => new CurrencyPair(p.From, p.To)).ToList());
+}

--- a/code/FinanceManager.Tests.Unit/Application/Backfill/CurrencyRateBackfillServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Backfill/CurrencyRateBackfillServiceTests.cs
@@ -39,10 +39,11 @@ public class CurrencyRateBackfillServiceTests
     public async Task FreshPair_SkipsProviderCall()
     {
         SetupPairs(("USD", "PLN"));
-        // The newest stored date is today, so it is already at least the last closed market day.
+        // A date in the future is always at least the last closed market day, so the pair is fresh
+        // regardless of any UTC-day (or Sunday→Monday) rollover between fixture setup and the SUT run.
         _exchangeRates
             .Setup(x => x.GetLatestDate("USD", "PLN", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(DateTime.UtcNow.Date);
+            .ReturnsAsync(DateTime.UtcNow.Date.AddDays(1));
 
         var result = await CreateSut().BackfillAsync(TestContext.Current.CancellationToken);
 

--- a/code/FinanceManager.Tests.Unit/Application/Backfill/StockPriceBackfillServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Backfill/StockPriceBackfillServiceTests.cs
@@ -41,13 +41,17 @@ public class StockPriceBackfillServiceTests
             .Callback<DateTime, DateTime, CancellationToken>((start, end, _) => (capturedStart, capturedEnd) = (start, end))
             .ReturnsAsync(new InvestmentPriceBackfillResult(Listings: 5, Covered: 4, Uncovered: 1));
 
+        var before = DateTime.UtcNow.Date;
         var result = await CreateSut().BackfillAsync(TestContext.Current.CancellationToken);
+        var after = DateTime.UtcNow.Date;
 
         Assert.Equal(5, result.TargetsInspected);
         Assert.Equal(1, result.Failures);
 
-        // The window is [today - lookback, today].
-        Assert.Equal(DateTime.UtcNow.Date, capturedEnd);
-        Assert.Equal(DateTime.UtcNow.Date.AddDays(-30), capturedStart);
+        // The window is [end - lookback, end] where end is "today" at the moment the SUT ran. Bound
+        // the assertion by the clock before/after the call so a UTC-day rollover mid-test can't flake it.
+        Assert.NotNull(capturedEnd);
+        Assert.InRange(capturedEnd!.Value, before, after);
+        Assert.Equal(capturedEnd.Value.AddDays(-30), capturedStart);
     }
 }

--- a/code/FinanceManager.Tests.Unit/Application/Backfill/StockPriceBackfillServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Backfill/StockPriceBackfillServiceTests.cs
@@ -1,0 +1,53 @@
+using FinanceManager.Application.Assets.Pricing;
+using FinanceManager.Application.Backfill;
+using FinanceManager.Application.Shared.Options;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Backfill;
+
+[Trait("Category", "Unit")]
+public class StockPriceBackfillServiceTests
+{
+    private readonly Mock<IInvestmentPriceBackfillService> _backfill = new();
+    private readonly BackfillOptions _options = new() { StockPricesEnabled = true, StockLookbackDays = 30 };
+
+    private StockPriceBackfillService CreateSut() => new(
+        _backfill.Object,
+        Options.Create(_options),
+        NullLogger<StockPriceBackfillService>.Instance);
+
+    [Fact]
+    public async Task Disabled_DoesNotInvokeWrappedService()
+    {
+        _options.StockPricesEnabled = false;
+
+        var result = await CreateSut().BackfillAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(BackfillResult.Empty, result);
+        _backfill.Verify(
+            x => x.BackfillAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Enabled_RunsRollingWindowAndMapsResult()
+    {
+        DateTime? capturedStart = null;
+        DateTime? capturedEnd = null;
+        _backfill
+            .Setup(x => x.BackfillAsync(It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Callback<DateTime, DateTime, CancellationToken>((start, end, _) => (capturedStart, capturedEnd) = (start, end))
+            .ReturnsAsync(new InvestmentPriceBackfillResult(Listings: 5, Covered: 4, Uncovered: 1));
+
+        var result = await CreateSut().BackfillAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(5, result.TargetsInspected);
+        Assert.Equal(1, result.Failures);
+
+        // The window is [today - lookback, today].
+        Assert.Equal(DateTime.UtcNow.Date, capturedEnd);
+        Assert.Equal(DateTime.UtcNow.Date.AddDays(-30), capturedStart);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/ExchangeRateRepositoryBackfillTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/ExchangeRateRepositoryBackfillTests.cs
@@ -1,0 +1,73 @@
+using FinanceManager.Infrastructure.Contexts;
+using FinanceManager.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Tests.Unit.Infrastructure.Repositories;
+
+/// <summary>
+/// Covers the backfill-facing exchange-rate repository methods (issue #597): latest-date lookup,
+/// existing-date filtering and idempotent bulk insert. Uses the EF Core in-memory provider (which
+/// ignores unique indexes, so cross-instance duplicate rejection is left to the real database; here
+/// idempotency is asserted through the repository's own filter-before-insert path).
+/// </summary>
+[Collection("Infrastructure")]
+[Trait("Category", "Unit")]
+public class ExchangeRateRepositoryBackfillTests
+{
+    private static AppDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static readonly DateTime _d1 = new(2026, 7, 20, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime _d2 = new(2026, 7, 21, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime _d3 = new(2026, 7, 22, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task AddRange_InsertsOnlyMissingDates()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var context = CreateContext();
+        var repo = new ExchangeRateRepository(context);
+
+        await repo.Add("USD", "PLN", _d2, 4.0m, ct);
+
+        var inserted = await repo.AddRange("USD", "PLN",
+            [(_d1, 3.9m), (_d2, 4.0m), (_d3, 4.1m)], ct);
+
+        Assert.Equal(2, inserted);
+        var dates = (await repo.GetExistingDates("USD", "PLN", _d1, _d3, ct)).Select(d => d.Date).OrderBy(d => d).ToList();
+        Assert.Equal([_d1.Date, _d2.Date, _d3.Date], dates);
+    }
+
+    [Fact]
+    public async Task AddRange_RunAgain_IsIdempotent()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var context = CreateContext();
+        var repo = new ExchangeRateRepository(context);
+
+        var rates = new[] { (_d1, 3.9m), (_d2, 4.0m), (_d3, 4.1m) };
+
+        var first = await repo.AddRange("USD", "PLN", rates, ct);
+        var second = await repo.AddRange("USD", "PLN", rates, ct);
+
+        Assert.Equal(3, first);
+        Assert.Equal(0, second);
+        Assert.Equal(3, await context.ExchangeRates.CountAsync(ct));
+    }
+
+    [Fact]
+    public async Task GetLatestDate_ReturnsNewestStoredDate_OrNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var context = CreateContext();
+        var repo = new ExchangeRateRepository(context);
+
+        Assert.Null(await repo.GetLatestDate("USD", "PLN", ct));
+
+        await repo.AddRange("USD", "PLN", [(_d1, 3.9m), (_d3, 4.1m), (_d2, 4.0m)], ct);
+
+        Assert.Equal(_d3.Date, await repo.GetLatestDate("USD", "PLN", ct));
+    }
+}


### PR DESCRIPTION
## Summary

Adds an idempotent startup backfill pipeline that fills in missing historical **stock closing prices** and **currency exchange rates** from Alpha Vantage every time the API starts, without blocking API readiness.

closes #597

## What changed

**Common contract & orchestrator**
- New `IBackfillService` contract (`Name`, `Order`, `BackfillAsync`) plus a `BackfillResult` summary (inspected / requests / inserted / skipped / failures / rate-limited).
- New hosted `StartupBackfillBackgroundService` (Api): creates a DI scope, resolves all `IBackfillService`s, runs them **sequentially in deterministic order** after startup, logs start/duration/result per service, **isolates failures** (one failed service doesn't stop the rest), and honours host cancellation. Gated by `Backfill:RunOnStartup`.

**Stock price backfill**
- `StockPriceBackfillService` is a thin adapter over the existing `IInvestmentPriceBackfillService`/`InvestmentPriceProvider`, so the distinct-listing discovery, rate-limited Alpha Vantage → EODHD fallback chain, freshness check and idempotent upsert are reused, not duplicated. The existing queued/manual `PriceBackfillBackgroundService` flow is untouched.

**Currency exchange-rate backfill**
- `CurrencyRateBackfillService` + `CurrencyPairDiscoveryService`: discovers normalized pairs (each traded listing currency × each user preferred currency, GBX→GBP etc.), skips fresh pairs, calls Alpha Vantage `FX_DAILY` **once per stale pair** via the new `AlphaVantageFxClient` (reuses the shared Alpha Vantage config), queries existing dates in one op and **inserts only missing dates** in a batch.
- Weekend / same-UTC-day restarts don't re-hit the provider (freshness gate against the last closed market day). A quota/rate-limit response **stops further calls for the run**; already-inserted rows stay committed and resume idempotently on the next start.

**Persistence**
- `IExchangeRateRepository`: `GetLatestDate`, `GetExistingDates`, and an idempotent bulk `AddRange` (filters existing dates, single transaction, unique `(From, To, Date)` index as the final concurrency guard).
- `IUserRepository.GetDistinctPreferredCurrencyIds` (single grouped query).

**Configuration**
- New `Backfill` section (`RunOnStartup`, `StockPricesEnabled`, `CurrencyRatesEnabled`, lookback days). Enabled in Production, off in Development and in the integration test host.

## Tests

Unit tests added for: orchestrator (runs all in order, continues after a failure, stops on cancellation, respects `RunOnStartup`), currency-pair discovery (normalization + cross product), currency backfill (fresh skip, stale imports only missing dates, existing dates filtered, idempotent re-run, rate-limit stops the run), the stock wrapper, and the repository batch-insert/latest-date path.

- `dotnet build` — clean (warnings-as-errors)
- `dotnet format --verify-no-changes` — clean
- Unit tests — 633 passing
- Architecture tests — 9 passing

## Notes / trade-offs

- The stock adapter reports coverage per listing (from the reused service) rather than row-level insert/skip counts, so those `BackfillResult` fields are 0 for stocks and the covered/total is logged instead.
- Cross-instance duplicate rejection relies on the DB unique index; the EF InMemory provider used by tests ignores it, so idempotency is asserted through the repository's filter-before-insert path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwHSFFkKmu76QX32yUB5i2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional startup backfill for stock prices and currency exchange rates.
  * Added configurable lookback periods and independent enablement controls.
  * Currency rates now automatically cover required trading and preferred-currency pairs.
  * Backfills skip existing data, handle provider rate limits, and continue safely after individual failures.
  * Added idempotent exchange-rate updates to prevent duplicate daily records.
* **Tests**
  * Added coverage for startup execution, cancellation, ordering, currency-pair discovery, backfill behavior, and duplicate prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->