### PR TITLE
Fix investment gain/loss showing +0.00 #600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- Investment account **asset appreciation** no longer shows `+0.00` when a holding's purchase-date exchange rate is missing. The account details page now shows the **capital value** (remaining buy cost) and the **current valuation** side by side and derives the gain/loss as their difference; when a trade-date rate is unavailable the capital value falls back to the current rate for the same pair instead of dropping the holding from the totals. #600
 - Dashboard time-series charts now scale to the displayed values with padding, making smaller changes clearly visible. #574
 - CSV files can now be imported into cash and bond accounts without the upload failing while the browser reads the selected file, including exports encoded as Windows-1250. #571
 - The **Category** filter button on cash account details now opens its dropdown again, so transactions can be filtered by category. #567

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Assets/AssetsServiceInvestment.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Assets/AssetsServiceInvestment.cs
@@ -119,11 +119,7 @@ internal class AssetsServiceInvestment(
                 var missingExchangeRate = false;
                 foreach (var buy in buys)
                 {
-                    var sourceCurrency = new Currency { ShortName = buy.Currency, Symbol = buy.Currency };
-                    var exchangeRate = string.Equals(buy.Currency, currency.ShortName, StringComparison.OrdinalIgnoreCase)
-                        ? 1m
-                        : await currencyExchangeService.GetExchangeRateAsync(
-                            sourceCurrency, currency, buy.TradeDate.ToDateTime(TimeOnly.MinValue));
+                    var exchangeRate = await GetBuyExchangeRateAsync(buy, currency, asOfDate);
                     if (exchangeRate is not decimal rate || rate <= 0m)
                     {
                         missingExchangeRate = true;
@@ -192,5 +188,25 @@ internal class AssetsServiceInvestment(
         }
 
         return results;
+    }
+
+    // The capital value of a holding is its remaining buy cost converted into the target currency at
+    // the trade-date rate. Historical FX rates are sometimes missing (old trades, thinly-quoted pairs),
+    // and dropping the whole holding from the totals in that case is exactly what made an account's
+    // capital value — and therefore its gain/loss — collapse to 0 even while the position was still
+    // valued fine. Fall back to the as-of-date rate for the same pair so the position keeps a
+    // best-effort capital value instead of being excluded.
+    private async Task<decimal?> GetBuyExchangeRateAsync(InvestmentTransaction buy, Currency targetCurrency, DateTime asOfDate)
+    {
+        if (string.Equals(buy.Currency, targetCurrency.ShortName, StringComparison.OrdinalIgnoreCase))
+            return 1m;
+
+        var sourceCurrency = new Currency { ShortName = buy.Currency, Symbol = buy.Currency };
+        var tradeDateRate = await currencyExchangeService.GetExchangeRateAsync(
+            sourceCurrency, targetCurrency, buy.TradeDate.ToDateTime(TimeOnly.MinValue));
+        if (tradeDateRate is decimal rate && rate > 0m)
+            return rate;
+
+        return await currencyExchangeService.GetExchangeRateAsync(sourceCurrency, targetCurrency, asOfDate);
     }
 }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
@@ -65,10 +65,8 @@ else
             {
                 <MudItem lg="4">
                     <MudStack Spacing="4">
-                        <BalanceChangeCard BalanceChange="@_balanceChange" Currency="@_currency.ShortName"
-                                           Label="Asset appreciation" ShowRange="false"
-                                           Description="Current value minus remaining buy cost"
-                                           RangeLabel="@_selectedRange" FromDate="@_dateStart" ToDate="@_dateEnd" />
+                        <AppreciationBreakdownCard CapitalValue="@_capitalValue" CurrentValue="@_currentValue"
+                                                   Currency="@_currency.ShortName" Label="Asset appreciation" />
 
                         @HoldingsCard
 
@@ -91,10 +89,8 @@ else
             </MudStack>
             <MudDivider />
             <MudStack Spacing="4" Class="pa-4">
-                <BalanceChangeCard BalanceChange="@_balanceChange" Currency="@_currency.ShortName"
-                                   Label="Asset appreciation" ShowRange="false"
-                                   Description="Current value minus remaining buy cost" RangeLabel="@_selectedRange"
-                                   FromDate="@_dateStart" ToDate="@_dateEnd" />
+                <AppreciationBreakdownCard CapitalValue="@_capitalValue" CurrentValue="@_currentValue"
+                                           Currency="@_currency.ShortName" Label="Asset appreciation" />
 
                 @HoldingsCard
 

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -48,6 +48,8 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
     private bool _isChartLoading;
     private int _chartRefreshVersion;
     private decimal _currentBalance;
+    private decimal _capitalValue;
+    private decimal _currentValue;
     private decimal _balanceChange;
     private decimal? _balanceChangePercent;
     public List<TimeSeriesModel> ChartData { get; set; } = [];
@@ -221,8 +223,14 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
         UnrealizedGainLossAccountResult? appreciation)
     {
         _currentBalance = balanceSeries.LastOrDefault()?.Value ?? 0;
-        _balanceChange = appreciation?.UnrealizedGainLoss ?? 0m;
-        _balanceChangePercent = appreciation is null ? null : appreciation.UnrealizedGainLossPercent;
+
+        // Capital value (remaining buy cost) and current valuation are the two source-of-truth
+        // figures; the gain/loss shown in the hero and the breakdown card is derived purely from
+        // their difference so the number can never disagree with the two amounts on display.
+        _capitalValue = appreciation?.CostBasis ?? 0m;
+        _currentValue = appreciation?.CurrentValue ?? 0m;
+        _balanceChange = _currentValue - _capitalValue;
+        _balanceChangePercent = _capitalValue == 0m ? null : _balanceChange / _capitalValue * 100m;
     }
 
     private void UpdateHoldings(IReadOnlyDictionary<long, decimal> holdings, DateTime asOf)

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AppreciationBreakdownCard.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AppreciationBreakdownCard.razor
@@ -1,0 +1,53 @@
+@namespace FinanceManager.Components.Components.Features.FinancialAccounts.Shared
+
+@{
+    var gain = CurrentValue - CapitalValue;
+    var gainPercent = CapitalValue == 0 ? (decimal?)null : gain / CapitalValue * 100m;
+    var gainColor = gain >= 0 ? Color.Success : Color.Error;
+}
+
+<MudCard Outlined="true" Style="background-color: transparent;">
+    <MudCardContent>
+        <MudText Typo="Typo.overline" Color="Color.Default">@Label</MudText>
+
+        <MudStack Spacing="1" Class="mt-2">
+            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+                <MudText Typo="Typo.body2" Color="Color.Default">Capital value</MudText>
+                <MudText Typo="Typo.body1" Class="fm-tabular">@CapitalValue.ToString("N2") @Currency</MudText>
+            </MudStack>
+            <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+                <MudText Typo="Typo.body2" Color="Color.Default">Current valuation</MudText>
+                <MudText Typo="Typo.body1" Class="fm-tabular">@CurrentValue.ToString("N2") @Currency</MudText>
+            </MudStack>
+        </MudStack>
+
+        <MudDivider Class="my-3" />
+
+        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+            <MudIcon Size="Size.Small"
+                     Icon="@(gain >= 0 ? Icons.Material.Filled.TrendingUp : Icons.Material.Filled.TrendingDown)"
+                     Color="@gainColor" />
+            <MudText Typo="Typo.h5" Class="fm-tabular" Color="@gainColor">
+                @(gain >= 0 ? "+" : "")@gain.ToString("N2") @Currency
+            </MudText>
+            @if (gainPercent.HasValue)
+            {
+                <MudText Typo="Typo.body2" Color="Color.Default" Class="fm-tabular">
+                    · @(gain >= 0 ? "+" : "")@gainPercent.Value.ToString("0.0")%
+                </MudText>
+            }
+        </MudStack>
+
+        <MudText Typo="Typo.caption" Color="Color.Default" Class="mt-1">
+            @(Description ?? "Current valuation minus capital value")
+        </MudText>
+    </MudCardContent>
+</MudCard>
+
+@code {
+    [Parameter] public decimal CapitalValue { get; set; }
+    [Parameter] public decimal CurrentValue { get; set; }
+    [Parameter] public required string Currency { get; set; }
+    [Parameter] public string Label { get; set; } = "Asset appreciation";
+    [Parameter] public string? Description { get; set; }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/AssetsServiceInvestmentTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/AssetsServiceInvestmentTests.cs
@@ -78,4 +78,64 @@ public class AssetsServiceInvestmentTests
         Assert.Equal(2500m, result.CurrentValue);
         Assert.Equal(460m, result.UnrealizedGainLoss);
     }
+
+    [Fact]
+    public async Task GetUnrealizedGainLossPerAccount_FallsBackToAsOfRate_WhenTradeDateRateMissing()
+    {
+        var accountRepository = new Mock<IFinancialAccountRepository>();
+        var transactionRepository = new Mock<IInvestmentTransactionRepository>();
+        var priceProvider = new Mock<IInvestmentPriceProvider>();
+        var exchangeService = new Mock<ICurrencyExchangeService>();
+        var valuationService = new Mock<IInvestmentValuationService>();
+        var account = new InvestmentAccount(1, 7, "Broker");
+        var tradeDate = new DateOnly(2026, 1, 10);
+        var asOfDate = new DateTime(2026, 7, 23);
+        var listing = new AssetListing { Id = 11, Ticker = "CSPX" };
+        var transactions = new List<InvestmentTransaction>
+        {
+            new()
+            {
+                AccountId = account.AccountId,
+                AssetListingId = listing.Id,
+                AssetListing = listing,
+                Type = InvestmentTransactionType.Buy,
+                Quantity = 10m,
+                UnitPrice = 100m,
+                Currency = "USD",
+                TradeDate = tradeDate,
+            },
+        };
+
+        accountRepository
+            .Setup(x => x.GetAccounts<InvestmentAccount>(1, DateTime.MinValue, It.IsAny<DateTime>()))
+            .Returns(new[] { account }.ToAsyncEnumerable());
+        transactionRepository.Setup(x => x.GetByAccount(account.AccountId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(transactions);
+        priceProvider.Setup(x => x.GetPricePerUnitAsync(listing.Id, DefaultCurrency.PLN, It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(500m);
+
+        // The trade-date rate is unavailable (returns null); only the as-of-date rate is known.
+        exchangeService.Setup(x => x.GetExchangeRateAsync(
+                It.Is<Currency>(c => c.ShortName == "USD"), DefaultCurrency.PLN,
+                tradeDate.ToDateTime(TimeOnly.MinValue)))
+            .ReturnsAsync((decimal?)null);
+        exchangeService.Setup(x => x.GetExchangeRateAsync(
+                It.Is<Currency>(c => c.ShortName == "USD"), DefaultCurrency.PLN, asOfDate))
+            .ReturnsAsync(4m);
+
+        var service = new AssetsServiceInvestment(
+            accountRepository.Object,
+            valuationService.Object,
+            transactionRepository.Object,
+            priceProvider.Object,
+            exchangeService.Object);
+
+        var result = Assert.Single(await service.GetUnrealizedGainLossPerAccount(1, DefaultCurrency.PLN, asOfDate));
+
+        // Capital value falls back to the as-of rate (10 * 100 * 4) instead of collapsing to zero,
+        // so gain/loss is a real figure: 5000 current value - 4000 capital value = 1000.
+        Assert.Equal(4000m, result.CostBasis);
+        Assert.Equal(5000m, result.CurrentValue);
+        Assert.Equal(1000m, result.UnrealizedGainLoss);
+    }
 }


### PR DESCRIPTION
## Summary

The investment account details page showed **Asset appreciation** as `+0.00 PLN · +0.0%` even when the account held a real balance (e.g. `34,220.60 PLN`).

The gain came from `AssetsServiceInvestment.GetUnrealizedGainLossPerInstrument`, which marks a holding `IsExcludedFromTotals` whenever a buy's **trade-date** FX rate is missing. `GetUnrealizedGainLossPerAccount` then drops every excluded holding, so cost basis and current value both sum to `0` and the gain collapses to exactly `0.00`. The value-series path that renders the displayed balance has FX fallbacks the gain path lacked, which is why the balance rendered while appreciation zeroed out.

This reworks the feature around the two figures the user actually wants to see:

1. **Capital value** — remaining buy cost of open holdings.
2. **Current valuation** — current market value.
3. **Gain/loss** is derived purely as `current valuation − capital value`, so it can never disagree with the two amounts on display.

## Changes

- **`AssetsServiceInvestment`**: a missing trade-date FX rate now falls back to the as-of-date rate for the same pair (new `GetBuyExchangeRateAsync` helper) instead of excluding the holding, so the capital value no longer collapses to zero.
- **`AppreciationBreakdownCard`** (new shared component): shows capital value and current valuation side by side and derives the coloured gain/loss + percentage from their difference.
- **`InvestmentAccountDetailsPageContent`**: tracks capital value and current valuation from the appreciation result and derives the hero's change from them; both the desktop sidebar and the mobile insights drawer now use the new card.

## Testing

- `dotnet build ./code/FinanceManager.slnx` — clean (warnings-as-errors).
- `dotnet test` unit suite — 635 passing, including a new test that a missing trade-date rate falls back to the as-of rate instead of zeroing the totals.
- `dotnet format` — no changes.
- Rendered on the guest account (desktop + mobile drawer): the card shows Capital value, Current valuation, and a non-zero derived gain/loss.

Closes #600

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMhdaWxqGBS7YKVoM8JeVt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an appreciation breakdown to investment account details, showing capital value, current valuation, gain or loss, and percentage change.
  * Updated appreciation figures to reflect the investment’s capital value and current valuation.

* **Bug Fixes**
  * Investment gain and loss calculations now fall back to the as-of-date exchange rate when the trade-date rate is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->