### PR TITLE
Show loading skeleton and gain/loss on investment transactions page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- The investment account details page now shows loading placeholders for the balance and asset appreciation (and the capital value / current valuation breakdown) while those figures are still being calculated, instead of briefly displaying a misleading `0.00`.
+- The investment transaction list now leads each purchase with its unrealised gain/loss (amount and percentage) rather than the original cash outlay; sells and not-yet-priced trades continue to show their cash impact.
 - MCP access tokens and grants can now be revoked server-side, and deployment guidance covers secure certificate configuration and rotation. #584
 - Investment accounts now show asset appreciation based on current holdings value minus the remaining buy cost, with transaction-date currency conversion. #578
 - The **Investment rate** chart is now interactive: selecting a month highlights its bar and shows that month's salary and invested amount, while the average line displays its value. #576

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
@@ -90,7 +90,7 @@ else
             <MudDivider />
             <MudStack Spacing="4" Class="pa-4">
                 <AppreciationBreakdownCard CapitalValue="@_capitalValue" CurrentValue="@_currentValue"
-                                           Currency="@_currency.ShortName" Label="Asset appreciation" />
+                                           Currency="@_currency.ShortName" Label="Asset appreciation" IsLoading="@_isChartLoading" />
 
                 @HoldingsCard
 

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
@@ -22,7 +22,7 @@ else
 {
     <AccountDetailsHero AccountName="@_accountName" AccountTypeLabel="@_accountTypeLabel" Currency="@_currency.ShortName"
                         Balance="@_currentBalance" BalanceChange="@_balanceChange" BalanceChangePercent="@_balanceChangePercent"
-                        ChangeLabel="Asset appreciation" ShowChangeRange="false"
+                        ChangeLabel="Asset appreciation" ShowChangeRange="false" IsBalanceLoading="@_isChartLoading"
                         SelectedRange="@_selectedRange" SelectedRangeChanged="OnRangeChanged" IsChartLoading="@_isChartLoading"
                         CustomDateRange="@_customDateRange" CustomDateRangeChanged="OnCustomDateRangeChanged"
                         ChartData="@ChartData" IsMobile="@_isMobile" />
@@ -66,7 +66,7 @@ else
                 <MudItem lg="4">
                     <MudStack Spacing="4">
                         <AppreciationBreakdownCard CapitalValue="@_capitalValue" CurrentValue="@_currentValue"
-                                                   Currency="@_currency.ShortName" Label="Asset appreciation" />
+                                                   Currency="@_currency.ShortName" Label="Asset appreciation" IsLoading="@_isChartLoading" />
 
                         @HoldingsCard
 

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentDayGroupCard.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentDayGroupCard.razor
@@ -60,12 +60,23 @@
 
     // A day-level net only makes sense when every trade settles in the same currency; otherwise the sum
     // would mix units. When mixed, the header suppresses the aggregate instead of showing a wrong total.
-    private bool IsSingleCurrency => TransactionList.Select(t => t.Currency).Distinct().Count() <= 1;
+    // Currency is taken from each row's displayed figure so the header always matches the sum of the rows.
+    private bool IsSingleCurrency => TransactionList.Select(DisplayCurrency).Distinct().Count() <= 1;
 
-    private string DayCurrency => TransactionList.FirstOrDefault()?.Currency ?? Currency;
+    private string DayCurrency => TransactionList.Select(DisplayCurrency).FirstOrDefault() ?? Currency;
 
-    // Daily net cash impact: sells add cash (gross minus fee), buys remove cash (gross plus fee).
-    private decimal DailyNet => TransactionList.Sum(CashImpact);
+    // The header aggregates whatever each row shows: unrealised gain/loss for priced purchases, cash
+    // impact for everything else. This keeps a single-trade day's header identical to its one row.
+    private decimal DailyNet => TransactionList.Sum(DisplayAmount);
+
+    private bool ShowGainLoss(InvestmentTransactionDto t) =>
+        t.Type == InvestmentTransactionType.Buy && GetValuation(t.Id) is { HasCurrentPrice: true };
+
+    private decimal DisplayAmount(InvestmentTransactionDto t) =>
+        ShowGainLoss(t) ? GetValuation(t.Id)!.GainLoss : CashImpact(t);
+
+    private string DisplayCurrency(InvestmentTransactionDto t) =>
+        ShowGainLoss(t) ? GetValuation(t.Id)!.Currency : t.Currency;
 
     private static decimal CashImpact(InvestmentTransactionDto t)
     {

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentTransactionRow.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentTransactionRow.razor
@@ -28,11 +28,17 @@
             </MudStack>
         </MudStack>
 
-        <MudText Typo="Typo.body1" Class="fm-tabular"
-                 Color="@(CashImpact >= 0 ? Color.Success : Color.Error)"
-                 Style="flex-shrink: 0;">
-            @(CashImpact >= 0 ? "+" : "")@CashImpact.ToString("N2") @Transaction.Currency
-        </MudText>
+        <MudStack Spacing="0" AlignItems="AlignItems.End" Style="flex-shrink: 0;">
+            <MudText Typo="Typo.body1" Class="fm-tabular"
+                     Color="@(PrimaryAmount >= 0 ? Color.Success : Color.Error)">
+                @(PrimaryAmount >= 0 ? "+" : "")@PrimaryAmount.ToString("N2") @PrimaryCurrency
+            </MudText>
+            <MudText Typo="Typo.caption" Color="Color.Default">
+                @(ShowGainLoss
+                    ? $"Gain / loss · {(Valuation!.GainLoss >= 0 ? "+" : "")}{Valuation.GainLossPercent.ToString("N2")}%"
+                    : "Cash impact")
+            </MudText>
+        </MudStack>
     </MudStack>
 </div>
 

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentTransactionRow.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentTransactionRow.razor.cs
@@ -31,6 +31,14 @@ public partial class InvestmentTransactionRow
         ? GrossValue - (Transaction.Fee ?? 0m)
         : -(GrossValue + (Transaction.Fee ?? 0m));
 
+    // The overview line leads with unrealised performance for priced purchases — what the position is
+    // worth now versus what it cost — because that answers "how is this doing?" more naturally than the
+    // purchase outlay. Sells and not-yet-priced buys have no gain/loss figure, so they fall back to the
+    // trade's cash impact, which is the only amount available for them.
+    private bool ShowGainLoss => Transaction.Type == InvestmentTransactionType.Buy && Valuation is { HasCurrentPrice: true };
+    private decimal PrimaryAmount => ShowGainLoss ? Valuation!.GainLoss : CashImpact;
+    private string PrimaryCurrency => ShowGainLoss ? Valuation!.Currency : Transaction.Currency;
+
     private void ToggleExpanded() => _expanded = !_expanded;
 
     private void OnKeyDown(KeyboardEventArgs e)

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor
@@ -46,31 +46,45 @@
             <MudStack Row="true" AlignItems="AlignItems.End" Justify="Justify.SpaceBetween" Spacing="4">
                 <MudStack Spacing="1">
                     <MudText Typo="Typo.overline" Color="MudBlazor.Color.Default">Balance</MudText>
-                    <MudStack Row="true" AlignItems="AlignItems.Baseline" Spacing="1">
-                        <MudText Typo="Typo.h3" Class="fm-tabular">@Balance.ToString("N2")</MudText>
-                        <MudText Typo="Typo.h5" Color="MudBlazor.Color.Default">@Currency</MudText>
-                    </MudStack>
+                    @if (IsBalanceLoading)
+                    {
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Animation="Animation.Wave" Width="180px" Height="60px" />
+                    }
+                    else
+                    {
+                        <MudStack Row="true" AlignItems="AlignItems.Baseline" Spacing="1">
+                            <MudText Typo="Typo.h3" Class="fm-tabular">@Balance.ToString("N2")</MudText>
+                            <MudText Typo="Typo.h5" Color="MudBlazor.Color.Default">@Currency</MudText>
+                        </MudStack>
+                    }
                 </MudStack>
 
                 <MudStack Spacing="1" AlignItems="AlignItems.End">
                     <MudText Typo="Typo.overline" Color="MudBlazor.Color.Default">@ChangeLabel@(ShowChangeRange ? $" · {SelectedRange}" : null)</MudText>
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                        <MudIcon
-                        Icon="@(BalanceChange >= 0 ? Icons.Material.Filled.TrendingUp : Icons.Material.Filled.TrendingDown)"
-                        Color="@(BalanceChange >= 0 ? MudBlazor.Color.Success : MudBlazor.Color.Error)"
-                        Size="MudBlazor.Size.Small" />
-                        <MudText Typo="Typo.h6"
-                                 Color="@(BalanceChange >= 0 ? MudBlazor.Color.Success : MudBlazor.Color.Error)"
-                                 Class="fm-tabular">
-                            @(BalanceChange >= 0 ? "+" : "")@BalanceChange.ToString("N2") @Currency
-                        </MudText>
-                        @if (BalanceChangePercent.HasValue)
-                        {
-                            <MudText Typo="Typo.body2" Color="MudBlazor.Color.Default" Class="fm-tabular">
-                                · @(BalanceChange >= 0 ? "+" : "")@BalanceChangePercent.Value.ToString("0.0")%
+                    @if (IsBalanceLoading)
+                    {
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Animation="Animation.Wave" Width="120px" Height="40px" />
+                    }
+                    else
+                    {
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                            <MudIcon
+                            Icon="@(BalanceChange >= 0 ? Icons.Material.Filled.TrendingUp : Icons.Material.Filled.TrendingDown)"
+                            Color="@(BalanceChange >= 0 ? MudBlazor.Color.Success : MudBlazor.Color.Error)"
+                            Size="MudBlazor.Size.Small" />
+                            <MudText Typo="Typo.h6"
+                                     Color="@(BalanceChange >= 0 ? MudBlazor.Color.Success : MudBlazor.Color.Error)"
+                                     Class="fm-tabular">
+                                @(BalanceChange >= 0 ? "+" : "")@BalanceChange.ToString("N2") @Currency
                             </MudText>
-                        }
-                    </MudStack>
+                            @if (BalanceChangePercent.HasValue)
+                            {
+                                <MudText Typo="Typo.body2" Color="MudBlazor.Color.Default" Class="fm-tabular">
+                                    · @(BalanceChange >= 0 ? "+" : "")@BalanceChangePercent.Value.ToString("0.0")%
+                                </MudText>
+                            }
+                        </MudStack>
+                    }
                 </MudStack>
             </MudStack>
         </MudStack>

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AccountDetailsHero.razor.cs
@@ -21,6 +21,12 @@ public partial class AccountDetailsHero
     [Parameter] public DateRange? CustomDateRange { get; set; }
     [Parameter] public EventCallback<DateRange?> CustomDateRangeChanged { get; set; }
     [Parameter] public bool IsChartLoading { get; set; }
+
+    // Some account types (investments) only know their balance/appreciation after an async
+    // valuation call that resolves after the transaction list has already rendered. While that
+    // is in flight this shows a skeleton in place of a misleading 0.00 figure. Left false by
+    // callers whose balance is known synchronously.
+    [Parameter] public bool IsBalanceLoading { get; set; }
     [Parameter] public List<TimeSeriesModel> ChartData { get; set; } = [];
     [Parameter] public bool IsMobile { get; set; }
 

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AppreciationBreakdownCard.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/Shared/AppreciationBreakdownCard.razor
@@ -13,30 +13,51 @@
         <MudStack Spacing="1" Class="mt-2">
             <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
                 <MudText Typo="Typo.body2" Color="Color.Default">Capital value</MudText>
-                <MudText Typo="Typo.body1" Class="fm-tabular">@CapitalValue.ToString("N2") @Currency</MudText>
+                @if (IsLoading)
+                {
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Animation="Animation.Wave" Width="90px" />
+                }
+                else
+                {
+                    <MudText Typo="Typo.body1" Class="fm-tabular">@CapitalValue.ToString("N2") @Currency</MudText>
+                }
             </MudStack>
             <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
                 <MudText Typo="Typo.body2" Color="Color.Default">Current valuation</MudText>
-                <MudText Typo="Typo.body1" Class="fm-tabular">@CurrentValue.ToString("N2") @Currency</MudText>
+                @if (IsLoading)
+                {
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Animation="Animation.Wave" Width="90px" />
+                }
+                else
+                {
+                    <MudText Typo="Typo.body1" Class="fm-tabular">@CurrentValue.ToString("N2") @Currency</MudText>
+                }
             </MudStack>
         </MudStack>
 
         <MudDivider Class="my-3" />
 
-        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-            <MudIcon Size="Size.Small"
-                     Icon="@(gain >= 0 ? Icons.Material.Filled.TrendingUp : Icons.Material.Filled.TrendingDown)"
-                     Color="@gainColor" />
-            <MudText Typo="Typo.h5" Class="fm-tabular" Color="@gainColor">
-                @(gain >= 0 ? "+" : "")@gain.ToString("N2") @Currency
-            </MudText>
-            @if (gainPercent.HasValue)
-            {
-                <MudText Typo="Typo.body2" Color="Color.Default" Class="fm-tabular">
-                    · @(gain >= 0 ? "+" : "")@gainPercent.Value.ToString("0.0")%
+        @if (IsLoading)
+        {
+            <MudSkeleton SkeletonType="SkeletonType.Text" Animation="Animation.Wave" Width="140px" Height="40px" />
+        }
+        else
+        {
+            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                <MudIcon Size="Size.Small"
+                         Icon="@(gain >= 0 ? Icons.Material.Filled.TrendingUp : Icons.Material.Filled.TrendingDown)"
+                         Color="@gainColor" />
+                <MudText Typo="Typo.h5" Class="fm-tabular" Color="@gainColor">
+                    @(gain >= 0 ? "+" : "")@gain.ToString("N2") @Currency
                 </MudText>
-            }
-        </MudStack>
+                @if (gainPercent.HasValue)
+                {
+                    <MudText Typo="Typo.body2" Color="Color.Default" Class="fm-tabular">
+                        · @(gain >= 0 ? "+" : "")@gainPercent.Value.ToString("0.0")%
+                    </MudText>
+                }
+            </MudStack>
+        }
 
         <MudText Typo="Typo.caption" Color="Color.Default" Class="mt-1">
             @(Description ?? "Current valuation minus capital value")
@@ -50,4 +71,5 @@
     [Parameter] public required string Currency { get; set; }
     [Parameter] public string Label { get; set; } = "Asset appreciation";
     [Parameter] public string? Description { get; set; }
+    [Parameter] public bool IsLoading { get; set; }
 }


### PR DESCRIPTION
## Summary

Two UX improvements to the investment account details page.

### 1. Loading placeholders instead of a misleading `0.00`

The balance, asset appreciation, and the capital-value / current-valuation breakdown are computed by an asynchronous valuation call that resolves **after** the transaction list has already rendered. Until it completed, the page showed `0.00 PLN` / `+0.00 PLN`, which reads as a real (wrong) value.

While that calculation is in flight the hero balance, the asset-appreciation figure, and the breakdown card now show `MudSkeleton` placeholders. A new `IsBalanceLoading` parameter on the shared `AccountDetailsHero` (defaulting to `false`) and an `IsLoading` parameter on `AppreciationBreakdownCard` gate this — only the investment page opts in, so the currency and bond pages (whose balance is known synchronously) are unchanged.

### 2. Gain/loss instead of purchase price in the transaction overview

Each purchase row led with its original cash outlay (e.g. `-659.71 USD`), which isn't the most natural thing to see at a glance. Rows now lead with the position's **unrealised gain/loss** (amount + percentage, coloured by sign) for priced purchases, with a `Gain / loss · +x%` caption. Sells and not-yet-priced buys have no gain/loss figure, so they fall back to their cash impact (captioned `Cash impact`). The day-group header aggregates the same per-row figures, so a single-trade day's header always matches its row. The expanded detail view is unchanged and still shows the full purchase value / current price / valuation / gain-loss breakdown.

## Verification

- `dotnet build ./code/FinanceManager.slnx` — clean (warnings-as-errors).
- `dotnet format` — no changes.
- `dotnet test` unit project — 635 passed.
- Rendered on the guest demo account (mobile + desktop): loaded state shows gain/loss per row and the real balance; a network-delayed run confirms the skeletons appear in place of `0.00` while valuations load.

## Notes

No GitHub issue is associated with this work, so the changelog entries (under `Changed`) omit an issue reference per the changelog rules.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EYmuEUA7jF8kHYyNDpj9zP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading placeholders for investment account balances, changes, and appreciation details while data is being retrieved.
  * Investment transaction summaries now show gain/loss for priced purchases and cash impact when valuation data is unavailable.
  * Transaction day headers now stay consistent with the amounts and currencies shown in individual rows.

* **Bug Fixes**
  * Prevented misleading zero-value balances from appearing while investment valuations are still loading.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->