### PR TITLE
Clarify investment valuation labels and add same metrics to bond details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Expanding a bond entry now shows the same valuation breakdown as investment purchases: the unit price and the position's value at the posting date versus now, plus the accrued gain/loss in amount and percentage. Figures come from the bond's own interest-accrual model and are shown in the bond's currency; the breakdown is hidden when the bond has no calculation method covering the dates so no misleading zero is shown.
 - The API now backfills historical stock closing prices and currency exchange rates in the background each time it starts, filling in any missing daily points from Alpha Vantage so charts and valuations stay complete without waiting for the weekly schedule. Runs are idempotent (existing rows are never overwritten or duplicated), skip instruments and currency pairs that are already up to date, avoid needless calls over weekends or on restarts the same day, and stop gracefully when the provider's rate limit is reached — resuming on the next start. Startup backfill can be turned off or tuned per dataset via the `Backfill` configuration section. #597
 - Expanding an investment purchase now shows its value on the purchase date, the current market price and valuation, and the gain/loss in both amount and percentage — converted to your preferred currency using the historical rate for the purchase and the latest rate for the current value, or shown in the instrument's own currency when no rate is available. #596
 - Connected AI clients can now read the signed-in user's financial accounts, filtered transaction history, investment positions and valuations, currencies, and financial labels through owner-isolated MCP tools. #590
@@ -24,6 +25,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- The expanded investment purchase details now label the valuation figures more clearly — pairing the unit price at purchase with the current unit price, and the value at purchase with the current value — so a per-unit price is no longer shown alongside position totals under ambiguous "Current price"/"Current valuation" labels.
 - The investment account details page now shows loading placeholders for the balance and asset appreciation (and the capital value / current valuation breakdown) while those figures are still being calculated, instead of briefly displaying a misleading `0.00`.
 - The investment transaction list now leads each purchase with its unrealised gain/loss (amount and percentage) rather than the original cash outlay; sells and not-yet-priced trades continue to show their cash impact.
 - MCP access tokens and grants can now be revoked server-side, and deployment guidance covers secure certificate configuration and rotation. #584

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentTransactionValuationService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentTransactionValuationService.cs
@@ -50,6 +50,9 @@ internal class InvestmentTransactionValuationService(
             var displayCurrency = converted ? targetCurrency : new Currency { ShortName = transaction.Currency, Symbol = transaction.Currency };
 
             var purchaseValue = converted ? purchaseValueInTradeCurrency * purchaseRate!.Value : purchaseValueInTradeCurrency;
+            // Per-unit purchase price in the display currency, so it can be compared like-for-like
+            // against the current unit price below.
+            var purchaseUnitPrice = converted ? transaction.UnitPrice * purchaseRate!.Value : transaction.UnitPrice;
 
             // Current price is fetched already denominated in the display currency: the provider
             // applies the latest exchange rate for us, matching "latest rate for current valuation".
@@ -62,6 +65,7 @@ internal class InvestmentTransactionValuationService(
 
             results.Add(new InvestmentTransactionValuationDto(
                 transaction.Id,
+                purchaseUnitPrice,
                 purchaseValue,
                 currentPrice,
                 currentValuation,

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondTransactionRow.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondTransactionRow.razor
@@ -67,6 +67,36 @@
                     <MudText Typo="Typo.body2">@BondDetails.UnitValue.ToString("0.00") @BondDetails.Currency.ShortName</MudText>
                 </MudItem>
             }
+            @if (_showValuation)
+            {
+                <MudItem xs="12">
+                    <MudDivider Class="my-1" Style="border-style: dashed;" />
+                </MudItem>
+                <MudItem xs="6">
+                    <MudText Typo="Typo.caption" Color="Color.Default">Unit price at purchase</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular">@_unitPricePurchase.ToString("N2") @_valuationCurrency</MudText>
+                </MudItem>
+                <MudItem xs="6">
+                    <MudText Typo="Typo.caption" Color="Color.Default">Unit price now</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular">@_unitPriceNow.ToString("N2") @_valuationCurrency</MudText>
+                </MudItem>
+                <MudItem xs="6">
+                    <MudText Typo="Typo.caption" Color="Color.Default">Value at purchase</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular">@_valuePurchase.ToString("N2") @_valuationCurrency</MudText>
+                </MudItem>
+                <MudItem xs="6">
+                    <MudText Typo="Typo.caption" Color="Color.Default">Value now</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular">@_valueNow.ToString("N2") @_valuationCurrency</MudText>
+                </MudItem>
+                <MudItem xs="12">
+                    <MudText Typo="Typo.caption" Color="Color.Default">Gain / loss</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular"
+                             Color="@(_gainLoss >= 0 ? Color.Success : Color.Error)">
+                        @(_gainLoss >= 0 ? "+" : "")@_gainLoss.ToString("N2") @_valuationCurrency
+                        (@(_gainLoss >= 0 ? "+" : "")@_gainLossPercent.ToString("N2")%)
+                    </MudText>
+                </MudItem>
+            }
             @if (Entry.Labels is not null && Entry.Labels.Any())
             {
                 <MudItem xs="6">

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondTransactionRow.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondTransactionRow.razor
@@ -73,16 +73,16 @@
                     <MudDivider Class="my-1" Style="border-style: dashed;" />
                 </MudItem>
                 <MudItem xs="6">
-                    <MudText Typo="Typo.caption" Color="Color.Default">Unit price at purchase</MudText>
-                    <MudText Typo="Typo.body2" Class="fm-tabular">@_unitPricePurchase.ToString("N2") @_valuationCurrency</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Default">Unit price at transaction</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular">@_unitPriceAtPosting.ToString("N2") @_valuationCurrency</MudText>
                 </MudItem>
                 <MudItem xs="6">
                     <MudText Typo="Typo.caption" Color="Color.Default">Unit price now</MudText>
                     <MudText Typo="Typo.body2" Class="fm-tabular">@_unitPriceNow.ToString("N2") @_valuationCurrency</MudText>
                 </MudItem>
                 <MudItem xs="6">
-                    <MudText Typo="Typo.caption" Color="Color.Default">Value at purchase</MudText>
-                    <MudText Typo="Typo.body2" Class="fm-tabular">@_valuePurchase.ToString("N2") @_valuationCurrency</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Default">Value at transaction</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular">@_valueAtPosting.ToString("N2") @_valuationCurrency</MudText>
                 </MudItem>
                 <MudItem xs="6">
                     <MudText Typo="Typo.caption" Color="Color.Default">Value now</MudText>

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondTransactionRow.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondTransactionRow.razor.cs
@@ -26,9 +26,9 @@ public partial class BondTransactionRow
     // Bonds are priced with the domain's own accrual model (BondAccountEntry.GetPriceAt), so the
     // "now" figures carry accrued interest and no external market data is needed.
     private bool _showValuation;
-    private decimal _unitPricePurchase;
+    private decimal _unitPriceAtPosting;
     private decimal _unitPriceNow;
-    private decimal _valuePurchase;
+    private decimal _valueAtPosting;
     private decimal _valueNow;
     private decimal _gainLoss;
     private decimal _gainLossPercent;
@@ -36,10 +36,11 @@ public partial class BondTransactionRow
 
     protected override void OnParametersSet() => ComputeValuation();
 
-    // Values the position established by this entry (Entry.Value units) at its posting-date price and at
-    // today's accrued price. Left hidden when there is no bond detail, no priced units, or the accrual
-    // model cannot produce a positive figure (e.g. no calculation method covers the dates), so the row
-    // never shows a misleading zero valuation or a -100% loss.
+    // Values the position held after this entry (Entry.Value units) at its posting-date price and at
+    // today's accrued price. Entries can also reduce a position (negative ValueChange), so the figures
+    // are labelled "at transaction" rather than "at purchase". Left hidden when there is no bond detail,
+    // no priced units, or the accrual model cannot produce a positive figure (e.g. no calculation method
+    // covers the dates), so the row never shows a misleading zero valuation or a -100% loss.
     private void ComputeValuation()
     {
         _showValuation = false;
@@ -52,17 +53,17 @@ public partial class BondTransactionRow
             var postingDay = DateOnly.FromDateTime(Entry.PostingDate);
             var today = DateOnly.FromDateTime(DateTime.UtcNow);
 
-            var valuePurchase = Entry.GetPriceAt(postingDay, BondDetails);
+            var valueAtPosting = Entry.GetPriceAt(postingDay, BondDetails);
             var valueNow = Entry.GetPriceAt(today, BondDetails);
-            if (valuePurchase <= 0m || valueNow <= 0m)
+            if (valueAtPosting <= 0m || valueNow <= 0m)
                 return;
 
-            _valuePurchase = valuePurchase;
+            _valueAtPosting = valueAtPosting;
             _valueNow = valueNow;
-            _unitPricePurchase = valuePurchase / Entry.Value;
+            _unitPriceAtPosting = valueAtPosting / Entry.Value;
             _unitPriceNow = valueNow / Entry.Value;
-            _gainLoss = valueNow - valuePurchase;
-            _gainLossPercent = (valueNow / valuePurchase - 1m) * 100m;
+            _gainLoss = valueNow - valueAtPosting;
+            _gainLossPercent = (valueNow / valueAtPosting - 1m) * 100m;
             _valuationCurrency = BondDetails.Currency.ShortName;
             _showValuation = true;
         }

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondTransactionRow.razor.cs
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/BondAccountComponents/TransactionHistory/BondTransactionRow.razor.cs
@@ -21,6 +21,58 @@ public partial class BondTransactionRow
     [Inject] public required AccountDataSynchronizationService AccountDataSynchronizationService { get; set; }
     [Inject] public required ILogger<BondTransactionRow> Logger { get; set; }
 
+    // Valuation figures for the detail view, mirroring the investment transaction row: the per-unit
+    // price and the position's value, at posting time versus now, plus the gain/loss between them.
+    // Bonds are priced with the domain's own accrual model (BondAccountEntry.GetPriceAt), so the
+    // "now" figures carry accrued interest and no external market data is needed.
+    private bool _showValuation;
+    private decimal _unitPricePurchase;
+    private decimal _unitPriceNow;
+    private decimal _valuePurchase;
+    private decimal _valueNow;
+    private decimal _gainLoss;
+    private decimal _gainLossPercent;
+    private string _valuationCurrency = string.Empty;
+
+    protected override void OnParametersSet() => ComputeValuation();
+
+    // Values the position established by this entry (Entry.Value units) at its posting-date price and at
+    // today's accrued price. Left hidden when there is no bond detail, no priced units, or the accrual
+    // model cannot produce a positive figure (e.g. no calculation method covers the dates), so the row
+    // never shows a misleading zero valuation or a -100% loss.
+    private void ComputeValuation()
+    {
+        _showValuation = false;
+
+        if (BondDetails is null || Entry.Value <= 0m || BondDetails.CalculationMethods.Count == 0)
+            return;
+
+        try
+        {
+            var postingDay = DateOnly.FromDateTime(Entry.PostingDate);
+            var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+            var valuePurchase = Entry.GetPriceAt(postingDay, BondDetails);
+            var valueNow = Entry.GetPriceAt(today, BondDetails);
+            if (valuePurchase <= 0m || valueNow <= 0m)
+                return;
+
+            _valuePurchase = valuePurchase;
+            _valueNow = valueNow;
+            _unitPricePurchase = valuePurchase / Entry.Value;
+            _unitPriceNow = valueNow / Entry.Value;
+            _gainLoss = valueNow - valuePurchase;
+            _gainLossPercent = (valueNow / valuePurchase - 1m) * 100m;
+            _valuationCurrency = BondDetails.Currency.ShortName;
+            _showValuation = true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Could not compute bond valuation for entry {EntryId}", Entry.EntryId);
+            _showValuation = false;
+        }
+    }
+
     private void ToggleExpanded() => _expanded = !_expanded;
 
     private void OnKeyDown(KeyboardEventArgs e)

--- a/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentTransactionRow.razor
+++ b/code/FinanceManager.Components/Components/Features/FinancialAccounts/InvestmentAccountComponents/TransactionHistory/InvestmentTransactionRow.razor
@@ -103,22 +103,26 @@
                     <MudDivider Class="my-1" Style="border-style: dashed;" />
                 </MudItem>
                 <MudItem xs="6" sm="6">
-                    <MudText Typo="Typo.overline" Color="Color.Default">Purchase value</MudText>
-                    <MudText Typo="Typo.body2" Class="fm-tabular">@Valuation!.PurchaseValue.ToString("N2") @Valuation.Currency</MudText>
+                    <MudText Typo="Typo.overline" Color="Color.Default">Unit price at purchase</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular">@Valuation!.PurchaseUnitPrice.ToString("N2") @Valuation.Currency</MudText>
                 </MudItem>
                 <MudItem xs="6" sm="6">
-                    <MudText Typo="Typo.overline" Color="Color.Default">Current price</MudText>
+                    <MudText Typo="Typo.overline" Color="Color.Default">Unit price now</MudText>
                     <MudText Typo="Typo.body2" Class="fm-tabular">
                         @(Valuation!.HasCurrentPrice ? $"{Valuation.CurrentPrice:N2} {Valuation.Currency}" : "—")
                     </MudText>
                 </MudItem>
                 <MudItem xs="6" sm="6">
-                    <MudText Typo="Typo.overline" Color="Color.Default">Current valuation</MudText>
+                    <MudText Typo="Typo.overline" Color="Color.Default">Value at purchase</MudText>
+                    <MudText Typo="Typo.body2" Class="fm-tabular">@Valuation!.PurchaseValue.ToString("N2") @Valuation.Currency</MudText>
+                </MudItem>
+                <MudItem xs="6" sm="6">
+                    <MudText Typo="Typo.overline" Color="Color.Default">Value now</MudText>
                     <MudText Typo="Typo.body2" Class="fm-tabular">
                         @(Valuation!.HasCurrentPrice ? $"{Valuation.CurrentValuation:N2} {Valuation.Currency}" : "—")
                     </MudText>
                 </MudItem>
-                <MudItem xs="6" sm="6">
+                <MudItem xs="12">
                     <MudText Typo="Typo.overline" Color="Color.Default">Gain / loss</MudText>
                     @if (Valuation!.HasCurrentPrice)
                     {

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionValuationDto.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionValuationDto.cs
@@ -5,9 +5,12 @@ namespace FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 /// used by the transaction detail view. All monetary figures are expressed in <see cref="Currency"/>:
 /// the user's default currency when <see cref="IsConverted"/> is <c>true</c>, otherwise the
 /// instrument/transaction currency (values are never mixed across currencies).
+/// <see cref="PurchaseUnitPrice"/> and <see cref="CurrentPrice"/> are per-unit prices (then vs now);
+/// <see cref="PurchaseValue"/> and <see cref="CurrentValuation"/> are the whole position's value (then vs now).
 /// </summary>
 public record InvestmentTransactionValuationDto(
     long TransactionId,
+    decimal PurchaseUnitPrice,
     decimal PurchaseValue,
     decimal CurrentPrice,
     decimal CurrentValuation,

--- a/code/FinanceManager.Tests.Integration/Controllers/InvestmentValuationControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Controllers/InvestmentValuationControllerTests.cs
@@ -167,6 +167,7 @@ public class InvestmentValuationControllerTests(OptionsProvider optionsProvider)
         Assert.True(valuation.IsConverted);
         Assert.Equal("USD", valuation.Currency);
         Assert.True(valuation.HasCurrentPrice);
+        Assert.Equal(90m, valuation.PurchaseUnitPrice); // 90 per unit
         Assert.Equal(450m, valuation.PurchaseValue);    // 5 * 90
         Assert.Equal(100m, valuation.CurrentPrice);
         Assert.Equal(500m, valuation.CurrentValuation); // 5 * 100

--- a/code/FinanceManager.Tests.Unit/Application/Services/InvestmentTransactionValuationServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/InvestmentTransactionValuationServiceTests.cs
@@ -60,6 +60,7 @@ public class InvestmentTransactionValuationServiceTests
         Assert.True(result.IsConverted);
         Assert.Equal("PLN", result.Currency);
         Assert.True(result.HasCurrentPrice);
+        Assert.Equal(400m, result.PurchaseUnitPrice); // 100 * 4
         Assert.Equal(4000m, result.PurchaseValue);   // 10 * 100 * 4
         Assert.Equal(500m, result.CurrentPrice);
         Assert.Equal(5000m, result.CurrentValuation); // 10 * 500
@@ -83,6 +84,7 @@ public class InvestmentTransactionValuationServiceTests
 
         Assert.False(result.IsConverted);
         Assert.Equal("EUR", result.Currency);
+        Assert.Equal(50m, result.PurchaseUnitPrice);  // 50, unconverted
         Assert.Equal(100m, result.PurchaseValue);     // 2 * 50, unconverted
         Assert.Equal(120m, result.CurrentValuation);  // 2 * 60
         Assert.Equal(20m, result.GainLoss);


### PR DESCRIPTION
## What & why

The expanded investment transaction detail mixed a **per-unit** price ("Current price") next to two **position totals** ("Purchase value", "Current valuation"), which read as apples-to-oranges and was confusing. This PR makes the comparison explicit and brings the same breakdown to bond entries.

### Investments — clearer labels
The valuation section is now grouped into three intentional rows:

| | Then | Now |
|---|---|---|
| **Unit price** | Unit price at purchase | Unit price now |
| **Value** | Value at purchase | Value now |
| **Gain / loss** | amount + percentage | |

- Added `PurchaseUnitPrice` to `InvestmentTransactionValuationDto`, computed in `InvestmentTransactionValuationService` in the display currency (trade-date rate when converted, otherwise the instrument currency) so it compares like-for-like against the current unit price.

### Bonds — same metrics
- `BondTransactionRow` now shows Unit price at purchase / now, Value at purchase / now, and Gain / loss, computed entirely from the domain's own accrual model (`BondAccountEntry.GetPriceAt`) in the bond's currency — no new endpoint or external market data.
- Hidden when there is no bond detail, no priced units, or no calculation method covers the dates, so the row never shows a misleading `0.00` valuation or a `-100%` loss.

## Screenshots (guest account)

Verified on mobile + desktop. Investment purchase now reads:
`Unit price at purchase 1,488.15 PLN` / `Unit price now 1,840.30 PLN`, `Value at purchase 1,867.18 PLN` / `Value now 2,309.02 PLN`, `Gain / loss +441.83 PLN (+23.66%)`.

Bond entry reads:
`Unit price at purchase 100.00 PLN` / `Unit price now 100.26 PLN`, `Value at purchase 300.00 PLN` / `Value now 300.78 PLN`, `Gain / loss +0.78 PLN (+0.26%)`.

## Testing
- `dotnet build` — clean, warnings-as-errors.
- `dotnet format` — no changes.
- Unit tests: 635 passing (added `PurchaseUnitPrice` assertions to `InvestmentTransactionValuationServiceTests`).
- Integration: added a `PurchaseUnitPrice` assertion to `InvestmentValuationControllerTests`.

## Notes
Follow-up refinement to the investment valuation feature (#596), extended to bonds. No dedicated issue number for this UI-clarity change; changelog entries follow the precedent of the file's no-issue entries.

https://claude.ai/code/session_01MPF6BYyparmPCZ5jRBYWqg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPF6BYyparmPCZ5jRBYWqg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bond transaction history now displays purchase and current unit prices, values, and color-coded gain/loss details.
  * Investment transaction valuations now show comparable purchase and current unit prices alongside total values.

* **Bug Fixes**
  * Purchase unit prices are now correctly displayed in the same currency as current valuations, including applicable exchange-rate conversions.

* **Tests**
  * Added coverage for converted and unconverted purchase prices and transaction valuation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->