### PR TITLE
Add API benchmark project for performance baseline #604

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,13 @@ dlldata.c
 # Benchmark Results
 BenchmarkDotNet.Artifacts/
 
+# Seeded SQLite databases built by FinanceManager.Benchmarks. Normally live under bin/, but
+# FM_BENCH_DATA_DIR can point anywhere, so keep them out of commits wherever they land.
+benchmark-data/
+*.sqlite
+*.sqlite-wal
+*.sqlite-shm
+
 # .NET Core
 project.lock.json
 project.fragment.lock.json

--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="TngTech.ArchUnitNET.xUnitV3" Version="0.13.3" />
     <PackageVersion Include="Blazor-ApexCharts" Version="6.1.0" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />

--- a/code/FinanceManager.Benchmarks/Benchmarks/AccountReadBenchmarks.cs
+++ b/code/FinanceManager.Benchmarks/Benchmarks/AccountReadBenchmarks.cs
@@ -1,0 +1,84 @@
+using BenchmarkDotNet.Attributes;
+
+namespace FinanceManager.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Account listing and detail reads — what the account pages call when a user drills into one account.
+/// </summary>
+/// <remarks>
+/// The interesting contrast here is the full-range read against the paged read. The account detail view
+/// can either pull a whole date range or ask for a fixed number of entries around a date; if the paged
+/// endpoint is not dramatically cheaper than the range endpoint, paging is not actually saving the user
+/// anything and that is a concrete refactor target.
+/// </remarks>
+[BenchmarkCategory("Accounts")]
+public class AccountReadBenchmarks : ApiBenchmark
+{
+    private const int _pageSize = 50;
+
+    protected override async Task Prime()
+    {
+        await CurrencyAccounts_List();
+        await CurrencyAccount_Summary();
+        await CurrencyAccount_DateRange();
+        await CurrencyAccount_EntryPage();
+        await InvestmentAccounts_List();
+        await InvestmentAccount_Details();
+        await InvestmentTransactions_ByAccount();
+        await InvestmentValuation_Holdings();
+        await InvestmentValuation_Value();
+        await InvestmentValuation_TransactionValuations();
+        await BondAccounts_List();
+        await BondAccount_DateRange();
+    }
+
+    [Benchmark(Description = "GET api/CurrencyAccount (list)", Baseline = true)]
+    public Task<long> CurrencyAccounts_List() => Get("api/CurrencyAccount");
+
+    [Benchmark(Description = "GET api/CurrencyAccount/{id} (summary)")]
+    public Task<long> CurrencyAccount_Summary() =>
+        Get($"api/CurrencyAccount/{Scenario.PrimaryCurrencyAccountId}");
+
+    /// <summary>
+    /// The route separates its segments with '&amp;' rather than '/' — that is the actual template
+    /// (<c>{accountId}&amp;{startDate}&amp;{endDate}</c>), matching what CurrencyAccountHttpClient builds.
+    /// </summary>
+    [Benchmark(Description = "GET api/CurrencyAccount/{id}&{start}&{end} (full range)")]
+    public Task<long> CurrencyAccount_DateRange() =>
+        Get($"api/CurrencyAccount/{Scenario.PrimaryCurrencyAccountId}&{Iso(Scenario.Start)}&{Iso(Scenario.End)}");
+
+    [Benchmark(Description = "GET api/CurrencyAccount/{id}/entries (page of 50)")]
+    public Task<long> CurrencyAccount_EntryPage() =>
+        Get($"api/CurrencyAccount/{Scenario.PrimaryCurrencyAccountId}/entries"
+            + $"?date={IsoQuery(Scenario.End)}&count={_pageSize}&olderThenDate=true");
+
+    [Benchmark(Description = "GET api/InvestmentAccount (list)")]
+    public Task<long> InvestmentAccounts_List() => Get("api/InvestmentAccount");
+
+    [Benchmark(Description = "GET api/InvestmentAccount/{id}")]
+    public Task<long> InvestmentAccount_Details() =>
+        Get($"api/InvestmentAccount/{Scenario.PrimaryInvestmentAccountId}");
+
+    [Benchmark(Description = "GET api/InvestmentTransaction/GetByAccount/{id}")]
+    public Task<long> InvestmentTransactions_ByAccount() =>
+        Get($"api/InvestmentTransaction/GetByAccount/{Scenario.PrimaryInvestmentAccountId}");
+
+    [Benchmark(Description = "GET api/InvestmentValuation/Holdings/{id}/{date}")]
+    public Task<long> InvestmentValuation_Holdings() =>
+        Get($"api/InvestmentValuation/Holdings/{Scenario.PrimaryInvestmentAccountId}/{Iso(Scenario.End)}");
+
+    [Benchmark(Description = "GET api/InvestmentValuation/Value/{id}/{currency}/{date}")]
+    public Task<long> InvestmentValuation_Value() =>
+        Get($"api/InvestmentValuation/Value/{Scenario.PrimaryInvestmentAccountId}/{Scenario.CurrencyId}/{Iso(Scenario.End)}");
+
+    [Benchmark(Description = "GET api/InvestmentValuation/TransactionValuations/{id}/{currency}")]
+    public Task<long> InvestmentValuation_TransactionValuations() =>
+        Get($"api/InvestmentValuation/TransactionValuations/{Scenario.PrimaryInvestmentAccountId}/{Scenario.CurrencyId}");
+
+    [Benchmark(Description = "GET api/BondAccount (list)")]
+    public Task<long> BondAccounts_List() => Get("api/BondAccount");
+
+    [Benchmark(Description = "GET api/BondAccount/{id}/{start}/{end} (full range)")]
+    public Task<long> BondAccount_DateRange() =>
+        Get($"api/BondAccount/{Scenario.PrimaryBondAccountId}/{Iso(Scenario.Start)}/{Iso(Scenario.End)}");
+}

--- a/code/FinanceManager.Benchmarks/Benchmarks/AnalysisBenchmarks.cs
+++ b/code/FinanceManager.Benchmarks/Benchmarks/AnalysisBenchmarks.cs
@@ -1,0 +1,61 @@
+using BenchmarkDotNet.Attributes;
+
+namespace FinanceManager.Benchmarks.Benchmarks;
+
+/// <summary>
+/// The analysis cards: expense distribution, essential spending, diversification and liabilities.
+/// </summary>
+/// <remarks>
+/// Each of these backs a card the dashboard renders on load, so they run concurrently with the
+/// money-flow and asset queries in real use. Benchmarked one at a time here — this suite measures the
+/// per-endpoint cost, not contention between them.
+/// </remarks>
+[BenchmarkCategory("Analysis")]
+public class AnalysisBenchmarks : ApiBenchmark
+{
+    protected override async Task Prime()
+    {
+        await ExpenseDistribution();
+        await EssentialSpending();
+        await DiversificationScore();
+        await DiversificationBreakdown();
+        await IsAnyAccountWithLiabilities();
+        await EndLiabilitiesPerAccount();
+        await EndLiabilitiesPerType();
+        await LiabilitiesTimeSeries();
+    }
+
+    [Benchmark(Description = "GET api/ExpenseDistribution/GetExpenseDistribution", Baseline = true)]
+    public Task<long> ExpenseDistribution() =>
+        Get($"api/ExpenseDistribution/GetExpenseDistribution/{Scenario.UserId}/{Scenario.CurrencyId}"
+            + $"/{Iso(Scenario.Start)}/{Iso(Scenario.End)}");
+
+    [Benchmark(Description = "GET api/EssentialSpending/GetEssentialSpending")]
+    public Task<long> EssentialSpending() =>
+        Get($"api/EssentialSpending/GetEssentialSpending/{Scenario.UserId}/{Scenario.CurrencyId}"
+            + $"/{Iso(Scenario.Start)}/{Iso(Scenario.End)}");
+
+    [Benchmark(Description = "GET api/Diversification (score)")]
+    public Task<long> DiversificationScore() =>
+        Get($"api/Diversification/{Scenario.UserId}/{Iso(Scenario.End)}");
+
+    [Benchmark(Description = "GET api/Diversification (breakdown)")]
+    public Task<long> DiversificationBreakdown() =>
+        Get($"api/Diversification/{Scenario.UserId}/{Iso(Scenario.End)}/breakdown");
+
+    [Benchmark(Description = "GET api/Liabilities/IsAnyAccountWithLiabilities")]
+    public Task<long> IsAnyAccountWithLiabilities() =>
+        Get($"api/Liabilities/IsAnyAccountWithLiabilities/{Scenario.UserId}");
+
+    [Benchmark(Description = "GET api/Liabilities/GetEndLiabilitiesPerAccount")]
+    public Task<long> EndLiabilitiesPerAccount() => Get(Liabilities("GetEndLiabilitiesPerAccount"));
+
+    [Benchmark(Description = "GET api/Liabilities/GetEndLiabilitiesPerType")]
+    public Task<long> EndLiabilitiesPerType() => Get(Liabilities("GetEndLiabilitiesPerType"));
+
+    [Benchmark(Description = "GET api/Liabilities/GetLiabilitiesTimeSeries")]
+    public Task<long> LiabilitiesTimeSeries() => Get(Liabilities("GetLiabilitiesTimeSeries"));
+
+    private string Liabilities(string action) =>
+        $"api/Liabilities/{action}/{Scenario.UserId}/{Iso(Scenario.Start)}/{Iso(Scenario.End)}";
+}

--- a/code/FinanceManager.Benchmarks/Benchmarks/ApiBenchmark.cs
+++ b/code/FinanceManager.Benchmarks/Benchmarks/ApiBenchmark.cs
@@ -1,0 +1,100 @@
+using BenchmarkDotNet.Attributes;
+using FinanceManager.Benchmarks.Hosting;
+using System.Globalization;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Shared plumbing for every endpoint benchmark: acquires the shared host in <c>[GlobalSetup]</c> and
+/// issues requests that consume the whole response body.
+/// </summary>
+public abstract class ApiBenchmark
+{
+    private BenchmarkEnvironment _api = default!;
+
+    /// <summary>Ids and date window of the seeded dataset.</summary>
+    protected BenchmarkScenario Scenario => _api.Scenario;
+
+    /// <summary>The shared host, for benchmarks that need to reset state between iterations.</summary>
+    protected BenchmarkEnvironment Api => _api;
+
+    [GlobalSetup]
+    public async Task GlobalSetup()
+    {
+        await Initialize();
+        await Prime();
+    }
+
+    /// <summary>
+    /// Acquires the shared host and applies <see cref="Configure"/>, but does not prime. Validation uses
+    /// this so a failing route is reported as one failed row rather than aborting the whole report from
+    /// inside <see cref="Prime"/>.
+    /// </summary>
+    public async Task Initialize()
+    {
+        _api = await BenchmarkEnvironment.GetOrCreate();
+        Configure();
+    }
+
+    /// <summary>
+    /// Derives whatever the benchmark methods need from <see cref="Scenario"/>. Runs before any request
+    /// is issued, on both the benchmark and validation paths.
+    /// </summary>
+    protected virtual void Configure()
+    {
+    }
+
+    /// <summary>
+    /// Runs the benchmarked routes once before measurement starts. This pays the one-off costs that
+    /// would otherwise land on whichever iteration happened to go first — EF Core model building and
+    /// query-plan compilation, controller and JSON metadata, SQLite page cache warmup — none of which a
+    /// user experiences per request.
+    /// </summary>
+    protected virtual Task Prime() => Task.CompletedTask;
+
+    /// <summary>
+    /// Issues a GET and reads the entire response body, returning its size so the result cannot be
+    /// optimized away.
+    /// </summary>
+    /// <remarks>
+    /// Reading to completion is what pulls JSON serialization into the measurement. Without it the
+    /// benchmark would stop at "headers written" and a change to a response DTO's shape would look free.
+    /// </remarks>
+    protected async Task<long> Get(string route)
+    {
+        using var response = await _api.Client.GetAsync(route);
+        var payload = await response.Content.ReadAsByteArrayAsync();
+
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException(BuildFailureMessage("GET", route, (int)response.StatusCode, payload));
+
+        return payload.LongLength;
+    }
+
+    /// <summary>Issues a POST with a JSON body and reads the entire response body.</summary>
+    protected async Task<long> Post<TBody>(string route, TBody body)
+    {
+        using var response = await _api.Client.PostAsJsonAsync(route, body);
+        var payload = await response.Content.ReadAsByteArrayAsync();
+
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException(BuildFailureMessage("POST", route, (int)response.StatusCode, payload));
+
+        return payload.LongLength;
+    }
+
+    /// <summary>Round-trip ("O") format, which is what the Blazor HTTP clients put on the wire.</summary>
+    protected static string Iso(DateTime value) => value.ToString("O", CultureInfo.InvariantCulture);
+
+    /// <summary>Round-trip format, escaped for use as a query-string value.</summary>
+    protected static string IsoQuery(DateTime value) => Uri.EscapeDataString(Iso(value));
+
+    // A non-success status means the benchmark is timing an error path, not the endpoint — surface the
+    // body so the cause (403 from a stale id, 400 from a rejected date) is obvious rather than guessed.
+    private static string BuildFailureMessage(string method, string route, int statusCode, byte[] payload)
+    {
+        var body = payload.Length == 0 ? "<empty>" : System.Text.Encoding.UTF8.GetString(payload);
+        return $"{method} {route} returned {statusCode}. The benchmark would be measuring a failure path. Response: {body}";
+    }
+}

--- a/code/FinanceManager.Benchmarks/Benchmarks/AssetsBenchmarks.cs
+++ b/code/FinanceManager.Benchmarks/Benchmarks/AssetsBenchmarks.cs
@@ -1,0 +1,60 @@
+using BenchmarkDotNet.Attributes;
+
+namespace FinanceManager.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Asset valuation and breakdown endpoints.
+/// </summary>
+/// <remarks>
+/// Every one of these prices the seeded holdings against the daily quote series, so they exercise the
+/// heaviest read path in the app: transactions joined to listings joined to quotes, then converted into
+/// the reporting currency. Expect these to be the slowest reads in the suite and the ones most worth
+/// optimizing.
+/// </remarks>
+[BenchmarkCategory("Assets")]
+public class AssetsBenchmarks : ApiBenchmark
+{
+    protected override async Task Prime()
+    {
+        await IsAnyAccountWithAssets();
+        await EndAssetsPerAccount();
+        await EndAssetsPerType();
+        await AssetsTimeSeries();
+        await InvestmentPaycheckEstimate();
+        await UnrealizedGainLossPerAccount();
+        await UnrealizedGainLossPerInstrument();
+    }
+
+    /// <summary>
+    /// Reads as a trivial existence check and gates whether the asset cards render at all, so it sits on
+    /// the critical path of every dashboard load. Kept as this category's baseline precisely because it
+    /// is <em>not</em> cheap in practice — a boolean that costs the same order as a full breakdown is the
+    /// clearest signal in this suite that the query behind it does more work than the answer needs.
+    /// </summary>
+    [Benchmark(Description = "GET api/Assets/IsAnyAccountWithAssets", Baseline = true)]
+    public Task<long> IsAnyAccountWithAssets() =>
+        Get($"api/Assets/IsAnyAccountWithAssets/{Scenario.UserId}");
+
+    [Benchmark(Description = "GET api/Assets/GetEndAssetsPerAccount")]
+    public Task<long> EndAssetsPerAccount() => Get(AsOf("GetEndAssetsPerAccount"));
+
+    [Benchmark(Description = "GET api/Assets/GetEndAssetsPerType")]
+    public Task<long> EndAssetsPerType() => Get(AsOf("GetEndAssetsPerType"));
+
+    [Benchmark(Description = "GET api/Assets/GetAssetsTimeSeries")]
+    public Task<long> AssetsTimeSeries() =>
+        Get($"api/Assets/GetAssetsTimeSeries/{Scenario.UserId}/{Scenario.CurrencyId}/{Iso(Scenario.Start)}/{Iso(Scenario.End)}");
+
+    [Benchmark(Description = "GET api/Assets/GetInvestmentPaycheckEstimate")]
+    public Task<long> InvestmentPaycheckEstimate() =>
+        Get($"{AsOf("GetInvestmentPaycheckEstimate")}?withdrawalRate=0.05&salaryMonths=3");
+
+    [Benchmark(Description = "GET api/Assets/GetUnrealizedGainLossPerAccount")]
+    public Task<long> UnrealizedGainLossPerAccount() => Get(AsOf("GetUnrealizedGainLossPerAccount"));
+
+    [Benchmark(Description = "GET api/Assets/GetUnrealizedGainLossPerInstrument")]
+    public Task<long> UnrealizedGainLossPerInstrument() => Get(AsOf("GetUnrealizedGainLossPerInstrument"));
+
+    private string AsOf(string action) =>
+        $"api/Assets/{action}/{Scenario.UserId}/{Scenario.CurrencyId}/{Iso(Scenario.End)}";
+}

--- a/code/FinanceManager.Benchmarks/Benchmarks/CurrencyEntryWriteBenchmarks.cs
+++ b/code/FinanceManager.Benchmarks/Benchmarks/CurrencyEntryWriteBenchmarks.cs
@@ -1,0 +1,70 @@
+using BenchmarkDotNet.Attributes;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Commands;
+
+namespace FinanceManager.Benchmarks.Benchmarks;
+
+/// <summary>
+/// The write path a user hits when recording a transaction by hand, plus the balance recalculation that
+/// follows a correction.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Adding an entry is not just an insert: it invalidates the user's cached read models and queues the
+/// entry for label classification. That invalidation is why the write path belongs in a UX baseline —
+/// a slow write is felt directly, and an over-broad invalidation makes the *next* read slow too.
+/// </para>
+/// <para>
+/// Entries are appended at a fixed date just past the end of the seeded history, so each insert lands at
+/// the head of the account and the balance recalculation has nothing after it to rewrite. Iteration
+/// cleanup deletes them again, which keeps the dataset stable across iterations and leaves the database
+/// as the read benchmarks found it. Within a single iteration the appended rows do accumulate — the
+/// account grows by roughly a hundred entries on a base of well over a thousand — so read a few percent
+/// of drift here as noise, not signal.
+/// </para>
+/// </remarks>
+[BenchmarkCategory("Writes")]
+public class CurrencyEntryWriteBenchmarks : ApiBenchmark
+{
+    private const decimal _entryValue = 4_200m;
+    private const decimal _entryValueChange = -25m;
+
+    private int _accountId;
+    private DateTime _appendDate;
+
+    protected override void Configure()
+    {
+        _accountId = Scenario.PrimaryCurrencyAccountId;
+        _appendDate = Scenario.End.AddDays(1);
+    }
+
+    protected override async Task Prime()
+    {
+        await AddEntry();
+        await RecalculateBalance();
+        Cleanup();
+    }
+
+    [IterationCleanup]
+    public void Cleanup() => Api.ResetAppendedEntries(_accountId, Scenario.End);
+
+    [Benchmark(Description = "POST api/CurrencyEntry (append entry)", Baseline = true)]
+    public Task<long> AddEntry() =>
+        Post("api/CurrencyEntry", new AddCurrencyAccountEntry(
+            AccountId: _accountId,
+            // The command validates EntryId as >= 1, but the controller ignores it and lets the
+            // repository assign the real id, so any valid placeholder works here.
+            EntryId: 1,
+            PostingDate: _appendDate,
+            Value: _entryValue,
+            ValueChange: _entryValueChange,
+            Description: "Benchmark append",
+            ContractorDetails: null));
+
+    /// <summary>
+    /// Rewrites every running balance on the account. Idempotent — recalculating already-correct values
+    /// produces the same rows — so it can be measured repeatedly without drifting the dataset, while
+    /// still exercising the heaviest write in the app.
+    /// </summary>
+    [Benchmark(Description = "POST api/CurrencyEntry/Recalculate/{accountId}")]
+    public Task<long> RecalculateBalance() => Post($"api/CurrencyEntry/Recalculate/{_accountId}", new { });
+}

--- a/code/FinanceManager.Benchmarks/Benchmarks/DashboardBenchmarks.cs
+++ b/code/FinanceManager.Benchmarks/Benchmarks/DashboardBenchmarks.cs
@@ -1,0 +1,32 @@
+using BenchmarkDotNet.Attributes;
+
+namespace FinanceManager.Benchmarks.Benchmarks;
+
+/// <summary>
+/// The dashboard first-paint aggregate — the single most important number in this suite.
+/// </summary>
+/// <remarks>
+/// <c>api/Dashboard/overview</c> is what the landing page waits on after login, and it fans out
+/// internally to net worth, cash flow, expense distribution and asset breakdowns. Whatever this costs
+/// is the floor on time-to-first-useful-screen, so it is measured over two windows: the six-month
+/// default and a one-month view. If the two are close, the cost is fixed overhead; if the six-month
+/// case is much worse, the aggregation scales with the range and that is where to look first.
+/// </remarks>
+[BenchmarkCategory("Dashboard")]
+public class DashboardBenchmarks : ApiBenchmark
+{
+    protected override async Task Prime()
+    {
+        await Overview_SixMonths();
+        await Overview_OneMonth();
+    }
+
+    [Benchmark(Description = "GET api/Dashboard/overview (6 months)", Baseline = true)]
+    public Task<long> Overview_SixMonths() => Get(OverviewRoute(Scenario.Start, Scenario.End));
+
+    [Benchmark(Description = "GET api/Dashboard/overview (1 month)")]
+    public Task<long> Overview_OneMonth() => Get(OverviewRoute(Scenario.LastMonthStart, Scenario.End));
+
+    private string OverviewRoute(DateTime start, DateTime end) =>
+        $"api/Dashboard/overview?userId={Scenario.UserId}&currencyId={Scenario.CurrencyId}&start={IsoQuery(start)}&end={IsoQuery(end)}";
+}

--- a/code/FinanceManager.Benchmarks/Benchmarks/MoneyFlowBenchmarks.cs
+++ b/code/FinanceManager.Benchmarks/Benchmarks/MoneyFlowBenchmarks.cs
@@ -1,0 +1,60 @@
+using BenchmarkDotNet.Attributes;
+
+namespace FinanceManager.Benchmarks.Benchmarks;
+
+/// <summary>
+/// The money-flow series behind the dashboard charts and the money-flow page.
+/// </summary>
+/// <remarks>
+/// These are the endpoints a user hits repeatedly while changing the date range, so their cost is felt
+/// as chart lag rather than as page-load time. They all walk the same entry history and differ only in
+/// how they fold it, which makes the spread between them a direct read on where the folding is
+/// expensive. <c>GetNetWorth</c> is measured both as a single-date point read and as a full series so
+/// the per-day cost is separable from the fixed cost.
+/// </remarks>
+[BenchmarkCategory("MoneyFlow")]
+public class MoneyFlowBenchmarks : ApiBenchmark
+{
+    protected override async Task Prime()
+    {
+        await NetWorth_SingleDate();
+        await NetWorth_Series();
+        await Inflow();
+        await Outflow();
+        await NetCashFlow();
+        await ClosingBalance();
+        await LabelsValue();
+        await InvestmentRate();
+    }
+
+    [Benchmark(Description = "GET api/MoneyFlow/GetNetWorth (single date)", Baseline = true)]
+    public Task<long> NetWorth_SingleDate() =>
+        Get($"api/MoneyFlow/GetNetWorth/{Scenario.UserId}/{Scenario.CurrencyId}/{Iso(Scenario.End)}");
+
+    [Benchmark(Description = "GET api/MoneyFlow/GetNetWorth (series)")]
+    public Task<long> NetWorth_Series() => Get(Range("GetNetWorth"));
+
+    [Benchmark(Description = "GET api/MoneyFlow/GetInflow")]
+    public Task<long> Inflow() => Get(Range("GetInflow"));
+
+    [Benchmark(Description = "GET api/MoneyFlow/GetOutflow")]
+    public Task<long> Outflow() => Get(Range("GetOutflow"));
+
+    [Benchmark(Description = "GET api/MoneyFlow/GetNetCashFlow")]
+    public Task<long> NetCashFlow() => Get(Range("GetNetCashFlow"));
+
+    [Benchmark(Description = "GET api/MoneyFlow/GetClosingBalance")]
+    public Task<long> ClosingBalance() => Get(Range("GetClosingBalance"));
+
+    [Benchmark(Description = "GET api/MoneyFlow/GetLabelsValue")]
+    public Task<long> LabelsValue() =>
+        Get($"api/MoneyFlow/GetLabelsValue?userId={Scenario.UserId}&start={IsoQuery(Scenario.Start)}&end={IsoQuery(Scenario.End)}");
+
+    [Benchmark(Description = "GET api/MoneyFlow/GetInvestmentRate")]
+    public Task<long> InvestmentRate() =>
+        Get($"api/MoneyFlow/GetInvestmentRate?userId={Scenario.UserId}&currencyId={Scenario.CurrencyId}"
+            + $"&start={IsoQuery(Scenario.Start)}&end={IsoQuery(Scenario.End)}");
+
+    private string Range(string action) =>
+        $"api/MoneyFlow/{action}/{Scenario.UserId}/{Scenario.CurrencyId}/{Iso(Scenario.Start)}/{Iso(Scenario.End)}";
+}

--- a/code/FinanceManager.Benchmarks/Benchmarks/SupportingReadBenchmarks.cs
+++ b/code/FinanceManager.Benchmarks/Benchmarks/SupportingReadBenchmarks.cs
@@ -1,0 +1,51 @@
+using BenchmarkDotNet.Attributes;
+
+namespace FinanceManager.Benchmarks.Benchmarks;
+
+/// <summary>
+/// Small reads that fire on nearly every page: the user record, the currency list, labels and the recent
+/// transaction log.
+/// </summary>
+/// <remarks>
+/// Individually trivial, which is exactly why they are worth measuring. They are called from layout and
+/// navigation code rather than from one page, so a few milliseconds each shows up on every interaction,
+/// and any of them landing far above the others points at a missing cache or an accidental full-table
+/// read.
+/// </remarks>
+[BenchmarkCategory("Supporting")]
+public class SupportingReadBenchmarks : ApiBenchmark
+{
+    private const int _labelPageSize = 50;
+    private const int _transactionLogCount = 10;
+
+    protected override async Task Prime()
+    {
+        await User_Get();
+        await Currency_GetAll();
+        await FinancialLabel_GetCount();
+        await FinancialLabel_GetPage();
+        await FinancialLabel_GetByAccount();
+        await TransactionLog_Get();
+    }
+
+    [Benchmark(Description = "GET api/User/Get/{userId}", Baseline = true)]
+    public Task<long> User_Get() => Get($"api/User/Get/{Scenario.UserId}");
+
+    [Benchmark(Description = "GET api/Currency/GetAll")]
+    public Task<long> Currency_GetAll() => Get("api/Currency/GetAll");
+
+    [Benchmark(Description = "GET api/FinancialLabel/get-count")]
+    public Task<long> FinancialLabel_GetCount() => Get("api/FinancialLabel/get-count");
+
+    [Benchmark(Description = "GET api/FinancialLabel/get-by-index-and-count")]
+    public Task<long> FinancialLabel_GetPage() =>
+        Get($"api/FinancialLabel/get-by-index-and-count?index=0&count={_labelPageSize}");
+
+    [Benchmark(Description = "GET api/FinancialLabel/get-by-account-id")]
+    public Task<long> FinancialLabel_GetByAccount() =>
+        Get($"api/FinancialLabel/get-by-account-id?accountId={Scenario.PrimaryCurrencyAccountId}");
+
+    [Benchmark(Description = "GET api/TransactionLog/Get/{userId}")]
+    public Task<long> TransactionLog_Get() =>
+        Get($"api/TransactionLog/Get/{Scenario.UserId}?count={_transactionLogCount}");
+}

--- a/code/FinanceManager.Benchmarks/Configuration/BenchmarkConfig.cs
+++ b/code/FinanceManager.Benchmarks/Configuration/BenchmarkConfig.cs
@@ -1,0 +1,64 @@
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using Perfolizer.Horology;
+
+namespace FinanceManager.Benchmarks.Configuration;
+
+/// <summary>
+/// BenchmarkDotNet configuration for the API suite.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Runs in-process by default. The usual reason to prefer a child process — isolating the benchmarked
+/// code from the harness's own JIT and GC state — matters most for nanosecond-scale microbenchmarks;
+/// these endpoints are milliseconds of I/O and aggregation, where the isolation buys little. In
+/// exchange, an in-process run needs no build at runtime, boots the API once for the whole suite, and
+/// lets every benchmark class share one seeded database. Set <c>FM_BENCH_OUT_OF_PROCESS=1</c> to use
+/// BenchmarkDotNet's default per-benchmark child processes instead and compare.
+/// </para>
+/// <para>
+/// The memory diagnoser is on: allocation per request is the most actionable single number for a
+/// read-path refactor, and it is far more stable across machines than wall time. It costs an extra run
+/// per benchmark.
+/// </para>
+/// </remarks>
+public static class BenchmarkConfig
+{
+    /// <summary>
+    /// Builds the suite's configuration on top of <see cref="DefaultConfig.Instance"/>, which supplies the
+    /// console logger, the standard columns, and the validators and analysers that flag a misconfigured run.
+    /// </summary>
+    public static IConfig Create()
+    {
+        var job = Job.Default
+            .WithWarmupCount(3)
+            .WithIterationCount(10)
+            // Requests are milliseconds, not nanoseconds; the default 500 ms target would spend most of a
+            // run on invocation counts that add no statistical value.
+            .WithIterationTime(TimeInterval.FromMilliseconds(250));
+
+        if (!UseOutOfProcessToolchain)
+            job = job.WithToolchain(InProcessEmitToolchain.Instance);
+
+        return ManualConfig.Create(DefaultConfig.Instance)
+            .AddJob(job)
+            .AddDiagnoser(MemoryDiagnoser.Default)
+            // P95 alongside the mean, because a smoother UX is mostly about the slow requests.
+            .AddColumn(StatisticColumn.Median, StatisticColumn.P95)
+            // Full JSON so a later run can be diffed against this one programmatically; the GitHub
+            // markdown export that DefaultConfig already provides covers pasting results into a PR.
+            .AddExporter(JsonExporter.Full)
+            .WithSummaryStyle(SummaryStyle.Default.WithTimeUnit(TimeUnit.Millisecond))
+            // One shared host and one shared database file mean the benchmark classes are not
+            // independent; a joined summary reports them as the single suite they actually are.
+            .WithOptions(ConfigOptions.JoinSummary);
+    }
+
+    private static bool UseOutOfProcessToolchain =>
+        Environment.GetEnvironmentVariable("FM_BENCH_OUT_OF_PROCESS") is "1" or "true";
+}

--- a/code/FinanceManager.Benchmarks/Configuration/BenchmarkOptions.cs
+++ b/code/FinanceManager.Benchmarks/Configuration/BenchmarkOptions.cs
@@ -1,0 +1,72 @@
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Benchmarks.Configuration;
+
+/// <summary>
+/// Knobs for the benchmark harness, all supplied through environment variables so a run can be
+/// re-shaped from CI or a shell without touching code. Every value has a working default.
+/// </summary>
+public static class BenchmarkOptions
+{
+    /// <summary>User id the seeded demo dataset belongs to, and the identity every request is signed for.</summary>
+    public const int UserId = 424_242;
+
+    /// <summary>Login name stamped into the benchmark JWT.</summary>
+    public const string UserName = "benchmark";
+
+    /// <summary>
+    /// Deterministic, non-secret signing key. HMAC-SHA512 needs &gt;= 64 bytes or the API's startup
+    /// guard rejects it.
+    /// </summary>
+    public const string JwtSigningKey = "benchmark-only-insecure-jwt-signing-key-do-not-use-anywhere-ever";
+
+    /// <summary>
+    /// Directory holding the seed template and the per-run working copy. Defaults to a
+    /// <c>benchmark-data</c> folder next to the benchmark binaries so repeat runs reuse the template.
+    /// Override with <c>FM_BENCH_DATA_DIR</c>.
+    /// </summary>
+    public static string DataDirectory =>
+        Environment.GetEnvironmentVariable("FM_BENCH_DATA_DIR") is { Length: > 0 } dir
+            ? Path.GetFullPath(dir)
+            : Path.Combine(AppContext.BaseDirectory, "benchmark-data");
+
+    /// <summary>
+    /// The pristine seeded database. Built on first use, then reused verbatim so a baseline run and a
+    /// post-refactor run measure byte-identical data.
+    /// </summary>
+    public static string TemplateDatabasePath => Path.Combine(DataDirectory, "seed-template.sqlite");
+
+    /// <summary>
+    /// Set <c>FM_BENCH_RESEED=1</c> to discard the template and generate a fresh dataset. Do this when
+    /// the schema or the seeders change — otherwise leave it alone, because reseeding changes the data
+    /// the numbers describe.
+    /// </summary>
+    public static bool ForceReseed => IsEnabled("FM_BENCH_RESEED");
+
+    /// <summary>
+    /// Set <c>FM_BENCH_COLD_CACHE=1</c> to swap <c>HybridCache</c> for a pass-through implementation.
+    /// The default (warm) measures what a returning user experiences; cold measures the repository and
+    /// EF Core work the cache normally hides, which is where a read-path refactor has headroom.
+    /// </summary>
+    public static bool ColdCache => IsEnabled("FM_BENCH_COLD_CACHE");
+
+    /// <summary>
+    /// Minimum log level for the benchmarked host. Warning by default so logging is not a measured cost
+    /// while real failures still reach the console; set <c>FM_BENCH_LOG_LEVEL=Information</c> (or Debug)
+    /// when diagnosing a failing endpoint.
+    /// </summary>
+    public static LogLevel LogLevel =>
+        Enum.TryParse<LogLevel>(Environment.GetEnvironmentVariable("FM_BENCH_LOG_LEVEL"), ignoreCase: true, out var level)
+            ? level
+            : Microsoft.Extensions.Logging.LogLevel.Warning;
+
+    /// <summary>Months of demo history to seed. Six matches the in-app guest sandbox.</summary>
+    public static int SeedMonths =>
+        int.TryParse(Environment.GetEnvironmentVariable("FM_BENCH_SEED_MONTHS"), out var months) && months > 0
+            ? months
+            : 6;
+
+    private static bool IsEnabled(string variable) =>
+        Environment.GetEnvironmentVariable(variable) is { Length: > 0 } value
+        && (value.Equals("1", StringComparison.Ordinal) || value.Equals("true", StringComparison.OrdinalIgnoreCase));
+}

--- a/code/FinanceManager.Benchmarks/FinanceManager.Benchmarks.csproj
+++ b/code/FinanceManager.Benchmarks/FinanceManager.Benchmarks.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<RootNamespace>FinanceManager.Benchmarks</RootNamespace>
+		<OutputType>Exe</OutputType>
+		<IsPackable>false</IsPackable>
+		<!-- BenchmarkDotNet refuses to measure a non-optimized build. Default to Release so a bare
+		     `dotnet run` from this directory produces usable numbers instead of an error. -->
+		<Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+		<!-- The generated benchmark runners and the seeded SQLite file are throwaway artefacts; keep the
+		     server GC off so measurements aren't skewed by background collections on a 2-4 core sandbox. -->
+		<ServerGarbageCollection>false</ServerGarbageCollection>
+		<ConcurrentGarbageCollection>false</ConcurrentGarbageCollection>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="BenchmarkDotNet" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+		<!-- Direct reference so the central pin (3.0.3) overrides the vulnerable 2.1.11 that
+		     Microsoft.EntityFrameworkCore.Sqlite brings in transitively (GHSA-2m69-gcr7-jv3q);
+		     transitive pinning is disabled centrally. Same reason as FinanceManager.Tests.Unit. -->
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\FinanceManager.Api\FinanceManager.Api.csproj" />
+		<ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/code/FinanceManager.Benchmarks/Hosting/BenchmarkApiHost.cs
+++ b/code/FinanceManager.Benchmarks/Hosting/BenchmarkApiHost.cs
@@ -1,0 +1,197 @@
+using FinanceManager.Api;
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Benchmarks.Configuration;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+using FinanceManager.Infrastructure.Contexts;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Benchmarks.Hosting;
+
+/// <summary>
+/// Boots the real API — the full middleware pipeline, MVC, auth, application services, repositories and
+/// EF Core — against a local SQLite file, with everything that would add non-deterministic cost removed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// What is measured: routing, model binding, JWT validation, authorization, the controller, the
+/// application/domain services, the repository layer, EF Core query translation and execution against
+/// SQLite, and JSON serialization of the full response body.
+/// </para>
+/// <para>
+/// What is <em>not</em> measured: Kestrel, sockets and TLS. <c>WebApplicationFactory</c> serves requests
+/// over an in-memory transport, so the OS network stack is out of scope. That is a deliberate trade:
+/// the excluded work is a near-constant per-request cost that a service or query refactor will not
+/// change, and excluding it removes the largest source of run-to-run variance. Treat the numbers as
+/// server-side work per request, not as end-to-end wire latency.
+/// </para>
+/// </remarks>
+public sealed class BenchmarkApiHost : WebApplicationFactory<ApiEntryPoint>
+{
+    private readonly string _connectionString;
+
+    static BenchmarkApiHost() =>
+        // Each host loads appsettings*.json with reloadOnChange, and every watcher costs an inotify
+        // instance. The benchmark process builds a seeding host and a measurement host; the watchers
+        // buy nothing here and the sandbox limit is easy to reach.
+        Environment.SetEnvironmentVariable("DOTNET_hostBuilder__reloadConfigOnChange", "false");
+
+    public BenchmarkApiHost(string connectionString) => _connectionString = connectionString;
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("benchmark");
+
+        // Program.cs validates most of these while the host is still building, which is too early for
+        // ConfigureAppConfiguration to matter — UseSetting lands them in the initial configuration.
+        builder.UseSetting("JwtConfig:Key", BenchmarkOptions.JwtSigningKey);
+        builder.UseSetting("JwtConfig:Issuer", "FinanceManager.api");
+        builder.UseSetting("JwtConfig:Audience", "FinanceManager.Frontend");
+        builder.UseSetting("JwtConfig:TokenValidityMins", "600");
+
+        // appsettings.json pins AllowedHosts to the production hostname; the in-memory transport serves
+        // http://localhost, which would otherwise be rejected with 400 before reaching a controller.
+        builder.UseSetting("AllowedHosts", "*");
+        builder.UseSetting("Cors:AllowedOrigins:0", "https://localhost:7206");
+        builder.UseSetting("ReverseProxy:KnownProxies:0", "127.0.0.1");
+
+        // A rate limiter would start rejecting requests a few thousand invocations into a run and the
+        // benchmark would end up measuring 429s.
+        builder.UseSetting("RateLimiting:Enabled", "false");
+
+        // Reaches Alpha Vantage on startup.
+        builder.UseSetting("Backfill:RunOnStartup", "false");
+
+        // OpenIddict needs signing certificates and contributes nothing to the endpoints under test.
+        builder.UseSetting("McpOAuth:Enabled", "false");
+
+        // Takes the simple AddDbContext branch in AddDatabase rather than the pooled relational one,
+        // which gives ConfigureServices a single options descriptor to replace with SQLite below.
+        builder.UseSetting("UseInMemoryDatabase", "true");
+
+        builder.ConfigureServices(services =>
+        {
+            RemoveApplicationBackgroundServices(services);
+            UseSqliteDatabase(services);
+            UseOfflineExternalProviders(services);
+
+            if (BenchmarkOptions.ColdCache)
+            {
+                services.RemoveAll<HybridCache>();
+                services.AddSingleton<HybridCache, PassThroughHybridCache>();
+            }
+
+            // Log writes are synchronous work inside the measured request, so the level is turned down to
+            // warnings — but the console provider stays, because an endpoint that starts returning 500
+            // has to be diagnosable. Raise it with FM_BENCH_LOG_LEVEL=Information to see EF's SQL.
+            services.AddLogging(logging =>
+            {
+                logging.ClearProviders();
+                logging.AddSimpleConsole();
+                logging.SetMinimumLevel(BenchmarkOptions.LogLevel);
+            });
+        });
+    }
+
+    /// <summary>
+    /// Creates the SQLite schema. EF Core migrations in this repo are generated for SQL Server, so they
+    /// cannot be replayed against SQLite; the model itself carries no provider-specific column types,
+    /// which makes <c>EnsureCreated</c> a faithful equivalent.
+    /// </summary>
+    public async Task CreateSchema(CancellationToken cancellationToken = default)
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        await context.Database.EnsureCreatedAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Fails fast if the host is not actually talking to SQLite. Silent fallback to the in-memory
+    /// provider would still answer every request and every number would be meaningless.
+    /// </summary>
+    public void AssertUsingSqlite()
+    {
+        using var scope = Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var provider = context.Database.ProviderName;
+
+        if (provider != "Microsoft.EntityFrameworkCore.Sqlite")
+            throw new InvalidOperationException(
+                $"Benchmark host is using '{provider}' instead of SQLite. The AppDbContext replacement in "
+                + $"{nameof(BenchmarkApiHost)}.{nameof(UseSqliteDatabase)} no longer matches how AddDatabase registers the context.");
+    }
+
+    private void UseSqliteDatabase(IServiceCollection services)
+    {
+        // AddDbContext registers the options with TryAdd, so the production registration has to go
+        // before ours is visible.
+        services.RemoveAll<AppDbContext>();
+        services.RemoveAll<DbContextOptions>();
+        services.RemoveAll<DbContextOptions<AppDbContext>>();
+        RemoveDbContextOptionsConfiguration(services);
+
+        services.AddDbContext<AppDbContext>(options => options
+            .UseSqlite(_connectionString)
+            .UseOpenIddict()
+            .ReplaceService<IModelCustomizer, SqliteModelCustomizer>());
+    }
+
+    /// <summary>
+    /// Drops EF Core's internal per-context options-configuration descriptors, which is where
+    /// <c>AddDbContext</c> keeps the provider callback on current EF versions. Matched by name so an EF
+    /// upgrade that renames or re-shapes the type cannot leave the in-memory provider wired up
+    /// alongside ours — <see cref="AssertUsingSqlite"/> is the backstop if it ever does.
+    /// </summary>
+    private static void RemoveDbContextOptionsConfiguration(IServiceCollection services)
+    {
+        var stale = services
+            .Where(descriptor => descriptor.ServiceType.IsGenericType
+                && descriptor.ServiceType.Name.StartsWith("IDbContextOptionsConfiguration", StringComparison.Ordinal)
+                && descriptor.ServiceType.GenericTypeArguments.Contains(typeof(AppDbContext)))
+            .ToList();
+
+        foreach (var descriptor in stale)
+            services.Remove(descriptor);
+    }
+
+    /// <summary>
+    /// Removes FinanceManager's own hosted services. They do migrations, seeding, AI insight generation,
+    /// label setting, imports, price backfills and log persistence — none of it serves a request, all of
+    /// it competes for the same CPU and SQLite file as the measured iterations.
+    /// </summary>
+    /// <remarks>
+    /// <c>DatabaseInitializer</c> in particular would throw on startup: outside Development it treats
+    /// the SQL Server migrations as pending against a SQLite database that has no migration history.
+    /// Filtering by assembly rather than by type keeps this working without reaching into the API
+    /// project's internals.
+    /// </remarks>
+    private static void RemoveApplicationBackgroundServices(IServiceCollection services)
+    {
+        var applicationHostedServices = services
+            .Where(descriptor => descriptor.ServiceType == typeof(IHostedService)
+                && IsApplicationType(descriptor.ImplementationType ?? descriptor.ImplementationInstance?.GetType()))
+            .ToList();
+
+        foreach (var descriptor in applicationHostedServices)
+            services.Remove(descriptor);
+
+        static bool IsApplicationType(Type? type) =>
+            type?.Assembly.GetName().Name?.StartsWith("FinanceManager", StringComparison.Ordinal) == true;
+    }
+
+    private static void UseOfflineExternalProviders(IServiceCollection services)
+    {
+        services.RemoveAll<ICurrencyExchangeRateProvider>();
+        services.AddScoped<ICurrencyExchangeRateProvider, OfflineCurrencyExchangeRateProvider>();
+
+        services.RemoveAll<IStockPriceSource>();
+        services.AddScoped<IStockPriceSource, OfflineStockPriceSource>();
+    }
+}

--- a/code/FinanceManager.Benchmarks/Hosting/BenchmarkDatabase.cs
+++ b/code/FinanceManager.Benchmarks/Hosting/BenchmarkDatabase.cs
@@ -1,0 +1,109 @@
+using FinanceManager.Benchmarks.Configuration;
+using Microsoft.Data.Sqlite;
+
+namespace FinanceManager.Benchmarks.Hosting;
+
+/// <summary>
+/// Owns the SQLite file the benchmarked API reads from: a pristine seeded <em>template</em> that is
+/// built once and reused, plus a per-process <em>working copy</em> that requests actually hit.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The template/copy split is what makes runs comparable. Seeding produces randomised amounts and is
+/// anchored to <c>UtcNow</c>, so re-seeding between a baseline and a post-refactor run would change
+/// the data underneath the comparison. Building it once and copying means every run measures the same
+/// bytes, and the write benchmarks can mutate freely without contaminating the next run.
+/// </para>
+/// <para>
+/// SQLite rather than SQL Server or PostgreSQL because a benchmark that has to reach a database server
+/// measures the network and that server's cache state as much as the API. A local file keeps the
+/// storage cost small, constant, and identical on every machine. The trade-off is that absolute
+/// numbers do not transfer to production hardware — these numbers are for comparing <em>before</em>
+/// against <em>after</em>, not for capacity planning.
+/// </para>
+/// </remarks>
+public sealed class BenchmarkDatabase : IDisposable
+{
+    private readonly string _workingPath;
+
+    private BenchmarkDatabase(string workingPath) => _workingPath = workingPath;
+
+    /// <summary>Connection string for the working copy, with pooling off so the file can be deleted on dispose.</summary>
+    public string ConnectionString => BuildConnectionString(_workingPath);
+
+    /// <summary>Absolute path of the working copy.</summary>
+    public string Path => _workingPath;
+
+    /// <summary>True when this run had to build the template from scratch.</summary>
+    public bool TemplateWasCreated { get; private init; }
+
+    /// <summary>
+    /// Ensures a seeded template exists (building it via <paramref name="seedTemplate"/> if needed) and
+    /// hands back a fresh working copy of it.
+    /// </summary>
+    /// <param name="seedTemplate">
+    /// Populates a brand-new, empty database at the given path. Only invoked when no reusable template
+    /// is present.
+    /// </param>
+    public static async Task<BenchmarkDatabase> Prepare(Func<string, Task> seedTemplate)
+    {
+        Directory.CreateDirectory(BenchmarkOptions.DataDirectory);
+
+        var templatePath = BenchmarkOptions.TemplateDatabasePath;
+        var created = false;
+
+        if (BenchmarkOptions.ForceReseed)
+            DeleteDatabaseFiles(templatePath);
+
+        if (!File.Exists(templatePath))
+        {
+            // Seed into a temporary file and move it into place only on success, so an interrupted or
+            // failed seed can never leave a half-populated template that later runs would silently reuse.
+            var stagingPath = templatePath + ".staging";
+            DeleteDatabaseFiles(stagingPath);
+
+            await seedTemplate(BuildConnectionString(stagingPath));
+
+            SqliteConnection.ClearAllPools();
+            File.Move(stagingPath, templatePath, overwrite: true);
+            created = true;
+        }
+
+        var workingPath = System.IO.Path.Combine(
+            BenchmarkOptions.DataDirectory,
+            $"run-{Environment.ProcessId}.sqlite");
+
+        DeleteDatabaseFiles(workingPath);
+        File.Copy(templatePath, workingPath);
+
+        return new BenchmarkDatabase(workingPath) { TemplateWasCreated = created };
+    }
+
+    public void Dispose()
+    {
+        // Every AppDbContext in the host is disposed by now, but SQLite keeps pooled handles per
+        // connection string; clearing them releases the file so the delete succeeds on Windows too.
+        SqliteConnection.ClearAllPools();
+        DeleteDatabaseFiles(_workingPath);
+    }
+
+    private static string BuildConnectionString(string path) =>
+        new SqliteConnectionStringBuilder
+        {
+            DataSource = path,
+            // Pooling keeps the file locked after the last context is disposed, which breaks the
+            // working-copy cleanup. Connection setup against a local file is cheap enough that the
+            // measured endpoints do not notice.
+            Pooling = false,
+        }.ToString();
+
+    private static void DeleteDatabaseFiles(string path)
+    {
+        // WAL and shared-memory sidecars must go too, or a stale -wal replays into the fresh copy.
+        foreach (var candidate in new[] { path, path + "-wal", path + "-shm" })
+        {
+            if (File.Exists(candidate))
+                File.Delete(candidate);
+        }
+    }
+}

--- a/code/FinanceManager.Benchmarks/Hosting/BenchmarkEnvironment.cs
+++ b/code/FinanceManager.Benchmarks/Hosting/BenchmarkEnvironment.cs
@@ -1,0 +1,214 @@
+using FinanceManager.Api.Services;
+using FinanceManager.Application.Identity.Seeders;
+using FinanceManager.Benchmarks.Configuration;
+using FinanceManager.Domain.Dashboard.Services;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.ValueObjects;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Infrastructure.Contexts;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Benchmarks.Hosting;
+
+/// <summary>
+/// Process-wide singleton holding the seeded database, the running API host, an authenticated
+/// <see cref="HttpClient"/> and the resolved <see cref="BenchmarkScenario"/>.
+/// </summary>
+/// <remarks>
+/// Shared rather than per-class because BenchmarkDotNet runs <c>[GlobalSetup]</c> once per benchmark
+/// class, and booting the API plus copying the database for each of them would add minutes to a run and
+/// give each class a differently-aged dataset. The in-process toolchain keeps all classes in one
+/// process, so a single instance serves them all.
+/// </remarks>
+public sealed class BenchmarkEnvironment : IDisposable
+{
+    private static readonly SemaphoreSlim _gate = new(1, 1);
+    private static BenchmarkEnvironment? _instance;
+
+    private readonly BenchmarkDatabase _database;
+    private readonly BenchmarkApiHost _host;
+
+    private BenchmarkEnvironment(BenchmarkDatabase database, BenchmarkApiHost host, HttpClient client, BenchmarkScenario scenario)
+    {
+        _database = database;
+        _host = host;
+        Client = client;
+        Scenario = scenario;
+    }
+
+    /// <summary>API client carrying a bearer token for the seeded user.</summary>
+    public HttpClient Client { get; }
+
+    /// <summary>Ids and date window the benchmarked requests are built from.</summary>
+    public BenchmarkScenario Scenario { get; }
+
+    /// <summary>
+    /// Returns the shared environment, building it on first call. Safe to await from every
+    /// <c>[GlobalSetup]</c>.
+    /// </summary>
+    public static async Task<BenchmarkEnvironment> GetOrCreate()
+    {
+        if (_instance is not null) return _instance;
+
+        await _gate.WaitAsync();
+        try
+        {
+            return _instance ??= await Create();
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <summary>Tears down the shared environment. Called once, from the process exit path.</summary>
+    public static void Shutdown()
+    {
+        _instance?.Dispose();
+        _instance = null;
+    }
+
+    public void Dispose()
+    {
+        Client.Dispose();
+        _host.Dispose();
+        // After the host, so every AppDbContext has released its SQLite handle.
+        _database.Dispose();
+    }
+
+    /// <summary>
+    /// Deletes every entry the write benchmarks appended to <paramref name="accountId"/> after
+    /// <paramref name="postedAfter"/>, and drops the owner's cached read models.
+    /// </summary>
+    /// <remarks>
+    /// Runs between benchmark iterations, so it goes straight to the database rather than through the
+    /// delete endpoint — the point is to restore state cheaply, and routing thousands of deletes through
+    /// MVC would take longer than the measurements. Invalidating the cache afterwards keeps the
+    /// repository's cached ranges from outliving the rows they describe.
+    /// </remarks>
+    public void ResetAppendedEntries(int accountId, DateTime postedAfter)
+    {
+        using var scope = _host.Services.CreateScope();
+
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        context.CurrencyEntries
+            .Where(entry => entry.AccountId == accountId && entry.PostingDate > postedAfter)
+            .ExecuteDelete();
+
+        scope.ServiceProvider.GetRequiredService<ICacheInvalidator>()
+            .InvalidateUser(Scenario.UserId)
+            .AsTask()
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    private static async Task<BenchmarkEnvironment> Create()
+    {
+        var database = await BenchmarkDatabase.Prepare(SeedTemplate);
+
+        var host = new BenchmarkApiHost(database.ConnectionString);
+        var client = host.CreateClient();
+        client.BaseAddress = new Uri("http://localhost/");
+        client.Timeout = TimeSpan.FromMinutes(2);
+        host.AssertUsingSqlite();
+
+        Authorize(host, client);
+
+        var scenario = await ResolveScenario(client);
+
+        return new BenchmarkEnvironment(database, host, client, scenario);
+    }
+
+    /// <summary>
+    /// Builds the pristine dataset: the same demo history the in-app guest sandbox generates — six months
+    /// of salary, rent, utilities and randomised merchant transactions across a cash and a loan account,
+    /// a monthly-contribution ETF position with a full daily price series, and a bond ladder.
+    /// </summary>
+    /// <remarks>
+    /// Reusing the product's own seeders instead of writing benchmark-specific fixtures means the shape
+    /// of the data — entry counts, label distribution, account mix — tracks whatever the app actually
+    /// shows a new user, and stays correct as the domain evolves.
+    /// </remarks>
+    private static async Task SeedTemplate(string connectionString)
+    {
+        using var host = new BenchmarkApiHost(connectionString);
+        host.AssertUsingSqlite();
+        await host.CreateSchema();
+
+        using var scope = host.Services.CreateScope();
+
+        var seeder = scope.ServiceProvider.GetRequiredService<GuestAccountSeeder>();
+        await seeder.SeedForGuest(BenchmarkOptions.UserId);
+
+        var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        // The guest seeder creates a Basic-tier user, which caps records at 10,000. The write benchmarks
+        // add entries on top of the seeded history, and FM_BENCH_SEED_MONTHS can push the history well
+        // past that on its own — a plan rejection would turn those iterations into 400s.
+        var user = await context.Users.FirstAsync(x => x.Id == BenchmarkOptions.UserId);
+        user.PricingLevel = PricingLevel.Premium;
+
+        // Touching the currency repository once materialises the default currency rows, so no measured
+        // request pays for the lazy EnsureDefaults insert.
+        _ = await context.Currencies.CountAsync();
+
+        await context.SaveChangesAsync();
+    }
+
+    private static void Authorize(BenchmarkApiHost host, HttpClient client)
+    {
+        using var scope = host.Services.CreateScope();
+        var tokenGenerator = scope.ServiceProvider.GetRequiredService<JwtTokenGenerator>();
+        var token = tokenGenerator.GenerateToken(BenchmarkOptions.UserName, BenchmarkOptions.UserId, UserRole.User);
+
+        // Set once, outside the measured region: minting a JWT is HMAC work that has nothing to do with
+        // the endpoints under test, and the API's own token lifetime is long enough to outlast a run.
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
+    }
+
+    private static async Task<BenchmarkScenario> ResolveScenario(HttpClient client)
+    {
+        var currencyAccountIds = await GetAccountIds(client, "api/CurrencyAccount");
+        var investmentAccountIds = await GetAccountIds(client, "api/InvestmentAccount");
+        var bondAccountIds = await GetAccountIds(client, "api/BondAccount");
+
+        if (currencyAccountIds.Count == 0)
+            throw new InvalidOperationException(
+                "The seeded dataset contains no currency accounts. Delete the template (or set FM_BENCH_RESEED=1) and try again.");
+
+        var (start, end) = await GetSeededWindow(client, currencyAccountIds[0]);
+
+        return new BenchmarkScenario(
+            BenchmarkOptions.UserId,
+            DefaultCurrency.PLN.Id,
+            start,
+            end,
+            currencyAccountIds,
+            investmentAccountIds,
+            bondAccountIds);
+    }
+
+    private static async Task<IReadOnlyList<int>> GetAccountIds(HttpClient client, string route)
+    {
+        var response = await client.GetAsync(route);
+        response.EnsureSuccessStatusCode();
+
+        var accounts = await response.Content.ReadFromJsonAsync<List<AvailableAccount>>();
+        return accounts?.Select(x => x.AccountId).ToList() ?? [];
+    }
+
+    private static async Task<(DateTime Start, DateTime End)> GetSeededWindow(HttpClient client, int accountId)
+    {
+        var oldest = await client.GetFromJsonAsync<DateTime?>($"api/CurrencyEntry/Oldest/{accountId}");
+        var youngest = await client.GetFromJsonAsync<DateTime?>($"api/CurrencyEntry/Youngest/{accountId}");
+
+        if (oldest is not DateTime start || youngest is not DateTime end)
+            throw new InvalidOperationException(
+                $"Currency account {accountId} has no entries, so there is no date window to benchmark. Re-seed with FM_BENCH_RESEED=1.");
+
+        return (start.Date, end.Date);
+    }
+}

--- a/code/FinanceManager.Benchmarks/Hosting/BenchmarkScenario.cs
+++ b/code/FinanceManager.Benchmarks/Hosting/BenchmarkScenario.cs
@@ -1,0 +1,49 @@
+namespace FinanceManager.Benchmarks.Hosting;
+
+/// <summary>
+/// The concrete inputs every benchmarked request is built from: the ids that exist in the seeded
+/// dataset and the date window that actually contains data.
+/// </summary>
+/// <remarks>
+/// Resolved from the running API during setup rather than hard-coded, because the seeders assign
+/// account ids and anchor the history to <c>UtcNow</c> at the moment the template was built. A
+/// hard-coded window would drift into empty ranges as the template ages and the endpoints would
+/// quietly start measuring "return nothing".
+/// </remarks>
+/// <param name="UserId">Owner of the seeded dataset; also the subject of the benchmark JWT.</param>
+/// <param name="CurrencyId">Reporting currency the aggregate endpoints convert into.</param>
+/// <param name="Start">First day covered by the seeded history.</param>
+/// <param name="End">Last day covered by the seeded history.</param>
+/// <param name="CurrencyAccountIds">Cash and loan accounts, in the order the API lists them.</param>
+/// <param name="InvestmentAccountIds">Investment accounts holding the seeded ETF position.</param>
+/// <param name="BondAccountIds">Bond accounts holding the seeded bond ladder.</param>
+public sealed record BenchmarkScenario(
+    int UserId,
+    int CurrencyId,
+    DateTime Start,
+    DateTime End,
+    IReadOnlyList<int> CurrencyAccountIds,
+    IReadOnlyList<int> InvestmentAccountIds,
+    IReadOnlyList<int> BondAccountIds)
+{
+    /// <summary>Primary cash account — the one the transaction list and entry writes target.</summary>
+    public int PrimaryCurrencyAccountId => First(CurrencyAccountIds, nameof(CurrencyAccountIds));
+
+    /// <summary>Primary investment account, used by the holdings and valuation endpoints.</summary>
+    public int PrimaryInvestmentAccountId => First(InvestmentAccountIds, nameof(InvestmentAccountIds));
+
+    /// <summary>Primary bond account.</summary>
+    public int PrimaryBondAccountId => First(BondAccountIds, nameof(BondAccountIds));
+
+    /// <summary>
+    /// A one-month tail of the history, matching the range the account and dashboard views open on by
+    /// default. Kept separate from the full window so a benchmark can show how cost scales with range.
+    /// </summary>
+    public DateTime LastMonthStart => End.AddMonths(-1) < Start ? Start : End.AddMonths(-1);
+
+    private static int First(IReadOnlyList<int> ids, string name) =>
+        ids.Count > 0
+            ? ids[0]
+            : throw new InvalidOperationException(
+                $"The seeded dataset contains no {name}. Re-seed with FM_BENCH_RESEED=1; if that does not help, a seeder has stopped producing data.");
+}

--- a/code/FinanceManager.Benchmarks/Hosting/OfflineCurrencyExchangeRateProvider.cs
+++ b/code/FinanceManager.Benchmarks/Hosting/OfflineCurrencyExchangeRateProvider.cs
@@ -1,0 +1,33 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+
+namespace FinanceManager.Benchmarks.Hosting;
+
+/// <summary>
+/// Returns a fixed exchange rate without leaving the process, replacing the CSV and HTTP-backed
+/// providers for the duration of a benchmark run.
+/// </summary>
+/// <remarks>
+/// The real chain ends at a third-party HTTP API. A single unlucky network round-trip inside a
+/// measured iteration is worth more than every other cost in the endpoint combined, which would make
+/// the baseline unreproducible. A constant rate keeps the conversion arithmetic on the hot path while
+/// removing the variance — the exact rate is irrelevant to timing.
+/// </remarks>
+public sealed class OfflineCurrencyExchangeRateProvider : ICurrencyExchangeRateProvider
+{
+    private const decimal _rate = 1.25m;
+
+    public Task<decimal?> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date) =>
+        Task.FromResult<decimal?>(fromCurrency.Id == toCurrency.Id ? 1m : _rate);
+
+    public Task<List<(DateTime Date, decimal? Value)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd)
+    {
+        var value = fromCurrency.Id == toCurrency.Id ? 1m : _rate;
+        var rates = new List<(DateTime Date, decimal? Value)>();
+
+        for (var date = dateStart.Date; date <= dateEnd.Date; date = date.AddDays(1))
+            rates.Add((date, value));
+
+        return Task.FromResult(rates);
+    }
+}

--- a/code/FinanceManager.Benchmarks/Hosting/OfflineStockPriceSource.cs
+++ b/code/FinanceManager.Benchmarks/Hosting/OfflineStockPriceSource.cs
@@ -1,0 +1,22 @@
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+
+namespace FinanceManager.Benchmarks.Hosting;
+
+/// <summary>
+/// A price source with no data, standing in for the Alpha Vantage → EODHD fallback chain.
+/// </summary>
+/// <remarks>
+/// The seeded dataset already contains a full daily <c>PriceQuote</c> series, so the pricing chain
+/// resolves every valuation from the repository and never reaches an external provider. This exists
+/// only so a gap in the seeded series cannot silently turn a measured iteration into an HTTP call to
+/// a rate-limited vendor. Returning an empty series is the interface's documented "no data" contract.
+/// </remarks>
+public sealed class OfflineStockPriceSource : IStockPriceSource
+{
+    public string Name => "Offline";
+
+    public Task<IReadOnlyList<StockPrice>> GetDailySeries(string symbol, string isin, DateTime start, DateTime end, Currency currency, CancellationToken ct = default) =>
+        Task.FromResult<IReadOnlyList<StockPrice>>([]);
+}

--- a/code/FinanceManager.Benchmarks/Hosting/PassThroughHybridCache.cs
+++ b/code/FinanceManager.Benchmarks/Hosting/PassThroughHybridCache.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace FinanceManager.Benchmarks.Hosting;
+
+/// <summary>
+/// A <see cref="HybridCache"/> that never stores anything: every read invokes the factory.
+/// </summary>
+/// <remarks>
+/// BenchmarkDotNet invokes the same endpoint thousands of times, so a real cache is warm from the
+/// second invocation onwards and the reported time collapses to "serialize an already-computed
+/// result". That is a legitimate number — it is what a user clicking around a warm dashboard sees —
+/// but it hides the repository and EF Core cost that a read-path refactor actually targets. Swapping
+/// this in (<c>FM_BENCH_COLD_CACHE=1</c>) forces every request down to SQLite so both baselines are
+/// measurable. See <see cref="Configuration.BenchmarkOptions.ColdCache"/>.
+/// </remarks>
+public sealed class PassThroughHybridCache : HybridCache
+{
+    public override ValueTask<T> GetOrCreateAsync<TState, T>(
+        string key,
+        TState state,
+        Func<TState, CancellationToken, ValueTask<T>> factory,
+        HybridCacheEntryOptions? options = null,
+        IEnumerable<string>? tags = null,
+        CancellationToken cancellationToken = default) => factory(state, cancellationToken);
+
+    public override ValueTask SetAsync<T>(
+        string key,
+        T value,
+        HybridCacheEntryOptions? options = null,
+        IEnumerable<string>? tags = null,
+        CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+    public override ValueTask RemoveAsync(string key, CancellationToken cancellationToken = default) =>
+        ValueTask.CompletedTask;
+
+    public override ValueTask RemoveByTagAsync(string tag, CancellationToken cancellationToken = default) =>
+        ValueTask.CompletedTask;
+}

--- a/code/FinanceManager.Benchmarks/Hosting/SqliteModelCustomizer.cs
+++ b/code/FinanceManager.Benchmarks/Hosting/SqliteModelCustomizer.cs
@@ -1,0 +1,42 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace FinanceManager.Benchmarks.Hosting;
+
+/// <summary>
+/// Stores every <see cref="DateTimeOffset"/> property as an order-preserving integer so SQLite can
+/// compare and sort them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// SQLite has no native date type, and EF Core's SQLite provider refuses to translate relational
+/// comparisons on <see cref="DateTimeOffset"/> at all — a <c>Where(q =&gt; q.PriceTime &lt;= asOf)</c>
+/// throws "could not be translated" rather than falling back. Price quotes, and therefore every asset
+/// valuation, net-worth and dashboard endpoint, are filtered exactly that way.
+/// </para>
+/// <para>
+/// <see cref="DateTimeOffsetToBinaryConverter"/> packs the UTC ticks into the high bits and the offset
+/// into the low bits, so integer ordering matches chronological ordering and the comparisons SQLite now
+/// translates return the same rows a real deployment would. This lives in the benchmark project, applied
+/// through EF's model-customizer hook, because production never runs on SQLite and the domain model
+/// should not carry a workaround for a provider it does not use.
+/// </para>
+/// </remarks>
+internal sealed class SqliteModelCustomizer(ModelCustomizerDependencies dependencies)
+    : RelationalModelCustomizer(dependencies)
+{
+    public override void Customize(ModelBuilder modelBuilder, DbContext context)
+    {
+        base.Customize(modelBuilder, context);
+
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            foreach (var property in entityType.GetProperties())
+            {
+                if (property.ClrType == typeof(DateTimeOffset) || property.ClrType == typeof(DateTimeOffset?))
+                    property.SetValueConverter(typeof(DateTimeOffsetToBinaryConverter));
+            }
+        }
+    }
+}

--- a/code/FinanceManager.Benchmarks/Program.cs
+++ b/code/FinanceManager.Benchmarks/Program.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Running;
+using FinanceManager.Benchmarks.Configuration;
+using FinanceManager.Benchmarks.Validation;
+
+namespace FinanceManager.Benchmarks;
+
+internal static class Program
+{
+    private static async Task<int> Main(string[] args)
+    {
+        try
+        {
+            if (args.Contains("--validate", StringComparer.OrdinalIgnoreCase))
+                return await EndpointValidator.Run() ? 0 : 1;
+
+            BenchmarkSwitcher
+                .FromAssembly(typeof(Program).Assembly)
+                .Run(WithDefaultFilter(args), BenchmarkConfig.Create());
+
+            return 0;
+        }
+        finally
+        {
+            // Releases the API host and deletes this run's working copy of the database. With the
+            // in-process toolchain the benchmarks ran here, so there is a real environment to tear down.
+            Hosting.BenchmarkEnvironment.Shutdown();
+        }
+    }
+
+    /// <summary>
+    /// Runs the whole suite when no filter was given, instead of dropping into BenchmarkDotNet's
+    /// interactive picker — a benchmark run started from CI or a background shell has nobody to answer it.
+    /// </summary>
+    private static string[] WithDefaultFilter(string[] args) =>
+        args.Any(arg => arg.Equals("--filter", StringComparison.OrdinalIgnoreCase) || arg.StartsWith("-f", StringComparison.Ordinal))
+            ? args
+            : [.. args, "--filter", "*"];
+}

--- a/code/FinanceManager.Benchmarks/README.md
+++ b/code/FinanceManager.Benchmarks/README.md
@@ -1,0 +1,165 @@
+# FinanceManager.Benchmarks
+
+Measures the per-request cost of FinanceManager's most-used API endpoints, so an optimization refactor
+has a baseline to be judged against.
+
+The suite boots the **real API** — full middleware pipeline, JWT auth, controllers, application and
+domain services, repositories, EF Core — against a **local SQLite file** seeded with the same six months
+of demo data the in-app guest sandbox generates.
+
+## Quick start
+
+```bash
+cd code/FinanceManager.Benchmarks
+
+# 1. Check every benchmarked endpoint still returns real data (seconds, not minutes).
+dotnet run -c Release -- --validate
+
+# 2. Run the whole suite (~6 minutes).
+dotnet run -c Release
+
+# Or one group at a time.
+dotnet run -c Release -- --filter '*Dashboard*'
+dotnet run -c Release -- --filter '*MoneyFlow*'
+```
+
+Results land in `BenchmarkDotNet.Artifacts/results/` as GitHub-flavoured markdown (paste into a PR) and
+full JSON (diff two runs programmatically).
+
+**Always run `--validate` first.** A benchmark that quietly measures a `403` or an empty result still
+produces a tidy table of numbers, which is the worst possible failure mode for a baseline. Validation
+runs the same calls the suite does — discovered by reflection, so it cannot drift out of sync — and
+prints the status and response size of each.
+
+## What is covered
+
+Read-heavy endpoints that sit on the critical path of a page load or a chart interaction, grouped by
+BenchmarkDotNet category:
+
+| Category | Endpoints | Why |
+|---|---|---|
+| `Dashboard` | `Dashboard/overview` over a 6-month and a 1-month window | The single most important number: what the landing page waits on after login. Two windows separate fixed overhead from cost that scales with range. |
+| `MoneyFlow` | net worth (point and series), inflow, outflow, net cash flow, closing balance, labels value, investment rate | Re-fired every time a user changes the date range; felt as chart lag. |
+| `Assets` | asset existence, end assets per account and per type, time series, paycheck estimate, unrealized gain/loss per account and per instrument | The heaviest reads in the app — transactions joined to listings joined to daily price quotes, then currency-converted. |
+| `Analysis` | expense distribution, essential spending, diversification score and breakdown, liabilities | One per dashboard card. |
+| `Accounts` | currency/investment/bond account lists and details, full-range vs paged entry reads, holdings and valuation | Drill-down pages. The range-vs-page contrast shows whether paging is actually saving the user anything. |
+| `Supporting` | user record, currency list, label count/page/by-account, recent transaction log | Called from layout and navigation, so their cost lands on *every* interaction. |
+| `Writes` | append a currency entry, recalculate account balances | A slow write is felt directly, and an over-broad cache invalidation makes the *next* read slow too. |
+
+### Deliberately excluded
+
+- **Import and export** — as requested. Bulk, user-initiated, and not on any interactive path.
+- **Login** (`POST api/Login`). Its cost is dominated by password hashing, which is *supposed* to be
+  slow and must not be "optimized". Including it would put a large, deliberately-fixed number next to
+  numbers that are meant to move.
+- **Admin, AI insight generation, label setting, price backfill, OAuth/MCP** — background or
+  low-frequency work, not interactive latency.
+
+## Reading the numbers
+
+`Allocated` is the most portable column — allocation per request barely varies across machines and is
+usually the fastest route to a real improvement. Wall time is only meaningful *relative to another run
+on the same machine*.
+
+`P95` is reported next to `Mean` because a smoother UX is mostly about the slow requests.
+
+The `Writes` category carries wider error bars than the reads by construction. Resetting state between
+invocations forces BenchmarkDotNet down to one invocation per iteration, so each measurement is a single
+request rather than an average over many. Compare write numbers across runs using `Median` and `P95`, and
+treat a change smaller than the error column as noise.
+
+## What is and is not measured
+
+**In scope:** routing, model binding, JWT validation, authorization, the controller, application and
+domain services, the repository layer, EF Core query translation and execution against SQLite, and JSON
+serialization of the whole response body (every benchmark reads the response to completion, so a change
+to a response DTO's shape cannot look free).
+
+**Out of scope:** Kestrel, sockets and TLS. `WebApplicationFactory` serves requests over an in-memory
+transport. This is deliberate — the excluded work is a near-constant per-request cost that a service or
+query refactor will not change, and excluding it removes the largest source of run-to-run variance.
+Read the numbers as *server-side work per request*, not as end-to-end wire latency.
+
+**Also out of scope:** concurrency. Endpoints are measured one at a time, so nothing here says anything
+about contention between the dashboard's parallel card requests.
+
+### SQLite caveats
+
+Absolute numbers do not transfer to production hardware — the point is comparing *before* against
+*after* on the same machine, not capacity planning. Two provider-specific differences are worth knowing:
+
+- **`decimal` is stored as TEXT.** SQLite has no decimal type, so EF Core stores money as text and
+  aggregates coerce it to floating point. Timings are representative; the last cents of a computed
+  total may not be.
+- **`DateTimeOffset` is stored as an order-preserving integer.** EF Core's SQLite provider refuses to
+  translate `DateTimeOffset` comparisons at all, and price quotes are filtered exactly that way. See
+  `SqliteModelCustomizer`.
+
+## Environment variables
+
+| Variable | Default | Effect |
+|---|---|---|
+| `FM_BENCH_COLD_CACHE` | off | Replaces `HybridCache` with a pass-through, forcing every request down to SQLite. See below. |
+| `FM_BENCH_RESEED` | off | Discards the seed template and generates a fresh dataset. |
+| `FM_BENCH_SEED_MONTHS` | `6` | Months of demo history to seed. |
+| `FM_BENCH_DATA_DIR` | `<bin>/benchmark-data` | Where the seed template and working copy live. |
+| `FM_BENCH_LOG_LEVEL` | `Warning` | Raise to `Information` to see EF Core's SQL when diagnosing a failure. |
+| `FM_BENCH_OUT_OF_PROCESS` | off | Use BenchmarkDotNet's default per-benchmark child processes instead of the in-process toolchain. |
+
+### Warm vs cold cache — run both
+
+```bash
+dotnet run -c Release                          # warm (default)
+FM_BENCH_COLD_CACHE=1 dotnet run -c Release    # cold
+```
+
+BenchmarkDotNet invokes each endpoint thousands of times, so a real cache is warm from the second
+invocation onwards and the reported time collapses towards "serialize an already-computed result". That
+is a legitimate number — it is what a user clicking around a warm dashboard sees — but it hides the
+repository and EF Core cost that a read-path refactor actually targets.
+
+**The gap between the two runs is the headroom.** A large gap means the cache is carrying the endpoint
+and the underlying query is slow; a small gap means the cache is not helping and the cost is real work
+on every request.
+
+The first run of this suite makes the point better than any explanation. `Dashboard/overview` over six
+months, same machine, same data:
+
+| | Mean | Allocated |
+|---|---:|---:|
+| Warm cache | 0.80 ms | 120 KB |
+| Cold cache | 470 ms | 16.6 MB |
+
+`HybridCache` is carrying that endpoint almost entirely. The number a user actually waits on is the cold
+one — it is paid on the first dashboard load of a session, and again after every write that invalidates
+the user's cached read models. Also worth noting from that first run: `Assets/IsAnyAccountWithAssets`
+returns a single boolean and costs ~13 ms, the same order as endpoints that return a full breakdown.
+
+## How the harness works
+
+1. **`BenchmarkDatabase`** builds a pristine seeded SQLite file *once* (`seed-template.sqlite`) and
+   copies it to a per-process working file for each run. The template is reused, so a baseline run and a
+   post-refactor run measure byte-identical data; the copy means write benchmarks can mutate freely
+   without contaminating the next run. Seeding writes to a staging file and moves it into place only on
+   success, so an interrupted seed cannot leave a half-populated template behind.
+2. **`BenchmarkApiHost`** boots the API against that file. It replaces the `AppDbContext` registration
+   with SQLite (and asserts the swap took, so a silent fallback to the in-memory provider cannot pass
+   unnoticed), removes FinanceManager's hosted services, disables rate limiting and startup backfill,
+   and swaps the currency-rate and stock-price providers for offline stand-ins so no measured iteration
+   can turn into an HTTP call to a rate-limited vendor.
+3. **`BenchmarkEnvironment`** is a process-wide singleton holding the host, an authenticated
+   `HttpClient`, and the resolved `BenchmarkScenario`.
+4. **`BenchmarkScenario`** carries the account ids and date window, *resolved from the running API*
+   rather than hard-coded — the seeders anchor history to `UtcNow`, so a hard-coded window would drift
+   into empty ranges as the template ages and endpoints would quietly start measuring "return nothing".
+
+Adding an endpoint: add a `[Benchmark]` method to the matching class (or a new `ApiBenchmark` subclass),
+call it from `Prime()` to keep first-call costs out of the measurement, and re-run `--validate`.
+
+## Note on `CurrencyEntryValueCalculator`
+
+Running-balance recalculation is a hand-written windowed `UPDATE` with no portable spelling. Before this
+project it had a PostgreSQL branch and an `else` branch that assumed SQL Server syntax, so *any* other
+relational provider got statements it could not parse. Adding SQLite support meant making that switch
+explicit (`DatabaseProviders`), which also means an unrecognised provider now falls back to the correct
+managed path instead of failing. Production behaviour on SQL Server and PostgreSQL is unchanged.

--- a/code/FinanceManager.Benchmarks/Validation/EndpointValidator.cs
+++ b/code/FinanceManager.Benchmarks/Validation/EndpointValidator.cs
@@ -1,0 +1,103 @@
+using BenchmarkDotNet.Attributes;
+using FinanceManager.Benchmarks.Benchmarks;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+
+namespace FinanceManager.Benchmarks.Validation;
+
+/// <summary>
+/// Runs every benchmarked call exactly once and reports what came back.
+/// </summary>
+/// <remarks>
+/// A benchmark that quietly measures a 403 or an empty result still produces a tidy table of numbers,
+/// which is the worst possible failure mode for a baseline. This is the cheap guard: seconds instead of
+/// minutes, it exercises the same methods the suite does (discovered by reflection, so it cannot drift
+/// out of sync), and it prints the response size next to the timing — a suspiciously small payload is
+/// usually an endpoint returning nothing because an id or date range missed the seeded data.
+/// </remarks>
+public static class EndpointValidator
+{
+    /// <summary>Returns true when every benchmarked call succeeded.</summary>
+    public static async Task<bool> Run()
+    {
+        var results = new List<ValidationResult>();
+
+        foreach (var type in DiscoverBenchmarkTypes())
+        {
+            var instance = (ApiBenchmark)Activator.CreateInstance(type)!;
+            await instance.Initialize();
+
+            foreach (var method in BenchmarkMethods(type))
+                results.Add(await Invoke(instance, method));
+
+            RunIterationCleanup(instance, type);
+        }
+
+        Report(results);
+        return results.All(result => result.Error is null);
+    }
+
+    private static IEnumerable<Type> DiscoverBenchmarkTypes() =>
+        typeof(EndpointValidator).Assembly
+            .GetTypes()
+            .Where(type => !type.IsAbstract && typeof(ApiBenchmark).IsAssignableFrom(type))
+            .OrderBy(type => type.Name, StringComparer.Ordinal);
+
+    private static IEnumerable<MethodInfo> BenchmarkMethods(Type type) =>
+        type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(method => method.GetCustomAttribute<BenchmarkAttribute>() is not null);
+
+    private static async Task<ValidationResult> Invoke(ApiBenchmark instance, MethodInfo method)
+    {
+        var label = method.GetCustomAttribute<BenchmarkAttribute>()?.Description ?? method.Name;
+        var stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            var payloadBytes = await (Task<long>)method.Invoke(instance, null)!;
+            stopwatch.Stop();
+            return new ValidationResult(instance.GetType().Name, label, stopwatch.Elapsed, payloadBytes, Error: null);
+        }
+        catch (Exception ex)
+        {
+            stopwatch.Stop();
+            // Reflection wraps whatever the endpoint threw; the inner exception carries the status code
+            // and response body that actually explain the failure.
+            var cause = (ex as TargetInvocationException)?.InnerException ?? ex;
+            return new ValidationResult(instance.GetType().Name, label, stopwatch.Elapsed, PayloadBytes: 0, cause.Message);
+        }
+    }
+
+    private static void RunIterationCleanup(ApiBenchmark instance, Type type)
+    {
+        foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(method => method.GetCustomAttribute<IterationCleanupAttribute>() is not null))
+        {
+            method.Invoke(instance, null);
+        }
+    }
+
+    private static void Report(List<ValidationResult> results)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"{"Category",-30} {"Call",-58} {"Time",10} {"Bytes",10}  Status");
+        Console.WriteLine(new string('-', 125));
+
+        foreach (var result in results)
+        {
+            var elapsed = result.Elapsed.TotalMilliseconds.ToString("F1", CultureInfo.InvariantCulture) + " ms";
+            var status = result.Error is null ? "ok" : "FAILED: " + result.Error;
+            Console.WriteLine($"{result.Category,-30} {Truncate(result.Call, 58),-58} {elapsed,10} {result.PayloadBytes,10}  {status}");
+        }
+
+        var failures = results.Count(result => result.Error is not null);
+        Console.WriteLine();
+        Console.WriteLine(failures == 0
+            ? $"All {results.Count} benchmarked calls succeeded."
+            : $"{failures} of {results.Count} benchmarked calls failed.");
+    }
+
+    private static string Truncate(string value, int length) =>
+        value.Length <= length ? value : value[..(length - 1)] + "…";
+}

--- a/code/FinanceManager.Benchmarks/Validation/ValidationResult.cs
+++ b/code/FinanceManager.Benchmarks/Validation/ValidationResult.cs
@@ -1,0 +1,16 @@
+namespace FinanceManager.Benchmarks.Validation;
+
+/// <summary>
+/// Outcome of one validation call: how long it took, how much it returned, and why it failed if it did.
+/// </summary>
+/// <param name="Category">Benchmark class the call belongs to.</param>
+/// <param name="Call">Human-readable description of the endpoint, taken from the benchmark attribute.</param>
+/// <param name="Elapsed">Wall time for the single call. Indicative only — includes first-call warmup.</param>
+/// <param name="PayloadBytes">Size of the response body; a zero or near-zero size on a list endpoint usually means the seeded data was missed.</param>
+/// <param name="Error">Failure message, or null when the call succeeded.</param>
+public sealed record ValidationResult(
+    string Category,
+    string Call,
+    TimeSpan Elapsed,
+    long PayloadBytes,
+    string? Error);

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryValueCalculator.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryValueCalculator.cs
@@ -7,13 +7,46 @@ internal sealed class BondEntryValueCalculator(AppDbContext context)
 {
     public async Task Recalculate(int accountId, DateTime startDate)
     {
-        if (!context.Database.IsRelational())
+        // Each supported provider gets its own dialect below; anything else falls back to the managed
+        // loop rather than being handed SQL Server syntax it cannot parse.
+        if (!context.Database.IsRelational() || !DatabaseProviders.HasSetBasedRecalculation(context))
         {
             await RecalculateInMemory(accountId, startDate);
             return;
         }
 
-        if (context.Database.ProviderName?.StartsWith("Npgsql") == true)
+        if (DatabaseProviders.IsSqlite(context))
+        {
+            // SQLite has no DISTINCT ON, so the per-bond anchor is picked with ROW_NUMBER as on SQL
+            // Server; the UPDATE names its target table rather than aliasing it, as SQLite requires.
+            await context.Database.ExecuteSqlAsync($"""
+                WITH anchors_raw AS (
+                    SELECT "BondDetailsId", "Value" AS "AnchorValue",
+                           ROW_NUMBER() OVER (PARTITION BY "BondDetailsId" ORDER BY "PostingDate" DESC, "EntryId" DESC) AS "rn"
+                    FROM "BondEntries"
+                    WHERE "AccountId" = {accountId} AND "PostingDate" < {startDate}
+                ),
+                anchors AS (
+                    SELECT "BondDetailsId", "AnchorValue" FROM anchors_raw WHERE "rn" = 1
+                ),
+                running AS (
+                    SELECT e."EntryId",
+                           COALESCE(a."AnchorValue", 0) + SUM(e."ValueChange") OVER (
+                               PARTITION BY e."BondDetailsId"
+                               ORDER BY e."PostingDate", e."EntryId"
+                               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                           ) AS "NewValue"
+                    FROM "BondEntries" e
+                    LEFT JOIN anchors a ON a."BondDetailsId" = e."BondDetailsId"
+                    WHERE e."AccountId" = {accountId} AND e."PostingDate" >= {startDate}
+                )
+                UPDATE "BondEntries"
+                SET "Value" = r."NewValue"
+                FROM running AS r
+                WHERE "BondEntries"."EntryId" = r."EntryId"
+                """);
+        }
+        else if (DatabaseProviders.IsNpgsql(context))
         {
             await context.Database.ExecuteSqlAsync($"""
                 WITH anchors AS (

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryValueCalculator.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryValueCalculator.cs
@@ -15,7 +15,9 @@ internal sealed class CurrencyEntryValueCalculator(AppDbContext context)
             .Select(e => (decimal?)e.Value)
             .FirstOrDefaultAsync();
 
-        if (!context.Database.IsRelational())
+        // Each supported provider gets its own dialect below; anything else falls back to the managed
+        // loop rather than being handed SQL Server syntax it cannot parse.
+        if (!context.Database.IsRelational() || !DatabaseProviders.HasSetBasedRecalculation(context))
         {
             var entries = await context.CurrencyEntries
                 .Where(e => e.AccountId == accountId && e.PostingDate >= startDate)
@@ -34,7 +36,28 @@ internal sealed class CurrencyEntryValueCalculator(AppDbContext context)
             return;
         }
 
-        if (context.Database.ProviderName?.StartsWith("Npgsql") == true)
+        if (DatabaseProviders.IsSqlite(context))
+        {
+            // SQLite supports window functions and UPDATE ... FROM, but not SQL Server's
+            // "UPDATE <alias> ... FROM <table> AS <alias>" form: the target is named, not aliased.
+            await context.Database.ExecuteSqlAsync($"""
+                WITH running AS (
+                    SELECT "EntryId",
+                           {anchor ?? 0m} + SUM("ValueChange") OVER (
+                               ORDER BY "PostingDate", "EntryId"
+                               ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                           ) AS "NewValue"
+                    FROM "CurrencyEntries"
+                    WHERE "AccountId" = {accountId}
+                      AND "PostingDate" >= {startDate}
+                )
+                UPDATE "CurrencyEntries"
+                SET "Value" = r."NewValue"
+                FROM running AS r
+                WHERE "CurrencyEntries"."EntryId" = r."EntryId"
+                """);
+        }
+        else if (DatabaseProviders.IsNpgsql(context))
         {
             await context.Database.ExecuteSqlAsync($"""
                 WITH running AS (

--- a/code/FinanceManager.Infrastructure/Repositories/DatabaseProviders.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/DatabaseProviders.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Infrastructure.Repositories;
+
+/// <summary>
+/// Identifies the EF Core provider behind an <see cref="DbContext"/> so the repositories can pick a SQL
+/// dialect for the hand-written set-based statements.
+/// </summary>
+/// <remarks>
+/// The running-balance recalculations are expressed as a single windowed UPDATE, which has no portable
+/// spelling — SQL Server, PostgreSQL and SQLite each want a different one. Deciding by provider name in
+/// one place keeps that dialect switch consistent between the currency and bond calculators, and gives
+/// them a shared answer to "is this a provider we have SQL for?" so an unrecognised one can take the
+/// portable managed path instead of being handed statements it cannot parse.
+/// </remarks>
+internal static class DatabaseProviders
+{
+    private const string _sqlitePrefix = "Microsoft.EntityFrameworkCore.Sqlite";
+    private const string _npgsqlPrefix = "Npgsql";
+    private const string _sqlServerPrefix = "Microsoft.EntityFrameworkCore.SqlServer";
+
+    /// <summary>True when the provider is SQLite (used by benchmarks and local tooling).</summary>
+    public static bool IsSqlite(DbContext context) => HasPrefix(context, _sqlitePrefix);
+
+    /// <summary>True when the provider is PostgreSQL.</summary>
+    public static bool IsNpgsql(DbContext context) => HasPrefix(context, _npgsqlPrefix);
+
+    /// <summary>True when the provider is SQL Server.</summary>
+    public static bool IsSqlServer(DbContext context) => HasPrefix(context, _sqlServerPrefix);
+
+    /// <summary>
+    /// True when a hand-written set-based UPDATE exists for this provider. False means the caller must
+    /// use its managed row-by-row fallback, which is correct on every provider but slower.
+    /// </summary>
+    public static bool HasSetBasedRecalculation(DbContext context) =>
+        IsSqlServer(context) || IsNpgsql(context) || IsSqlite(context);
+
+    private static bool HasPrefix(DbContext context, string prefix) =>
+        context.Database.ProviderName?.StartsWith(prefix, StringComparison.Ordinal) == true;
+}

--- a/code/FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj
+++ b/code/FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj
@@ -16,6 +16,13 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+		<!-- SqliteRecalculateValuesTests exercises the hand-written set-based UPDATE on a real
+		     relational provider; SQLite is the only one that runs in-process with no server. -->
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+		<!-- Direct reference so the central pin (3.0.3) overrides the vulnerable 2.1.11 that
+		     Microsoft.EntityFrameworkCore.Sqlite brings in transitively (GHSA-2m69-gcr7-jv3q);
+		     transitive pinning is disabled centrally. -->
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="xunit.runner.visualstudio">

--- a/code/FinanceManager.Tests.Integration/Repositories/SqliteRecalculateValuesTests.cs
+++ b/code/FinanceManager.Tests.Integration/Repositories/SqliteRecalculateValuesTests.cs
@@ -1,0 +1,191 @@
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Infrastructure.Contexts;
+using FinanceManager.Infrastructure.Repositories.Account.Entry;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Repositories;
+
+/// <summary>
+/// Covers running-balance recalculation on a <em>relational</em> provider, exercising the hand-written
+/// set-based <c>UPDATE</c> rather than the managed row-by-row fallback that
+/// <see cref="RecalculateValuesTests"/> covers.
+/// </summary>
+/// <remarks>
+/// The windowed UPDATE has a different spelling per provider and had no automated coverage at all: the
+/// InMemory provider takes the managed path, so a broken dialect could only be found by running against
+/// a real database. SQLite is the one relational provider that runs in-process with no external server,
+/// so these tests can assert the set-based SQL actually produces correct balances. The SQL Server and
+/// PostgreSQL branches remain structurally equivalent statements validated against those databases.
+///
+/// Amounts are whole numbers on purpose. SQLite has no decimal type, so EF Core stores money as TEXT and
+/// <c>SUM</c> coerces it to floating point; integral values keep the assertions about ordering and
+/// anchoring free of float-representation noise, which is what these tests are actually about.
+/// </remarks>
+[Trait("Category", "Integration")]
+public sealed class SqliteRecalculateValuesTests : IDisposable
+{
+    private const int _accountId = 9101;
+
+    private readonly SqliteConnection _connection;
+    private readonly AppDbContext _context;
+
+    public SqliteRecalculateValuesTests()
+    {
+        // A shared-cache in-memory database lives exactly as long as this connection, which keeps each
+        // test isolated without touching the filesystem.
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _context = new AppDbContext(
+            new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(_connection)
+                .Options);
+
+        // Migrations in this repo are generated for SQL Server, so the schema is created from the model.
+        _context.Database.EnsureCreated();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task Currency_SetBasedRecalculation_ProducesRunningBalances()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repo = new CurrencyEntryRepository(_context);
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan15 = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var jan20 = new DateTime(2025, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        await repo.Add(new CurrencyAccountEntry(_accountId, 0, jan10, 1000m, 1000m), recalculate: false);
+        await repo.Add(new CurrencyAccountEntry(_accountId, 0, jan15, 200m, 200m), recalculate: false);
+        await repo.Add(new CurrencyAccountEntry(_accountId, 0, jan20, 500m, 500m), recalculate: false);
+
+        await repo.RecalculateValues(_accountId);
+
+        var entries = await ReadCurrencyEntries(ct);
+
+        Assert.Equal(3, entries.Count);
+        Assert.Equal(1000m, entries[0].Value); // jan10
+        Assert.Equal(1200m, entries[1].Value); // jan15: 1000 + 200
+        Assert.Equal(1700m, entries[2].Value); // jan20: 1200 + 500
+    }
+
+    [Fact]
+    public async Task Currency_OutOfOrderInsert_RecalculatesFromAnchor()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repo = new CurrencyEntryRepository(_context);
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan15 = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var jan20 = new DateTime(2025, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        await repo.Add(new CurrencyAccountEntry(_accountId, 0, jan10, 0, 1000m), recalculate: true);
+        await repo.Add(new CurrencyAccountEntry(_accountId, 0, jan20, 0, 500m), recalculate: true);
+
+        // Inserting between existing entries recalculates from jan15 on, seeded by the jan10 anchor —
+        // the part of the statement that reads a value from outside the updated range.
+        await repo.Add(new CurrencyAccountEntry(_accountId, 0, jan15, 0, 200m), recalculate: true);
+
+        var entries = await ReadCurrencyEntries(ct);
+
+        Assert.Equal(3, entries.Count);
+        Assert.Equal(1000m, entries[0].Value); // jan10
+        Assert.Equal(1200m, entries[1].Value); // jan15: anchored on jan10
+        Assert.Equal(1700m, entries[2].Value); // jan20: 1200 + 500
+    }
+
+    [Fact]
+    public async Task Bond_SetBasedRecalculation_PartitionsByBondDetailsId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repo = new BondEntryRepository(_context);
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan15 = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var jan20 = new DateTime(2025, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        const int bondA = 1;
+        const int bondB = 2;
+
+        await repo.Add(new BondAccountEntry(_accountId, 0, jan10, 500m, 500m, bondA), recalculate: false);
+        await repo.Add(new BondAccountEntry(_accountId, 0, jan15, 100m, 100m, bondA), recalculate: false);
+        await repo.Add(new BondAccountEntry(_accountId, 0, jan20, 300m, 300m, bondA), recalculate: false);
+        // A second bond in the same account must keep its own running total.
+        await repo.Add(new BondAccountEntry(_accountId, 0, jan10, 1000m, 1000m, bondB), recalculate: false);
+
+        await repo.RecalculateValues(_accountId);
+
+        var bondAEntries = await ReadBondEntries(bondA, ct);
+        var bondBEntries = await ReadBondEntries(bondB, ct);
+
+        Assert.Equal(3, bondAEntries.Count);
+        Assert.Equal(500m, bondAEntries[0].Value); // jan10
+        Assert.Equal(600m, bondAEntries[1].Value); // jan15: 500 + 100
+        Assert.Equal(900m, bondAEntries[2].Value); // jan20: 600 + 300
+
+        Assert.Single(bondBEntries);
+        Assert.Equal(1000m, bondBEntries[0].Value);
+    }
+
+    [Fact]
+    public async Task Bond_OutOfOrderInsert_AnchorsPerBondDetailsId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var repo = new BondEntryRepository(_context);
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan15 = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var jan20 = new DateTime(2025, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        const int bondA = 1;
+        const int bondB = 2;
+
+        await repo.Add(new BondAccountEntry(_accountId, 0, jan10, 0, 500m, bondA), recalculate: true);
+        await repo.Add(new BondAccountEntry(_accountId, 0, jan20, 0, 300m, bondA), recalculate: true);
+        await repo.Add(new BondAccountEntry(_accountId, 0, jan10, 0, 1000m, bondB), recalculate: true);
+
+        // Exercises the per-bond anchor selection: bondA anchors on its own jan10 row, not bondB's.
+        await repo.Add(new BondAccountEntry(_accountId, 0, jan15, 0, 100m, bondA), recalculate: true);
+
+        var bondAEntries = await ReadBondEntries(bondA, ct);
+        var bondBEntries = await ReadBondEntries(bondB, ct);
+
+        Assert.Equal(3, bondAEntries.Count);
+        Assert.Equal(500m, bondAEntries[0].Value); // jan10
+        Assert.Equal(600m, bondAEntries[1].Value); // jan15: 500 + 100
+        Assert.Equal(900m, bondAEntries[2].Value); // jan20: 600 + 300
+
+        Assert.Single(bondBEntries);
+        Assert.Equal(1000m, bondBEntries[0].Value);
+    }
+
+    /// <summary>
+    /// Guards the dialect switch itself: this fixture must be on the SQLite branch, not silently taking
+    /// the managed fallback that would make every assertion above pass without testing any SQL.
+    /// </summary>
+    [Fact]
+    public void Fixture_UsesRelationalSqliteProvider()
+    {
+        Assert.True(_context.Database.IsRelational());
+        Assert.Equal("Microsoft.EntityFrameworkCore.Sqlite", _context.Database.ProviderName);
+    }
+
+    private async Task<List<CurrencyAccountEntry>> ReadCurrencyEntries(CancellationToken ct) =>
+        await _context.CurrencyEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == _accountId)
+            .OrderBy(e => e.PostingDate)
+            .ToListAsync(ct);
+
+    private async Task<List<BondAccountEntry>> ReadBondEntries(int bondDetailsId, CancellationToken ct) =>
+        await _context.BondEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == _accountId && e.BondDetailsId == bondDetailsId)
+            .OrderBy(e => e.PostingDate)
+            .ToListAsync(ct);
+}

--- a/code/FinanceManager.slnx
+++ b/code/FinanceManager.slnx
@@ -17,6 +17,7 @@
     <File Path="GlobalUsings.cs" />
   </Folder>
   <Project Path="FinanceManager.Application/FinanceManager.Application.csproj" />
+  <Project Path="FinanceManager.Benchmarks/FinanceManager.Benchmarks.csproj" />
   <Project Path="FinanceManager.Tests.Architecture/FinanceManager.Tests.Architecture.csproj" />
   <Project Path="FinanceManager.Domain/FinanceManager.Domain.csproj" />
   <Project Path="FinanceManager.Infrastructure/FinanceManager.Infrastructure.csproj" />


### PR DESCRIPTION
closes #604

Adds `FinanceManager.Benchmarks`: a BenchmarkDotNet suite measuring the per-request cost of the most-used API endpoints against the **real API host** backed by a **local SQLite file**, so the upcoming optimization refactor has a baseline to be judged against.

## What it covers

| Category | Endpoints |
|---|---|
| `Dashboard` | `Dashboard/overview` over a 6-month and a 1-month window |
| `MoneyFlow` | net worth (point + series), inflow, outflow, net cash flow, closing balance, labels value, investment rate |
| `Assets` | asset existence, end assets per account/type, time series, paycheck estimate, unrealized gain/loss per account/instrument |
| `Analysis` | expense distribution, essential spending, diversification score + breakdown, liabilities |
| `Accounts` | currency/investment/bond lists and details, full-range vs paged entry reads, holdings and valuation |
| `Supporting` | user record, currency list, label count/page/by-account, recent transaction log |
| `Writes` | append a currency entry, recalculate account balances |

45 benchmarks, ~5.5 minutes for a full run.

**Excluded:** import/export (bulk, off the interactive path, as requested). Login — its cost is dominated by password hashing, which is *supposed* to be slow and must not be "optimized"; putting a large deliberately-fixed number next to numbers meant to move would mislead. Admin, AI insight generation, label setting, price backfill, OAuth/MCP — background or low-frequency work.

## Harness design

- **Reproducible data.** A pristine seeded SQLite template is built once and copied per run, so a baseline and a post-refactor run measure byte-identical data, and the write benchmarks can mutate freely without contaminating the next run. Seeding stages to a temp file and moves it into place only on success, so an interrupted seed cannot leave a half-populated template that later runs silently reuse.
- **Product seeders, not fixtures.** Data comes from the guest demo seeders, so entry counts, label distribution and account mix track what the app actually shows a new user.
- **Ids and dates resolved at runtime.** The seeders anchor history to `UtcNow`; hard-coded values would drift into empty ranges as the template ages and endpoints would quietly start measuring "return nothing".
- **No network.** Currency-rate and stock-price providers are swapped for offline stand-ins, so one unlucky HTTP call to a rate-limited vendor cannot land inside a measured iteration.
- **Fails loudly on misconfiguration.** The SQLite swap is asserted at startup — a silent fallback to the in-memory provider would still answer every request and every number would be meaningless.
- **`--validate` mode.** Runs every benchmarked call once and reports status and payload size. A benchmark quietly timing a `403` still produces a tidy table of numbers, which is the worst possible failure mode for a baseline. Discovered by reflection, so it cannot drift out of sync with the suite.

## Warm vs cold cache — the headline result

BenchmarkDotNet invokes each endpoint thousands of times, so a real `HybridCache` is warm from the second invocation onwards and the reported time collapses towards "serialize an already-computed result". `FM_BENCH_COLD_CACHE=1` swaps in a pass-through cache. `Dashboard/overview` over six months, same machine, same data:

| | Mean | Allocated |
|---|---:|---:|
| Warm cache | 0.80 ms | 120 KB |
| Cold cache | 470 ms | 16.6 MB |

The cache is carrying that endpoint almost entirely. The number a user actually waits on is the cold one — paid on the first dashboard load of a session, and again after every write that invalidates their cached read models.

Also from the first run: `Assets/IsAnyAccountWithAssets` returns a single boolean and costs ~13 ms, the same order as endpoints returning a full breakdown.

## Included bug fix

Running SQLite surfaced a latent bug. `CurrencyEntryValueCalculator` and `BondEntryValueCalculator` express running-balance recalculation as a hand-written windowed `UPDATE`; they branched on PostgreSQL and let the `else` branch assume SQL Server syntax, so **any** other relational provider was handed statements it could not parse.

The dialect switch is now explicit (`DatabaseProviders`), SQLite has its own statements, and an unrecognised provider falls back to the correct managed row-by-row path instead of failing. **Behaviour on SQL Server and PostgreSQL is unchanged.**

`SqliteRecalculateValuesTests` gives that set-based SQL its first automated coverage — the existing `RecalculateValuesTests` run on the InMemory provider, which takes the managed fallback, so a broken dialect was previously only findable by running against a real database.

## Scope notes

- **Measured:** routing, model binding, JWT validation, authorization, controllers, application/domain services, repositories, EF Core against SQLite, and full JSON response serialization (every benchmark reads the body to completion, so a response-DTO change cannot look free).
- **Not measured:** Kestrel, sockets, TLS — `WebApplicationFactory` uses an in-memory transport. Deliberate: that work is a near-constant per-request cost a service or query refactor will not change, and excluding it removes the largest source of variance. Also not measured: concurrency between the dashboard's parallel card requests.
- **SQLite caveats:** absolute numbers do not transfer to production hardware — this is for comparing before against after on one machine, not capacity planning. `decimal` is stored as TEXT (timings representative, last cents of a computed total may not be), and `DateTimeOffset` needs an order-preserving integer converter because EF Core's SQLite provider refuses to translate `DateTimeOffset` comparisons at all.

No `CHANGELOG.md` entry: this is developer tooling plus a provider guard that is a no-op for both deployed providers, so there is no user-visible change.

## Validation

- `dotnet build ./code/FinanceManager.slnx` — succeeded (warnings are errors in this repo)
- `dotnet format ./code/FinanceManager.slnx --verify-no-changes` — clean
- Unit tests — 635/635 passed
- Architecture tests — 9/9 passed
- New `SqliteRecalculateValuesTests` — 5/5 passed
- `--validate` — all 45 benchmarked calls return real data
- Full suite run end to end, plus a cold-cache run

The full integration suite is still running locally at time of writing (it is slow by nature — it builds a `WebApplicationFactory` host per test class; CI allots it 25 minutes). I'll confirm the result on this PR.

No UI change, so no screenshots.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RTU1QchtTD69x1hsX9it4A)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive API performance benchmarking suite covering accounts, assets, analysis, dashboard, money flow, supporting reads, and write operations.
  * Added endpoint validation with timing, response-size, and pass/fail reporting.
  * Added configurable benchmark data, cache behavior, logging, and execution modes.

* **Bug Fixes**
  * Improved SQLite support for running-balance recalculation, including out-of-order currency and bond entries.
  * Added integration coverage to verify recalculation accuracy across supported scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->