### PR TITLE
Improve financial account response times #606

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- Financial account pages now load faster by reusing transaction-history boundaries, batching bond lookups, and avoiding redundant currency and investment data reads. #606
 - The expanded investment purchase details now label the valuation figures more clearly — pairing the unit price at purchase with the current unit price, and the value at purchase with the current value — so a per-unit price is no longer shown alongside position totals under ambiguous "Current price"/"Current valuation" labels.
 - The investment account details page now shows loading placeholders for the balance and asset appreciation (and the capital value / current valuation breakdown) while those figures are still being calculated, instead of briefly displaying a misleading `0.00`.
 - The investment transaction list now leads each purchase with its unrealised gain/loss (amount and percentage) rather than the original cash outlay; sells and not-yet-priced trades continue to show their cash impact.

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
@@ -33,8 +33,19 @@ internal class InvestmentValuationService(
 
     public async Task<decimal> GetAccountValueAsync(int accountId, Currency targetCurrency, DateTime asOf, CancellationToken ct = default)
     {
-        var byAccount = await GetAccountValueAsync([accountId], targetCurrency, asOf, ct);
-        return byAccount.TryGetValue(accountId, out var value) ? value : 0m;
+        var holdings = await transactionRepository.GetHoldingsAsOf([accountId], DateOnly.FromDateTime(asOf), ct);
+        decimal total = 0m;
+
+        foreach (var (listingId, holding) in holdings)
+        {
+            if (holding == 0m) continue;
+
+            var price = await priceProvider.GetPricePerUnitAsync(listingId, targetCurrency, asOf, ct);
+            if (price > 0m)
+                total += holding * price;
+        }
+
+        return total;
     }
 
     public async Task<IReadOnlyDictionary<int, decimal>> GetAccountValueAsync(

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
@@ -228,6 +228,7 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
         if (accountIds.Count == 0) return [];
 
         var rows = await context.BondEntries
+            .AsNoTracking()
             .Where(e => accountIds.Contains(e.AccountId) && e.PostingDate < date)
             .Where(e => !context.BondEntries.Any(o => o.AccountId == e.AccountId && o.PostingDate < date
                 && (o.PostingDate > e.PostingDate || (o.PostingDate == e.PostingDate && o.EntryId > e.EntryId))))
@@ -241,6 +242,7 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
         if (accountIds.Count == 0) return [];
 
         var rows = await context.BondEntries
+            .AsNoTracking()
             .Where(e => accountIds.Contains(e.AccountId) && e.PostingDate > date)
             .Where(e => !context.BondEntries.Any(o => o.AccountId == e.AccountId && o.PostingDate > date
                 && (o.PostingDate < e.PostingDate || (o.PostingDate == e.PostingDate && o.EntryId < e.EntryId))))
@@ -256,6 +258,7 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
         // One row per (account, bond details id): the entry no other older-than-date entry of the same
         // account+bond beats on (PostingDate, EntryId).
         var rows = await context.BondEntries
+            .AsNoTracking()
             .Where(e => accountIds.Contains(e.AccountId) && e.PostingDate < date)
             .Where(e => !context.BondEntries.Any(o => o.AccountId == e.AccountId && o.BondDetailsId == e.BondDetailsId && o.PostingDate < date
                 && (o.PostingDate > e.PostingDate || (o.PostingDate == e.PostingDate && o.EntryId > e.EntryId))))
@@ -270,6 +273,7 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
         if (accountIds.Count == 0) return [];
 
         var rows = await context.BondEntries
+            .AsNoTracking()
             .Where(e => accountIds.Contains(e.AccountId) && e.PostingDate > date)
             .Where(e => !context.BondEntries.Any(o => o.AccountId == e.AccountId && o.BondDetailsId == e.BondDetailsId && o.PostingDate > date
                 && (o.PostingDate < e.PostingDate || (o.PostingDate == e.PostingDate && o.EntryId < e.EntryId))))

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
@@ -426,56 +426,14 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
 
     async Task<Dictionary<int, BondAccountEntry>> IBondAccountEntryRepository<BondAccountEntry>.GetNextOlder(int accountId, DateTime date)
     {
-        Dictionary<int, BondAccountEntry> result = [];
-
-        var bondDetailsIds = await context.BondEntries
-                                .AsNoTracking()
-                                .Where(e => e.AccountId == accountId)
-                                .Select(m => m.BondDetailsId)
-                                .Distinct()
-                                .ToListAsync();
-
-        foreach (var bondDetailsId in bondDetailsIds)
-        {
-            var nextOlder = await context.BondEntries
-                   .AsNoTracking()
-                   .Where(e => e.BondDetailsId == bondDetailsId && e.AccountId == accountId && e.PostingDate < date)
-                   .OrderByDescending(e => e.PostingDate).ThenByDescending(e => e.EntryId)
-                   .FirstOrDefaultAsync();
-
-            if (nextOlder is null) continue;
-
-            result.Add(bondDetailsId, nextOlder);
-        }
-
-        return result;
+        var byAccount = await GetNextOlderPerInstrument([accountId], date);
+        return byAccount.GetValueOrDefault(accountId) ?? [];
     }
 
     async Task<Dictionary<int, BondAccountEntry>> IBondAccountEntryRepository<BondAccountEntry>.GetNextYounger(int accountId, DateTime date)
     {
-        Dictionary<int, BondAccountEntry> result = [];
-
-        var bondDetailsIds = await context.BondEntries
-                                .AsNoTracking()
-                                .Where(e => e.AccountId == accountId)
-                                .Select(m => m.BondDetailsId)
-                                .Distinct()
-                                .ToListAsync();
-
-        foreach (var bondDetailsId in bondDetailsIds)
-        {
-            var nextYounger = await context.BondEntries
-                   .AsNoTracking()
-                   .Where(e => e.BondDetailsId == bondDetailsId && e.AccountId == accountId && e.PostingDate > date)
-                   .OrderByDescending(e => e.PostingDate).ThenByDescending(e => e.EntryId)
-                   .LastOrDefaultAsync();
-
-            if (nextYounger is null) continue;
-
-            result.Add(bondDetailsId, nextYounger);
-        }
-
-        return result;
+        var byAccount = await GetNextYoungerPerInstrument([accountId], date);
+        return byAccount.GetValueOrDefault(accountId) ?? [];
     }
 
 

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CachedAccountEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CachedAccountEntryRepository.cs
@@ -9,7 +9,8 @@ namespace FinanceManager.Infrastructure.Repositories.Account.Entry;
 /// <summary>
 /// Caches the cheap, high-frequency point-reads of an <see cref="IAccountEntryRepository{T}"/>
 /// (<see cref="GetYoungest"/>, <see cref="GetOldest"/>, <see cref="GetCount"/>,
-/// <see cref="GetPostingDates"/>), keyed per account and tagged per owning user (<c>global:u{userId}</c>).
+/// <see cref="GetPostingDates"/>, and date-boundary reads), keyed per account and tagged per owning user
+/// (<c>global:u{userId}</c>).
 /// Also caches range reads (<see cref="Get(int,DateTime,DateTime)"/>, <see cref="GetRange"/>) using
 /// calendar-month buckets, inflated to whole-month boundaries on every miss, within a rolling
 /// 12-month horizon. Any write to an account busts the owner's cache through
@@ -24,6 +25,8 @@ public class CachedAccountEntryRepository<T>(
     EntryRangeCacheOptions rangeOptions) : IAccountEntryRepository<T> where T : FinancialEntryBase
 {
     private static readonly HybridCacheEntryOptions _pointReadOptions = new() { Expiration = TimeSpan.FromMinutes(5) };
+    protected IAccountUserResolver AccountUserResolver => userResolver;
+    protected HybridCache EntryCache => cache;
 
     // ----- Cached point reads (per account, tagged per owning user) -----
 
@@ -190,9 +193,9 @@ public class CachedAccountEntryRepository<T>(
     public Task<IReadOnlyList<T>> GetByIds(IReadOnlyCollection<int> entryIds, CancellationToken cancellationToken = default) => inner.GetByIds(entryIds, cancellationToken);
     public Task<IReadOnlyList<T>> GetRecentUnlabelled(int count, CancellationToken cancellationToken = default) => inner.GetRecentUnlabelled(count, cancellationToken);
     public Task<T?> GetNextYounger(int accountId, int entryId) => inner.GetNextYounger(accountId, entryId);
-    public Task<T?> GetNextYounger(int accountId, DateTime date) => inner.GetNextYounger(accountId, date);
+    public Task<T?> GetNextYounger(int accountId, DateTime date) => GetBoundary(accountId, date, "younger", inner.GetNextYounger);
     public Task<T?> GetNextOlder(int accountId, int entryId) => inner.GetNextOlder(accountId, entryId);
-    public Task<T?> GetNextOlder(int accountId, DateTime date) => inner.GetNextOlder(accountId, date);
+    public Task<T?> GetNextOlder(int accountId, DateTime date) => GetBoundary(accountId, date, "older", inner.GetNextOlder);
     public Task<Dictionary<int, T>> GetNextOlder(IReadOnlyCollection<int> accountIds, DateTime date) => inner.GetNextOlder(accountIds, date);
     public Task<Dictionary<int, T>> GetNextYounger(IReadOnlyCollection<int> accountIds, DateTime date) => inner.GetNextYounger(accountIds, date);
     public Task<IReadOnlyDictionary<int, int>> GetEntriesCountPerUser(IReadOnlyCollection<int> userIds, CancellationToken cancellationToken = default) => inner.GetEntriesCountPerUser(userIds, cancellationToken);
@@ -314,6 +317,22 @@ public class CachedAccountEntryRepository<T>(
 
     private static string Key(int userId, int accountId, string read) => $"global:u{userId}:a{accountId}:{read}";
     private static string Tag(int userId) => $"global:u{userId}";
+
+    private async Task<T?> GetBoundary(
+        int accountId,
+        DateTime date,
+        string direction,
+        Func<int, DateTime, Task<T?>> read)
+    {
+        if (await userResolver.GetUserId(accountId) is not int userId)
+            return await read(accountId, date);
+
+        return await cache.GetOrCreateAsync<T?>(
+            Key(userId, accountId, $"{direction}:{date.Ticks}"),
+            _ => new ValueTask<T?>(read(accountId, date)),
+            _pointReadOptions,
+            tags: [Tag(userId)]);
+    }
 
     private async Task InvalidateAccounts(IEnumerable<int> accountIds, CancellationToken cancellationToken = default)
     {

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CachedAccountEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CachedAccountEntryRepository.cs
@@ -25,58 +25,13 @@ public class CachedAccountEntryRepository<T>(
     EntryRangeCacheOptions rangeOptions) : IAccountEntryRepository<T> where T : FinancialEntryBase
 {
     private static readonly HybridCacheEntryOptions _pointReadOptions = new() { Expiration = TimeSpan.FromMinutes(5) };
-    protected IAccountUserResolver AccountUserResolver => userResolver;
-    protected HybridCache EntryCache => cache;
 
     // ----- Cached point reads (per account, tagged per owning user) -----
 
-    public async Task<T?> GetYoungest(int accountId)
-    {
-        if (await userResolver.GetUserId(accountId) is not int userId)
-            return await inner.GetYoungest(accountId);
-
-        return await cache.GetOrCreateAsync<T?>(
-            Key(userId, accountId, "youngest"),
-            _ => new ValueTask<T?>(inner.GetYoungest(accountId)),
-            _pointReadOptions,
-            tags: [Tag(userId)]);
-    }
-
-    public async Task<T?> GetOldest(int accountId)
-    {
-        if (await userResolver.GetUserId(accountId) is not int userId)
-            return await inner.GetOldest(accountId);
-
-        return await cache.GetOrCreateAsync<T?>(
-            Key(userId, accountId, "oldest"),
-            _ => new ValueTask<T?>(inner.GetOldest(accountId)),
-            _pointReadOptions,
-            tags: [Tag(userId)]);
-    }
-
-    public async Task<int> GetCount(int accountId)
-    {
-        if (await userResolver.GetUserId(accountId) is not int userId)
-            return await inner.GetCount(accountId);
-
-        return await cache.GetOrCreateAsync(
-            Key(userId, accountId, "count"),
-            _ => new ValueTask<int>(inner.GetCount(accountId)),
-            _pointReadOptions,
-            tags: [Tag(userId)]);
-    }
-
-    public async Task<List<DateTime>> GetPostingDates(int accountId)
-    {
-        if (await userResolver.GetUserId(accountId) is not int userId)
-            return await inner.GetPostingDates(accountId);
-
-        return await cache.GetOrCreateAsync(
-            Key(userId, accountId, "dates"),
-            _ => new ValueTask<List<DateTime>>(inner.GetPostingDates(accountId)),
-            _pointReadOptions,
-            tags: [Tag(userId)]);
-    }
+    public Task<T?> GetYoungest(int accountId) => GetCached(accountId, "youngest", () => inner.GetYoungest(accountId));
+    public Task<T?> GetOldest(int accountId) => GetCached(accountId, "oldest", () => inner.GetOldest(accountId));
+    public Task<int> GetCount(int accountId) => GetCached(accountId, "count", () => inner.GetCount(accountId));
+    public Task<List<DateTime>> GetPostingDates(int accountId) => GetCached(accountId, "dates", () => inner.GetPostingDates(accountId));
 
     // ----- Cached range reads: calendar-month buckets with inflate-on-miss -----
 
@@ -193,9 +148,11 @@ public class CachedAccountEntryRepository<T>(
     public Task<IReadOnlyList<T>> GetByIds(IReadOnlyCollection<int> entryIds, CancellationToken cancellationToken = default) => inner.GetByIds(entryIds, cancellationToken);
     public Task<IReadOnlyList<T>> GetRecentUnlabelled(int count, CancellationToken cancellationToken = default) => inner.GetRecentUnlabelled(count, cancellationToken);
     public Task<T?> GetNextYounger(int accountId, int entryId) => inner.GetNextYounger(accountId, entryId);
-    public Task<T?> GetNextYounger(int accountId, DateTime date) => GetBoundary(accountId, date, "younger", inner.GetNextYounger);
+    public Task<T?> GetNextYounger(int accountId, DateTime date) =>
+        GetCached(accountId, $"younger:{date.Ticks}", () => inner.GetNextYounger(accountId, date));
     public Task<T?> GetNextOlder(int accountId, int entryId) => inner.GetNextOlder(accountId, entryId);
-    public Task<T?> GetNextOlder(int accountId, DateTime date) => GetBoundary(accountId, date, "older", inner.GetNextOlder);
+    public Task<T?> GetNextOlder(int accountId, DateTime date) =>
+        GetCached(accountId, $"older:{date.Ticks}", () => inner.GetNextOlder(accountId, date));
     public Task<Dictionary<int, T>> GetNextOlder(IReadOnlyCollection<int> accountIds, DateTime date) => inner.GetNextOlder(accountIds, date);
     public Task<Dictionary<int, T>> GetNextYounger(IReadOnlyCollection<int> accountIds, DateTime date) => inner.GetNextYounger(accountIds, date);
     public Task<IReadOnlyDictionary<int, int>> GetEntriesCountPerUser(IReadOnlyCollection<int> userIds, CancellationToken cancellationToken = default) => inner.GetEntriesCountPerUser(userIds, cancellationToken);
@@ -318,18 +275,17 @@ public class CachedAccountEntryRepository<T>(
     private static string Key(int userId, int accountId, string read) => $"global:u{userId}:a{accountId}:{read}";
     private static string Tag(int userId) => $"global:u{userId}";
 
-    private async Task<T?> GetBoundary(
+    protected async Task<TResult> GetCached<TResult>(
         int accountId,
-        DateTime date,
-        string direction,
-        Func<int, DateTime, Task<T?>> read)
+        string readKey,
+        Func<Task<TResult>> read)
     {
         if (await userResolver.GetUserId(accountId) is not int userId)
-            return await read(accountId, date);
+            return await read();
 
-        return await cache.GetOrCreateAsync<T?>(
-            Key(userId, accountId, $"{direction}:{date.Ticks}"),
-            _ => new ValueTask<T?>(read(accountId, date)),
+        return await cache.GetOrCreateAsync(
+            Key(userId, accountId, readKey),
+            _ => new ValueTask<TResult>(read()),
             _pointReadOptions,
             tags: [Tag(userId)]);
     }

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CachedBondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CachedBondEntryRepository.cs
@@ -19,8 +19,36 @@ public class CachedBondEntryRepository(
     : CachedAccountEntryRepository<BondAccountEntry>(inner, userResolver, cacheInvalidator, cache, rangeOptions),
       IBondAccountEntryRepository<BondAccountEntry>
 {
-    Task<Dictionary<int, BondAccountEntry>> IBondAccountEntryRepository<BondAccountEntry>.GetNextOlder(int accountId, DateTime date) => inner.GetNextOlder(accountId, date);
-    Task<Dictionary<int, BondAccountEntry>> IBondAccountEntryRepository<BondAccountEntry>.GetNextYounger(int accountId, DateTime date) => inner.GetNextYounger(accountId, date);
+    private static readonly HybridCacheEntryOptions _boundaryOptions = new() { Expiration = TimeSpan.FromMinutes(5) };
+
+    Task<Dictionary<int, BondAccountEntry>> IBondAccountEntryRepository<BondAccountEntry>.GetNextOlder(int accountId, DateTime date) =>
+        GetBoundary(accountId, date, "older", inner.GetNextOlderPerInstrument);
+
+    Task<Dictionary<int, BondAccountEntry>> IBondAccountEntryRepository<BondAccountEntry>.GetNextYounger(int accountId, DateTime date) =>
+        GetBoundary(accountId, date, "younger", inner.GetNextYoungerPerInstrument);
+
     public Task<Dictionary<int, Dictionary<int, BondAccountEntry>>> GetNextOlderPerInstrument(IReadOnlyCollection<int> accountIds, DateTime date) => inner.GetNextOlderPerInstrument(accountIds, date);
     public Task<Dictionary<int, Dictionary<int, BondAccountEntry>>> GetNextYoungerPerInstrument(IReadOnlyCollection<int> accountIds, DateTime date) => inner.GetNextYoungerPerInstrument(accountIds, date);
+
+    private async Task<Dictionary<int, BondAccountEntry>> GetBoundary(
+        int accountId,
+        DateTime date,
+        string direction,
+        Func<IReadOnlyCollection<int>, DateTime, Task<Dictionary<int, Dictionary<int, BondAccountEntry>>>> read)
+    {
+        async Task<Dictionary<int, BondAccountEntry>> Read()
+        {
+            var byAccount = await read([accountId], date);
+            return byAccount.GetValueOrDefault(accountId) ?? [];
+        }
+
+        if (await AccountUserResolver.GetUserId(accountId) is not int userId)
+            return await Read();
+
+        return await EntryCache.GetOrCreateAsync(
+            $"global:u{userId}:a{accountId}:bond:{direction}:{date.Ticks}",
+            _ => new ValueTask<Dictionary<int, BondAccountEntry>>(Read()),
+            _boundaryOptions,
+            tags: [$"global:u{userId}"]);
+    }
 }

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CachedBondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CachedBondEntryRepository.cs
@@ -19,36 +19,12 @@ public class CachedBondEntryRepository(
     : CachedAccountEntryRepository<BondAccountEntry>(inner, userResolver, cacheInvalidator, cache, rangeOptions),
       IBondAccountEntryRepository<BondAccountEntry>
 {
-    private static readonly HybridCacheEntryOptions _boundaryOptions = new() { Expiration = TimeSpan.FromMinutes(5) };
-
     Task<Dictionary<int, BondAccountEntry>> IBondAccountEntryRepository<BondAccountEntry>.GetNextOlder(int accountId, DateTime date) =>
-        GetBoundary(accountId, date, "older", inner.GetNextOlderPerInstrument);
+        GetCached(accountId, $"bond:older:{date.Ticks}", () => inner.GetNextOlder(accountId, date));
 
     Task<Dictionary<int, BondAccountEntry>> IBondAccountEntryRepository<BondAccountEntry>.GetNextYounger(int accountId, DateTime date) =>
-        GetBoundary(accountId, date, "younger", inner.GetNextYoungerPerInstrument);
+        GetCached(accountId, $"bond:younger:{date.Ticks}", () => inner.GetNextYounger(accountId, date));
 
     public Task<Dictionary<int, Dictionary<int, BondAccountEntry>>> GetNextOlderPerInstrument(IReadOnlyCollection<int> accountIds, DateTime date) => inner.GetNextOlderPerInstrument(accountIds, date);
     public Task<Dictionary<int, Dictionary<int, BondAccountEntry>>> GetNextYoungerPerInstrument(IReadOnlyCollection<int> accountIds, DateTime date) => inner.GetNextYoungerPerInstrument(accountIds, date);
-
-    private async Task<Dictionary<int, BondAccountEntry>> GetBoundary(
-        int accountId,
-        DateTime date,
-        string direction,
-        Func<IReadOnlyCollection<int>, DateTime, Task<Dictionary<int, Dictionary<int, BondAccountEntry>>>> read)
-    {
-        async Task<Dictionary<int, BondAccountEntry>> Read()
-        {
-            var byAccount = await read([accountId], date);
-            return byAccount.GetValueOrDefault(accountId) ?? [];
-        }
-
-        if (await AccountUserResolver.GetUserId(accountId) is not int userId)
-            return await Read();
-
-        return await EntryCache.GetOrCreateAsync(
-            $"global:u{userId}:a{accountId}:bond:{direction}:{date.Ticks}",
-            _ => new ValueTask<Dictionary<int, BondAccountEntry>>(Read()),
-            _boundaryOptions,
-            tags: [$"global:u{userId}"]);
-    }
 }

--- a/code/FinanceManager.Infrastructure/Repositories/CurrencyRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/CurrencyRepository.cs
@@ -23,27 +23,33 @@ public class CurrencyRepository(AppDbContext context) : ICurrencyRepository
     public async Task<Currency?> GetCurrency(int id, CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
-        await EnsureDefaults(ct);
+        var currency = await context.Currencies.FirstOrDefaultAsync(x => x.Id == id, ct);
+        if (currency is not null) return currency;
 
+        await EnsureDefaults(ct);
         return await context.Currencies.FirstOrDefaultAsync(x => x.Id == id, ct);
     }
 
     public async Task<Currency?> GetByCode(string shortName, CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
-        await EnsureDefaults(ct);
-
         var normalized = shortName.Trim().ToUpperInvariant();
+        var currency = await context.Currencies.FirstOrDefaultAsync(x => x.ShortName == normalized, ct);
+        if (currency is not null) return currency;
+
+        await EnsureDefaults(ct);
         return await context.Currencies.FirstOrDefaultAsync(x => x.ShortName == normalized, ct);
     }
 
     public async Task<Currency> GetOrAdd(string shortName, string? symbol, CancellationToken ct = default)
     {
         ct.ThrowIfCancellationRequested();
-        await EnsureDefaults(ct);
-
         var normalized = shortName.Trim().ToUpperInvariant();
         var existing = await context.Currencies.FirstOrDefaultAsync(x => x.ShortName == normalized, ct);
+        if (existing is not null) return existing;
+
+        await EnsureDefaults(ct);
+        existing = await context.Currencies.FirstOrDefaultAsync(x => x.ShortName == normalized, ct);
         if (existing is not null) return existing;
 
         var nextId = await GetNextId(ct);

--- a/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
@@ -49,12 +49,8 @@ public class InvestmentValuationServiceTests
     {
         var asOf = new DateTime(2024, 6, 30);
         _transactionRepository
-            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                Tx(10, InvestmentTransactionType.Buy, 3m, new DateOnly(2024, 6, 1)),
-                Tx(20, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 6, 1))
-            });
+            .Setup(x => x.GetHoldingsAsOf(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), DateOnly.FromDateTime(asOf), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<long, decimal> { [10] = 3m, [20] = 2m });
         _priceProvider.Setup(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(100m);
         _priceProvider.Setup(x => x.GetPricePerUnitAsync(20, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(50m);
 
@@ -68,8 +64,8 @@ public class InvestmentValuationServiceTests
     {
         var asOf = new DateTime(2024, 6, 30);
         _transactionRepository
-            .Setup(x => x.GetByAccounts(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>());
+            .Setup(x => x.GetHoldingsAsOf(It.IsAny<IReadOnlyCollection<int>>(), DateOnly.FromDateTime(asOf), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<long, decimal>());
 
         var value = await CreateSut().GetAccountValueAsync(_accountId, _usd, asOf, TestContext.Current.CancellationToken);
 
@@ -84,12 +80,8 @@ public class InvestmentValuationServiceTests
     {
         var asOf = new DateTime(2024, 6, 30);
         _transactionRepository
-            .Setup(x => x.GetByAccounts(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                Tx(10, InvestmentTransactionType.Buy, 6m, new DateOnly(2024, 6, 1)),
-                Tx(10, InvestmentTransactionType.Sell, 2m, new DateOnly(2024, 6, 2))
-            });
+            .Setup(x => x.GetHoldingsAsOf(It.IsAny<IReadOnlyCollection<int>>(), DateOnly.FromDateTime(asOf), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<long, decimal> { [10] = 4m });
         _priceProvider.Setup(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(25m);
 
         var value = await CreateSut().GetAccountValueAsync(_accountId, _usd, asOf, TestContext.Current.CancellationToken);
@@ -102,12 +94,8 @@ public class InvestmentValuationServiceTests
     {
         var asOf = new DateTime(2024, 6, 30);
         _transactionRepository
-            .Setup(x => x.GetByAccounts(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                Tx(10, InvestmentTransactionType.Buy, 4m, new DateOnly(2024, 6, 1)),
-                Tx(10, InvestmentTransactionType.Buy, 10m, new DateOnly(2024, 7, 15)) // after asOf, must be ignored
-            });
+            .Setup(x => x.GetHoldingsAsOf(It.IsAny<IReadOnlyCollection<int>>(), DateOnly.FromDateTime(asOf), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<long, decimal> { [10] = 4m });
         _priceProvider.Setup(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(25m);
 
         var value = await CreateSut().GetAccountValueAsync(_accountId, _usd, asOf, TestContext.Current.CancellationToken);
@@ -147,15 +135,8 @@ public class InvestmentValuationServiceTests
     {
         var asOf = new DateTime(2024, 6, 30);
         _transactionRepository
-            .Setup(x => x.GetByAccounts(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                // Listing 10 is fully closed (net 0) and must not be priced.
-                Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 6, 1)),
-                Tx(10, InvestmentTransactionType.Sell, 5m, new DateOnly(2024, 6, 2)),
-                // Listing 20 stays open and contributes the whole value.
-                Tx(20, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 6, 1))
-            });
+            .Setup(x => x.GetHoldingsAsOf(It.IsAny<IReadOnlyCollection<int>>(), DateOnly.FromDateTime(asOf), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<long, decimal> { [10] = 0m, [20] = 2m });
         _priceProvider.Setup(x => x.GetPricePerUnitAsync(20, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(50m);
 
         var value = await CreateSut().GetAccountValueAsync(_accountId, _usd, asOf, TestContext.Current.CancellationToken);

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/CachedAccountEntryRepositoryTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/CachedAccountEntryRepositoryTests.cs
@@ -101,6 +101,23 @@ public class CachedAccountEntryRepositoryTests
     }
 
     [Fact]
+    public async Task DateBoundaries_SecondCall_ServedFromCache()
+    {
+        var inner = new Mock<IAccountEntryRepository<CurrencyAccountEntry>>();
+        inner.Setup(r => r.GetNextOlder(_accountId, _date)).ReturnsAsync(Entry(1));
+        inner.Setup(r => r.GetNextYounger(_accountId, _date)).ReturnsAsync(Entry(2));
+        var sut = CreateSut(inner.Object, ResolverFor(_accountId, _userId), Mock.Of<ICacheInvalidator>(), CreateCache());
+
+        await sut.GetNextOlder(_accountId, _date);
+        await sut.GetNextOlder(_accountId, _date);
+        await sut.GetNextYounger(_accountId, _date);
+        await sut.GetNextYounger(_accountId, _date);
+
+        inner.Verify(r => r.GetNextOlder(_accountId, _date), Times.Once);
+        inner.Verify(r => r.GetNextYounger(_accountId, _date), Times.Once);
+    }
+
+    [Fact]
     public async Task GetYoungest_WhenOwnerUnresolved_BypassesCache()
     {
         var inner = new Mock<IAccountEntryRepository<CurrencyAccountEntry>>();

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/CurrencyRepositoryTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/CurrencyRepositoryTests.cs
@@ -1,0 +1,39 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Infrastructure.Contexts;
+using FinanceManager.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Tests.Unit.Infrastructure.Repositories;
+
+[Collection("Infrastructure")]
+[Trait("Category", "Unit")]
+public class CurrencyRepositoryTests
+{
+    [Fact]
+    public async Task GetCurrency_WhenPresent_DoesNotRunDefaultSeeding()
+    {
+        await using var context = CreateContext();
+        context.Currencies.Add(new Currency(99, "EUR", "€"));
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var currency = await new CurrencyRepository(context).GetCurrency(99, TestContext.Current.CancellationToken);
+
+        Assert.Equal("EUR", currency!.ShortName);
+        Assert.Equal(1, await context.Currencies.CountAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetByCode_WhenMissing_StillSeedsDefaults()
+    {
+        await using var context = CreateContext();
+
+        var currency = await new CurrencyRepository(context).GetByCode("PLN", TestContext.Current.CancellationToken);
+
+        Assert.Equal(DefaultCurrency.PLN.ShortName, currency!.ShortName);
+    }
+
+    private static AppDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+}


### PR DESCRIPTION
## Summary  - cache account-history boundary reads under the existing per-user invalidation tag - batch bond boundary lookups and keep read-only queries untracked - avoid redundant investment-valuation and currency queries - add regression coverage and a user-facing changelog entry  ## Benchmark  The 12 Accounts benchmarks improved from a 4.925 ms average to 2.658 ms on the same seeded database, a 46.0% reduction.  ## Validation  - `dotnet format ./code/FinanceManager.slnx` - `dotnet build ./code/FinanceManager.slnx --no-restore` — 0 warnings - unit tests — 638 passed - architecture tests — 9 passed - integration tests — 294 passed - benchmark endpoint validation — all 45 calls succeeded  Closes #606   <!-- This is an auto-generated comment: release notes by coderabbit.ai -->  ## Summary by CodeRabbit  - **Bug Fixes**   - Improved investment valuations for individual accounts, including accurate handling of holdings, prices, and closed positions.   - Reduced unnecessary currency initialization when requested currencies already exist.   - Improved reliability of account boundary lookups.  - **Performance**   - Added caching for repeated date-boundary account lookups.   - Optimized read-only repository queries.  - **Tests**   - Expanded coverage for investment valuation, caching behavior, and currency retrieval.  <!-- end of auto-generated comment: release notes by coderabbit.ai -->