### PR TITLE
Improve asset and liability response times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- Asset and liability charts now load substantially faster, especially on the first uncached view. #610
 - The dashboard now loads account data once per overview request, making the first uncached view substantially faster. #608
 - Financial account pages now load faster by reusing transaction-history boundaries, batching bond lookups, and avoiding redundant currency and investment data reads. #606
 - The expanded investment purchase details now label the valuation figures more clearly — pairing the unit price at purchase with the current unit price, and the value at purchase with the current value — so a per-unit price is no longer shown alongside position totals under ambiguous "Current price"/"Current valuation" labels.

--- a/code/FinanceManager.Application/FinancialAccounts/Bond/Assets/AssetsServiceBond.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Bond/Assets/AssetsServiceBond.cs
@@ -27,7 +27,8 @@ public class AssetsServiceBond(
         Dictionary<DateTime, decimal> prices = [];
         TimeSpan step = TimeSpan.FromDays(1);
         List<BondDetails> bondDetails = await bondDetailsRepository.GetAllAsync().ToListAsync();
-        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, start, end).Where(x => x.ContainsAssets))
+        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(
+            userId, start, end, includeEntryMetadata: false).Where(x => x.ContainsAssets))
         {
             foreach (var price in account.GetDailyPrice(DateOnly.FromDateTime(start), DateOnly.FromDateTime(end), bondDetails))
             {
@@ -49,7 +50,8 @@ public class AssetsServiceBond(
         Dictionary<DateTime, decimal> prices = [];
         TimeSpan step = TimeSpan.FromDays(1);
         List<BondDetails> bondDetails = await bondDetailsRepository.GetAllAsync().ToListAsync();
-        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, start, end).Where(x => x.ContainsAssets && x.AccountType.ToString() == investmentType.ToString()))
+        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(
+            userId, start, end, includeEntryMetadata: false).Where(x => x.ContainsAssets && x.AccountType.ToString() == investmentType.ToString()))
         {
             foreach (var price in account.GetDailyPrice(DateOnly.FromDateTime(start), DateOnly.FromDateTime(end), bondDetails))
             {

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/Assets/AssetsServiceCurrency.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/Assets/AssetsServiceCurrency.cs
@@ -21,7 +21,8 @@ internal class AssetsServiceCurrency(IFinancialAccountRepository financialAccoun
         Dictionary<DateTime, decimal> prices = [];
         TimeSpan step = TimeSpan.FromDays(1);
 
-        await foreach (CurrencyAccount? account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end).Where(x => x.ContainsAssets))
+        await foreach (CurrencyAccount? account in financialAccountRepository.GetAccounts<CurrencyAccount>(
+            userId, start, end, includeEntryMetadata: false).Where(x => x.ContainsAssets))
         {
             var entry = account.GetThisOrNextOlder(end);
             if (entry is null || entry.Value <= 0) continue;
@@ -52,7 +53,8 @@ internal class AssetsServiceCurrency(IFinancialAccountRepository financialAccoun
         if (end > DateTime.UtcNow) end = DateTime.UtcNow;
         List<(DateTime Date, decimal Value)> assets = [];
 
-        await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end).Where(x => x.ContainsAssets && x.AccountType.ToString() == investmentType.ToString()))
+        await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(
+            userId, start, end, includeEntryMetadata: false).Where(x => x.ContainsAssets && x.AccountType.ToString() == investmentType.ToString()))
             assets.AddRange(account.Entries.GetAssets(start, end));
 
         List<TimeSeriesModel> result = [];
@@ -73,8 +75,6 @@ internal class AssetsServiceCurrency(IFinancialAccountRepository financialAccoun
 
     public async IAsyncEnumerable<NameValueResult> GetEndAssetsPerType(int userId, Currency currency, DateTime asOfDate)
     {
-        financialAccountRepository.GetAccounts<CurrencyAccount>(userId, asOfDate.AddMinutes(-1), asOfDate).Select(x => x.AccountType).Distinct();
-
         Dictionary<AccountLabel, NameValueResult> accountLabelResults = [];
 
         await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, asOfDate.AddMinutes(-1), asOfDate).Where(x => x.ContainsAssets))

--- a/code/FinanceManager.Application/MoneyFlow/NetWorth/LiabilitiesService.cs
+++ b/code/FinanceManager.Application/MoneyFlow/NetWorth/LiabilitiesService.cs
@@ -32,7 +32,7 @@ public class LiabilitiesService(IFinancialAccountRepository financialAccountServ
     }
     public async IAsyncEnumerable<NameValueResult> GetEndLiabilitiesPerAccount(int userId, DateTime start, DateTime end)
     {
-        await foreach (CurrencyAccount account in financialAccountService.GetAccounts<CurrencyAccount>(userId, start, end))
+        await foreach (CurrencyAccount account in financialAccountService.GetAccounts<CurrencyAccount>(userId, end, end))
         {
             if (account is null || account.Entries is null) continue;
             var entry = account.Entries.FirstOrDefault();
@@ -55,7 +55,7 @@ public class LiabilitiesService(IFinancialAccountRepository financialAccountServ
     }
     public async IAsyncEnumerable<NameValueResult> GetEndLiabilitiesPerType(int userId, DateTime start, DateTime end)
     {
-        await foreach (var accounts in financialAccountService.GetAccounts<CurrencyAccount>(userId, start, end).GroupBy(x => x.AccountType))
+        await foreach (var accounts in financialAccountService.GetAccounts<CurrencyAccount>(userId, end, end).GroupBy(x => x.AccountType))
         {
             NameValueResult? result = null;
             foreach (var account in accounts)
@@ -97,7 +97,8 @@ public class LiabilitiesService(IFinancialAccountRepository financialAccountServ
         Dictionary<DateTime, decimal> prices = [];
         TimeSpan step = new(1, 0, 0, 0);
 
-        await foreach (var account in financialAccountService.GetAccounts<CurrencyAccount>(userId, start, end))
+        await foreach (var account in financialAccountService.GetAccounts<CurrencyAccount>(
+            userId, start, end, includeEntryMetadata: false))
         {
             if (account is null || account.Entries is null) continue;
 
@@ -109,7 +110,6 @@ public class LiabilitiesService(IFinancialAccountRepository financialAccountServ
                 previousValue = account.NextOlderEntry.Value;
 
             if (previousValue > 0) continue;
-
 
             for (var date = start; date <= end; date = date.Add(step))
             {

--- a/code/FinanceManager.Domain/FinancialAccounts/Shared/Repositories/IAccountEntryRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Shared/Repositories/IAccountEntryRepository.cs
@@ -38,6 +38,12 @@ public interface IAccountEntryRepository<T>
     Task<List<T>> GetRange(IReadOnlyCollection<int> accountIds, DateTime startDate, DateTime endDate);
 
     /// <summary>
+    /// Returns the same value history without loading labels or using cache buckets. Intended for
+    /// calculations that only need entry dates and amounts.
+    /// </summary>
+    Task<List<T>> GetValueRange(IReadOnlyCollection<int> accountIds, DateTime startDate, DateTime endDate);
+
+    /// <summary>
     /// Returns, per account, the single newest entry strictly older than <paramref name="date"/> in one
     /// query. Instrument-aware repositories (stock/bond) expose a per-instrument variant of their own.
     /// </summary>

--- a/code/FinanceManager.Domain/FinancialAccounts/Shared/Repositories/IFinancalAccountRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Shared/Repositories/IFinancalAccountRepository.cs
@@ -7,7 +7,7 @@ public interface IFinancialAccountRepository
     public Task<Dictionary<int, Type>> GetAvailableAccounts(int userId);
     public Task<int> GetAccountsCount();
     public Task<T?> GetAccount<T>(int userId, int id, DateTime dateStart, DateTime dateEnd) where T : BasicAccountInformation;
-    public IAsyncEnumerable<T> GetAccounts<T>(int userId, DateTime dateStart, DateTime dateEnd) where T : BasicAccountInformation;
+    public IAsyncEnumerable<T> GetAccounts<T>(int userId, DateTime dateStart, DateTime dateEnd, bool includeEntryMetadata = true) where T : BasicAccountInformation;
 
     public Task<int?> AddAccount<T>(T account) where T : BasicAccountInformation;
     public Task UpdateAccount<T>(T account) where T : BasicAccountInformation;

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/BondEntryRepository.cs
@@ -223,6 +223,18 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
             .ToListAsync();
     }
 
+    public async Task<List<BondAccountEntry>> GetValueRange(IReadOnlyCollection<int> accountIds, DateTime startDate, DateTime endDate)
+    {
+        if (accountIds.Count == 0) return [];
+
+        return await context.BondEntries
+            .AsNoTracking()
+            .Where(x => accountIds.Contains(x.AccountId) && x.PostingDate >= startDate && x.PostingDate <= endDate)
+            .OrderByDescending(x => x.PostingDate)
+            .ThenByDescending(x => x.EntryId)
+            .ToListAsync();
+    }
+
     public async Task<Dictionary<int, BondAccountEntry>> GetNextOlder(IReadOnlyCollection<int> accountIds, DateTime date)
     {
         if (accountIds.Count == 0) return [];

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CachedAccountEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CachedAccountEntryRepository.cs
@@ -141,6 +141,35 @@ public class CachedAccountEntryRepository<T>(
         return results;
     }
 
+    public async Task<List<T>> GetValueRange(IReadOnlyCollection<int> accountIds, DateTime startDate, DateTime endDate)
+    {
+        if (accountIds.Count == 0) return [];
+
+        var orderedIds = accountIds.Order().ToList();
+        if (await userResolver.GetUserId(orderedIds[0]) is not int userId)
+            return await inner.GetValueRange(orderedIds, startDate, endDate);
+
+        var bucketStart = new DateTime(startDate.Year, startDate.Month, 1, 0, 0, 0, startDate.Kind);
+        var bucketEnd = MonthBucket.MonthEndInclusive(new DateTime(endDate.Year, endDate.Month, 1, 0, 0, 0, endDate.Kind));
+        var cacheKey = $"{Tag(userId)}:{typeof(T).Name}:values:{string.Join('-', orderedIds)}:{bucketStart:yyyyMM}:{bucketEnd:yyyyMM}";
+        var options = new HybridCacheEntryOptions
+        {
+            Expiration = bucketEnd >= DateTime.UtcNow
+                ? rangeOptions.OpenMonthTtl
+                : rangeOptions.ElapsedMonthTtl
+        };
+
+        var entries = await cache.GetOrCreateAsync(
+            cacheKey,
+            _ => new ValueTask<List<T>>(inner.GetValueRange(orderedIds, bucketStart, bucketEnd)),
+            options,
+            tags: [Tag(userId)]);
+
+        return entries!
+            .Where(entry => entry.PostingDate >= startDate && entry.PostingDate <= endDate)
+            .ToList();
+    }
+
     // ----- Pass-through reads (relative / single-entry; not range reads) -----
 
     public Task<List<T>> Get(int accountId, DateTime date, int count, bool olderThenDate = true) => inner.Get(accountId, date, count, olderThenDate);

--- a/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/Account/Entry/CurrencyEntryRepository.cs
@@ -241,6 +241,18 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
             .ToListAsync();
     }
 
+    public async Task<List<CurrencyAccountEntry>> GetValueRange(IReadOnlyCollection<int> accountIds, DateTime startDate, DateTime endDate)
+    {
+        if (accountIds.Count == 0) return [];
+
+        return await context.CurrencyEntries
+            .AsNoTracking()
+            .Where(x => accountIds.Contains(x.AccountId) && x.PostingDate >= startDate && x.PostingDate <= endDate)
+            .OrderByDescending(x => x.PostingDate)
+            .ThenByDescending(x => x.EntryId)
+            .ToListAsync();
+    }
+
     public async Task<Dictionary<int, CurrencyAccountEntry>> GetNextOlder(IReadOnlyCollection<int> accountIds, DateTime date)
     {
         if (accountIds.Count == 0) return [];

--- a/code/FinanceManager.Infrastructure/Repositories/AccountRepository.cs
+++ b/code/FinanceManager.Infrastructure/Repositories/AccountRepository.cs
@@ -13,7 +13,7 @@ public class AccountRepository(ICurrencyAccountRepository<CurrencyAccount> curre
     IAccountEntryRepository<CurrencyAccountEntry> currencyEntryRepository, IBondAccountEntryRepository<BondAccountEntry> bondEntryRepository
      ) : IFinancialAccountRepository
 {
-    private readonly Dictionary<(Type Type, int UserId, DateTime Start, DateTime End), IReadOnlyList<BasicAccountInformation>> _readCache = [];
+    private readonly Dictionary<(Type Type, int UserId, DateTime Start, DateTime End, bool IncludeEntryMetadata), IReadOnlyList<BasicAccountInformation>> _readCache = [];
 
     public async Task<Dictionary<int, Type>> GetAvailableAccounts(int userId)
     {
@@ -93,9 +93,9 @@ public class AccountRepository(ICurrencyAccountRepository<CurrencyAccount> curre
         throw new NotSupportedException($"Account type {typeof(T)} is not supported.");
     }
     public Task<T?> GetAccount<T>(int userId, int id) where T : BasicAccountInformation => GetAccount<T>(userId, id, DateTime.UtcNow, DateTime.UtcNow);
-    public async IAsyncEnumerable<T> GetAccounts<T>(int userId, DateTime dateStart, DateTime dateEnd) where T : BasicAccountInformation
+    public async IAsyncEnumerable<T> GetAccounts<T>(int userId, DateTime dateStart, DateTime dateEnd, bool includeEntryMetadata = true) where T : BasicAccountInformation
     {
-        var cacheKey = (typeof(T), userId, dateStart, dateEnd);
+        var cacheKey = (typeof(T), userId, dateStart, dateEnd, includeEntryMetadata);
         if (_readCache.TryGetValue(cacheKey, out var cachedAccounts))
         {
             foreach (var account in cachedAccounts)
@@ -107,7 +107,7 @@ public class AccountRepository(ICurrencyAccountRepository<CurrencyAccount> curre
         switch (typeof(T))
         {
             case Type t when t == typeof(CurrencyAccount):
-                accounts = (await GetCurrencyAccounts(userId, dateStart, dateEnd))
+                accounts = (await GetCurrencyAccounts(userId, dateStart, dateEnd, includeEntryMetadata))
                     .Select(account => (T)(BasicAccountInformation)account)
                     .ToList();
                 break;
@@ -119,7 +119,7 @@ public class AccountRepository(ICurrencyAccountRepository<CurrencyAccount> curre
                 break;
 
             case Type t when t == typeof(BondAccount):
-                accounts = (await GetBondAccounts(userId, dateStart, dateEnd))
+                accounts = (await GetBondAccounts(userId, dateStart, dateEnd, includeEntryMetadata))
                     .Select(account => (T)(BasicAccountInformation)account)
                     .ToList();
                 break;
@@ -137,13 +137,16 @@ public class AccountRepository(ICurrencyAccountRepository<CurrencyAccount> curre
     // The methods below load a whole user's accounts of one type in a constant number of queries
     // (accounts, in-range entries, next-older boundary, next-younger boundary) instead of the ~5 queries
     // per account that GetAccount issues. This collapses the dashboard N+1 described in issue #411.
-    private async Task<List<CurrencyAccount>> GetCurrencyAccounts(int userId, DateTime dateStart, DateTime dateEnd)
+    private async Task<List<CurrencyAccount>> GetCurrencyAccounts(int userId, DateTime dateStart, DateTime dateEnd, bool includeEntryMetadata)
     {
         var accounts = await currencyAccountRepository.GetAll(userId);
         if (accounts.Count == 0) return [];
 
         var accountIds = accounts.Select(a => a.AccountId).ToList();
-        var entriesByAccount = (await currencyEntryRepository.GetRange(accountIds, dateStart, dateEnd))
+        var rangeEntries = includeEntryMetadata
+            ? await currencyEntryRepository.GetRange(accountIds, dateStart, dateEnd)
+            : await currencyEntryRepository.GetValueRange(accountIds, dateStart, dateEnd);
+        var entriesByAccount = rangeEntries
             .GroupBy(e => e.AccountId)
             .ToDictionary(g => g.Key, g => g.ToList());
         var nextOlder = await currencyEntryRepository.GetNextOlder(accountIds, dateStart);
@@ -165,13 +168,16 @@ public class AccountRepository(ICurrencyAccountRepository<CurrencyAccount> curre
         return result;
     }
 
-    private async Task<List<BondAccount>> GetBondAccounts(int userId, DateTime dateStart, DateTime dateEnd)
+    private async Task<List<BondAccount>> GetBondAccounts(int userId, DateTime dateStart, DateTime dateEnd, bool includeEntryMetadata)
     {
         var accounts = await bondAccountRepository.GetAll(userId);
         if (accounts.Count == 0) return [];
 
         var accountIds = accounts.Select(a => a.AccountId).ToList();
-        var entriesByAccount = (await bondEntryRepository.GetRange(accountIds, dateStart, dateEnd))
+        var rangeEntries = includeEntryMetadata
+            ? await bondEntryRepository.GetRange(accountIds, dateStart, dateEnd)
+            : await bondEntryRepository.GetValueRange(accountIds, dateStart, dateEnd);
+        var entriesByAccount = rangeEntries
             .GroupBy(e => e.AccountId)
             .ToDictionary(g => g.Key, g => g.ToList());
         var nextOlder = await bondEntryRepository.GetNextOlderPerInstrument(accountIds, dateStart);

--- a/code/FinanceManager.Tests.Unit/Application/Services/AssetsServiceBondTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/AssetsServiceBondTests.cs
@@ -74,7 +74,7 @@ public class AssetsServiceBondTests
         };
 
         _financialAccountRepositoryMock
-            .Setup(x => x.GetAccounts<BondAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Setup(x => x.GetAccounts<BondAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<bool>()))
             .Returns(new[] { account }.ToAsyncEnumerable());
         _bondDetailsRepositoryMock
             .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))
@@ -127,7 +127,7 @@ public class AssetsServiceBondTests
         };
 
         _financialAccountRepositoryMock
-            .Setup(x => x.GetAccounts<BondAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Setup(x => x.GetAccounts<BondAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<bool>()))
             .Returns(new[] { account }.ToAsyncEnumerable());
         _bondDetailsRepositoryMock
             .Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>()))

--- a/code/FinanceManager.Tests.Unit/Application/Services/AssetsServiceCurrencyTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/AssetsServiceCurrencyTests.cs
@@ -25,7 +25,7 @@ public class AssetsServiceCurrencyTests
         var account = new CurrencyAccount(1, 1, "acct-a", AccountLabel.Cash);
         account.Add(new CurrencyAccountEntry(1, 1, _end, 10, 0), false);
 
-        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<bool>()))
         .Returns(new[] { account }.ToAsyncEnumerable());
 
         // act
@@ -42,7 +42,7 @@ public class AssetsServiceCurrencyTests
         var account = new CurrencyAccount(1, 1, "currency-a", AccountLabel.Cash);
         account.Add(new CurrencyAccountEntry(1, 1, _end, 15, 0), false);
 
-        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<bool>()))
         .Returns(new[] { account }.ToAsyncEnumerable());
 
         // act
@@ -64,7 +64,7 @@ public class AssetsServiceCurrencyTests
         var account2 = new CurrencyAccount(1, 2, "currency-b", AccountLabel.Cash);
         account2.Add(new CurrencyAccountEntry(1, 1, _end, 5, 0), false);
 
-        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<bool>()))
         .Returns(new[] { account1, account2 }.ToAsyncEnumerable());
 
         // act
@@ -84,7 +84,7 @@ public class AssetsServiceCurrencyTests
         account.Add(new CurrencyAccountEntry(1, 1, _start, 10, 0), false);
         account.Add(new CurrencyAccountEntry(1, 2, _end, 0, 20));
 
-        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<bool>()))
         .Returns(new[] { account }.ToAsyncEnumerable());
 
         // act

--- a/code/FinanceManager.Tests.Unit/Application/Services/LiabilitiesServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/LiabilitiesServiceTests.cs
@@ -23,7 +23,7 @@ public class LiabilitiesServiceTests
         var account = new CurrencyAccount(1, 1, "loan", AccountLabel.Loan);
         account.Add(new CurrencyAccountEntry(1, 1, DateTime.UtcNow, -100, -100));
 
-        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<bool>()))
         .Returns(new[] { account }.ToAsyncEnumerable());
 
         // Act
@@ -40,7 +40,7 @@ public class LiabilitiesServiceTests
         var account = new CurrencyAccount(1, 1, "loan", AccountLabel.Loan);
         account.Add(new CurrencyAccountEntry(1, 1, DateTime.UtcNow, -200, -200));
 
-        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<bool>()))
         .Returns(new[] { account }.ToAsyncEnumerable());
 
         // Act
@@ -63,7 +63,7 @@ public class LiabilitiesServiceTests
         var account2 = new CurrencyAccount(1, 2, "loan2", AccountLabel.Loan);
         account2.Add(new CurrencyAccountEntry(1, 1, DateTime.UtcNow, -50, -50));
 
-        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<bool>()))
         .Returns(new[] { account1, account2 }.ToAsyncEnumerable());
 
         // Act
@@ -83,7 +83,7 @@ public class LiabilitiesServiceTests
         var account = new CurrencyAccount(1, 1, "loan", AccountLabel.Loan);
         account.Add(new CurrencyAccountEntry(1, 1, DateTime.UtcNow, -100, -100));
 
-        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+        _financialAccountRepositoryMock.Setup(x => x.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<bool>()))
         .Returns(new[] { account }.ToAsyncEnumerable());
 
         // Act

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/CachedAccountEntryRepositoryRangeTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Repositories/CachedAccountEntryRepositoryRangeTests.cs
@@ -373,6 +373,33 @@ public class CachedAccountEntryRepositoryRangeTests
     }
 
     [Fact]
+    public async Task GetValueRange_OverlappingRequests_ShareOneMetadataFreeQuery()
+    {
+        var jan5 = _jan.AddDays(4);
+        var jan10 = _jan.AddDays(9);
+        var jan20 = _jan.AddDays(19);
+        var jan25 = _jan.AddDays(24);
+        var janEnd = MonthBucket.MonthEndInclusive(_jan);
+
+        var inner = new Mock<IAccountEntryRepository<CurrencyAccountEntry>>();
+        inner.Setup(r => r.GetValueRange(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.SequenceEqual(new[] { _accountId })),
+                _jan,
+                janEnd))
+            .ReturnsAsync([Entry(2, jan20), Entry(1, jan10)]);
+
+        var sut = CreateSut(inner.Object, BuildCache());
+
+        var first = await sut.GetValueRange([_accountId], jan10, jan20);
+        var second = await sut.GetValueRange([_accountId], jan5, jan25);
+
+        Assert.Equal(2, first.Count);
+        Assert.Equal(2, second.Count);
+        inner.Verify(r => r.GetValueRange(
+            It.IsAny<IReadOnlyCollection<int>>(), _jan, janEnd), Times.Once);
+    }
+
+    [Fact]
     public async Task GetEntriesWithMinimumCount_UsesCachedPostingDatesAndBucketedGet()
     {
         var jan5 = _jan.AddDays(4);


### PR DESCRIPTION
## What changed

- add a value-only account-history read for calculations that do not need labels
- fetch cold valuation ranges in one query and cache normalized month ranges
- restrict liability end-balance reads to the requested end date

## Why

Asset and liability charts were paying for label metadata and splitting an uncached six-month range into account-by-month queries. Liability end views also loaded the whole selected history even though they only display the closing balance.

## Benchmarks

Cold-cache means on the seeded six-month scenario:

| Endpoint | Before | After | Improvement |
|---|---:|---:|---:|
| Assets time series | 69.9 ms | 43.5 ms | 37.7% |
| Liabilities time series | 34.2 ms | 10.4 ms | 69.6% |
| Liabilities per account | 34.9 ms | 18.1 ms | 48.1% |
| Liabilities per type | 33.9 ms | 16.8 ms | 50.4% |

## Validation

- `dotnet format ./code/FinanceManager.slnx --no-restore`
- `dotnet build FinanceManager.slnx --no-restore`
- 640 unit tests
- 9 architecture tests
- 294 integration tests
- all 45 benchmark endpoint validations

Closes #610


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added efficient date-range retrieval for account values.
  * Added optional control over loading account entry details.
  * Improved caching for overlapping date-range requests.

* **Bug Fixes**
  * Improved end-date liability calculations.
  * Reduced unnecessary data loading when generating asset and liability time series.

* **Tests**
  * Updated service tests and added coverage for shared cached range requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->