### PR TITLE
Standardize stale-while-revalidate UI snapshots #615

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ Razor component → typed HttpClient → API controller → application/domain s
 - **DI registration**: each layer exposes a `ServiceCollectionExtension.cs` with an `Add*` extension method. Wire new services there.
 - **Typed HTTP clients** (`code/FinanceManager.Components/HttpClients/`) wrap all API route details; Razor components never call `HttpClient` directly.
 - **Provider fallback chain**: AI calls go through a configured fallback (OpenRouter → GitHub Models → Ollama). Stock price reads check repository/cache before hitting Alpha Vantage.
+- **UI snapshots vs. data caching**: cards and transaction lists paint their last-rendered state from local storage and *always* re-fetch, via `ISnapshotRefreshCoordinator`. `LocalStorageStateCacheService` is the separate time-based cache that *skips* the request. See [`docs/codebase/UI-SNAPSHOTS.md`](./docs/codebase/UI-SNAPSHOTS.md) before adding either.
 - **Background services + channels**: async jobs (insights, label setting, import) run as hosted services registered in `Program.cs`, communicating via SignalR (`/hubs/currency-import`).
 - **Razor code-behind**: complex components split into `.razor` + `.razor.cs` pairs.
 

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Dashboard.razor.cs
@@ -10,8 +10,6 @@ using FinanceManager.Domain.Dashboard.Services;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
 using FinanceManager.Domain.Identity.Services;
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.Logging;
-using System.Text.Json;
 
 namespace FinanceManager.Components.Features.Dashboard.Components;
 
@@ -32,7 +30,7 @@ public partial class Dashboard : ComponentBase
     // Guards against a slower, earlier reload overwriting a newer date selection:
     // every LoadOverview claims an incrementing version and only commits its result
     // if it is still the latest in-flight request.
-    private int _loadOverviewVersion;
+    private readonly RefreshVersionGate _overviewGate = new();
 
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; } = DateTime.UtcNow;
@@ -45,11 +43,10 @@ public partial class Dashboard : ComponentBase
 
     [Inject] public required IFinancialAccountService FinancialAccountService { get; set; }
     [Inject] public required DashboardHttpClient DashboardHttpClient { get; set; }
-    [Inject] public required ISnapshotService SnapshotService { get; set; }
+    [Inject] public required ISnapshotRefreshCoordinator SnapshotRefreshCoordinator { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
     [Inject] public required DashboardCardVisibilityService CardVisibility { get; set; }
-    [Inject] public required ILogger<Dashboard> Logger { get; set; }
 
     // Card-specific models mapped from the single overview response. They are null
     // until the first load resolves (and when the overview is unavailable), in which
@@ -98,9 +95,14 @@ public partial class Dashboard : ComponentBase
         _ = LoadOverview();
     }
 
+    // Stale-while-revalidate: paint the stored snapshot, always re-fetch, and only repaint and
+    // re-persist when the fresh overview differs. SnapshotRefreshCoordinator owns that workflow —
+    // see docs/codebase/UI-SNAPSHOTS.md.
     private async Task LoadOverview()
     {
-        var requestVersion = Interlocked.Increment(ref _loadOverviewVersion);
+        // Claimed here rather than inside the coordinator so the same version also guards the
+        // logged-out branch below, which commits state before the run starts.
+        var requestVersion = _overviewGate.Claim();
         var startDate = StartDate;
         var endDate = EndDate;
 
@@ -109,7 +111,7 @@ public partial class Dashboard : ComponentBase
         var user = await LoginService.GetLoggedUser();
         if (user is null)
         {
-            if (requestVersion == _loadOverviewVersion)
+            if (_overviewGate.IsCurrent(requestVersion))
             {
                 _overview = null;
                 _isLoading = false;
@@ -119,97 +121,54 @@ public partial class Dashboard : ComponentBase
         }
 
         var currency = await SettingsService.GetCurrencyAsync();
-        var snapshotKey = BuildSnapshotKey(user.UserId, currency.Id);
 
-        // Paint the last-rendered snapshot immediately so the page feels instant on
-        // re-navigation. The API call below always runs and reconciles the view.
-        DashboardOverviewSnapshot? snapshot = null;
-        try
+        var result = await SnapshotRefreshCoordinator.RunAsync(new SnapshotRefreshRequest<DashboardOverviewSnapshot, DashboardOverviewDto>
         {
-            snapshot = await SnapshotService.GetAsync<DashboardOverviewSnapshot>(snapshotKey);
-        }
-        catch (Exception snapshotReadEx)
-        {
-            // A storage/interop failure on read must not abort the load — fall through to the fresh fetch.
-            Logger.LogWarning(snapshotReadEx, "Failed to read dashboard snapshot; continuing with fresh fetch.");
-        }
+            Key = BuildSnapshotKey(user.UserId, currency.Id),
+            Gate = _overviewGate,
+            ClaimedVersion = requestVersion,
+            ToModel = snapshot => snapshot.ToDto(),
+            FetchAsync = () => DashboardHttpClient.GetOverview(user.UserId, currency.Id, startDate, endDate),
+            ToSnapshot = DashboardOverviewSnapshot.FromDto,
 
-        if (snapshot is not null && requestVersion == _loadOverviewVersion)
-        {
-            _overview = snapshot.ToDto();
-            _overviewStart = snapshot.StartDate;
-            _overviewEnd = snapshot.EndDate;
-            _isLoading = false;
-            StateHasChanged();
-        }
-        else if (requestVersion == _loadOverviewVersion)
-        {
-            _isLoading = true;
-            StateHasChanged();
-        }
-
-        DashboardOverviewDto? freshOverview = null;
-        var changed = false;
-        try
-        {
-            freshOverview = await DashboardHttpClient.GetOverview(user.UserId, currency.Id, startDate, endDate);
-
-            // Only repaint and persist when the fresh data actually differs from the
-            // snapshot we already rendered — avoids a redundant flush on every visit.
-            changed = freshOverview is not null && !IsSameAsSnapshot(freshOverview, snapshot);
-
-            if (requestVersion == _loadOverviewVersion && changed)
+            // The snapshot renders the range it was captured for; fresh data renders the requested one.
+            OnSnapshotPainted = overview => ShowOverview(overview, overview.StartDate, overview.EndDate),
+            OnSnapshotMissing = () =>
             {
-                _overview = freshOverview;
-                _overviewStart = startDate;
-                _overviewEnd = endDate;
-            }
-        }
-        catch (Exception ex)
-        {
-            // If we already rendered a snapshot, keep it visible rather than blanking the screen.
-            if (requestVersion == _loadOverviewVersion && snapshot is null)
-            {
-                _overview = null;
-                _hasError = true;
-            }
-            Logger.LogError(ex, "Error loading dashboard overview");
-        }
-        finally
-        {
-            if (requestVersion == _loadOverviewVersion)
-            {
-                _isLoading = false;
+                _isLoading = true;
                 StateHasChanged();
-            }
+                return Task.CompletedTask;
+            },
+            OnRefreshed = overview => ShowOverview(overview, startDate, endDate),
+        });
+
+        if (!_overviewGate.IsCurrent(requestVersion))
+            return;
+
+        // A failed fetch behind a painted snapshot keeps the snapshot on screen; only a surface
+        // with nothing to show falls back to the error state.
+        if (result.IsBlockingFailure)
+        {
+            _overview = null;
+            _hasError = true;
         }
 
-        // Skip the write when a newer load has superseded this one, so a slower
-        // earlier request can't overwrite the latest request's snapshot.
-        if (requestVersion == _loadOverviewVersion && freshOverview is not null && changed)
-        {
-            try
-            {
-                await SnapshotService.SetAsync(snapshotKey, DashboardOverviewSnapshot.FromDto(freshOverview));
-            }
-            catch (Exception snapshotEx)
-            {
-                Logger.LogWarning(snapshotEx, "Dashboard overview loaded but snapshot save failed.");
-            }
-        }
+        _isLoading = false;
+        StateHasChanged();
+    }
+
+    private Task ShowOverview(DashboardOverviewDto overview, DateTime start, DateTime end)
+    {
+        _overview = overview;
+        _overviewStart = start;
+        _overviewEnd = end;
+        _isLoading = false;
+        StateHasChanged();
+        return Task.CompletedTask;
     }
 
     // Per-user key with no date component, so a single snapshot per user is overwritten each save.
     // The key is currency-scoped so a snapshot saved before a preferred-currency change is never
     // painted with the new currency's labels.
     private static string BuildSnapshotKey(int userId, int currencyId) => $"dashboard-overview:{userId}:{currencyId}";
-
-    private static bool IsSameAsSnapshot(DashboardOverviewDto overview, DashboardOverviewSnapshot? snapshot)
-    {
-        if (snapshot is null)
-            return false;
-
-        // Compare rendered content only; FetchedAtUtc lives on the snapshot, not the DTO.
-        return JsonSerializer.Serialize(overview) == JsonSerializer.Serialize(snapshot.ToDto());
-    }
 }

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
@@ -6,6 +6,7 @@ using FinanceManager.Components.Features.FinancialAccounts.Services;
 using FinanceManager.Components.Features.Identity.Services;
 using FinanceManager.Components.Features.MoneyFlow.HttpClients;
 using FinanceManager.Components.Shared.Helpers;
+using FinanceManager.Components.Shared.Services;
 using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
@@ -25,6 +26,13 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     private bool _insightsDrawerOpen;
 
     private const int _initialMinimumEntriesCount = 100;
+
+    // How long the initial load may run before the blocking spinner replaces the empty page.
+    // Only applies when there is no snapshot to paint in the meantime.
+    private static readonly TimeSpan _spinnerDelay = TimeSpan.FromSeconds(2);
+
+    // Keeps a slower initial load from overwriting state a newer load already committed.
+    private readonly RefreshVersionGate _entriesGate = new();
 
     private string _selectedRange = "Month";
     private DateTime _dateStart;
@@ -174,23 +182,8 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
             }
 
             SetDateRangeForSelection();
-
-            // Paint the last-rendered entries instantly, then reconcile against a fresh fetch.
-            var previousSnapshot = await PaintSnapshotIfAvailable();
-
-            var loadTask = UpdateEntries(initialLoad: true);
-            if (previousSnapshot is null)
-            {
-                var delayTask = Task.Delay(2000);
-                if (await Task.WhenAny(loadTask, delayTask) == delayTask)
-                {
-                    IsLoading = true;
-                    StateHasChanged();
-                }
-            }
-            await loadTask;
+            await LoadInitialEntries();
             IsLoading = false;
-            await SaveSnapshotIfChanged(previousSnapshot);
 
             AccountDataSynchronizationService.AccountsChanged += AccountDataSynchronizationService_AccountsChanged;
         }
@@ -225,14 +218,8 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
         {
             if (_user is null) return;
 
-            if (_selectedRange != AccountDetailsHero.CustomRangeKey)
-                _dateEnd = DateTime.UtcNow;
-
             var selectedStart = _dateStart;
-            Account = initialLoad
-                ? await FinancialAccountService.GetInitialTransactionHistory<BondAccount>(_user.UserId, AccountId, _dateStart, _dateEnd,
-                    _initialMinimumEntriesCount)
-                : await FinancialAccountService.GetAccount<BondAccount>(_user.UserId, AccountId, _dateStart, _dateEnd);
+            Account = await FetchAccount(initialLoad);
 
             if (initialLoad)
                 ApplyAutomaticCustomRange(selectedStart);
@@ -245,6 +232,21 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
             ErrorMessage = ex.Message;
             Logger.LogError(ex, "Error while loading bond account details for account ID {AccountId}", AccountId);
         }
+    }
+
+    // Loads the account without touching rendered state, so a stale-while-revalidate run can decide
+    // whether the response is worth painting.
+    private async Task<BondAccount?> FetchAccount(bool initialLoad)
+    {
+        if (_user is null) return null;
+
+        if (_selectedRange != AccountDetailsHero.CustomRangeKey)
+            _dateEnd = DateTime.UtcNow;
+
+        return initialLoad
+            ? await FinancialAccountService.GetInitialTransactionHistory<BondAccount>(_user.UserId, AccountId, _dateStart, _dateEnd,
+                _initialMinimumEntriesCount)
+            : await FinancialAccountService.GetAccount<BondAccount>(_user.UserId, AccountId, _dateStart, _dateEnd);
     }
 
     private void QueueChartDataRefresh()
@@ -417,35 +419,65 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
         _customDateRange = new DateRange(_dateStart, _dateEnd);
     }
 
-    // Reads the persisted snapshot and paints its entries so the page feels instant on
-    // re-navigation. Chart data is not snapshotted; UpdateInfo queues a fresh API load.
-    private async Task<AccountDetailsSnapshot<BondAccountEntry>?> PaintSnapshotIfAvailable()
+    // Stale-while-revalidate: paint the last-rendered entries instantly, always re-fetch, and only
+    // repaint and re-persist when the entries actually changed. Chart data is never snapshotted —
+    // UpdateInfo queues a fresh API load for it. See docs/codebase/UI-SNAPSHOTS.md.
+    private async Task LoadInitialEntries()
     {
-        if (_user is null) return null;
+        if (_user is null) return;
 
-        var snapshot = await SnapshotStore.GetAsync<BondAccountEntry>(_user.UserId, AccountId);
-        if (snapshot is null) return null;
+        var snapshotPainted = false;
 
-        Account = new BondAccount(snapshot.UserId, snapshot.AccountId, snapshot.Name, snapshot.Entries, snapshot.AccountType);
+        var result = await SnapshotStore.RefreshAsync<BondAccountEntry>(
+            _user.UserId,
+            AccountId,
+            _entriesGate,
+            fetchAsync: () => FetchInitialAccountModel(snapshotPainted),
+            onSnapshotPainted: model =>
+            {
+                snapshotPainted = true;
+                return ApplyAccountModel(model, expandRange: false);
+            },
+            onRefreshed: model => ApplyAccountModel(model, expandRange: true));
+
+        // A failed refresh behind a painted snapshot keeps the stale entries on screen instead of
+        // replacing them with an error the user cannot act on.
+        if (result.IsBlockingFailure && result.Error is Exception error)
+            ErrorMessage = error.Message;
+    }
+
+    private async Task<AccountDetailsModel<BondAccountEntry>?> FetchInitialAccountModel(bool snapshotPainted)
+    {
+        var loadTask = FetchAccount(initialLoad: true);
+
+        // With nothing painted the page is blank, so show the spinner once the load looks slow.
+        if (!snapshotPainted)
+        {
+            var delayTask = Task.Delay(_spinnerDelay);
+            if (await Task.WhenAny(loadTask, delayTask) == delayTask)
+            {
+                IsLoading = true;
+                StateHasChanged();
+            }
+        }
+
+        var account = await loadTask;
+        if (account is null || _user is null) return null;
+
+        return new AccountDetailsModel<BondAccountEntry>(_user.UserId, AccountId, account.Name, account.AccountType, account.Entries);
+    }
+
+    private async Task ApplyAccountModel(AccountDetailsModel<BondAccountEntry> model, bool expandRange)
+    {
+        Account = new BondAccount(model.UserId, model.AccountId, model.Name, model.Entries, model.AccountType);
+
+        // Only a fresh response may widen the selected range: it is the one that knows how far
+        // back the account's entries actually reach.
+        if (expandRange)
+            ApplyAutomaticCustomRange(_dateStart);
+
         await UpdateInfo();
         IsLoading = false;
         StateHasChanged();
-        return snapshot;
-    }
-
-    // Persists the freshly loaded entries, skipping the write when they match the snapshot we already painted.
-    private async Task SaveSnapshotIfChanged(AccountDetailsSnapshot<BondAccountEntry>? previous)
-    {
-        if (_user is null || Account is null) return;
-
-        var snapshot = new AccountDetailsSnapshot<BondAccountEntry>
-        {
-            UserId = _user.UserId,
-            AccountId = AccountId,
-            Name = Account.Name,
-            AccountType = Account.AccountType,
-            Entries = Account.Entries,
-        };
-        await SnapshotStore.SaveIfChangedAsync(snapshot, previous);
     }
 }

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
@@ -428,17 +428,28 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
 
         var snapshotPainted = false;
 
+        // The fresh account is applied as served. Only its rendered content goes through the
+        // snapshot model, so state the snapshot cannot carry — NextOlderEntry/NextYoungerEntry,
+        // which decide whether the page shows history at all — survives the refresh.
+        BondAccount? freshAccount = null;
+
         var result = await SnapshotStore.RefreshAsync<BondAccountEntry>(
             _user.UserId,
             AccountId,
             _entriesGate,
-            fetchAsync: () => FetchInitialAccountModel(snapshotPainted),
+            fetchAsync: async () =>
+            {
+                freshAccount = await FetchInitialAccount(snapshotPainted);
+                return freshAccount is null || _user is null
+                    ? null
+                    : new AccountDetailsModel<BondAccountEntry>(_user.UserId, AccountId, freshAccount.Name, freshAccount.AccountType, freshAccount.Entries);
+            },
             onSnapshotPainted: model =>
             {
                 snapshotPainted = true;
-                return ApplyAccountModel(model, expandRange: false);
+                return ApplyAccount(BuildAccount(model), expandRange: false);
             },
-            onRefreshed: model => ApplyAccountModel(model, expandRange: true));
+            onRefreshed: model => ApplyAccount(freshAccount ?? BuildAccount(model), expandRange: true));
 
         // A failed refresh behind a painted snapshot keeps the stale entries on screen instead of
         // replacing them with an error the user cannot act on.
@@ -446,7 +457,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
             ErrorMessage = error.Message;
     }
 
-    private async Task<AccountDetailsModel<BondAccountEntry>?> FetchInitialAccountModel(bool snapshotPainted)
+    private async Task<BondAccount?> FetchInitialAccount(bool snapshotPainted)
     {
         var loadTask = FetchAccount(initialLoad: true);
 
@@ -461,15 +472,16 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
             }
         }
 
-        var account = await loadTask;
-        if (account is null || _user is null) return null;
-
-        return new AccountDetailsModel<BondAccountEntry>(_user.UserId, AccountId, account.Name, account.AccountType, account.Entries);
+        return await loadTask;
     }
 
-    private async Task ApplyAccountModel(AccountDetailsModel<BondAccountEntry> model, bool expandRange)
+    // Rebuilds an account from a snapshot, which stores rendered entries only.
+    private static BondAccount BuildAccount(AccountDetailsModel<BondAccountEntry> model) =>
+        new(model.UserId, model.AccountId, model.Name, model.Entries, model.AccountType);
+
+    private async Task ApplyAccount(BondAccount account, bool expandRange)
     {
-        Account = new BondAccount(model.UserId, model.AccountId, model.Name, model.Entries, model.AccountType);
+        Account = account;
 
         // Only a fresh response may widen the selected range: it is the one that knows how far
         // back the account's entries actually reach.

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor.cs
@@ -424,17 +424,28 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
 
         var snapshotPainted = false;
 
+        // The fresh account is applied as served. Only its rendered content goes through the
+        // snapshot model, so state the snapshot cannot carry — NextOlderEntry/NextYoungerEntry,
+        // which decide whether the page shows history at all — survives the refresh.
+        CurrencyAccount? freshAccount = null;
+
         var result = await SnapshotStore.RefreshAsync<CurrencyAccountEntry>(
             _user.UserId,
             AccountId,
             _entriesGate,
-            fetchAsync: () => FetchInitialAccountModel(snapshotPainted),
+            fetchAsync: async () =>
+            {
+                freshAccount = await FetchInitialAccount(snapshotPainted);
+                return freshAccount is null || _user is null
+                    ? null
+                    : new AccountDetailsModel<CurrencyAccountEntry>(_user.UserId, AccountId, freshAccount.Name, freshAccount.AccountType, freshAccount.Entries);
+            },
             onSnapshotPainted: model =>
             {
                 snapshotPainted = true;
-                return ApplyAccountModel(model, expandRange: false);
+                return ApplyAccount(BuildAccount(model), expandRange: false);
             },
-            onRefreshed: model => ApplyAccountModel(model, expandRange: true));
+            onRefreshed: model => ApplyAccount(freshAccount ?? BuildAccount(model), expandRange: true));
 
         // A failed refresh behind a painted snapshot keeps the stale entries on screen instead of
         // replacing them with an error the user cannot act on.
@@ -442,7 +453,7 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
             ErrorMessage = error.Message;
     }
 
-    private async Task<AccountDetailsModel<CurrencyAccountEntry>?> FetchInitialAccountModel(bool snapshotPainted)
+    private async Task<CurrencyAccount?> FetchInitialAccount(bool snapshotPainted)
     {
         var loadTask = FetchAccount(initialLoad: true);
 
@@ -457,15 +468,16 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
             }
         }
 
-        var account = await loadTask;
-        if (account is null || _user is null) return null;
-
-        return new AccountDetailsModel<CurrencyAccountEntry>(_user.UserId, AccountId, account.Name, account.AccountType, account.Entries);
+        return await loadTask;
     }
 
-    private async Task ApplyAccountModel(AccountDetailsModel<CurrencyAccountEntry> model, bool expandRange)
+    // Rebuilds an account from a snapshot, which stores rendered entries only.
+    private static CurrencyAccount BuildAccount(AccountDetailsModel<CurrencyAccountEntry> model) =>
+        new(model.UserId, model.AccountId, model.Name, model.Entries, model.AccountType);
+
+    private async Task ApplyAccount(CurrencyAccount account, bool expandRange)
     {
-        Account = new CurrencyAccount(model.UserId, model.AccountId, model.Name, model.Entries, model.AccountType);
+        Account = account;
 
         // Only a fresh response may widen the selected range: it is the one that knows how far
         // back the account's entries actually reach.

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/CurrencyAccountComponents/TransactionHistory/CurrencyAccountDetailsPageContent.razor.cs
@@ -5,6 +5,7 @@ using FinanceManager.Components.Features.FinancialAccounts.Services;
 using FinanceManager.Components.Features.Identity.Services;
 using FinanceManager.Components.Features.MoneyFlow.HttpClients;
 using FinanceManager.Components.Shared.Helpers;
+using FinanceManager.Components.Shared.Services;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
@@ -24,6 +25,13 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
     private bool _insightsDrawerOpen;
 
     private const int _initialMinimumEntriesCount = 100;
+
+    // How long the initial load may run before the blocking spinner replaces the empty page.
+    // Only applies when there is no snapshot to paint in the meantime.
+    private static readonly TimeSpan _spinnerDelay = TimeSpan.FromSeconds(1);
+
+    // Keeps a slower initial load from overwriting state a newer load already committed.
+    private readonly RefreshVersionGate _entriesGate = new();
 
     private string _selectedRange = "Month";
     private DateTime _dateStart;
@@ -178,22 +186,7 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
             if (_user is null) return;
 
             SetDateRangeForSelection();
-
-            // Paint the last-rendered entries instantly, then reconcile against a fresh fetch.
-            var previousSnapshot = await PaintSnapshotIfAvailable();
-
-            var loadTask = UpdateEntries(initialLoad: true);
-            if (previousSnapshot is null)
-            {
-                var delayTask = Task.Delay(1000);
-                if (await Task.WhenAny(loadTask, delayTask) == delayTask)
-                {
-                    IsLoading = true;
-                    StateHasChanged();
-                }
-            }
-            await loadTask;
-            await SaveSnapshotIfChanged(previousSnapshot);
+            await LoadInitialEntries();
 
             AccountDataSynchronizationService.AccountsChanged += AccountDataSynchronizationService_AccountsChanged;
         }
@@ -233,14 +226,8 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
         {
             if (_user is null) return;
 
-            if (_selectedRange != AccountDetailsHero.CustomRangeKey)
-                _dateEnd = DateTime.UtcNow;
-
             var selectedStart = _dateStart;
-            Account = initialLoad
-                ? await FinancialAccountService.GetInitialTransactionHistory<CurrencyAccount>(_user.UserId, AccountId, _dateStart, _dateEnd,
-                    _initialMinimumEntriesCount)
-                : await FinancialAccountService.GetAccount<CurrencyAccount>(_user.UserId, AccountId, _dateStart, _dateEnd);
+            Account = await FetchAccount(initialLoad);
 
             if (initialLoad)
                 ApplyAutomaticCustomRange(selectedStart);
@@ -253,6 +240,21 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
             ErrorMessage = ex.Message;
             Logger.LogError(ex, "Error while loading currency account details for account ID {AccountId}", AccountId);
         }
+    }
+
+    // Loads the account without touching rendered state, so a stale-while-revalidate run can decide
+    // whether the response is worth painting.
+    private async Task<CurrencyAccount?> FetchAccount(bool initialLoad)
+    {
+        if (_user is null) return null;
+
+        if (_selectedRange != AccountDetailsHero.CustomRangeKey)
+            _dateEnd = DateTime.UtcNow;
+
+        return initialLoad
+            ? await FinancialAccountService.GetInitialTransactionHistory<CurrencyAccount>(_user.UserId, AccountId, _dateStart, _dateEnd,
+                _initialMinimumEntriesCount)
+            : await FinancialAccountService.GetAccount<CurrencyAccount>(_user.UserId, AccountId, _dateStart, _dateEnd);
     }
 
     private void QueueChartDataRefresh()
@@ -413,35 +415,65 @@ public partial class CurrencyAccountDetailsPageContent : ComponentBase, IAsyncDi
         _customDateRange = new DateRange(_dateStart, _dateEnd);
     }
 
-    // Reads the persisted snapshot and paints its entries so the page feels instant on
-    // re-navigation. Chart data is not snapshotted; UpdateInfo queues a fresh API load.
-    private async Task<AccountDetailsSnapshot<CurrencyAccountEntry>?> PaintSnapshotIfAvailable()
+    // Stale-while-revalidate: paint the last-rendered entries instantly, always re-fetch, and only
+    // repaint and re-persist when the entries actually changed. Chart data is never snapshotted —
+    // UpdateInfo queues a fresh API load for it. See docs/codebase/UI-SNAPSHOTS.md.
+    private async Task LoadInitialEntries()
     {
-        if (_user is null) return null;
+        if (_user is null) return;
 
-        var snapshot = await SnapshotStore.GetAsync<CurrencyAccountEntry>(_user.UserId, AccountId);
-        if (snapshot is null) return null;
+        var snapshotPainted = false;
 
-        Account = new CurrencyAccount(snapshot.UserId, snapshot.AccountId, snapshot.Name, snapshot.Entries, snapshot.AccountType);
+        var result = await SnapshotStore.RefreshAsync<CurrencyAccountEntry>(
+            _user.UserId,
+            AccountId,
+            _entriesGate,
+            fetchAsync: () => FetchInitialAccountModel(snapshotPainted),
+            onSnapshotPainted: model =>
+            {
+                snapshotPainted = true;
+                return ApplyAccountModel(model, expandRange: false);
+            },
+            onRefreshed: model => ApplyAccountModel(model, expandRange: true));
+
+        // A failed refresh behind a painted snapshot keeps the stale entries on screen instead of
+        // replacing them with an error the user cannot act on.
+        if (result.IsBlockingFailure && result.Error is Exception error)
+            ErrorMessage = error.Message;
+    }
+
+    private async Task<AccountDetailsModel<CurrencyAccountEntry>?> FetchInitialAccountModel(bool snapshotPainted)
+    {
+        var loadTask = FetchAccount(initialLoad: true);
+
+        // With nothing painted the page is blank, so show the spinner once the load looks slow.
+        if (!snapshotPainted)
+        {
+            var delayTask = Task.Delay(_spinnerDelay);
+            if (await Task.WhenAny(loadTask, delayTask) == delayTask)
+            {
+                IsLoading = true;
+                StateHasChanged();
+            }
+        }
+
+        var account = await loadTask;
+        if (account is null || _user is null) return null;
+
+        return new AccountDetailsModel<CurrencyAccountEntry>(_user.UserId, AccountId, account.Name, account.AccountType, account.Entries);
+    }
+
+    private async Task ApplyAccountModel(AccountDetailsModel<CurrencyAccountEntry> model, bool expandRange)
+    {
+        Account = new CurrencyAccount(model.UserId, model.AccountId, model.Name, model.Entries, model.AccountType);
+
+        // Only a fresh response may widen the selected range: it is the one that knows how far
+        // back the account's entries actually reach.
+        if (expandRange)
+            ApplyAutomaticCustomRange(_dateStart);
+
         await UpdateInfo();
         IsLoading = false;
         StateHasChanged();
-        return snapshot;
-    }
-
-    // Persists the freshly loaded entries, skipping the write when they match the snapshot we already painted.
-    private async Task SaveSnapshotIfChanged(AccountDetailsSnapshot<CurrencyAccountEntry>? previous)
-    {
-        if (_user is null || Account is null) return;
-
-        var snapshot = new AccountDetailsSnapshot<CurrencyAccountEntry>
-        {
-            UserId = _user.UserId,
-            AccountId = AccountId,
-            Name = Account.Name,
-            AccountType = Account.AccountType,
-            Entries = Account.Entries,
-        };
-        await SnapshotStore.SaveIfChangedAsync(snapshot, previous);
     }
 }

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Models/AccountDetailsModel.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Models/AccountDetailsModel.cs
@@ -1,0 +1,16 @@
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+
+namespace FinanceManager.Components.Features.FinancialAccounts.Models;
+
+/// <summary>
+/// The account-details transaction list as rendered: everything the page needs to rebuild the
+/// account, and nothing else. Content equality between a stored snapshot and a fresh API response
+/// is evaluated on this model, so snapshot metadata can never look like a change.
+/// </summary>
+/// <typeparam name="TEntry">The concrete entry type (e.g. CurrencyAccountEntry).</typeparam>
+public sealed record AccountDetailsModel<TEntry>(
+    int UserId,
+    int AccountId,
+    string Name,
+    AccountLabel AccountType,
+    List<TEntry> Entries);

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Services/AccountDetailsSnapshotStore.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Services/AccountDetailsSnapshotStore.cs
@@ -1,42 +1,54 @@
 using FinanceManager.Components.Features.FinancialAccounts.Models;
+using FinanceManager.Components.Shared.Models;
 using FinanceManager.Components.Shared.Services;
-using Microsoft.Extensions.Logging;
-using System.Text.Json;
 
 namespace FinanceManager.Components.Features.FinancialAccounts.Services;
 
-public sealed class AccountDetailsSnapshotStore(
-    ISnapshotService snapshots,
-    ILogger<AccountDetailsSnapshotStore> logger)
+/// <summary>
+/// Runs the stale-while-revalidate workflow for account-details transaction lists: paints the
+/// stored entries, always re-fetches, and re-persists only when the rendered entries changed.
+/// Owns the snapshot key shape so every account-details page scopes it identically.
+/// </summary>
+/// <remarks>The workflow itself lives in <see cref="ISnapshotRefreshCoordinator"/> — see docs/codebase/UI-SNAPSHOTS.md.</remarks>
+public sealed class AccountDetailsSnapshotStore(ISnapshotRefreshCoordinator coordinator)
 {
-    public async Task<AccountDetailsSnapshot<TEntry>?> GetAsync<TEntry>(int userId, int accountId)
-    {
-        try
+    /// <param name="userId">Owner of the account; scopes the snapshot key.</param>
+    /// <param name="accountId">Account being rendered; scopes the snapshot key.</param>
+    /// <param name="gate">Race protection shared with the page's other reloads.</param>
+    /// <param name="fetchAsync">Loads the account fresh from the API. Returns <c>null</c> when there is nothing to render.</param>
+    /// <param name="onSnapshotPainted">Renders the stored entries before the fresh request completes.</param>
+    /// <param name="onSnapshotMissing">Runs instead of <paramref name="onSnapshotPainted"/> when no usable snapshot exists.</param>
+    /// <param name="onRefreshed">Renders the fresh entries; only invoked when they differ from what was painted.</param>
+    public Task<SnapshotRefreshResult<AccountDetailsModel<TEntry>>> RefreshAsync<TEntry>(
+        int userId,
+        int accountId,
+        RefreshVersionGate gate,
+        Func<Task<AccountDetailsModel<TEntry>?>> fetchAsync,
+        Func<AccountDetailsModel<TEntry>, Task>? onSnapshotPainted = null,
+        Func<Task>? onSnapshotMissing = null,
+        Func<AccountDetailsModel<TEntry>, Task>? onRefreshed = null)
+        => coordinator.RunAsync(new SnapshotRefreshRequest<AccountDetailsSnapshot<TEntry>, AccountDetailsModel<TEntry>>
         {
-            var snapshot = await snapshots.GetAsync<AccountDetailsSnapshot<TEntry>>(Key(userId, accountId));
-            return snapshot?.AccountId == accountId ? snapshot : null;
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Failed to read account details snapshot; continuing with fresh fetch.");
-            return null;
-        }
-    }
+            Key = BuildKey(userId, accountId),
+            Gate = gate,
 
-    public async Task SaveIfChangedAsync<TEntry>(AccountDetailsSnapshot<TEntry> snapshot, AccountDetailsSnapshot<TEntry>? previous)
-    {
-        if (previous is not null && JsonSerializer.Serialize(snapshot.Entries) == JsonSerializer.Serialize(previous.Entries))
-            return;
+            // A snapshot stored for another account is unusable; rejecting it falls back to a plain load.
+            ToModel = snapshot => snapshot.AccountId == accountId
+                ? new AccountDetailsModel<TEntry>(snapshot.UserId, snapshot.AccountId, snapshot.Name, snapshot.AccountType, snapshot.Entries)
+                : null,
+            FetchAsync = fetchAsync,
+            ToSnapshot = model => new AccountDetailsSnapshot<TEntry>
+            {
+                UserId = model.UserId,
+                AccountId = model.AccountId,
+                Name = model.Name,
+                AccountType = model.AccountType,
+                Entries = model.Entries,
+            },
+            OnSnapshotPainted = onSnapshotPainted,
+            OnSnapshotMissing = onSnapshotMissing,
+            OnRefreshed = onRefreshed,
+        });
 
-        try
-        {
-            await snapshots.SetAsync(Key(snapshot.UserId, snapshot.AccountId), snapshot);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex, "Account details loaded but snapshot save failed.");
-        }
-    }
-
-    private static string Key(int userId, int accountId) => $"account-details:{userId}:{accountId}";
+    private static string BuildKey(int userId, int accountId) => $"account-details:{userId}:{accountId}";
 }

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -67,6 +67,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<DashboardOverviewCardsCacheService>()
                 .AddScoped<DashboardCardVisibilityService>()
                 .AddScoped<ISnapshotService, LocalStorageSnapshotService>()
+                .AddScoped<ISnapshotRefreshCoordinator, SnapshotRefreshCoordinator>()
                 .AddScoped<AccountDetailsSnapshotStore>()
                 .AddTransient<CurrencyImportJobTracker>()
                 .AddScoped<AssetsPageCardsCacheService>()

--- a/code/FinanceManager.Components/Shared/Models/SnapshotRefreshOutcome.cs
+++ b/code/FinanceManager.Components/Shared/Models/SnapshotRefreshOutcome.cs
@@ -1,0 +1,24 @@
+namespace FinanceManager.Components.Shared.Models;
+
+/// <summary>
+/// How a stale-while-revalidate run ended. Describes the <em>refresh</em> half of the run;
+/// whether a snapshot was painted first is reported separately by
+/// <see cref="SnapshotRefreshResult{TModel}.SnapshotPainted"/>.
+/// </summary>
+public enum SnapshotRefreshOutcome
+{
+    /// <summary>Fresh data differed from what was painted; the UI and the stored snapshot were replaced.</summary>
+    Refreshed,
+
+    /// <summary>Fresh data matched the painted snapshot; nothing was repainted and nothing was written.</summary>
+    Unchanged,
+
+    /// <summary>The fresh request threw. A painted snapshot (if any) stays on screen.</summary>
+    Failed,
+
+    /// <summary>The fresh request succeeded but produced nothing to render.</summary>
+    Empty,
+
+    /// <summary>A newer run claimed the version gate while this one was in flight; it committed nothing.</summary>
+    Superseded,
+}

--- a/code/FinanceManager.Components/Shared/Models/SnapshotRefreshResult.cs
+++ b/code/FinanceManager.Components/Shared/Models/SnapshotRefreshResult.cs
@@ -1,0 +1,24 @@
+namespace FinanceManager.Components.Shared.Models;
+
+/// <summary>
+/// Result of one stale-while-revalidate run. <paramref name="Model"/> is whatever the caller
+/// should have on screen when the run finishes: the fresh model when it differed, the painted
+/// snapshot when the fresh data matched or the request failed, and <c>null</c> when neither
+/// fresh nor cached data was available.
+/// </summary>
+/// <param name="Outcome">How the refresh half of the run ended.</param>
+/// <param name="Model">The model that should be displayed, or <c>null</c> when there is nothing to display.</param>
+/// <param name="SnapshotPainted">Whether a stored snapshot was read and handed to the caller before the fresh request ran.</param>
+/// <param name="Error">The exception thrown by the fresh request, when <paramref name="Outcome"/> is <see cref="SnapshotRefreshOutcome.Failed"/>.</param>
+public sealed record SnapshotRefreshResult<TModel>(
+    SnapshotRefreshOutcome Outcome,
+    TModel? Model,
+    bool SnapshotPainted,
+    Exception? Error = null) where TModel : class
+{
+    /// <summary>
+    /// <c>true</c> when the surface has nothing to show and the failure must be surfaced as a
+    /// blocking error state. A failed refresh behind a painted snapshot is not blocking.
+    /// </summary>
+    public bool IsBlockingFailure => Outcome == SnapshotRefreshOutcome.Failed && !SnapshotPainted;
+}

--- a/code/FinanceManager.Components/Shared/Services/ISnapshotRefreshCoordinator.cs
+++ b/code/FinanceManager.Components/Shared/Services/ISnapshotRefreshCoordinator.cs
@@ -1,0 +1,29 @@
+using FinanceManager.Components.Shared.Models;
+
+namespace FinanceManager.Components.Shared.Services;
+
+/// <summary>
+/// Runs the stale-while-revalidate UI snapshot workflow: paint the last-rendered state from local
+/// storage, always re-request fresh data, and reconcile the two.
+/// </summary>
+/// <remarks>
+/// <para>This is not a data cache. The fresh request always runs; the snapshot only decides what is
+/// on screen while it is in flight. Use <c>LocalStorageStateCacheService</c> instead when the goal
+/// is to <em>skip</em> the API request while cached data is still valid.</para>
+/// <para>Per run the coordinator guarantees:</para>
+/// <list type="bullet">
+/// <item>a snapshot read failure is logged, the unusable entry is evicted, and the run continues as a plain load;</item>
+/// <item>the fresh request runs whether or not a snapshot was painted;</item>
+/// <item>fresh data equal to the painted snapshot repaints nothing and writes nothing;</item>
+/// <item>a failed fresh request leaves a painted snapshot on screen, and is only blocking when nothing was painted;</item>
+/// <item>a run superseded on the version gate commits neither UI nor storage;</item>
+/// <item>a snapshot write failure is logged but never discards the fresh result.</item>
+/// </list>
+/// </remarks>
+public interface ISnapshotRefreshCoordinator
+{
+    /// <summary>Executes <paramref name="request"/> and reports what happened.</summary>
+    Task<SnapshotRefreshResult<TModel>> RunAsync<TSnapshot, TModel>(SnapshotRefreshRequest<TSnapshot, TModel> request)
+        where TSnapshot : SnapshotBase
+        where TModel : class;
+}

--- a/code/FinanceManager.Components/Shared/Services/ISnapshotService.cs
+++ b/code/FinanceManager.Components/Shared/Services/ISnapshotService.cs
@@ -10,6 +10,8 @@ namespace FinanceManager.Components.Shared.Services;
 /// <remarks>
 /// Keys should be scoped to the owning user (e.g. include the user id) and must not
 /// encode a date/range, so a single snapshot per surface is overwritten on each save.
+/// This is raw storage — components should go through <see cref="ISnapshotRefreshCoordinator"/>,
+/// which owns the stale-while-revalidate workflow around it (docs/codebase/UI-SNAPSHOTS.md).
 /// </remarks>
 public interface ISnapshotService
 {

--- a/code/FinanceManager.Components/Shared/Services/JsonContentComparer.cs
+++ b/code/FinanceManager.Components/Shared/Services/JsonContentComparer.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+
+namespace FinanceManager.Components.Shared.Services;
+
+/// <summary>
+/// Default content equality for rendered models: two models are equal when they serialize to
+/// the same JSON. Suits the DTO/record shapes the UI renders and spares callers from writing
+/// the comparison by hand.
+/// </summary>
+/// <remarks>
+/// Content equality is evaluated on the <em>rendered model</em>, never on the stored snapshot,
+/// so snapshot metadata such as <c>FetchedAtUtc</c> can never make an unchanged surface look
+/// changed. Supply a custom <see cref="IEqualityComparer{T}"/> when a model carries fields that
+/// move on every fetch but do not affect what the user sees.
+/// </remarks>
+public sealed class JsonContentComparer<T> : IEqualityComparer<T> where T : class
+{
+    public static readonly JsonContentComparer<T> Default = new();
+
+    public bool Equals(T? x, T? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null || y is null) return false;
+        return Serialize(x) == Serialize(y);
+    }
+
+    public int GetHashCode(T obj) => Serialize(obj).GetHashCode(StringComparison.Ordinal);
+
+    private static string Serialize(T value) => JsonSerializer.Serialize(value);
+}

--- a/code/FinanceManager.Components/Shared/Services/LocalStorageStateCacheService.cs
+++ b/code/FinanceManager.Components/Shared/Services/LocalStorageStateCacheService.cs
@@ -5,6 +5,15 @@ using System.Text.Json;
 
 namespace FinanceManager.Components.Shared.Services;
 
+/// <summary>
+/// Time-based data cache over memory + local storage: while a cached entry is still valid it is
+/// returned and <b>no API request is made</b>.
+/// </summary>
+/// <remarks>
+/// This is not the UI snapshot mechanism. Use <see cref="ISnapshotRefreshCoordinator"/> when the
+/// goal is to paint the last-rendered state immediately and still always re-request fresh data —
+/// see docs/codebase/UI-SNAPSHOTS.md for the comparison.
+/// </remarks>
 public abstract class LocalStorageStateCacheService<TState, TRefreshContext, TCacheKey>(
     ILocalStorageService localStorageService,
     IMemoryCache memoryCache,

--- a/code/FinanceManager.Components/Shared/Services/RefreshVersionGate.cs
+++ b/code/FinanceManager.Components/Shared/Services/RefreshVersionGate.cs
@@ -1,0 +1,24 @@
+namespace FinanceManager.Components.Shared.Services;
+
+/// <summary>
+/// Guards a surface against an older, slower load overwriting a newer one. Every load claims
+/// an incrementing version up front and only commits its result while that version is still
+/// the latest claimed one.
+/// </summary>
+/// <remarks>
+/// One gate instance per refreshable surface — typically a private readonly field on the
+/// component that owns the state being reloaded.
+/// </remarks>
+public sealed class RefreshVersionGate
+{
+    private int _version;
+
+    /// <summary>Claims the next version for a load that is about to start.</summary>
+    public int Claim() => Interlocked.Increment(ref _version);
+
+    /// <summary>
+    /// <c>true</c> while <paramref name="version"/> is still the most recently claimed one,
+    /// i.e. no newer load has started since.
+    /// </summary>
+    public bool IsCurrent(int version) => Volatile.Read(ref _version) == version;
+}

--- a/code/FinanceManager.Components/Shared/Services/SnapshotRefreshCoordinator.cs
+++ b/code/FinanceManager.Components/Shared/Services/SnapshotRefreshCoordinator.cs
@@ -8,6 +8,10 @@ namespace FinanceManager.Components.Shared.Services;
 /// its own — race protection lives in the <see cref="RefreshVersionGate"/> the caller owns — so a
 /// single instance can serve every surface.
 /// </summary>
+/// <remarks>
+/// Diagnostics name the snapshot <em>type</em>, never the key: keys embed the owning user and
+/// account ids, which must not reach logs.
+/// </remarks>
 public sealed class SnapshotRefreshCoordinator(
     ISnapshotService snapshots,
     ILogger<SnapshotRefreshCoordinator> logger) : ISnapshotRefreshCoordinator
@@ -19,7 +23,8 @@ public sealed class SnapshotRefreshCoordinator(
         var version = request.ClaimedVersion ?? request.Gate?.Claim() ?? 0;
         bool IsCurrent() => request.Gate is null || request.Gate.IsCurrent(version);
 
-        var snapshot = await ReadSnapshotAsync(request.Key, typeof(TSnapshot).Name, () => snapshots.GetAsync<TSnapshot>(request.Key));
+        var snapshotTypeName = typeof(TSnapshot).Name;
+        var snapshot = await ReadSnapshotAsync(request.Key, snapshotTypeName, () => snapshots.GetAsync<TSnapshot>(request.Key));
 
         if (!IsCurrent())
             return new SnapshotRefreshResult<TModel>(SnapshotRefreshOutcome.Superseded, null, false);
@@ -44,7 +49,9 @@ public sealed class SnapshotRefreshCoordinator(
         catch (Exception ex)
         {
             // A painted snapshot stays on screen; only a surface with nothing to show reports a blocking failure.
-            logger.LogError(ex, "Fresh load for snapshot {SnapshotKey} failed.", request.Key);
+            // Request timeouts surface here as TaskCanceledException and must keep that treatment, so
+            // cancellation is deliberately not singled out.
+            logger.LogError(ex, "Fresh load for {SnapshotType} failed.", snapshotTypeName);
             return new SnapshotRefreshResult<TModel>(SnapshotRefreshOutcome.Failed, paintedModel, paintedModel is not null, ex);
         }
 
@@ -67,7 +74,7 @@ public sealed class SnapshotRefreshCoordinator(
 
         // Skip the write once a newer run has claimed the gate — that run owns the stored snapshot now.
         if (IsCurrent())
-            await WriteSnapshotAsync(request.Key, () => snapshots.SetAsync(request.Key, request.ToSnapshot(freshModel)));
+            await WriteSnapshotAsync(snapshotTypeName, () => snapshots.SetAsync(request.Key, request.ToSnapshot(freshModel)));
 
         return new SnapshotRefreshResult<TModel>(SnapshotRefreshOutcome.Refreshed, freshModel, paintedModel is not null);
     }
@@ -79,23 +86,30 @@ public sealed class SnapshotRefreshCoordinator(
         {
             return await read();
         }
+        catch (OperationCanceledException ex)
+        {
+            // A cancelled read says nothing about whether the stored snapshot is usable, so it must
+            // not trigger eviction. Fall through to a plain fetch and leave the entry alone.
+            logger.LogDebug(ex, "Reading {SnapshotType} snapshot was cancelled; continuing with fresh fetch.", snapshotTypeName);
+            return null;
+        }
         catch (Exception ex)
         {
             // An unreadable snapshot must never abort the load; drop it and fall through to a plain fetch.
-            logger.LogWarning(ex, "Failed to read {SnapshotType} snapshot {SnapshotKey}; continuing with fresh fetch.", snapshotTypeName, key);
+            logger.LogWarning(ex, "Failed to read {SnapshotType} snapshot; continuing with fresh fetch.", snapshotTypeName);
             try
             {
                 await snapshots.RemoveAsync(key);
             }
             catch (Exception removeEx)
             {
-                logger.LogWarning(removeEx, "Failed to evict unusable snapshot {SnapshotKey}.", key);
+                logger.LogWarning(removeEx, "Failed to evict unusable {SnapshotType} snapshot.", snapshotTypeName);
             }
             return null;
         }
     }
 
-    private async Task WriteSnapshotAsync(string key, Func<Task> write)
+    private async Task WriteSnapshotAsync(string snapshotTypeName, Func<Task> write)
     {
         try
         {
@@ -104,7 +118,7 @@ public sealed class SnapshotRefreshCoordinator(
         catch (Exception ex)
         {
             // Persistence is best-effort: the fresh data is already rendered either way.
-            logger.LogWarning(ex, "Fresh data rendered but saving snapshot {SnapshotKey} failed.", key);
+            logger.LogWarning(ex, "Fresh data rendered but saving {SnapshotType} snapshot failed.", snapshotTypeName);
         }
     }
 }

--- a/code/FinanceManager.Components/Shared/Services/SnapshotRefreshCoordinator.cs
+++ b/code/FinanceManager.Components/Shared/Services/SnapshotRefreshCoordinator.cs
@@ -1,0 +1,110 @@
+using FinanceManager.Components.Shared.Models;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Components.Shared.Services;
+
+/// <summary>
+/// <see cref="ISnapshotRefreshCoordinator"/> over <see cref="ISnapshotService"/>. Holds no state of
+/// its own — race protection lives in the <see cref="RefreshVersionGate"/> the caller owns — so a
+/// single instance can serve every surface.
+/// </summary>
+public sealed class SnapshotRefreshCoordinator(
+    ISnapshotService snapshots,
+    ILogger<SnapshotRefreshCoordinator> logger) : ISnapshotRefreshCoordinator
+{
+    public async Task<SnapshotRefreshResult<TModel>> RunAsync<TSnapshot, TModel>(SnapshotRefreshRequest<TSnapshot, TModel> request)
+        where TSnapshot : SnapshotBase
+        where TModel : class
+    {
+        var version = request.ClaimedVersion ?? request.Gate?.Claim() ?? 0;
+        bool IsCurrent() => request.Gate is null || request.Gate.IsCurrent(version);
+
+        var snapshot = await ReadSnapshotAsync(request.Key, typeof(TSnapshot).Name, () => snapshots.GetAsync<TSnapshot>(request.Key));
+
+        if (!IsCurrent())
+            return new SnapshotRefreshResult<TModel>(SnapshotRefreshOutcome.Superseded, null, false);
+
+        // Paint the last-rendered state first so the surface feels instant; the fetch below runs regardless.
+        var paintedModel = snapshot is null ? null : request.ToModel(snapshot);
+        if (paintedModel is not null)
+        {
+            if (request.OnSnapshotPainted is not null)
+                await request.OnSnapshotPainted(paintedModel);
+        }
+        else if (request.OnSnapshotMissing is not null)
+        {
+            await request.OnSnapshotMissing();
+        }
+
+        TModel? freshModel;
+        try
+        {
+            freshModel = await request.FetchAsync();
+        }
+        catch (Exception ex)
+        {
+            // A painted snapshot stays on screen; only a surface with nothing to show reports a blocking failure.
+            logger.LogError(ex, "Fresh load for snapshot {SnapshotKey} failed.", request.Key);
+            return new SnapshotRefreshResult<TModel>(SnapshotRefreshOutcome.Failed, paintedModel, paintedModel is not null, ex);
+        }
+
+        if (!IsCurrent())
+            return new SnapshotRefreshResult<TModel>(SnapshotRefreshOutcome.Superseded, paintedModel, paintedModel is not null);
+
+        if (freshModel is null)
+        {
+            return paintedModel is null
+                ? new SnapshotRefreshResult<TModel>(SnapshotRefreshOutcome.Empty, null, false)
+                : new SnapshotRefreshResult<TModel>(SnapshotRefreshOutcome.Unchanged, paintedModel, true);
+        }
+
+        // Content equality runs over the rendered models, so snapshot metadata never counts as a change.
+        if (paintedModel is not null && request.ContentComparer.Equals(freshModel, paintedModel))
+            return new SnapshotRefreshResult<TModel>(SnapshotRefreshOutcome.Unchanged, paintedModel, true);
+
+        if (request.OnRefreshed is not null)
+            await request.OnRefreshed(freshModel);
+
+        // Skip the write once a newer run has claimed the gate — that run owns the stored snapshot now.
+        if (IsCurrent())
+            await WriteSnapshotAsync(request.Key, () => snapshots.SetAsync(request.Key, request.ToSnapshot(freshModel)));
+
+        return new SnapshotRefreshResult<TModel>(SnapshotRefreshOutcome.Refreshed, freshModel, paintedModel is not null);
+    }
+
+    private async Task<TSnapshot?> ReadSnapshotAsync<TSnapshot>(string key, string snapshotTypeName, Func<Task<TSnapshot?>> read)
+        where TSnapshot : SnapshotBase
+    {
+        try
+        {
+            return await read();
+        }
+        catch (Exception ex)
+        {
+            // An unreadable snapshot must never abort the load; drop it and fall through to a plain fetch.
+            logger.LogWarning(ex, "Failed to read {SnapshotType} snapshot {SnapshotKey}; continuing with fresh fetch.", snapshotTypeName, key);
+            try
+            {
+                await snapshots.RemoveAsync(key);
+            }
+            catch (Exception removeEx)
+            {
+                logger.LogWarning(removeEx, "Failed to evict unusable snapshot {SnapshotKey}.", key);
+            }
+            return null;
+        }
+    }
+
+    private async Task WriteSnapshotAsync(string key, Func<Task> write)
+    {
+        try
+        {
+            await write();
+        }
+        catch (Exception ex)
+        {
+            // Persistence is best-effort: the fresh data is already rendered either way.
+            logger.LogWarning(ex, "Fresh data rendered but saving snapshot {SnapshotKey} failed.", key);
+        }
+    }
+}

--- a/code/FinanceManager.Components/Shared/Services/SnapshotRefreshRequest.cs
+++ b/code/FinanceManager.Components/Shared/Services/SnapshotRefreshRequest.cs
@@ -1,0 +1,66 @@
+using FinanceManager.Components.Shared.Models;
+
+namespace FinanceManager.Components.Shared.Services;
+
+/// <summary>
+/// One stale-while-revalidate run described declaratively: where the snapshot lives, how to turn
+/// it into a rendered model, how to fetch fresh data, and how to turn the fresh model back into a
+/// snapshot. Handed to <see cref="ISnapshotRefreshCoordinator.RunAsync"/>, which owns the ordering,
+/// the equality check, the race protection and the non-fatal storage handling.
+/// </summary>
+/// <typeparam name="TSnapshot">The persisted snapshot type.</typeparam>
+/// <typeparam name="TModel">The model the UI renders. Must not carry snapshot metadata.</typeparam>
+public sealed class SnapshotRefreshRequest<TSnapshot, TModel>
+    where TSnapshot : SnapshotBase
+    where TModel : class
+{
+    /// <summary>
+    /// Storage key for the snapshot. Scope it to the owning user and to the surface identity that
+    /// changes what is rendered (currency, account), but not to the selected date range — one
+    /// snapshot per surface is overwritten on each save.
+    /// </summary>
+    public required string Key { get; init; }
+
+    /// <summary>
+    /// Maps a stored snapshot to the model to paint. Return <c>null</c> to reject the snapshot as
+    /// unusable (e.g. it belongs to a different account); the run then continues as a plain load.
+    /// </summary>
+    public required Func<TSnapshot, TModel?> ToModel { get; init; }
+
+    /// <summary>
+    /// Requests fresh data and maps it to the rendered model. Always invoked, snapshot or not.
+    /// Return <c>null</c> when the response holds nothing to render; throw to report a failure.
+    /// </summary>
+    public required Func<Task<TModel?>> FetchAsync { get; init; }
+
+    /// <summary>Maps the fresh model back to the snapshot to persist.</summary>
+    public required Func<TModel, TSnapshot> ToSnapshot { get; init; }
+
+    /// <summary>
+    /// Decides whether fresh data actually changed what the user sees. Defaults to JSON equality
+    /// over the model (see <see cref="JsonContentComparer{T}"/>).
+    /// </summary>
+    public IEqualityComparer<TModel> ContentComparer { get; init; } = JsonContentComparer<TModel>.Default;
+
+    /// <summary>
+    /// Race protection shared by every run against the same surface. When omitted the run always
+    /// commits — only safe for surfaces that cannot be reloaded concurrently.
+    /// </summary>
+    public RefreshVersionGate? Gate { get; init; }
+
+    /// <summary>
+    /// A version already claimed from <see cref="Gate"/>. Set it when the caller has to claim before
+    /// the run starts — typically because it resolves user/settings context first and needs the same
+    /// version to guard that context's own state changes. When omitted the coordinator claims one.
+    /// </summary>
+    public int? ClaimedVersion { get; init; }
+
+    /// <summary>Invoked with the snapshot model before the fresh request starts, so the surface paints immediately.</summary>
+    public Func<TModel, Task>? OnSnapshotPainted { get; init; }
+
+    /// <summary>Invoked instead of <see cref="OnSnapshotPainted"/> when no usable snapshot existed — the place to show a loading state.</summary>
+    public Func<Task>? OnSnapshotMissing { get; init; }
+
+    /// <summary>Invoked with the fresh model only when it differs from what was painted. Never invoked for an unchanged refresh.</summary>
+    public Func<TModel, Task>? OnRefreshed { get; init; }
+}

--- a/code/FinanceManager.Components/Shared/Services/SnapshotRefreshRequest.cs
+++ b/code/FinanceManager.Components/Shared/Services/SnapshotRefreshRequest.cs
@@ -29,8 +29,14 @@ public sealed class SnapshotRefreshRequest<TSnapshot, TModel>
 
     /// <summary>
     /// Requests fresh data and maps it to the rendered model. Always invoked, snapshot or not.
-    /// Return <c>null</c> when the response holds nothing to render; throw to report a failure.
+    /// Throw to report a failure. Return <c>null</c> only when no usable response came back — that
+    /// is treated as a soft failure, leaving a painted snapshot on screen.
     /// </summary>
+    /// <remarks>
+    /// A surface that legitimately has <em>no data</em> must return an empty model rather than
+    /// <c>null</c>: an empty model compares unequal to a populated snapshot, so it clears the UI and
+    /// replaces the stored snapshot, whereas <c>null</c> deliberately changes nothing.
+    /// </remarks>
     public required Func<Task<TModel?>> FetchAsync { get; init; }
 
     /// <summary>Maps the fresh model back to the snapshot to persist.</summary>

--- a/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Services/AccountDetailsSnapshotStoreTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Services/AccountDetailsSnapshotStoreTests.cs
@@ -1,6 +1,8 @@
 using FinanceManager.Components.Features.FinancialAccounts.Models;
 using FinanceManager.Components.Features.FinancialAccounts.Services;
+using FinanceManager.Components.Shared.Models;
 using FinanceManager.Components.Shared.Services;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 
@@ -9,44 +11,75 @@ namespace FinanceManager.Tests.Unit.Components.Features.FinancialAccounts.Servic
 [Trait("Category", "Unit")]
 public class AccountDetailsSnapshotStoreTests
 {
+    private const string _key = "account-details:1:2";
+
     private readonly Mock<ISnapshotService> _snapshots = new();
 
     private AccountDetailsSnapshotStore CreateService() =>
-        new(_snapshots.Object, NullLogger<AccountDetailsSnapshotStore>.Instance);
+        new(new SnapshotRefreshCoordinator(_snapshots.Object, NullLogger<SnapshotRefreshCoordinator>.Instance));
 
     [Fact]
-    public async Task GetAsync_ReadFailure_ReturnsNull()
+    public async Task RefreshAsync_ReadFailure_PaintsNothingAndLoadsFresh()
     {
-        _snapshots.Setup(x => x.GetAsync<AccountDetailsSnapshot<int>>("account-details:1:2"))
-            .ThrowsAsync(new InvalidOperationException());
+        _snapshots.Setup(x => x.GetAsync<AccountDetailsSnapshot<int>>(_key)).ThrowsAsync(new InvalidOperationException());
 
-        Assert.Null(await CreateService().GetAsync<int>(1, 2));
+        var result = await Refresh(fresh: Model([1, 2]));
+
+        Assert.False(result.SnapshotPainted);
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+        _snapshots.Verify(x => x.RemoveAsync(_key), Times.Once);
     }
 
     [Fact]
-    public async Task SaveIfChangedAsync_UnchangedEntries_SkipsWrite()
+    public async Task RefreshAsync_UnchangedEntries_SkipsWrite()
     {
-        var previous = Snapshot([1, 2]);
+        GivenStoredSnapshot([1, 2]);
 
-        await CreateService().SaveIfChangedAsync(Snapshot([1, 2]), previous);
+        var result = await Refresh(fresh: Model([1, 2]));
 
+        Assert.Equal(SnapshotRefreshOutcome.Unchanged, result.Outcome);
         _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<AccountDetailsSnapshot<int>>()), Times.Never);
     }
 
     [Fact]
-    public async Task SaveIfChangedAsync_ChangedEntries_WritesUserAndAccountScopedKey()
+    public async Task RefreshAsync_ChangedEntries_WritesUserAndAccountScopedKey()
     {
-        var snapshot = Snapshot([1, 3]);
+        GivenStoredSnapshot([1, 2]);
 
-        await CreateService().SaveIfChangedAsync(snapshot, Snapshot([1, 2]));
+        var result = await Refresh(fresh: Model([1, 3]));
 
-        _snapshots.Verify(x => x.SetAsync("account-details:1:2", snapshot), Times.Once);
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+        _snapshots.Verify(x => x.SetAsync(_key, It.Is<AccountDetailsSnapshot<int>>(
+            s => s.UserId == 1 && s.AccountId == 2 && s.Entries.SequenceEqual(new[] { 1, 3 }))), Times.Once);
     }
 
-    private static AccountDetailsSnapshot<int> Snapshot(List<int> entries) => new()
+    [Fact]
+    public async Task RefreshAsync_SnapshotFromAnotherAccount_IsNotPainted()
     {
-        UserId = 1,
-        AccountId = 2,
-        Entries = entries,
-    };
+        // A stale entry left under this key by a different account must never be rendered here.
+        _snapshots.Setup(x => x.GetAsync<AccountDetailsSnapshot<int>>(_key))
+            .ReturnsAsync(new AccountDetailsSnapshot<int> { UserId = 1, AccountId = 99, Entries = [1, 2] });
+
+        var painted = false;
+        var result = await Refresh(fresh: Model([1, 2]), onSnapshotPainted: _ =>
+        {
+            painted = true;
+            return Task.CompletedTask;
+        });
+
+        Assert.False(painted);
+        Assert.False(result.SnapshotPainted);
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+    }
+
+    private void GivenStoredSnapshot(List<int> entries) =>
+        _snapshots.Setup(x => x.GetAsync<AccountDetailsSnapshot<int>>(_key))
+            .ReturnsAsync(new AccountDetailsSnapshot<int> { UserId = 1, AccountId = 2, AccountType = AccountLabel.Other, Entries = entries });
+
+    private Task<SnapshotRefreshResult<AccountDetailsModel<int>>> Refresh(
+        AccountDetailsModel<int>? fresh,
+        Func<AccountDetailsModel<int>, Task>? onSnapshotPainted = null) =>
+        CreateService().RefreshAsync(1, 2, new RefreshVersionGate(), () => Task.FromResult(fresh), onSnapshotPainted);
+
+    private static AccountDetailsModel<int> Model(List<int> entries) => new(1, 2, string.Empty, AccountLabel.Other, entries);
 }

--- a/code/FinanceManager.Tests.Unit/Components/Shared/Services/RefreshVersionGateTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Shared/Services/RefreshVersionGateTests.cs
@@ -1,0 +1,27 @@
+using FinanceManager.Components.Shared.Services;
+
+namespace FinanceManager.Tests.Unit.Components.Shared.Services;
+
+[Trait("Category", "Unit")]
+public class RefreshVersionGateTests
+{
+    [Fact]
+    public void Claim_OnlyTheLatestClaimIsCurrent()
+    {
+        var gate = new RefreshVersionGate();
+
+        var first = gate.Claim();
+        var second = gate.Claim();
+
+        Assert.False(gate.IsCurrent(first));
+        Assert.True(gate.IsCurrent(second));
+    }
+
+    [Fact]
+    public void IsCurrent_SingleClaim_StaysCurrent()
+    {
+        var gate = new RefreshVersionGate();
+
+        Assert.True(gate.IsCurrent(gate.Claim()));
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/Shared/Services/SnapshotRefreshCoordinatorTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Shared/Services/SnapshotRefreshCoordinatorTests.cs
@@ -1,0 +1,308 @@
+using FinanceManager.Components.Shared.Models;
+using FinanceManager.Components.Shared.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Components.Shared.Services;
+
+[Trait("Category", "Unit")]
+public class SnapshotRefreshCoordinatorTests
+{
+    private const string _key = "test-surface:7";
+
+    private readonly Mock<ISnapshotService> _snapshots = new();
+
+    private sealed class TestSnapshot : SnapshotBase
+    {
+        public string Payload { get; set; } = string.Empty;
+    }
+
+    private sealed record TestModel(string Payload);
+
+    private SnapshotRefreshCoordinator CreateCoordinator() =>
+        new(_snapshots.Object, NullLogger<SnapshotRefreshCoordinator>.Instance);
+
+    private void GivenStoredSnapshot(string payload) =>
+        _snapshots.Setup(x => x.GetAsync<TestSnapshot>(_key)).ReturnsAsync(new TestSnapshot { Payload = payload });
+
+    private static SnapshotRefreshRequest<TestSnapshot, TestModel> Request(
+        Func<Task<TestModel?>> fetchAsync,
+        Func<TestModel, Task>? onSnapshotPainted = null,
+        Func<Task>? onSnapshotMissing = null,
+        Func<TestModel, Task>? onRefreshed = null,
+        RefreshVersionGate? gate = null) => new()
+        {
+            Key = _key,
+            Gate = gate,
+            ToModel = snapshot => new TestModel(snapshot.Payload),
+            FetchAsync = fetchAsync,
+            ToSnapshot = model => new TestSnapshot { Payload = model.Payload },
+            OnSnapshotPainted = onSnapshotPainted,
+            OnSnapshotMissing = onSnapshotMissing,
+            OnRefreshed = onRefreshed,
+        };
+
+    [Fact]
+    public async Task RunAsync_PaintsSnapshotBeforeFreshRequestCompletes()
+    {
+        GivenStoredSnapshot("cached");
+        var fetchGate = new TaskCompletionSource<TestModel?>();
+        var paintedWhileFetchPending = false;
+        TestModel? painted = null;
+
+        var run = CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => fetchGate.Task,
+            onSnapshotPainted: model =>
+            {
+                painted = model;
+                paintedWhileFetchPending = !fetchGate.Task.IsCompleted;
+                return Task.CompletedTask;
+            }));
+
+        Assert.False(run.IsCompleted);
+        Assert.Equal(new TestModel("cached"), painted);
+        Assert.True(paintedWhileFetchPending);
+
+        fetchGate.SetResult(new TestModel("cached"));
+        await run;
+    }
+
+    [Fact]
+    public async Task RunAsync_WithSnapshot_StillRunsFreshRequest()
+    {
+        GivenStoredSnapshot("cached");
+        var fetchCount = 0;
+
+        await CreateCoordinator().RunAsync(Request(fetchAsync: () =>
+        {
+            fetchCount++;
+            return Task.FromResult<TestModel?>(new TestModel("cached"));
+        }));
+
+        Assert.Equal(1, fetchCount);
+    }
+
+    [Fact]
+    public async Task RunAsync_WithoutSnapshot_ReportsSnapshotMissing()
+    {
+        var missingReported = false;
+
+        var result = await CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => Task.FromResult<TestModel?>(new TestModel("fresh")),
+            onSnapshotMissing: () =>
+            {
+                missingReported = true;
+                return Task.CompletedTask;
+            }));
+
+        Assert.True(missingReported);
+        Assert.False(result.SnapshotPainted);
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+    }
+
+    [Fact]
+    public async Task RunAsync_FreshDataEqualsSnapshot_DoesNotRepaintOrWrite()
+    {
+        GivenStoredSnapshot("same");
+        var repainted = false;
+
+        var result = await CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => Task.FromResult<TestModel?>(new TestModel("same")),
+            onRefreshed: _ =>
+            {
+                repainted = true;
+                return Task.CompletedTask;
+            }));
+
+        Assert.Equal(SnapshotRefreshOutcome.Unchanged, result.Outcome);
+        Assert.Equal(new TestModel("same"), result.Model);
+        Assert.False(repainted);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<TestSnapshot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_SnapshotMetadataDiffers_CountsAsUnchanged()
+    {
+        // The stored snapshot was captured a week ago; only the rendered payload may decide equality.
+        _snapshots.Setup(x => x.GetAsync<TestSnapshot>(_key))
+            .ReturnsAsync(new TestSnapshot { Payload = "same", FetchedAtUtc = DateTime.UtcNow.AddDays(-7) });
+
+        var result = await CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => Task.FromResult<TestModel?>(new TestModel("same"))));
+
+        Assert.Equal(SnapshotRefreshOutcome.Unchanged, result.Outcome);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<TestSnapshot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_FreshDataDiffers_ReplacesModelAndSnapshot()
+    {
+        GivenStoredSnapshot("cached");
+        TestModel? repainted = null;
+
+        var result = await CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => Task.FromResult<TestModel?>(new TestModel("fresh")),
+            onRefreshed: model =>
+            {
+                repainted = model;
+                return Task.CompletedTask;
+            }));
+
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+        Assert.Equal(new TestModel("fresh"), result.Model);
+        Assert.Equal(new TestModel("fresh"), repainted);
+        _snapshots.Verify(x => x.SetAsync(_key, It.Is<TestSnapshot>(s => s.Payload == "fresh")), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_FetchFails_KeepsPaintedSnapshot()
+    {
+        GivenStoredSnapshot("cached");
+        var failure = new HttpRequestException("boom");
+
+        var result = await CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => Task.FromException<TestModel?>(failure)));
+
+        Assert.Equal(SnapshotRefreshOutcome.Failed, result.Outcome);
+        Assert.Equal(new TestModel("cached"), result.Model);
+        Assert.True(result.SnapshotPainted);
+        Assert.False(result.IsBlockingFailure);
+        Assert.Same(failure, result.Error);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<TestSnapshot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_FetchFailsWithoutSnapshot_ReportsBlockingFailure()
+    {
+        var failure = new HttpRequestException("boom");
+
+        var result = await CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => Task.FromException<TestModel?>(failure)));
+
+        Assert.Equal(SnapshotRefreshOutcome.Failed, result.Outcome);
+        Assert.Null(result.Model);
+        Assert.True(result.IsBlockingFailure);
+        Assert.Same(failure, result.Error);
+    }
+
+    [Fact]
+    public async Task RunAsync_FetchReturnsNothingWithoutSnapshot_ReportsEmpty()
+    {
+        var result = await CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => Task.FromResult<TestModel?>(null)));
+
+        Assert.Equal(SnapshotRefreshOutcome.Empty, result.Outcome);
+        Assert.Null(result.Model);
+        Assert.False(result.IsBlockingFailure);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<TestSnapshot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_UnreadableSnapshot_EvictsItAndLoadsFresh()
+    {
+        _snapshots.Setup(x => x.GetAsync<TestSnapshot>(_key)).ThrowsAsync(new InvalidOperationException("unreadable"));
+        var missingReported = false;
+
+        var result = await CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => Task.FromResult<TestModel?>(new TestModel("fresh")),
+            onSnapshotMissing: () =>
+            {
+                missingReported = true;
+                return Task.CompletedTask;
+            }));
+
+        _snapshots.Verify(x => x.RemoveAsync(_key), Times.Once);
+        Assert.True(missingReported);
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+        Assert.Equal(new TestModel("fresh"), result.Model);
+    }
+
+    [Fact]
+    public async Task RunAsync_RejectedSnapshot_LoadsFreshWithoutPainting()
+    {
+        GivenStoredSnapshot("belongs-to-another-surface");
+        var request = Request(fetchAsync: () => Task.FromResult<TestModel?>(new TestModel("fresh")));
+
+        var result = await CreateCoordinator().RunAsync(new SnapshotRefreshRequest<TestSnapshot, TestModel>
+        {
+            Key = request.Key,
+            ToModel = _ => null,
+            FetchAsync = request.FetchAsync,
+            ToSnapshot = request.ToSnapshot,
+        });
+
+        Assert.False(result.SnapshotPainted);
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+    }
+
+    [Fact]
+    public async Task RunAsync_SupersededRun_CommitsNeitherUiNorSnapshot()
+    {
+        var gate = new RefreshVersionGate();
+        var fetchGate = new TaskCompletionSource<TestModel?>();
+        var repainted = false;
+
+        var run = CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => fetchGate.Task,
+            onRefreshed: _ =>
+            {
+                repainted = true;
+                return Task.CompletedTask;
+            },
+            gate: gate));
+
+        // A newer load starts while the first fetch is still in flight.
+        gate.Claim();
+        fetchGate.SetResult(new TestModel("stale-result"));
+        var result = await run;
+
+        Assert.Equal(SnapshotRefreshOutcome.Superseded, result.Outcome);
+        Assert.False(repainted);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<TestSnapshot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_SnapshotWriteFails_KeepsFreshResult()
+    {
+        _snapshots.Setup(x => x.SetAsync(_key, It.IsAny<TestSnapshot>())).ThrowsAsync(new InvalidOperationException("storage full"));
+        TestModel? repainted = null;
+
+        var result = await CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => Task.FromResult<TestModel?>(new TestModel("fresh")),
+            onRefreshed: model =>
+            {
+                repainted = model;
+                return Task.CompletedTask;
+            }));
+
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+        Assert.Equal(new TestModel("fresh"), result.Model);
+        Assert.Equal(new TestModel("fresh"), repainted);
+    }
+
+    [Fact]
+    public async Task RunAsync_CustomComparer_DecidesWhetherContentChanged()
+    {
+        GivenStoredSnapshot("CACHED");
+
+        var result = await CreateCoordinator().RunAsync(new SnapshotRefreshRequest<TestSnapshot, TestModel>
+        {
+            Key = _key,
+            ToModel = snapshot => new TestModel(snapshot.Payload),
+            FetchAsync = () => Task.FromResult<TestModel?>(new TestModel("cached")),
+            ToSnapshot = model => new TestSnapshot { Payload = model.Payload },
+            ContentComparer = new CaseInsensitivePayloadComparer(),
+        });
+
+        Assert.Equal(SnapshotRefreshOutcome.Unchanged, result.Outcome);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<TestSnapshot>()), Times.Never);
+    }
+
+    private sealed class CaseInsensitivePayloadComparer : IEqualityComparer<TestModel>
+    {
+        public bool Equals(TestModel? x, TestModel? y) =>
+            string.Equals(x?.Payload, y?.Payload, StringComparison.OrdinalIgnoreCase);
+
+        public int GetHashCode(TestModel obj) => obj.Payload.GetHashCode(StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/Shared/Services/SnapshotRefreshCoordinatorTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Shared/Services/SnapshotRefreshCoordinatorTests.cs
@@ -262,6 +262,19 @@ public class SnapshotRefreshCoordinatorTests
     }
 
     [Fact]
+    public async Task RunAsync_CancelledSnapshotRead_DoesNotEvictSnapshot()
+    {
+        // Cancellation says nothing about whether the stored snapshot is usable, so it must survive.
+        _snapshots.Setup(x => x.GetAsync<TestSnapshot>(_key)).ThrowsAsync(new OperationCanceledException());
+
+        var result = await CreateCoordinator().RunAsync(Request(
+            fetchAsync: () => Task.FromResult<TestModel?>(new TestModel("fresh"))));
+
+        _snapshots.Verify(x => x.RemoveAsync(It.IsAny<string>()), Times.Never);
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+    }
+
+    [Fact]
     public async Task RunAsync_SnapshotWriteFails_KeepsFreshResult()
     {
         _snapshots.Setup(x => x.SetAsync(_key, It.IsAny<TestSnapshot>())).ThrowsAsync(new InvalidOperationException("storage full"));

--- a/docs/codebase/ARCHITECTURE.md
+++ b/docs/codebase/ARCHITECTURE.md
@@ -48,6 +48,7 @@ Representative flow for stock prices:
 | Hosted background services + channel abstractions | `code\FinanceManager.Api\Program.cs` | Runs asynchronous insights, label setting, and import jobs outside request handlers |
 | Provider fallback strategy | `code\FinanceManager.Application\Providers\StockPriceProvider.cs`, `code\FinanceManager.Infrastructure\Services\Ai\ServiceCollectionExtension.cs`, `code\FinanceManager.Api\appsettings.json` | Falls back from cached/local data to external stock or AI providers |
 | Razor code-behind | `code\FinanceManager.Components\Components\AssetsPage.razor` + `.razor.cs`, `code\FinanceManager.Components\Components\FinancialAccounts\...` | Splits markup from complex component logic |
+| Stale-while-revalidate UI snapshots | `code\FinanceManager.Components\Shared\Services\SnapshotRefreshCoordinator.cs`, `docs\codebase\UI-SNAPSHOTS.md` | Paints a surface's last-rendered state instantly, then reconciles it against an always-issued fresh request — distinct from the time-based `LocalStorageStateCacheService` |
 
 ### 5) Known Architectural Risks
 

--- a/docs/codebase/UI-SNAPSHOTS.md
+++ b/docs/codebase/UI-SNAPSHOTS.md
@@ -1,0 +1,95 @@
+# UI Snapshots (stale-while-revalidate) vs. time-based data caching
+
+The client has two mechanisms that both persist data in browser local storage. They look similar
+and are not interchangeable. Pick by asking one question: **may the API request be skipped?**
+
+| | **UI snapshot (stale-while-revalidate)** | **Time-based data cache** |
+|---|---|---|
+| Type | `ISnapshotRefreshCoordinator` over `ISnapshotService` | `LocalStorageStateCacheService<TState, TRefreshContext, TCacheKey>` |
+| API request | **Always** runs | **Skipped** while the cached entry is still valid |
+| What is stored | The last *rendered* state of a UI surface | The last *fetched* data, with its validity window |
+| Why | The surface paints instantly instead of flashing a spinner | Fewer requests for data that does not change often |
+| Freshness | Guaranteed on every visit — reconciled against the response | Bounded by the entry's expiry rules |
+| Use for | Dashboard cards, transaction lists, charts | Nav menu state, assets-page cards, investment rate/estimate lookups |
+
+A UI snapshot is never a source of truth. It is what the user looks at during the few hundred
+milliseconds the real request takes.
+
+## The workflow
+
+`SnapshotRefreshCoordinator.RunAsync` performs, in order:
+
+1. Read the snapshot stored under the request's key.
+2. Map it to a rendered model and hand it to `OnSnapshotPainted` — the surface renders immediately.
+   When there is no usable snapshot, `OnSnapshotMissing` runs instead (show a loading state there).
+3. Run the fresh request — always, snapshot or not.
+4. Compare the fresh model with the painted one using the request's `ContentComparer`.
+5. Only when they differ: hand the fresh model to `OnRefreshed` and overwrite the stored snapshot.
+
+Guarantees the coordinator makes so no caller has to re-implement them:
+
+- **Equal data is inert.** A refresh that matches what is on screen repaints nothing and writes nothing.
+- **Metadata never counts as a change.** Equality runs over the *rendered model*, so `SnapshotBase.FetchedAtUtc`
+  and anything else that only lives on the snapshot cannot make an unchanged surface look changed.
+- **A failed refresh is not destructive.** With a snapshot on screen the stale content stays; only a
+  surface with nothing to show reports a blocking failure (`SnapshotRefreshResult.IsBlockingFailure`).
+- **Storage failures are non-fatal.** An unreadable snapshot is logged, evicted, and the run continues
+  as a plain load. A failed write is logged and never discards the fresh result.
+- **Stale runs cannot win.** With a `RefreshVersionGate`, a run superseded by a newer one commits
+  neither UI nor storage.
+
+## Using it
+
+```csharp
+// One gate per refreshable surface, on the component that owns the state.
+private readonly RefreshVersionGate _gate = new();
+
+var result = await SnapshotRefreshCoordinator.RunAsync(new SnapshotRefreshRequest<MySnapshot, MyModel>
+{
+    Key = $"my-surface:{userId}:{currencyId}",
+    Gate = _gate,
+    ToModel = snapshot => snapshot.ToModel(),
+    FetchAsync = () => MyHttpClient.Get(userId, currencyId, start, end),
+    ToSnapshot = MySnapshot.FromModel,
+    OnSnapshotPainted = model => Render(model),
+    OnSnapshotMissing = () => ShowSpinner(),
+    OnRefreshed = model => Render(model),
+});
+
+if (result.IsBlockingFailure)
+    ShowError();
+```
+
+### Keys
+
+Scope the key to the owning user and to whatever else changes *what is rendered* — currency,
+account id. Do **not** put the selected date range in the key: one surface keeps one snapshot that
+each save overwrites, rather than accumulating an entry per range the user has ever picked. Store
+the range inside the snapshot instead when the view needs to know what produced it (the dashboard
+does this so amounts and their period label stay paired during a reload).
+
+### Content equality
+
+The default `JsonContentComparer<TModel>` treats two models as equal when they serialize
+identically. Keep the model free of fields that move on every fetch — a request timestamp, a
+server-generated id — or the surface repaints and rewrites storage every time. When such a field
+cannot be avoided, pass a custom `IEqualityComparer<TModel>` as `ContentComparer`.
+
+### Component structure
+
+Data fetching and snapshot reconciliation belong in the page coordinator or a container component,
+not in a reusable view component. View components should take a prepared model and render it. The
+dashboard follows this shape: `Dashboard.razor.cs` resolves user and currency, runs the coordinator,
+and hands finished card models down to the cards.
+
+## Where it is used
+
+| Surface | Entry point |
+|---|---|
+| Dashboard overview | `code\FinanceManager.Components\Features\Dashboard\Components\Dashboard.razor.cs` |
+| Account transaction lists | `code\FinanceManager.Components\Features\FinancialAccounts\Services\AccountDetailsSnapshotStore.cs` |
+
+`AccountDetailsSnapshotStore` shows the recommended shape for a surface with several callers: a thin
+feature-level wrapper that owns the key shape and the snapshot↔model mapping, leaving the workflow
+to the coordinator. Follow-up card and chart migrations should add a similar wrapper rather than
+re-implementing the orchestration.

--- a/docs/codebase/UI-SNAPSHOTS.md
+++ b/docs/codebase/UI-SNAPSHOTS.md
@@ -75,6 +75,22 @@ identically. Keep the model free of fields that move on every fetch — a reques
 server-generated id — or the surface repaints and rewrites storage every time. When such a field
 cannot be avoided, pass a custom `IEqualityComparer<TModel>` as `ContentComparer`.
 
+### Empty results vs. no result
+
+`FetchAsync` returning `null` means *no usable response came back*. It is treated as a soft failure:
+a painted snapshot stays on screen and storage is left alone. A surface that legitimately has **no
+data** must return an *empty model* instead — an empty model compares unequal to a populated
+snapshot, so it clears the UI and replaces the stored snapshot, which is what "the account now has
+zero entries" should do. Returning `null` for that case would silently keep stale content visible.
+
+### Preserving state the snapshot cannot carry
+
+A snapshot stores rendered content only. When the API response carries more than that — pagination
+cursors, neighbouring-entry markers such as `NextOlderEntry` — apply the *fetched object itself* on
+refresh and use the model purely for equality and persistence. Rebuilding the response from the
+model would silently drop those fields; the account-details pages keep the fetched account in a
+local and hand it to their apply step for exactly this reason.
+
 ### Component structure
 
 Data fetching and snapshot reconciliation belong in the page coordinator or a container component,


### PR DESCRIPTION
closes #615

## What

Introduces one documented stale-while-revalidate UI snapshot abstraction and moves the two reference flows onto it, without changing their UX.

### Shared infrastructure (`FinanceManager.Components/Shared`)

- **`ISnapshotRefreshCoordinator` / `SnapshotRefreshCoordinator`** — owns the whole workflow: read snapshot → paint → always fetch → compare → repaint & persist only on change.
- **`SnapshotRefreshRequest<TSnapshot, TModel>`** — declarative description of a run (key, snapshot↔model mapping, fetch, comparer, gate, callbacks).
- **`SnapshotRefreshResult<TModel>` / `SnapshotRefreshOutcome`** — result type reporting `Refreshed` / `Unchanged` / `Failed` / `Empty` / `Superseded`, plus `IsBlockingFailure` for "nothing to show".
- **`RefreshVersionGate`** — centralized race protection; a superseded run commits neither UI nor storage.
- **`JsonContentComparer<T>`** — default content equality, overridable per request.

Guarantees the coordinator makes so no caller re-implements them:

- equal fresh data repaints nothing and writes nothing;
- equality runs over the *rendered model*, so `FetchedAtUtc` and other snapshot metadata can never look like a change;
- a failed refresh behind a painted snapshot keeps the snapshot visible; only a surface with nothing to show reports a blocking error;
- an unreadable snapshot is logged, evicted, and the run continues as a plain load;
- a failed snapshot write never discards the fresh result.

### Refactored flows

- `Dashboard.razor.cs` — the hand-rolled version counter, snapshot read/compare/write and error handling collapse into one `RunAsync` call.
- `AccountDetailsSnapshotStore` — now a thin feature wrapper owning the key shape and snapshot↔model mapping; `CurrencyAccountDetailsPageContent` and `BondAccountDetailsPageContent` use it via a new `AccountDetailsModel<TEntry>`. Fetching no longer mutates rendered state directly, so "unchanged" really means "not repainted".

### Docs

`docs/codebase/UI-SNAPSHOTS.md` contrasts the UI snapshot mechanism (always re-requests) with the time-based `LocalStorageStateCacheService` (skips the request), covers key scoping, content equality and component structure, and points follow-up card/chart migrations at the wrapper pattern. Cross-referenced from `CLAUDE.md`, `ARCHITECTURE.md` and both services' XML docs.

## Tests

`SnapshotRefreshCoordinatorTests` (+ `RefreshVersionGateTests`, rewritten `AccountDetailsSnapshotStoreTests`) cover: cached model painted before the fetch completes, fetch always runs with a snapshot present, unchanged data writes nothing, changed data replaces model and snapshot, metadata-only difference counts as unchanged, failure with and without a snapshot, unreadable snapshot evicted, rejected snapshot, superseded run, write failure, custom comparer.

`dotnet build` clean (0 warnings), `dotnet format` applied, 657/657 unit tests pass.

## Verification

Dashboard and currency/bond account details rendered on the guest account at desktop and mobile viewports, including a repeat visit that exercises the snapshot-paint path. No console errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coordinated snapshot refresh behavior across dashboard and account transaction views.
  * Stored data can appear immediately while fresh information loads in the background.
  * Added protection against outdated refreshes overwriting newer results.
  * Refresh outcomes now distinguish updated, unchanged, empty, failed, and superseded loads.

* **Bug Fixes**
  * Improved handling of failed or unreadable saved data.
  * Prevented invalid account snapshots from being displayed.
  * Reduced unnecessary snapshot updates when content is unchanged.

* **Tests**
  * Added coverage for refresh timing, failures, concurrency, comparisons, and snapshot recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->