### PR TITLE
Update NuGet dependencies to latest compatible versions

### DIFF
--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -8,14 +8,14 @@
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="TngTech.ArchUnitNET.xUnitV3" Version="0.13.3" />
-    <PackageVersion Include="Blazor-ApexCharts" Version="6.1.0" />
+    <PackageVersion Include="Blazor-ApexCharts" Version="7.0.0" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageVersion Include="Blazored.SessionStorage" Version="2.4.0" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="GitHub.Copilot.SDK" Version="1.0.0-beta.4" />
-    <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.4" />
+    <PackageVersion Include="GitHubActionsTestLogger" Version="3.0.5" />
     <!-- Pinned to patch the transitive MessagePack pulled in by Aspire.Hosting: versions
          below 2.5.301 carry the high-severity LZ4 out-of-bounds read (GHSA-hv8m-jj95-wg3x). -->
     <PackageVersion Include="MessagePack" Version="3.1.8" />
@@ -37,7 +37,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.8.0" />
@@ -62,11 +62,11 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="OllamaSharp" Version="5.4.25" />
-    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.5.0" />
-    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.AspNetCore" Version="7.6.0" />
+    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="7.6.0" />
     <PackageVersion Include="Scalar.AspNetCore" Version="2.16.16" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />
-    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
     <PackageVersion Include="System.Memory.Data" Version="10.0.10" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />


### PR DESCRIPTION
## Summary
Updated multiple NuGet packages to their latest compatible versions. All builds and unit tests passed.

## Changes
- **Blazor-ApexCharts**: 6.1.0 → 7.0.0 (major version)
- **GitHubActionsTestLogger**: 3.0.4 → 3.0.5 (patch)
- **Microsoft.Extensions.AI.OpenAI**: 10.8.0 → 10.8.1 (patch)
- **OpenIddict.AspNetCore**: 7.5.0 → 7.6.0 (minor)
- **OpenIddict.EntityFrameworkCore**: 7.5.0 → 7.6.0 (minor)
- **SQLitePCLRaw.bundle_e_sqlite3**: 3.0.3 → 3.0.5 (patch)

## Excluded Updates
The following packages had breaking changes and were not updated:
- **OllamaSharp**: 5.4.30 → Compiler compatibility issue with source generators
- **GitHub.Copilot.SDK**: 1.0.8 → Breaking namespace changes (SDK namespace removed)
- **Microsoft.OpenApi**: 3.9.0 → Incompatible with OpenAPI source generator (IOpenApiMediaType.Example is read-only)

## Validation
✅ Build: Successful
✅ Unit Tests: 640 tests passed
⏳ Integration Tests: Running

---
_Generated by [Claude Code](https://claude.ai/code/session_01Er8E3F5NmsbRtYmfQ3mUia)_