### PR TITLE
Skip Fawaz currency API calls outside its supported historical range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- Historical currency backfills now skip unavailable Fawaz API dates before March 2, 2024 without sending requests or flooding warnings, while allowing other configured providers to supply those rates. #617
 - Investment account **asset appreciation** no longer shows `+0.00` when a holding's purchase-date exchange rate is missing. The account details page now shows the **capital value** (remaining buy cost) and the **current valuation** side by side and derives the gain/loss as their difference; when a trade-date rate is unavailable the capital value falls back to the current rate for the same pair instead of dropping the holding from the totals. #600
 - Dashboard time-series charts now scale to the displayed values with padding, making smaller changes clearly visible. #574
 - CSV files can now be imported into cash and bond accounts without the upload failing while the browser reads the selected file, including exports encoded as Windows-1250. #571

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CsvCurrencyExchangeProvider.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CsvCurrencyExchangeProvider.cs
@@ -17,37 +17,47 @@ internal sealed class CsvCurrencyExchangeProvider(
 {
     private static readonly ConcurrentDictionary<string, List<(DateTime Date, decimal Close)>> _csvCache = new();
 
-    public async Task<decimal?> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
+    public async Task<CurrencyExchangeRateProviderResult> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
     {
-        var csvDirectory = configuration["CurrencyExchangeRates:CsvDirectory"];
-        if (string.IsNullOrWhiteSpace(csvDirectory))
-            return null;
-
-        var direct = await TryLoadCsvAsync(csvDirectory, fromCurrency.ShortName, toCurrency.ShortName);
-        if (direct is not null)
+        try
         {
-            var entry = direct.FirstOrDefault(x => x.Date.Date <= date.Date);
-            if (entry != default) return entry.Close;
-        }
+            var csvDirectory = configuration["CurrencyExchangeRates:CsvDirectory"];
+            if (string.IsNullOrWhiteSpace(csvDirectory))
+                return new(CurrencyExchangeRateProviderStatus.NotFound);
 
-        var inverse = await TryLoadCsvAsync(csvDirectory, toCurrency.ShortName, fromCurrency.ShortName);
-        if (inverse is not null)
+            var direct = await TryLoadCsvAsync(csvDirectory, fromCurrency.ShortName, toCurrency.ShortName);
+            if (direct is not null)
+            {
+                var entry = direct.FirstOrDefault(x => x.Date.Date <= date.Date);
+                if (entry != default)
+                    return new(CurrencyExchangeRateProviderStatus.Success, entry.Close);
+            }
+
+            var inverse = await TryLoadCsvAsync(csvDirectory, toCurrency.ShortName, fromCurrency.ShortName);
+            if (inverse is not null)
+            {
+                var entry = inverse.FirstOrDefault(x => x.Date.Date <= date.Date);
+                if (entry != default && entry.Close != 0)
+                    return new(CurrencyExchangeRateProviderStatus.Success, 1m / entry.Close);
+            }
+
+            return new(CurrencyExchangeRateProviderStatus.NotFound);
+        }
+        catch (Exception ex)
         {
-            var entry = inverse.FirstOrDefault(x => x.Date.Date <= date.Date);
-            if (entry != default && entry.Close != 0) return 1m / entry.Close;
+            logger.LogError(ex, "Failed to load CSV exchange rate for {FromCurrency} to {ToCurrency} on {Date}", fromCurrency, toCurrency, date);
+            return new(CurrencyExchangeRateProviderStatus.Failed);
         }
-
-        return null;
     }
 
-    public async Task<List<(DateTime Date, decimal? Value)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd)
+    public async Task<List<(DateTime Date, CurrencyExchangeRateProviderResult Result)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd)
     {
         var start = dateStart.Date;
         var end = dateEnd.Date;
         var totalDays = (end - start).Days + 1;
         if (totalDays <= 0) return [];
 
-        List<(DateTime Date, decimal? Value)> rates = [];
+        List<(DateTime Date, CurrencyExchangeRateProviderResult Result)> rates = [];
         for (var i = 0; i < totalDays; i++)
         {
             var date = start.AddDays(i);
@@ -67,17 +77,9 @@ internal sealed class CsvCurrencyExchangeProvider(
         if (_csvCache.TryGetValue(filePath, out var cached))
             return cached;
 
-        try
-        {
-            var rows = await LoadCsvRowsAsync(filePath);
-            _csvCache[filePath] = rows;
-            return rows;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to load CSV exchange rate file {FilePath}", filePath);
-            return null;
-        }
+        var rows = await LoadCsvRowsAsync(filePath);
+        _csvCache[filePath] = rows;
+        return rows;
     }
 
     private static async Task<List<(DateTime Date, decimal Close)>> LoadCsvRowsAsync(string filePath)

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
@@ -105,16 +105,21 @@ internal class CurrencyExchangeService(
 
     public async Task<decimal?> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
     {
-        var rate = await ResolveDirectAsync(fromCurrency, toCurrency, date);
+        HashSet<ICurrencyExchangeRateProvider> outOfRangeProviders = [];
+        var rate = await ResolveDirectAsync(fromCurrency, toCurrency, date, outOfRangeProviders);
         if (rate is not null) return rate;
 
-        return await ResolveViaUsdAsync(fromCurrency, toCurrency, date);
+        return await ResolveViaUsdAsync(fromCurrency, toCurrency, date, outOfRangeProviders);
     }
 
     // Cheapest sources first: the application's own database, then the configured providers
     // (local CSV files, then external APIs). External hits are persisted so the same pair and
     // date never leave the app twice.
-    private async Task<decimal?> ResolveDirectAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
+    private async Task<decimal?> ResolveDirectAsync(
+        Currency fromCurrency,
+        Currency toCurrency,
+        DateTime date,
+        HashSet<ICurrencyExchangeRateProvider> outOfRangeProviders)
     {
         var stored = await exchangeRateRepository.Get(fromCurrency.ShortName, toCurrency.ShortName, date);
         if (stored is not null) return stored;
@@ -124,10 +129,19 @@ internal class CurrencyExchangeService(
 
         foreach (var provider in providers)
         {
-            var rate = await provider.GetExchangeRateAsync(fromCurrency, toCurrency, date);
-            if (rate is not null)
+            if (outOfRangeProviders.Contains(provider))
+                continue;
+
+            var result = await provider.GetExchangeRateAsync(fromCurrency, toCurrency, date);
+            if (result.Status == CurrencyExchangeRateProviderStatus.OutOfRange)
             {
-                await exchangeRateRepository.Add(fromCurrency.ShortName, toCurrency.ShortName, date, rate.Value);
+                outOfRangeProviders.Add(provider);
+                continue;
+            }
+
+            if (result is { Status: CurrencyExchangeRateProviderStatus.Success, Value: decimal rate })
+            {
+                await exchangeRateRepository.Add(fromCurrency.ShortName, toCurrency.ShortName, date, rate);
                 return rate;
             }
         }
@@ -137,15 +151,19 @@ internal class CurrencyExchangeService(
 
     // When no source knows the pair directly, cross through USD (from → USD → to) so values can
     // still be expressed in the requested currency.
-    private async Task<decimal?> ResolveViaUsdAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
+    private async Task<decimal?> ResolveViaUsdAsync(
+        Currency fromCurrency,
+        Currency toCurrency,
+        DateTime date,
+        HashSet<ICurrencyExchangeRateProvider> outOfRangeProviders)
     {
         var usd = DefaultCurrency.USD;
         if (IsUsd(fromCurrency) || IsUsd(toCurrency)) return null;
 
-        var fromToUsd = await ResolveDirectAsync(fromCurrency, usd, date);
+        var fromToUsd = await ResolveDirectAsync(fromCurrency, usd, date, outOfRangeProviders);
         if (fromToUsd is null) return null;
 
-        var usdToTarget = await ResolveDirectAsync(usd, toCurrency, date);
+        var usdToTarget = await ResolveDirectAsync(usd, toCurrency, date, outOfRangeProviders);
         if (usdToTarget is null) return null;
 
         return fromToUsd * usdToTarget;

--- a/code/FinanceManager.Benchmarks/Hosting/OfflineCurrencyExchangeRateProvider.cs
+++ b/code/FinanceManager.Benchmarks/Hosting/OfflineCurrencyExchangeRateProvider.cs
@@ -17,16 +17,18 @@ public sealed class OfflineCurrencyExchangeRateProvider : ICurrencyExchangeRateP
 {
     private const decimal _rate = 1.25m;
 
-    public Task<decimal?> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date) =>
-        Task.FromResult<decimal?>(fromCurrency.Id == toCurrency.Id ? 1m : _rate);
+    public Task<CurrencyExchangeRateProviderResult> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date) =>
+        Task.FromResult(new CurrencyExchangeRateProviderResult(
+            CurrencyExchangeRateProviderStatus.Success,
+            fromCurrency.Id == toCurrency.Id ? 1m : _rate));
 
-    public Task<List<(DateTime Date, decimal? Value)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd)
+    public Task<List<(DateTime Date, CurrencyExchangeRateProviderResult Result)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd)
     {
         var value = fromCurrency.Id == toCurrency.Id ? 1m : _rate;
-        var rates = new List<(DateTime Date, decimal? Value)>();
+        var rates = new List<(DateTime Date, CurrencyExchangeRateProviderResult Result)>();
 
         for (var date = dateStart.Date; date <= dateEnd.Date; date = date.AddDays(1))
-            rates.Add((date, value));
+            rates.Add((date, new(CurrencyExchangeRateProviderStatus.Success, value)));
 
         return Task.FromResult(rates);
     }

--- a/code/FinanceManager.Domain/FinancialAccounts/Currencies/Services/CurrencyExchangeRateProviderResult.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Currencies/Services/CurrencyExchangeRateProviderResult.cs
@@ -1,0 +1,5 @@
+namespace FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+
+public readonly record struct CurrencyExchangeRateProviderResult(
+    CurrencyExchangeRateProviderStatus Status,
+    decimal? Value = null);

--- a/code/FinanceManager.Domain/FinancialAccounts/Currencies/Services/CurrencyExchangeRateProviderStatus.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Currencies/Services/CurrencyExchangeRateProviderStatus.cs
@@ -1,0 +1,9 @@
+namespace FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+
+public enum CurrencyExchangeRateProviderStatus
+{
+    Success,
+    NotFound,
+    OutOfRange,
+    Failed,
+}

--- a/code/FinanceManager.Domain/FinancialAccounts/Currencies/Services/ICurrencyExchangeRateProvider.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Currencies/Services/ICurrencyExchangeRateProvider.cs
@@ -4,6 +4,6 @@ namespace FinanceManager.Domain.FinancialAccounts.Currencies.Services;
 
 public interface ICurrencyExchangeRateProvider
 {
-    Task<decimal?> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date);
-    Task<List<(DateTime Date, decimal? Value)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd);
+    Task<CurrencyExchangeRateProviderResult> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date);
+    Task<List<(DateTime Date, CurrencyExchangeRateProviderResult Result)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd);
 }

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Providers/FawazAhmedCurrencyApiClient.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Providers/FawazAhmedCurrencyApiClient.cs
@@ -11,41 +11,49 @@ internal sealed class FawazAhmedCurrencyApiClient(
     HttpClient httpClient,
     ILogger<FawazAhmedCurrencyApiClient> logger) : ICurrencyExchangeRateProvider
 {
-    public async Task<decimal?> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
+    // The npm-backed API has no date-versioned releases before its migration on 2024-03-02.
+    private static readonly DateOnly _firstAvailableDate = new(2024, 3, 2);
+
+    public async Task<CurrencyExchangeRateProviderResult> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
     {
+        if (DateOnly.FromDateTime(date) < _firstAvailableDate)
+            return new(CurrencyExchangeRateProviderStatus.OutOfRange);
+
         try
         {
-            var response = await httpClient.GetAsync($"https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@{date:yyyy-MM-dd}/v1/currencies/{fromCurrency.ShortName.ToLower()}.json");
+            using var response = await httpClient.GetAsync($"https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@{date:yyyy-MM-dd}/v1/currencies/{fromCurrency.ShortName.ToLowerInvariant()}.json");
             if (!response.IsSuccessStatusCode)
             {
                 var errorMessage = await response.Content.ReadAsStringAsync();
                 logger.LogWarning("Currency API returned {StatusCode} for {FromCurrency} to {ToCurrency} on {Date}: {Message}", response.StatusCode, fromCurrency, toCurrency, date, errorMessage.Trim());
-                return null;
+                return new(response.StatusCode == System.Net.HttpStatusCode.NotFound
+                    ? CurrencyExchangeRateProviderStatus.NotFound
+                    : CurrencyExchangeRateProviderStatus.Failed);
             }
 
             await using var contentStream = await response.Content.ReadAsStreamAsync();
             using var document = await JsonDocument.ParseAsync(contentStream);
 
-            if (document.RootElement.TryGetProperty(fromCurrency.ShortName.ToLower(), out var fromCurrencyRates) &&
-                fromCurrencyRates.TryGetProperty(toCurrency.ShortName.ToLower(), out var exchangeRate) &&
+            if (document.RootElement.TryGetProperty(fromCurrency.ShortName.ToLowerInvariant(), out var fromCurrencyRates) &&
+                fromCurrencyRates.TryGetProperty(toCurrency.ShortName.ToLowerInvariant(), out var exchangeRate) &&
                 exchangeRate.TryGetDecimal(out var value))
-                return value;
+                return new(CurrencyExchangeRateProviderStatus.Success, value);
 
-            return null;
+            return new(CurrencyExchangeRateProviderStatus.NotFound);
         }
         catch (JsonException ex)
         {
             logger.LogWarning(ex, "Currency API returned invalid JSON for {FromCurrency} to {ToCurrency} on {Date}", fromCurrency, toCurrency, date);
-            return null;
+            return new(CurrencyExchangeRateProviderStatus.Failed);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to get exchange rate from {FromCurrency} to {ToCurrency} on {Date}", fromCurrency, toCurrency, date);
-            return null;
+            return new(CurrencyExchangeRateProviderStatus.Failed);
         }
     }
 
-    public async Task<List<(DateTime Date, decimal? Value)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd)
+    public async Task<List<(DateTime Date, CurrencyExchangeRateProviderResult Result)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd)
     {
         var start = dateStart.Date;
         var end = dateEnd.Date;
@@ -53,19 +61,21 @@ internal sealed class FawazAhmedCurrencyApiClient(
         if (totalDays <= 0) return [];
 
         const int batchSize = 50;
-        List<(DateTime Date, decimal? Value)> rates = [];
+        List<(DateTime Date, CurrencyExchangeRateProviderResult Result)> rates = [];
 
         for (var offset = 0; offset < totalDays; offset += batchSize)
         {
             var currentBatchSize = Math.Min(batchSize, totalDays - offset);
             List<DateTime> batchDates = [];
-            List<Task<decimal?>> batchTasks = [];
+            List<Task<CurrencyExchangeRateProviderResult>> batchTasks = [];
 
             for (var i = 0; i < currentBatchSize; i++)
             {
                 var date = start.AddDays(offset + i);
                 batchDates.Add(date);
-                batchTasks.Add(GetExchangeRateAsync(fromCurrency, toCurrency, date));
+                batchTasks.Add(DateOnly.FromDateTime(date) < _firstAvailableDate
+                    ? Task.FromResult(new CurrencyExchangeRateProviderResult(CurrencyExchangeRateProviderStatus.OutOfRange))
+                    : GetExchangeRateAsync(fromCurrency, toCurrency, date));
             }
 
             var batchResults = await Task.WhenAll(batchTasks);

--- a/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
@@ -19,7 +19,7 @@ namespace FinanceManager.Tests.Unit.Application.Services;
 [Trait("Category", "Unit")]
 public class CurrencyExchangeServiceTests : IDisposable
 {
-    private readonly ILogger<FawazAhmedCurrencyApiClient> _loggerMock = LoggerFactory.Create(builder => builder.AddConsole()).CreateLogger<FawazAhmedCurrencyApiClient>();
+    private readonly ListLogger<FawazAhmedCurrencyApiClient> _logger = new();
     private readonly Mock<HttpMessageHandler> _httpMessageHandlerMock = new();
     private readonly Mock<IExchangeRateRepository> _exchangeRateRepositoryMock = new();
     private readonly HttpClient _httpClient;
@@ -35,7 +35,7 @@ public class CurrencyExchangeServiceTests : IDisposable
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
         var expectedRate = 0.92m;
 
         var jsonResponse = $@"{{""usd"": {{""eur"": {expectedRate}}}}}";
@@ -52,12 +52,12 @@ public class CurrencyExchangeServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task GetExchangeRateAsync_HttpRequestFails_ReturnsNull()
+    public async Task GetExchangeRateAsync_HttpRequestFails_ReturnsFailed()
     {
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
 
         _httpMessageHandlerMock.Protected()
             .Setup<Task<HttpResponseMessage>>("SendAsync",
@@ -65,69 +65,132 @@ public class CurrencyExchangeServiceTests : IDisposable
                 ItExpr.IsAny<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("Network error"));
 
-        var service = CreateService();
+        var provider = CreateProvider();
 
         // Act
-        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, date);
+        var result = await provider.GetExchangeRateAsync(fromCurrency, toCurrency, date);
 
         // Assert
-        Assert.Null(result);
+        Assert.Equal(CurrencyExchangeRateProviderStatus.Failed, result.Status);
     }
 
     [Fact]
-    public async Task GetExchangeRateAsync_InvalidJson_ReturnsNull()
+    public async Task GetExchangeRateAsync_InvalidJson_ReturnsFailed()
     {
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
 
         SetupHttpResponse(HttpStatusCode.OK, "invalid json {");
-        var service = CreateService();
+        var provider = CreateProvider();
 
         // Act
-        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, date);
+        var result = await provider.GetExchangeRateAsync(fromCurrency, toCurrency, date);
 
         // Assert
-        Assert.Null(result);
+        Assert.Equal(CurrencyExchangeRateProviderStatus.Failed, result.Status);
     }
 
     [Fact]
-    public async Task GetExchangeRateAsync_MissingRateInResponse_ReturnsNull()
+    public async Task GetExchangeRateAsync_MissingRateInResponse_ReturnsNotFound()
     {
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
 
         var jsonResponse = @"{""usd"": {""gbp"": 0.78}}"; // EUR missing
         SetupHttpResponse(HttpStatusCode.OK, jsonResponse);
 
-        var service = CreateService();
+        var provider = CreateProvider();
 
         // Act
-        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, date);
+        var result = await provider.GetExchangeRateAsync(fromCurrency, toCurrency, date);
 
         // Assert
-        Assert.Null(result);
+        Assert.Equal(CurrencyExchangeRateProviderStatus.NotFound, result.Status);
     }
 
     [Fact]
-    public async Task GetExchangeRateAsync_NotFoundResponse_ReturnsNull()
+    public async Task GetExchangeRateAsync_NotFoundResponse_ReturnsNotFound()
     {
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
 
         SetupHttpResponse(HttpStatusCode.NotFound, "Not found");
-        var service = CreateService();
+        var provider = CreateProvider();
 
         // Act
-        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, date);
+        var result = await provider.GetExchangeRateAsync(fromCurrency, toCurrency, date);
 
         // Assert
-        Assert.Null(result);
+        Assert.Equal(CurrencyExchangeRateProviderStatus.NotFound, result.Status);
+    }
+
+    [Fact]
+    public async Task GetExchangeRateAsync_BeforeFirstAvailableDate_ReturnsOutOfRangeWithoutHttpOrWarning()
+    {
+        var result = await CreateProvider().GetExchangeRateAsync(
+            new Currency(1, "USD", "$"),
+            new Currency(2, "EUR", "€"),
+            new DateTime(2024, 3, 1));
+
+        Assert.Equal(CurrencyExchangeRateProviderStatus.OutOfRange, result.Status);
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+        VerifyNoWarningOrErrorLogs();
+    }
+
+    [Fact]
+    public async Task GetExchangeRateAsync_FirstAvailableDate_PerformsNormalRequest()
+    {
+        SetupHttpResponse(HttpStatusCode.OK, """{"usd":{"eur":0.92}}""");
+
+        var result = await CreateProvider().GetExchangeRateAsync(
+            new Currency(1, "USD", "$"),
+            new Currency(2, "EUR", "€"),
+            new DateTime(2024, 3, 2));
+
+        Assert.Equal(new(CurrencyExchangeRateProviderStatus.Success, 0.92m), result);
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetExchangeRateAsync_MixedRange_OnlyFetchesSupportedDatesInOrder()
+    {
+        SetupHttpResponse(HttpStatusCode.OK, """{"usd":{"eur":0.92}}""");
+
+        var result = await CreateProvider().GetExchangeRateAsync(
+            new Currency(1, "USD", "$"),
+            new Currency(2, "EUR", "€"),
+            new DateTime(2024, 3, 1),
+            new DateTime(2024, 3, 3));
+
+        Assert.Equal(
+            [
+                CurrencyExchangeRateProviderStatus.OutOfRange,
+                CurrencyExchangeRateProviderStatus.Success,
+                CurrencyExchangeRateProviderStatus.Success,
+            ],
+            result.Select(x => x.Result.Status));
+        Assert.Equal(
+            [new DateTime(2024, 3, 1), new DateTime(2024, 3, 2), new DateTime(2024, 3, 3)],
+            result.Select(x => x.Date));
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(2),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
     }
 
     [Fact]
@@ -161,7 +224,7 @@ public class CurrencyExchangeServiceTests : IDisposable
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var date = new DateTime(2024, 1, 6); // Saturday
+        var date = new DateTime(2024, 3, 2); // Saturday
         var expectedRate = 0.92m;
 
         var jsonResponse = $@"{{""usd"": {{""eur"": {expectedRate}}}}}";
@@ -183,7 +246,7 @@ public class CurrencyExchangeServiceTests : IDisposable
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
 
         SetupHttpResponse(HttpStatusCode.OK, "{}");
         var service = CreateService();
@@ -201,7 +264,7 @@ public class CurrencyExchangeServiceTests : IDisposable
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "JPY", "¥");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
         var expectedRate = 149.85m;
 
         var jsonResponse = $@"{{""usd"": {{""jpy"": {expectedRate}}}}}";
@@ -223,7 +286,7 @@ public class CurrencyExchangeServiceTests : IDisposable
         // Arrange
         var fromCurrency = new Currency(1, "JPY", "¥");
         var toCurrency = new Currency(2, "USD", "$");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
         var expectedRate = 0.006678m;
 
         var jsonResponse = $@"{{""jpy"": {{""usd"": {expectedRate}}}}}";
@@ -245,7 +308,7 @@ public class CurrencyExchangeServiceTests : IDisposable
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
 
         _exchangeRateRepositoryMock
             .Setup(x => x.Get("USD", "EUR", date, It.IsAny<CancellationToken>()))
@@ -271,7 +334,7 @@ public class CurrencyExchangeServiceTests : IDisposable
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
 
         _exchangeRateRepositoryMock
             .Setup(x => x.Get("EUR", "USD", date, It.IsAny<CancellationToken>()))
@@ -297,7 +360,7 @@ public class CurrencyExchangeServiceTests : IDisposable
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
 
         var jsonResponse = @"{""usd"": {""eur"": 0.92}}";
         SetupHttpResponse(HttpStatusCode.OK, jsonResponse);
@@ -318,7 +381,7 @@ public class CurrencyExchangeServiceTests : IDisposable
         // Arrange
         var fromCurrency = new Currency(1, "GBP", "£");
         var toCurrency = new Currency(2, "PLN", "zł");
-        var date = new DateTime(2024, 1, 15);
+        var date = new DateTime(2024, 3, 15);
 
         _exchangeRateRepositoryMock
             .Setup(x => x.Get("GBP", "USD", date, It.IsAny<CancellationToken>()))
@@ -340,21 +403,71 @@ public class CurrencyExchangeServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetExchangeRateAsync_OutOfRangeProvider_ContinuesToLaterProvider()
+    {
+        var fromCurrency = new Currency(1, "USD", "$");
+        var toCurrency = new Currency(2, "EUR", "€");
+        var date = new DateTime(2024, 3, 1);
+        var laterProvider = new Mock<ICurrencyExchangeRateProvider>();
+        laterProvider
+            .Setup(x => x.GetExchangeRateAsync(fromCurrency, toCurrency, date))
+            .ReturnsAsync(new CurrencyExchangeRateProviderResult(CurrencyExchangeRateProviderStatus.Success, 0.92m));
+
+        var service = CreateService([CreateProvider(), laterProvider.Object]);
+
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, date);
+
+        Assert.Equal(0.92m, result);
+        laterProvider.Verify(x => x.GetExchangeRateAsync(fromCurrency, toCurrency, date), Times.Once);
+        _exchangeRateRepositoryMock.Verify(
+            x => x.Add("USD", "EUR", date, 0.92m, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetExchangeRateAsync_OutOfRangeProvider_IsNotRetriedForUsdCross()
+    {
+        var provider = new Mock<ICurrencyExchangeRateProvider>();
+        provider
+            .Setup(x => x.GetExchangeRateAsync(
+                It.IsAny<Currency>(),
+                It.IsAny<Currency>(),
+                It.IsAny<DateTime>()))
+            .ReturnsAsync(new CurrencyExchangeRateProviderResult(CurrencyExchangeRateProviderStatus.OutOfRange));
+        var service = CreateService([provider.Object]);
+
+        var result = await service.GetExchangeRateAsync(
+            new Currency(1, "GBP", "£"),
+            new Currency(2, "PLN", "zł"),
+            new DateTime(2024, 3, 1));
+
+        Assert.Null(result);
+        provider.Verify(
+            x => x.GetExchangeRateAsync(It.IsAny<Currency>(), It.IsAny<Currency>(), It.IsAny<DateTime>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task GetExchangeRateAsync_FullyStoredRange_UsesBulkReadAndNoProviderCalls()
     {
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var dateStart = new DateTime(2024, 1, 15);
-        var dateEnd = new DateTime(2024, 1, 17);
+        var dateStart = new DateTime(2024, 3, 15);
+        var dateEnd = new DateTime(2024, 3, 17);
 
         // Setup bulk read to return all rates
         IReadOnlyDictionary<(string From, string To, DateTime Date), decimal> storedRates =
             new Dictionary<(string, string, DateTime), decimal>
             {
-                { ("USD", "EUR", new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc)), 0.92m },
-                { ("USD", "EUR", new DateTime(2024, 1, 16, 0, 0, 0, DateTimeKind.Utc)), 0.91m },
-                { ("USD", "EUR", new DateTime(2024, 1, 17, 0, 0, 0, DateTimeKind.Utc)), 0.93m }
+                { ("USD", "EUR", new DateTime(2024, 3, 15, 0, 0, 0, DateTimeKind.Utc)), 0.92m },
+                { ("USD", "EUR", new DateTime(2024, 3, 16, 0, 0, 0, DateTimeKind.Utc)), 0.91m },
+                { ("USD", "EUR", new DateTime(2024, 3, 17, 0, 0, 0, DateTimeKind.Utc)), 0.93m }
             };
 
         _exchangeRateRepositoryMock
@@ -391,15 +504,15 @@ public class CurrencyExchangeServiceTests : IDisposable
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var dateStart = new DateTime(2024, 1, 15);
-        var dateEnd = new DateTime(2024, 1, 17);
+        var dateStart = new DateTime(2024, 3, 15);
+        var dateEnd = new DateTime(2024, 3, 17);
 
         // Setup bulk read to return only first and last rates
         IReadOnlyDictionary<(string From, string To, DateTime Date), decimal> storedRates =
             new Dictionary<(string, string, DateTime), decimal>
             {
-                { ("USD", "EUR", new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc)), 0.92m },
-                { ("USD", "EUR", new DateTime(2024, 1, 17, 0, 0, 0, DateTimeKind.Utc)), 0.93m }
+                { ("USD", "EUR", new DateTime(2024, 3, 15, 0, 0, 0, DateTimeKind.Utc)), 0.92m },
+                { ("USD", "EUR", new DateTime(2024, 3, 17, 0, 0, 0, DateTimeKind.Utc)), 0.93m }
             };
 
         _exchangeRateRepositoryMock
@@ -450,13 +563,13 @@ public class CurrencyExchangeServiceTests : IDisposable
         // more than the per-call provider resolution cap of 60.
         var fromCurrency = new Currency(1, "USD", "$");
         var toCurrency = new Currency(2, "EUR", "€");
-        var dateStart = new DateTime(2024, 1, 1);
+        var dateStart = new DateTime(2024, 3, 2);
         var dateEnd = dateStart.AddDays(99);
 
         IReadOnlyDictionary<(string From, string To, DateTime Date), decimal> storedRates =
             new Dictionary<(string, string, DateTime), decimal>
             {
-                { ("USD", "EUR", new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)), 0.92m }
+                { ("USD", "EUR", new DateTime(2024, 3, 2, 0, 0, 0, DateTimeKind.Utc)), 0.92m }
             };
 
         _exchangeRateRepositoryMock
@@ -489,8 +602,33 @@ public class CurrencyExchangeServiceTests : IDisposable
 
     private CurrencyExchangeService CreateService()
     {
-        ICurrencyExchangeRateProvider[] providers = [new FawazAhmedCurrencyApiClient(_httpClient, _loggerMock)];
+        ICurrencyExchangeRateProvider[] providers = [CreateProvider()];
         return new CurrencyExchangeService(_exchangeRateRepositoryMock.Object, providers);
+    }
+
+    private CurrencyExchangeService CreateService(ICurrencyExchangeRateProvider[] providers) =>
+        new(_exchangeRateRepositoryMock.Object, providers);
+
+    private FawazAhmedCurrencyApiClient CreateProvider() => new(_httpClient, _logger);
+
+    private void VerifyNoWarningOrErrorLogs() =>
+        Assert.DoesNotContain(_logger.Levels, level => level >= LogLevel.Warning);
+
+    private sealed class ListLogger<T> : ILogger<T>
+    {
+        public List<LogLevel> Levels { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Levels.Add(logLevel);
     }
     public void Dispose() => _httpClient?.Dispose();
     private void SetupHttpResponse(HttpStatusCode statusCode, string content)

--- a/docs/codebase/INTEGRATIONS.md
+++ b/docs/codebase/INTEGRATIONS.md
@@ -9,7 +9,7 @@
 | SQL Server | Relational database | Primary persistence option for accounts, users, prices, labels, imports | Connection string from config/env | High | `code\FinanceManager.Infrastructure\ServiceCollectionExtension.cs`, `code\FinanceManager.Api\appsettings.Development.json` |
 | PostgreSQL | Relational database | Alternate persistence option and Aspire-local database | Connection string / service binding | High | `code\FinanceManager.Infrastructure\ServiceCollectionExtension.cs`, `code\AppHost\AppHost.cs` |
 | Alpha Vantage | External HTTP API | Stock symbol search, daily price history, listings | API key | High | `code\FinanceManager.Infrastructure\Services\Stocks\AlphaVantageClient.cs`, `code\FinanceManager.Api\appsettings.json` |
-| Fawaz Ahmed Currency API via jsDelivr | External HTTP API | Currency exchange-rate lookup | No app-level auth detected | Medium | `code\FinanceManager.Infrastructure\Services\Currencies\FawazAhmedCurrencyApiClient.cs` |
+| Fawaz Ahmed Currency API via jsDelivr | External HTTP API | Currency exchange-rate lookup | No API key | Medium | `code\FinanceManager.Infrastructure\Features\FinancialAccounts\Currencies\Providers\FawazAhmedCurrencyApiClient.cs` |
 | OpenRouter | External AI API | AI chat provider for insights/label generation | API key | Medium | `code\FinanceManager.Infrastructure\Services\Ai\OpenRouterChatClient.cs`, `code\FinanceManager.Api\appsettings.json` |
 | GitHub Models via Copilot SDK | External AI service | Alternate AI provider in configured fallback chain | Copilot SDK session auth `[TODO]` | Medium | `code\FinanceManager.Infrastructure\Services\Ai\CopilotChatClient.cs`, `code\FinanceManager.Api\appsettings.json` |
 | Ollama | Local/remote AI endpoint | Final AI fallback provider | No auth detected in code | Medium | `code\FinanceManager.Infrastructure\Services\Ai\OllamaChatClient.cs`, `code\FinanceManager.Api\appsettings.json` |
@@ -38,6 +38,7 @@
 - Retry/backoff behavior: shared HTTP clients get the standard .NET resilience handler via `ServiceDefaults`, but individual external adapters often just log and return empty/null results
 - Timeout policy: `HttpClientResilience` timeouts are configurable in appsettings and applied in `ServiceDefaults`; OpenRouter timeout is separately configurable in `OpenRouterOptions`
 - Circuit-breaker or fallback behavior: HTTP circuit-breaker sampling is configured in `ServiceDefaults`; AI calls are wired through a fallback chain in config and DI; stock price reads first check repository/cache before hitting Alpha Vantage
+- Fawaz currency data is free, requires no API key, and has no provider request-rate limit. It is published as daily date-versioned npm packages beginning on `2024-03-02`; earlier dates return `OutOfRange` without an HTTP request so another configured provider can resolve them.
 
 ### 5) Observability for Integrations
 
@@ -49,7 +50,7 @@
 
 - `code\FinanceManager.Infrastructure\ServiceCollectionExtension.cs`
 - `code\FinanceManager.Infrastructure\Services\Stocks\AlphaVantageClient.cs`
-- `code\FinanceManager.Infrastructure\Services\Currencies\FawazAhmedCurrencyApiClient.cs`
+- `code\FinanceManager.Infrastructure\Features\FinancialAccounts\Currencies\Providers\FawazAhmedCurrencyApiClient.cs`
 - `code\FinanceManager.Infrastructure\Services\Ai\ServiceCollectionExtension.cs`
 - `code\FinanceManager.Api\appsettings.json`
 - `code\FinanceManager.Api\appsettings.Development.json`


### PR DESCRIPTION
## Summary

- add explicit `Success`, `NotFound`, `OutOfRange`, and `Failed` results at the currency provider boundary
- short-circuit Fawaz requests before March 2, 2024 without HTTP calls or warning/error logs
- continue through later providers and avoid retrying an out-of-range provider during USD-cross resolution
- document the provider range and update the changelog

## Root cause

Fawaz historical dates are encoded as npm package versions. No package releases exist before March 2, 2024, but the client still requested those versions and treated the resulting 404s like ordinary missing rates.

## Impact

Historical backfills no longer generate impossible Fawaz requests or warning floods, while CSV and future providers can still resolve older dates.

## Validation

- `dotnet build .\code\FinanceManager.slnx --no-restore`
- `dotnet test --project .\FinanceManager.Tests.Unit\FinanceManager.Tests.Unit.csproj --no-build` (663 passed)
- `dotnet format .\code\FinanceManager.slnx --verify-no-changes --verbosity minimal`

Closes #617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exchange-rate lookups now provide clear outcomes, including successful, unavailable, out-of-range, and failed results.
  * Historical API availability is handled explicitly, avoiding requests for unsupported dates.
  * Date-range lookups now report the status for each date.

* **Bug Fixes**
  * Prevented repeated retries against providers that cannot serve a requested date.
  * Improved direct and inverse currency-rate resolution, including protection against invalid zero-rate calculations.
  * Added more reliable fallback behavior across multiple providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->