### PR TITLE
fix: resolve #614 - Fix Investment Paycheck card recalculation and investment value labeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- The dashboard **Investment paycheck** card no longer re-fetches when you move the withdrawal-rate slider or pick a Conservative/Standard/Aggressive preset — its data loads once and the paycheck and salary-coverage figures now recalculate instantly on the client. The footer value is relabelled **Total investments value** with a tooltip clarifying it covers all investments you own, and the `X of Y mo` salary-history counter is hidden once the full range is shown. #614
 - Asset and liability charts now load substantially faster, especially on the first uncached view. #610
 - The dashboard now loads account data once per overview request, making the first uncached view substantially faster. #608
 - Financial account pages now load faster by reusing transaction-history boundaries, batching bond lookups, and avoiding redundant currency and investment data reads. #606

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCard.razor
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCard.razor
@@ -24,7 +24,7 @@
                                 <dd>Presets at 3% / 4% / 5%. Lower rates reduce the risk of running out; higher rates pay more but deplete faster.</dd>
                                 <dt>Replacement %</dt>
                                 <dd>What share of your average monthly salary this paycheck would cover.</dd>
-                                <dt>Investments value</dt>
+                                <dt>Total investments value</dt>
                                 <dd>Current market value of your investable assets (stocks, bonds, funds). Cash and liabilities are excluded.</dd>
                                 <dt>@_estimate.SalaryMonthsUsed of @_estimate.SalaryMonthsRequested months</dt>
                                 <dd>Months of salary history the average is calculated from.</dd>
@@ -96,12 +96,17 @@
 
         <div class="pc-foot">
             <span>
-                Investments value:
+                <MudTooltip Text="The total value of all investments currently owned by the user.">
+                    <span class="pc-foot-label">Total investments value:</span>
+                </MudTooltip>
                 <span class="pc-foot-num">@FormatCurrency(_estimate.InvestableAssetsValue)</span>
             </span>
-            <span class="@(_estimate.HasPartialSalaryHistory ? "pc-foot-meta pc-foot-meta--warn" : "pc-foot-meta")">
-                @_estimate.SalaryMonthsUsed of @_estimate.SalaryMonthsRequested mo
-            </span>
+            @if (_estimate.SalaryMonthsUsed != _estimate.SalaryMonthsRequested)
+            {
+                <span class="@(_estimate.HasPartialSalaryHistory ? "pc-foot-meta pc-foot-meta--warn" : "pc-foot-meta")">
+                    @_estimate.SalaryMonthsUsed of @_estimate.SalaryMonthsRequested mo
+                </span>
+            }
         </div>
     </MudCardContent>
 </MudCard>

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCard.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCard.razor.cs
@@ -39,7 +39,10 @@ public partial class InvestmentPaycheckEstimatorCard
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
 
-    internal decimal MonthlyPaycheck => _estimate.InvestableAssetsValue * _annualWithdrawalRate / 12m;
+    // Rounded to the same precision as InvestmentPaycheckEstimatorService (paycheck to 2 decimals,
+    // ratio to 4 decimals from the rounded paycheck) so a local rate-change recompute yields the
+    // same figures as a server refresh instead of drifting by a fractional cent.
+    internal decimal MonthlyPaycheck => Math.Round(_estimate.InvestableAssetsValue * _annualWithdrawalRate / 12m, 2);
 
     internal decimal? ReplacementRatio
     {
@@ -47,7 +50,7 @@ public partial class InvestmentPaycheckEstimatorCard
         {
             if (_estimate.AverageMonthlySalary is not { } avg || avg == 0m)
                 return null;
-            return MonthlyPaycheck / avg;
+            return Math.Round(MonthlyPaycheck / avg, 4);
         }
     }
 

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCard.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCard.razor.cs
@@ -28,9 +28,8 @@ public partial class InvestmentPaycheckEstimatorCard
 
     private bool _isLoading;
     private Currency _currency = DefaultCurrency.PLN;
-    private InvestmentPaycheckEstimate _estimate = new() { AnnualWithdrawalRate = _defaultRate, SalaryMonthsRequested = 3 };
-    private decimal _annualWithdrawalRate = _defaultRate;
-    private CancellationTokenSource? _persistCts;
+    internal InvestmentPaycheckEstimate _estimate = new() { AnnualWithdrawalRate = _defaultRate, SalaryMonthsRequested = 3 };
+    internal decimal _annualWithdrawalRate = _defaultRate;
 
     [Parameter] public string Height { get; set; } = "300px";
     [Parameter] public int SalaryMonths { get; set; } = 3;
@@ -40,9 +39,9 @@ public partial class InvestmentPaycheckEstimatorCard
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
 
-    private decimal MonthlyPaycheck => _estimate.InvestableAssetsValue * _annualWithdrawalRate / 12m;
+    internal decimal MonthlyPaycheck => _estimate.InvestableAssetsValue * _annualWithdrawalRate / 12m;
 
-    private decimal? ReplacementRatio
+    internal decimal? ReplacementRatio
     {
         get
         {
@@ -55,19 +54,15 @@ public partial class InvestmentPaycheckEstimatorCard
     protected override async Task OnInitializedAsync()
     {
         _currency = await SettingsService.GetCurrencyAsync();
-        await RefreshEstimate(showLoading: true);
+        await RefreshEstimate();
     }
 
-    // showLoading is suppressed for slider/preset changes: the paycheck is recomputed
-    // client-side from the (rate-independent) estimate, so the value is already correct
-    // the instant the rate moves. Flashing the spinner there only hides an unchanged value.
-    private async Task RefreshEstimate(bool showLoading)
+    // Source data is loaded once during initialization. Withdrawal-rate changes are
+    // recomputed client-side from the (rate-independent) estimate, so they never re-fetch.
+    private async Task RefreshEstimate()
     {
-        if (showLoading)
-        {
-            _isLoading = true;
-            StateHasChanged();
-        }
+        _isLoading = true;
+        StateHasChanged();
 
         try
         {
@@ -104,38 +99,11 @@ public partial class InvestmentPaycheckEstimatorCard
         }
     }
 
-    private void OnRateChanged(decimal value)
-    {
-        _annualWithdrawalRate = value;
-        SchedulePersist();
-    }
+    // Rate changes only recompute the displayed paycheck locally (see MonthlyPaycheck /
+    // ReplacementRatio); no API request is made. Blazor re-renders after the event callback.
+    internal void OnRateChanged(decimal value) => _annualWithdrawalRate = value;
 
-    private void OnPresetSelected(decimal rate)
-    {
-        _annualWithdrawalRate = rate;
-        SchedulePersist();
-    }
-
-    private void SchedulePersist()
-    {
-        _persistCts?.Cancel();
-        _persistCts = new CancellationTokenSource();
-        var token = _persistCts.Token;
-
-        _ = Task.Run(async () =>
-        {
-            try
-            {
-                await Task.Delay(TimeSpan.FromMilliseconds(350), token);
-                if (token.IsCancellationRequested)
-                    return;
-                await InvokeAsync(() => RefreshEstimate(showLoading: false));
-            }
-            catch (TaskCanceledException)
-            {
-            }
-        });
-    }
+    internal void OnPresetSelected(decimal rate) => _annualWithdrawalRate = rate;
 
     private string FormatCurrency(decimal value) => $"{value:0.00} {_currency.ShortName}";
 

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCard.razor.css
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCard.razor.css
@@ -204,6 +204,12 @@
     color: var(--mud-palette-text-secondary);
 }
 
+.pc-foot-label {
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+    cursor: help;
+}
+
 .pc-foot-num {
     color: var(--mud-palette-text-primary);
     font-weight: 500;

--- a/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCardTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCardTests.cs
@@ -1,0 +1,92 @@
+using FinanceManager.Components.Features.Dashboard.Components.Cards.Assets;
+using FinanceManager.Domain.MoneyFlow.Entities;
+using System.Runtime.CompilerServices;
+
+namespace FinanceManager.Tests.Unit.Components.Features.Dashboard.Components.Cards.Assets;
+
+[Trait("Category", "Unit")]
+public class InvestmentPaycheckEstimatorCardTests
+{
+    // GetUninitializedObject skips the constructor and all field initializers, so the
+    // injected cache service stays null. Any call that tried to fetch fresh data would
+    // therefore throw a NullReferenceException — a passing test proves the rate change
+    // recomputed the paycheck purely from data already held by the card.
+    private static InvestmentPaycheckEstimatorCard CreateCard(InvestmentPaycheckEstimate estimate, decimal rate)
+    {
+        var card = (InvestmentPaycheckEstimatorCard)RuntimeHelpers.GetUninitializedObject(typeof(InvestmentPaycheckEstimatorCard));
+        card._estimate = estimate;
+        card._annualWithdrawalRate = rate;
+        return card;
+    }
+
+    [Fact]
+    public void MonthlyPaycheck_ComputesLocallyFromInvestableValueAndRate()
+    {
+        var card = CreateCard(new InvestmentPaycheckEstimate { InvestableAssetsValue = 120_000m }, 0.04m);
+
+        // 120000 * 0.04 / 12 = 400
+        Assert.Equal(400m, card.MonthlyPaycheck);
+    }
+
+    [Fact]
+    public void OnPresetSelected_RecalculatesPaycheckLocally_WithoutFetching()
+    {
+        var card = CreateCard(new InvestmentPaycheckEstimate { InvestableAssetsValue = 120_000m }, 0.04m);
+
+        card.OnPresetSelected(0.05m);
+
+        Assert.Equal(0.05m, card._annualWithdrawalRate);
+        // 120000 * 0.05 / 12 = 500
+        Assert.Equal(500m, card.MonthlyPaycheck);
+    }
+
+    [Fact]
+    public void OnRateChanged_RecalculatesPaycheckLocally_WithoutFetching()
+    {
+        var card = CreateCard(new InvestmentPaycheckEstimate { InvestableAssetsValue = 240_000m }, 0.04m);
+
+        card.OnRateChanged(0.03m);
+
+        Assert.Equal(0.03m, card._annualWithdrawalRate);
+        // 240000 * 0.03 / 12 = 600
+        Assert.Equal(600m, card.MonthlyPaycheck);
+    }
+
+    [Fact]
+    public void ReplacementRatio_DerivesFromLocalPaycheckAndAverageSalary()
+    {
+        var card = CreateCard(new InvestmentPaycheckEstimate
+        {
+            InvestableAssetsValue = 120_000m,
+            SalaryMonthsUsed = 3,
+            AverageMonthlySalary = 800m,
+        }, 0.04m);
+
+        // paycheck 400 / salary 800 = 0.5
+        Assert.Equal(0.5m, card.ReplacementRatio);
+    }
+
+    [Fact]
+    public void ReplacementRatio_TracksRateChangesLocally()
+    {
+        var card = CreateCard(new InvestmentPaycheckEstimate
+        {
+            InvestableAssetsValue = 120_000m,
+            SalaryMonthsUsed = 3,
+            AverageMonthlySalary = 800m,
+        }, 0.04m);
+
+        card.OnPresetSelected(0.08m);
+
+        // paycheck 800 / salary 800 = 1.0
+        Assert.Equal(1.0m, card.ReplacementRatio);
+    }
+
+    [Fact]
+    public void ReplacementRatio_IsNull_WhenNoSalaryData()
+    {
+        var card = CreateCard(new InvestmentPaycheckEstimate { InvestableAssetsValue = 120_000m }, 0.04m);
+
+        Assert.Null(card.ReplacementRatio);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCardTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCardTests.cs
@@ -83,6 +83,24 @@ public class InvestmentPaycheckEstimatorCardTests
     }
 
     [Fact]
+    public void MonthlyPaycheck_And_ReplacementRatio_RoundToServerPrecision()
+    {
+        // Matches InvestmentPaycheckEstimatorService: paycheck rounded to 2 decimals,
+        // ratio rounded to 4 decimals from that rounded paycheck.
+        var card = CreateCard(new InvestmentPaycheckEstimate
+        {
+            InvestableAssetsValue = 100_000m,
+            SalaryMonthsUsed = 3,
+            AverageMonthlySalary = 3_000m,
+        }, 0.05m);
+
+        // 100000 * 0.05 / 12 = 416.66666... -> 416.67
+        Assert.Equal(416.67m, card.MonthlyPaycheck);
+        // 416.67 / 3000 = 0.138890 -> 0.1389
+        Assert.Equal(0.1389m, card.ReplacementRatio);
+    }
+
+    [Fact]
     public void ReplacementRatio_IsNull_WhenNoSalaryData()
     {
         var card = CreateCard(new InvestmentPaycheckEstimate { InvestableAssetsValue = 120_000m }, 0.04m);


### PR DESCRIPTION
Closes #614

## Summary

Fixes two UX/data-flow issues on the **Assets → Investment paycheck** card (`InvestmentPaycheckEstimatorCard`).

### 1. Withdrawal-rate changes no longer re-fetch
Previously `OnRateChanged` / `OnPresetSelected` called `SchedulePersist()`, which after a 350 ms debounce ran `RefreshEstimate(...)`. Because the cache key includes the withdrawal rate, every rate change was a cache miss → a fresh `AssetsHttpClient` request whose result was reassigned onto `_estimate`, making the card look like it was reloading.

The displayed values were already derived locally (`MonthlyPaycheck = InvestableAssetsValue × rate ÷ 12`, `ReplacementRatio = MonthlyPaycheck ÷ avgSalary`) from rate-independent source data, so:
- Removed `SchedulePersist()`, the `_persistCts` `CancellationTokenSource`, and the debounced re-fetch entirely.
- The rate handlers now only set `_annualWithdrawalRate`; Blazor's automatic re-render after the event callback recomputes the paycheck and coverage % client-side. Source data is still loaded once in `OnInitializedAsync`.

### 2. Labeling & month counter
- Footer label renamed `Investments value:` → **`Total investments value:`**, wrapped in a `MudTooltip` (*"The total value of all investments currently owned by the user."*); the matching info-popover `<dt>` was renamed for consistency, and a dotted-underline affordance signals the tooltip.
- The `X of Y mo` salary-history counter is hidden when the range is complete (`SalaryMonthsUsed == SalaryMonthsRequested`); partial history (e.g. `1 of 3 mo`) still shows.

## Changes
- `InvestmentPaycheckEstimatorCard.razor` — footer label + tooltip, conditional month counter, popover `<dt>`.
- `InvestmentPaycheckEstimatorCard.razor.cs` — dropped the persist/re-fetch logic; rate handlers recompute locally; exposed computed values/handlers as `internal` for testing.
- `InvestmentPaycheckEstimatorCard.razor.css` — `.pc-foot-label` tooltip affordance.
- `InvestmentPaycheckEstimatorCardTests.cs` — new unit tests (local recomputation of paycheck and replacement ratio on slider/preset change without any fetch).
- `CHANGELOG.md` — user-visible entry.

## Testing
- `dotnet build ./code/FinanceManager.slnx` — succeeds, 0 warnings.
- `dotnet test` (unit) — **664 passed**, incl. 6 new card tests.
- Rendered `/Assets` on the guest account (mobile 430×920 and desktop 1280×1000): footer reads *Total investments value*, tooltip affordance present, `3 of 3 mo` counter correctly hidden, paycheck updates locally on rate change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXPqKvRQ3aJRYtA4L7dvUh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified the “investments value” label to “Total investments value.”
  * Added a tooltip to explain the investments total.
  * Salary-history month details now show only when the recorded history is incomplete.
  * Withdrawal rate changes now update estimates immediately, without extra refresh behavior.
* **Style**
  * Improved visual help styling for the footer investment label.
* **Tests**
  * Added unit tests covering local recomputation, rounding to server precision, rate/preset changes, and null behavior when salary data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->