### PR TITLE
Add stale-while-revalidate snapshots to liabilities cards #616

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- The dashboard **Liabilities value over time** and **Liabilities distribution** cards now repaint their last-rendered state instantly on re-navigation and reconcile against a fresh request in the background, only redrawing when the data actually changed. A failed refresh keeps the cached view on screen instead of blanking to a spinner or error. Each card keeps using its own existing API call. #616
 - The dashboard **Investment paycheck** card no longer re-fetches when you move the withdrawal-rate slider or pick a Conservative/Standard/Aggressive preset — its data loads once and the paycheck and salary-coverage figures now recalculate instantly on the client. The footer value is relabelled **Total investments value** with a tooltip clarifying it covers all investments you own, and the `X of Y mo` salary-history counter is hidden once the full range is shown. #614
 - Asset and liability charts now load substantially faster, especially on the first uncached view. #610
 - The dashboard now loads account data once per overview request, making the first uncached view substantially faster. #608

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Liabilities/LiabilitiesDistributionOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Liabilities/LiabilitiesDistributionOverviewCard.razor.cs
@@ -1,7 +1,9 @@
 using FinanceManager.Application.Identity.Users;
 using FinanceManager.Components.Features.Dashboard.Models;
+using FinanceManager.Components.Features.Dashboard.Services;
 using FinanceManager.Components.Features.Identity.Services;
 using FinanceManager.Components.Features.MoneyFlow.HttpClients;
+using FinanceManager.Components.Shared.Services;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
 using FinanceManager.Domain.Identity.Services;
@@ -18,6 +20,9 @@ public partial class LiabilitiesDistributionOverviewCard
     private List<NameValueResult> _typeData = [];
     private List<NameValueResult> _accountData = [];
 
+    // Guards against a slower, earlier self-load overwriting a newer range/currency selection.
+    private readonly RefreshVersionGate _gate = new();
+
     [Parameter] public string Height { get; set; } = "300px";
     [Parameter] public DateTime StartDateTime { get; set; }
     [Parameter] public DateTime EndDateTime { get; set; } = DateTime.UtcNow;
@@ -30,6 +35,7 @@ public partial class LiabilitiesDistributionOverviewCard
     [Inject] public required LiabilitiesHttpClient LiabilitiesHttpClient { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
+    [Inject] public required LiabilitiesSnapshotStore SnapshotStore { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
@@ -38,49 +44,91 @@ public partial class LiabilitiesDistributionOverviewCard
 
     protected override async Task OnParametersSetAsync()
     {
-        _isLoading = true;
-        StateHasChanged();
-
-        try
+        // The dashboard-supplied model is already backed by the dashboard overview snapshot, so it
+        // renders directly and this card only snapshots its standalone self-loading path.
+        if (Model is not null)
         {
-            if (Model is not null)
-            {
-                _typeData = ToPositive(Model.TypeData);
-                _accountData = ToPositive(Model.AccountData);
-                return;
-            }
-
-            if (StartDateTime == new DateTime())
-            {
-                _typeData = [];
-                _accountData = [];
-                return;
-            }
-
-            var user = await LoginService.GetLoggedUser();
-            if (user is null)
-            {
-                _typeData = [];
-                _accountData = [];
-                return;
-            }
-
-            var typeTask = LiabilitiesHttpClient.GetEndLiabilitiesPerType(user.UserId, StartDateTime, EndDateTime).ToListAsync().AsTask();
-            var accountTask = LiabilitiesHttpClient.GetEndLiabilitiesPerAccount(user.UserId, StartDateTime, EndDateTime).ToListAsync().AsTask();
-            await Task.WhenAll(typeTask, accountTask);
-
-            _typeData = ToPositive(await typeTask);
-            _accountData = ToPositive(await accountTask);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError(ex, "Error loading liabilities distribution");
-        }
-        finally
-        {
+            _typeData = ToPositive(Model.TypeData);
+            _accountData = ToPositive(Model.AccountData);
             _isLoading = false;
             StateHasChanged();
+            return;
         }
+
+        await LoadSelf();
+    }
+
+    // Stale-while-revalidate self-load: paint the stored breakdown, always re-fetch, and only repaint
+    // and re-persist when the fresh breakdown differs. See docs/codebase/UI-SNAPSHOTS.md.
+    private async Task LoadSelf()
+    {
+        var requestVersion = _gate.Claim();
+        var startDate = StartDateTime;
+        var endDate = EndDateTime;
+
+        if (startDate == new DateTime())
+        {
+            CommitEmpty(requestVersion);
+            return;
+        }
+
+        var user = await LoginService.GetLoggedUser();
+        if (user is null)
+        {
+            CommitEmpty(requestVersion);
+            return;
+        }
+
+        var result = await SnapshotStore.RefreshDistributionAsync(
+            user.UserId,
+            _currency.Id,
+            startDate,
+            endDate,
+            _gate,
+            fetchAsync: async () =>
+            {
+                var typeTask = LiabilitiesHttpClient.GetEndLiabilitiesPerType(user.UserId, startDate, endDate).ToListAsync().AsTask();
+                var accountTask = LiabilitiesHttpClient.GetEndLiabilitiesPerAccount(user.UserId, startDate, endDate).ToListAsync().AsTask();
+                await Task.WhenAll(typeTask, accountTask);
+                return new DistributionCardModel(ToPositive(await typeTask), ToPositive(await accountTask));
+            },
+            onSnapshotPainted: ShowData,
+            onSnapshotMissing: () =>
+            {
+                _isLoading = true;
+                StateHasChanged();
+                return Task.CompletedTask;
+            },
+            onRefreshed: ShowData);
+
+        if (!_gate.IsCurrent(requestVersion))
+            return;
+
+        // This card has no blocking error surface; a failed refresh behind a painted snapshot keeps it
+        // visible, and a failed first load simply leaves the empty state (matching the previous behaviour).
+        if (result.IsBlockingFailure)
+            Logger.LogError(result.Error, "Error loading liabilities distribution");
+
+        _isLoading = false;
+        StateHasChanged();
+    }
+
+    private Task ShowData(DistributionCardModel model)
+    {
+        _typeData = model.TypeData;
+        _accountData = model.AccountData;
+        _isLoading = false;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    private void CommitEmpty(int requestVersion)
+    {
+        if (!_gate.IsCurrent(requestVersion)) return;
+        _typeData = [];
+        _accountData = [];
+        _isLoading = false;
+        StateHasChanged();
     }
 
     // Liabilities are returned as negative magnitudes; flip them so the pie and legend show positive amounts.

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Liabilities/LiabilitiesDistributionOverviewCard.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Liabilities/LiabilitiesDistributionOverviewCard.razor.cs
@@ -48,6 +48,9 @@ public partial class LiabilitiesDistributionOverviewCard
         // renders directly and this card only snapshots its standalone self-loading path.
         if (Model is not null)
         {
+            // Claim the gate so any self-load still in flight (from an earlier render when Model was null)
+            // is superseded and cannot overwrite the dashboard-supplied data with stale self-loaded values.
+            _gate.Claim();
             _typeData = ToPositive(Model.TypeData);
             _accountData = ToPositive(Model.AccountData);
             _isLoading = false;
@@ -85,6 +88,7 @@ public partial class LiabilitiesDistributionOverviewCard
             startDate,
             endDate,
             _gate,
+            requestVersion,
             fetchAsync: async () =>
             {
                 var typeTask = LiabilitiesHttpClient.GetEndLiabilitiesPerType(user.UserId, startDate, endDate).ToListAsync().AsTask();

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Liabilities/LiabilitiesTimeSeriesCard.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Liabilities/LiabilitiesTimeSeriesCard.razor.cs
@@ -1,6 +1,8 @@
-using FinanceManager.Application.Identity.Users;
+using FinanceManager.Components.Features.Dashboard.Models;
+using FinanceManager.Components.Features.Dashboard.Services;
 using FinanceManager.Components.Features.Identity.Services;
 using FinanceManager.Components.Features.MoneyFlow.HttpClients;
+using FinanceManager.Components.Shared.Services;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
 using FinanceManager.Domain.Identity.Services;
 using FinanceManager.Domain.MoneyFlow.Entities;
@@ -14,6 +16,11 @@ public partial class LiabilitiesTimeSeriesCard
     private bool _isLoading;
     private bool _hasError;
     private string _currency = "PLN";
+
+    // Guards against a slower, earlier reload overwriting a newer date/currency selection: every
+    // Reload claims an incrementing version and only commits its result if it is still the latest.
+    private readonly RefreshVersionGate _gate = new();
+
     public List<TimeSeriesModel> ChartData { get; set; } = [];
 
     [Parameter] public DateTime StartDateTime { get; set; }
@@ -24,33 +31,78 @@ public partial class LiabilitiesTimeSeriesCard
     [Inject] public required LiabilitiesHttpClient LiabilitiesHttpClient { get; set; }
     [Inject] public required ISettingsService SettingsService { get; set; }
     [Inject] public required ILoginService LoginService { get; set; }
+    [Inject] public required LiabilitiesSnapshotStore SnapshotStore { get; set; }
 
     protected override Task OnParametersSetAsync() => Reload();
 
+    // Stale-while-revalidate: paint the stored chart, always re-fetch, and only repaint and
+    // re-persist when the fresh series differs. LiabilitiesSnapshotStore / SnapshotRefreshCoordinator
+    // own that workflow — see docs/codebase/UI-SNAPSHOTS.md.
     private async Task Reload()
     {
-        var user = await LoginService.GetLoggedUser();
-        if (user is null) return;
+        // Claimed here rather than inside the coordinator so the same version also guards the
+        // logged-out branch below, which commits state before the run starts.
+        var requestVersion = _gate.Claim();
+        var startDate = StartDateTime;
+        var endDate = EndDateTime;
 
-        _isLoading = true;
         _hasError = false;
-        StateHasChanged();
-        try
-        {
-            _currency = (await SettingsService.GetCurrencyAsync()).ShortName;
 
-            ChartData.Clear();
-            var data = await LiabilitiesHttpClient.GetLiabilitiesTimeSeries(user.UserId, StartDateTime, EndDateTime).ToListAsync();
-            ChartData.AddRange(data.OrderBy(x => x.DateTime));
-        }
-        catch (Exception ex)
+        var user = await LoginService.GetLoggedUser();
+        if (user is null)
         {
+            if (_gate.IsCurrent(requestVersion))
+            {
+                ChartData = [];
+                _isLoading = false;
+                StateHasChanged();
+            }
+            return;
+        }
+
+        _currency = (await SettingsService.GetCurrencyAsync()).ShortName;
+
+        var result = await SnapshotStore.RefreshTimeSeriesAsync(
+            user.UserId,
+            _currency,
+            startDate,
+            endDate,
+            _gate,
+            fetchAsync: async () =>
+            {
+                var data = await LiabilitiesHttpClient.GetLiabilitiesTimeSeries(user.UserId, startDate, endDate).ToListAsync();
+                return new TimeSeriesCardModel([.. data.OrderBy(x => x.DateTime)]);
+            },
+            onSnapshotPainted: ShowData,
+            onSnapshotMissing: () =>
+            {
+                _isLoading = true;
+                StateHasChanged();
+                return Task.CompletedTask;
+            },
+            onRefreshed: ShowData);
+
+        if (!_gate.IsCurrent(requestVersion))
+            return;
+
+        // A failed fetch behind a painted snapshot keeps the chart on screen; only a surface with
+        // nothing to show falls back to the error state.
+        if (result.IsBlockingFailure)
+        {
+            Logger.LogError(result.Error, "Error getting liabilities time series data");
+            ChartData = [];
             _hasError = true;
-            Logger.LogError(ex, "Error getting liabilities time series data");
         }
-        finally
-        {
-            _isLoading = false;
-        }
+
+        _isLoading = false;
+        StateHasChanged();
+    }
+
+    private Task ShowData(TimeSeriesCardModel model)
+    {
+        ChartData = model.Series;
+        _isLoading = false;
+        StateHasChanged();
+        return Task.CompletedTask;
     }
 }

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Liabilities/LiabilitiesTimeSeriesCard.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Cards/Liabilities/LiabilitiesTimeSeriesCard.razor.cs
@@ -68,6 +68,7 @@ public partial class LiabilitiesTimeSeriesCard
             startDate,
             endDate,
             _gate,
+            requestVersion,
             fetchAsync: async () =>
             {
                 var data = await LiabilitiesHttpClient.GetLiabilitiesTimeSeries(user.UserId, startDate, endDate).ToListAsync();

--- a/code/FinanceManager.Components/Features/Dashboard/Models/LiabilitiesDistributionSnapshot.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Models/LiabilitiesDistributionSnapshot.cs
@@ -1,0 +1,23 @@
+using FinanceManager.Components.Shared.Models;
+using FinanceManager.Domain.MoneyFlow.Entities;
+
+namespace FinanceManager.Components.Features.Dashboard.Models;
+
+/// <summary>
+/// Persisted snapshot of the liabilities distribution card's self-loaded state so it can paint its
+/// last-rendered breakdown instantly on re-navigation, then reconcile against a fresh API response.
+/// </summary>
+/// <remarks>
+/// Only the self-loading path is snapshotted; when the dashboard supplies a prepared model the card
+/// renders it directly and the dashboard overview owns that snapshot. Scoped to the owning user and
+/// preferred currency id; the captured range is stored for context but is not part of the key.
+/// </remarks>
+public sealed class LiabilitiesDistributionSnapshot : SnapshotBase
+{
+    public int UserId { get; set; }
+    public int CurrencyId { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+    public List<NameValueResult> TypeData { get; set; } = [];
+    public List<NameValueResult> AccountData { get; set; } = [];
+}

--- a/code/FinanceManager.Components/Features/Dashboard/Models/LiabilitiesTimeSeriesSnapshot.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Models/LiabilitiesTimeSeriesSnapshot.cs
@@ -1,0 +1,24 @@
+using FinanceManager.Components.Shared.Models;
+using FinanceManager.Domain.MoneyFlow.Entities;
+
+namespace FinanceManager.Components.Features.Dashboard.Models;
+
+/// <summary>
+/// Persisted snapshot of the liabilities time-series card so it can paint its last-rendered
+/// chart instantly on re-navigation, then reconcile against a fresh API response.
+/// </summary>
+/// <remarks>
+/// Scoped to the owning user and preferred currency. The captured date range is stored for
+/// context but is deliberately not part of the snapshot key — one snapshot per user/currency
+/// is overwritten on each save. Content equality runs over the rendered
+/// <see cref="Dashboard.Models.TimeSeriesCardModel"/>, so <see cref="SnapshotBase.FetchedAtUtc"/>
+/// and the range never count as a change.
+/// </remarks>
+public sealed class LiabilitiesTimeSeriesSnapshot : SnapshotBase
+{
+    public int UserId { get; set; }
+    public string Currency { get; set; } = string.Empty;
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+    public List<TimeSeriesModel> Series { get; set; } = [];
+}

--- a/code/FinanceManager.Components/Features/Dashboard/Services/LiabilitiesSnapshotStore.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Services/LiabilitiesSnapshotStore.cs
@@ -1,0 +1,106 @@
+using FinanceManager.Components.Features.Dashboard.Models;
+using FinanceManager.Components.Shared.Models;
+using FinanceManager.Components.Shared.Services;
+
+namespace FinanceManager.Components.Features.Dashboard.Services;
+
+/// <summary>
+/// Runs the stale-while-revalidate workflow for the Liabilities-page cards: paints the stored
+/// render model, always re-fetches, and re-persists only when the rendered content changed. Owns
+/// the snapshot key shapes so each card scopes them identically. Each card keeps its own existing
+/// API call — no aggregate liabilities request is introduced.
+/// </summary>
+/// <remarks>The workflow itself lives in <see cref="ISnapshotRefreshCoordinator"/> — see docs/codebase/UI-SNAPSHOTS.md.</remarks>
+public sealed class LiabilitiesSnapshotStore(ISnapshotRefreshCoordinator coordinator)
+{
+    /// <summary>Stale-while-revalidate for the liabilities time-series chart, scoped to user + preferred currency.</summary>
+    /// <param name="userId">Owner of the data; scopes the snapshot key.</param>
+    /// <param name="currency">Preferred currency short name; scopes the snapshot key.</param>
+    /// <param name="start">Range start the fresh model was requested for; stored for context only.</param>
+    /// <param name="end">Range end the fresh model was requested for; stored for context only.</param>
+    /// <param name="gate">Race protection shared with the card's other reloads.</param>
+    /// <param name="fetchAsync">Loads the chart fresh from the API. Returns an empty model when there is nothing to render.</param>
+    /// <param name="onSnapshotPainted">Renders the stored series before the fresh request completes.</param>
+    /// <param name="onSnapshotMissing">Runs instead of <paramref name="onSnapshotPainted"/> when no usable snapshot exists.</param>
+    /// <param name="onRefreshed">Renders the fresh series; only invoked when it differs from what was painted.</param>
+    public Task<SnapshotRefreshResult<TimeSeriesCardModel>> RefreshTimeSeriesAsync(
+        int userId,
+        string currency,
+        DateTime start,
+        DateTime end,
+        RefreshVersionGate gate,
+        Func<Task<TimeSeriesCardModel?>> fetchAsync,
+        Func<TimeSeriesCardModel, Task>? onSnapshotPainted = null,
+        Func<Task>? onSnapshotMissing = null,
+        Func<TimeSeriesCardModel, Task>? onRefreshed = null)
+        => coordinator.RunAsync(new SnapshotRefreshRequest<LiabilitiesTimeSeriesSnapshot, TimeSeriesCardModel>
+        {
+            Key = BuildTimeSeriesKey(userId, currency),
+            Gate = gate,
+
+            // A snapshot stored for a different user or currency is unusable; rejecting it falls back to a plain load.
+            ToModel = snapshot => snapshot.UserId == userId && snapshot.Currency == currency
+                ? new TimeSeriesCardModel(snapshot.Series)
+                : null,
+            FetchAsync = fetchAsync,
+            ToSnapshot = model => new LiabilitiesTimeSeriesSnapshot
+            {
+                UserId = userId,
+                Currency = currency,
+                StartDate = start,
+                EndDate = end,
+                Series = model.Series,
+            },
+            OnSnapshotPainted = onSnapshotPainted,
+            OnSnapshotMissing = onSnapshotMissing,
+            OnRefreshed = onRefreshed,
+        });
+
+    /// <summary>Stale-while-revalidate for the liabilities distribution breakdown, scoped to user + preferred currency id.</summary>
+    /// <param name="userId">Owner of the data; scopes the snapshot key.</param>
+    /// <param name="currencyId">Preferred currency id; scopes the snapshot key.</param>
+    /// <param name="start">Range start the fresh model was requested for; stored for context only.</param>
+    /// <param name="end">Range end the fresh model was requested for; stored for context only.</param>
+    /// <param name="gate">Race protection shared with the card's other reloads.</param>
+    /// <param name="fetchAsync">Loads the breakdown fresh from the API. Returns an empty model when there is nothing to render.</param>
+    /// <param name="onSnapshotPainted">Renders the stored breakdown before the fresh request completes.</param>
+    /// <param name="onSnapshotMissing">Runs instead of <paramref name="onSnapshotPainted"/> when no usable snapshot exists.</param>
+    /// <param name="onRefreshed">Renders the fresh breakdown; only invoked when it differs from what was painted.</param>
+    public Task<SnapshotRefreshResult<DistributionCardModel>> RefreshDistributionAsync(
+        int userId,
+        int currencyId,
+        DateTime start,
+        DateTime end,
+        RefreshVersionGate gate,
+        Func<Task<DistributionCardModel?>> fetchAsync,
+        Func<DistributionCardModel, Task>? onSnapshotPainted = null,
+        Func<Task>? onSnapshotMissing = null,
+        Func<DistributionCardModel, Task>? onRefreshed = null)
+        => coordinator.RunAsync(new SnapshotRefreshRequest<LiabilitiesDistributionSnapshot, DistributionCardModel>
+        {
+            Key = BuildDistributionKey(userId, currencyId),
+            Gate = gate,
+
+            ToModel = snapshot => snapshot.UserId == userId && snapshot.CurrencyId == currencyId
+                ? new DistributionCardModel(snapshot.TypeData, snapshot.AccountData)
+                : null,
+            FetchAsync = fetchAsync,
+            ToSnapshot = model => new LiabilitiesDistributionSnapshot
+            {
+                UserId = userId,
+                CurrencyId = currencyId,
+                StartDate = start,
+                EndDate = end,
+                TypeData = model.TypeData,
+                AccountData = model.AccountData,
+            },
+            OnSnapshotPainted = onSnapshotPainted,
+            OnSnapshotMissing = onSnapshotMissing,
+            OnRefreshed = onRefreshed,
+        });
+
+    // Per-user keys with no date component, so a single snapshot per surface is overwritten on each save.
+    // Currency-scoped so a snapshot saved before a preferred-currency change is never painted with new labels.
+    private static string BuildTimeSeriesKey(int userId, string currency) => $"liabilities-timeseries:{userId}:{currency}";
+    private static string BuildDistributionKey(int userId, int currencyId) => $"liabilities-distribution:{userId}:{currencyId}";
+}

--- a/code/FinanceManager.Components/Features/Dashboard/Services/LiabilitiesSnapshotStore.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Services/LiabilitiesSnapshotStore.cs
@@ -19,6 +19,12 @@ public sealed class LiabilitiesSnapshotStore(ISnapshotRefreshCoordinator coordin
     /// <param name="start">Range start the fresh model was requested for; stored for context only.</param>
     /// <param name="end">Range end the fresh model was requested for; stored for context only.</param>
     /// <param name="gate">Race protection shared with the card's other reloads.</param>
+    /// <param name="claimedVersion">
+    /// The version the caller already claimed from <paramref name="gate"/> before this call. Forwarded to the
+    /// coordinator so it reuses that version instead of claiming a newer one — otherwise the caller's own
+    /// post-run <c>IsCurrent</c> guard (which uses the pre-claimed version) would never match. Pass <c>null</c>
+    /// only when the caller has not pre-claimed.
+    /// </param>
     /// <param name="fetchAsync">Loads the chart fresh from the API. Returns an empty model when there is nothing to render.</param>
     /// <param name="onSnapshotPainted">Renders the stored series before the fresh request completes.</param>
     /// <param name="onSnapshotMissing">Runs instead of <paramref name="onSnapshotPainted"/> when no usable snapshot exists.</param>
@@ -29,6 +35,7 @@ public sealed class LiabilitiesSnapshotStore(ISnapshotRefreshCoordinator coordin
         DateTime start,
         DateTime end,
         RefreshVersionGate gate,
+        int? claimedVersion,
         Func<Task<TimeSeriesCardModel?>> fetchAsync,
         Func<TimeSeriesCardModel, Task>? onSnapshotPainted = null,
         Func<Task>? onSnapshotMissing = null,
@@ -37,6 +44,7 @@ public sealed class LiabilitiesSnapshotStore(ISnapshotRefreshCoordinator coordin
         {
             Key = BuildTimeSeriesKey(userId, currency),
             Gate = gate,
+            ClaimedVersion = claimedVersion,
 
             // A snapshot stored for a different user or currency is unusable; rejecting it falls back to a plain load.
             ToModel = snapshot => snapshot.UserId == userId && snapshot.Currency == currency
@@ -62,6 +70,12 @@ public sealed class LiabilitiesSnapshotStore(ISnapshotRefreshCoordinator coordin
     /// <param name="start">Range start the fresh model was requested for; stored for context only.</param>
     /// <param name="end">Range end the fresh model was requested for; stored for context only.</param>
     /// <param name="gate">Race protection shared with the card's other reloads.</param>
+    /// <param name="claimedVersion">
+    /// The version the caller already claimed from <paramref name="gate"/> before this call. Forwarded to the
+    /// coordinator so it reuses that version instead of claiming a newer one — otherwise the caller's own
+    /// post-run <c>IsCurrent</c> guard (which uses the pre-claimed version) would never match. Pass <c>null</c>
+    /// only when the caller has not pre-claimed.
+    /// </param>
     /// <param name="fetchAsync">Loads the breakdown fresh from the API. Returns an empty model when there is nothing to render.</param>
     /// <param name="onSnapshotPainted">Renders the stored breakdown before the fresh request completes.</param>
     /// <param name="onSnapshotMissing">Runs instead of <paramref name="onSnapshotPainted"/> when no usable snapshot exists.</param>
@@ -72,6 +86,7 @@ public sealed class LiabilitiesSnapshotStore(ISnapshotRefreshCoordinator coordin
         DateTime start,
         DateTime end,
         RefreshVersionGate gate,
+        int? claimedVersion,
         Func<Task<DistributionCardModel?>> fetchAsync,
         Func<DistributionCardModel, Task>? onSnapshotPainted = null,
         Func<Task>? onSnapshotMissing = null,
@@ -80,6 +95,7 @@ public sealed class LiabilitiesSnapshotStore(ISnapshotRefreshCoordinator coordin
         {
             Key = BuildDistributionKey(userId, currencyId),
             Gate = gate,
+            ClaimedVersion = claimedVersion,
 
             ToModel = snapshot => snapshot.UserId == userId && snapshot.CurrencyId == currencyId
                 ? new DistributionCardModel(snapshot.TypeData, snapshot.AccountData)

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -69,6 +69,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<ISnapshotService, LocalStorageSnapshotService>()
                 .AddScoped<ISnapshotRefreshCoordinator, SnapshotRefreshCoordinator>()
                 .AddScoped<AccountDetailsSnapshotStore>()
+                .AddScoped<LiabilitiesSnapshotStore>()
                 .AddTransient<CurrencyImportJobTracker>()
                 .AddScoped<AssetsPageCardsCacheService>()
                 .AddScoped<InvestmentPaycheckEstimateCacheService>()

--- a/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Services/LiabilitiesSnapshotStoreTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Services/LiabilitiesSnapshotStoreTests.cs
@@ -1,0 +1,193 @@
+using FinanceManager.Components.Features.Dashboard.Models;
+using FinanceManager.Components.Features.Dashboard.Services;
+using FinanceManager.Components.Shared.Models;
+using FinanceManager.Components.Shared.Services;
+using FinanceManager.Domain.MoneyFlow.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Components.Features.Dashboard.Services;
+
+[Trait("Category", "Unit")]
+public class LiabilitiesSnapshotStoreTests
+{
+    private const string _timeSeriesKey = "liabilities-timeseries:1:PLN";
+    private const string _distributionKey = "liabilities-distribution:1:2";
+
+    private static readonly DateTime _start = new(2024, 1, 1);
+    private static readonly DateTime _end = new(2024, 2, 1);
+
+    private readonly Mock<ISnapshotService> _snapshots = new();
+
+    private LiabilitiesSnapshotStore CreateStore() =>
+        new(new SnapshotRefreshCoordinator(_snapshots.Object, NullLogger<SnapshotRefreshCoordinator>.Instance));
+
+    // ---- time-series surface ----
+
+    [Fact]
+    public async Task RefreshTimeSeries_ReadFailure_PaintsNothingAndLoadsFresh()
+    {
+        _snapshots.Setup(x => x.GetAsync<LiabilitiesTimeSeriesSnapshot>(_timeSeriesKey)).ThrowsAsync(new InvalidOperationException());
+
+        var result = await RefreshTimeSeries(fresh: Series(1m));
+
+        Assert.False(result.SnapshotPainted);
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+        _snapshots.Verify(x => x.RemoveAsync(_timeSeriesKey), Times.Once);
+    }
+
+    [Fact]
+    public async Task RefreshTimeSeries_UnchangedSeries_PaintsAndSkipsWrite()
+    {
+        GivenStoredTimeSeries(1m, 2m);
+
+        var painted = false;
+        var result = await RefreshTimeSeries(fresh: Series(1m, 2m), onSnapshotPainted: _ =>
+        {
+            painted = true;
+            return Task.CompletedTask;
+        });
+
+        Assert.True(painted);
+        Assert.True(result.SnapshotPainted);
+        Assert.Equal(SnapshotRefreshOutcome.Unchanged, result.Outcome);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<LiabilitiesTimeSeriesSnapshot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefreshTimeSeries_ChangedSeries_WritesUserAndCurrencyScopedKey()
+    {
+        GivenStoredTimeSeries(1m, 2m);
+
+        var result = await RefreshTimeSeries(fresh: Series(1m, 3m));
+
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+        _snapshots.Verify(x => x.SetAsync(_timeSeriesKey, It.Is<LiabilitiesTimeSeriesSnapshot>(
+            s => s.UserId == 1 && s.Currency == "PLN" && s.StartDate == _start && s.EndDate == _end
+                 && s.Series.Select(p => p.Value).SequenceEqual(new[] { 1m, 3m }))), Times.Once);
+    }
+
+    [Fact]
+    public async Task RefreshTimeSeries_SnapshotFromAnotherCurrency_IsNotPainted()
+    {
+        // A stale entry left under this key by a different currency must never be rendered here.
+        _snapshots.Setup(x => x.GetAsync<LiabilitiesTimeSeriesSnapshot>(_timeSeriesKey))
+            .ReturnsAsync(new LiabilitiesTimeSeriesSnapshot { UserId = 1, Currency = "USD", Series = Points(1m, 2m) });
+
+        var painted = false;
+        var result = await RefreshTimeSeries(fresh: Series(1m, 2m), onSnapshotPainted: _ =>
+        {
+            painted = true;
+            return Task.CompletedTask;
+        });
+
+        Assert.False(painted);
+        Assert.False(result.SnapshotPainted);
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+    }
+
+    [Fact]
+    public async Task RefreshTimeSeries_FetchFailureBehindSnapshot_KeepsPaintedSnapshot()
+    {
+        GivenStoredTimeSeries(1m, 2m);
+        var store = CreateStore();
+
+        var result = await store.RefreshTimeSeriesAsync(1, "PLN", _start, _end, new RefreshVersionGate(),
+            fetchAsync: () => throw new HttpRequestException());
+
+        Assert.Equal(SnapshotRefreshOutcome.Failed, result.Outcome);
+        Assert.True(result.SnapshotPainted);
+        Assert.False(result.IsBlockingFailure);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<LiabilitiesTimeSeriesSnapshot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefreshTimeSeries_SupersededBeforeCommit_DoesNotWrite()
+    {
+        GivenStoredTimeSeries(1m, 2m);
+        var gate = new RefreshVersionGate();
+        var store = CreateStore();
+
+        var result = await store.RefreshTimeSeriesAsync(1, "PLN", _start, _end, gate,
+            fetchAsync: () =>
+            {
+                // A newer reload claims the gate mid-flight; this run must commit nothing.
+                gate.Claim();
+                return Task.FromResult<TimeSeriesCardModel?>(Series(9m));
+            });
+
+        Assert.Equal(SnapshotRefreshOutcome.Superseded, result.Outcome);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<LiabilitiesTimeSeriesSnapshot>()), Times.Never);
+    }
+
+    // ---- distribution surface ----
+
+    [Fact]
+    public async Task RefreshDistribution_ChangedData_WritesUserAndCurrencyScopedKey()
+    {
+        _snapshots.Setup(x => x.GetAsync<LiabilitiesDistributionSnapshot>(_distributionKey))
+            .ReturnsAsync(new LiabilitiesDistributionSnapshot { UserId = 1, CurrencyId = 2, TypeData = Values(("Loan", 5m)), AccountData = [] });
+
+        var result = await RefreshDistribution(fresh: new DistributionCardModel(Values(("Loan", 7m)), []));
+
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+        _snapshots.Verify(x => x.SetAsync(_distributionKey, It.Is<LiabilitiesDistributionSnapshot>(
+            s => s.UserId == 1 && s.CurrencyId == 2 && s.TypeData.Single().Value == 7m)), Times.Once);
+    }
+
+    [Fact]
+    public async Task RefreshDistribution_UnchangedData_SkipsWrite()
+    {
+        _snapshots.Setup(x => x.GetAsync<LiabilitiesDistributionSnapshot>(_distributionKey))
+            .ReturnsAsync(new LiabilitiesDistributionSnapshot { UserId = 1, CurrencyId = 2, TypeData = Values(("Loan", 5m)), AccountData = Values(("Acc", 5m)) });
+
+        var result = await RefreshDistribution(fresh: new DistributionCardModel(Values(("Loan", 5m)), Values(("Acc", 5m))));
+
+        Assert.Equal(SnapshotRefreshOutcome.Unchanged, result.Outcome);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<LiabilitiesDistributionSnapshot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefreshDistribution_SnapshotFromAnotherUser_IsNotPainted()
+    {
+        _snapshots.Setup(x => x.GetAsync<LiabilitiesDistributionSnapshot>(_distributionKey))
+            .ReturnsAsync(new LiabilitiesDistributionSnapshot { UserId = 99, CurrencyId = 2, TypeData = Values(("Loan", 5m)), AccountData = [] });
+
+        var painted = false;
+        var result = await RefreshDistribution(fresh: new DistributionCardModel(Values(("Loan", 5m)), []), onSnapshotPainted: _ =>
+        {
+            painted = true;
+            return Task.CompletedTask;
+        });
+
+        Assert.False(painted);
+        Assert.False(result.SnapshotPainted);
+        Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
+    }
+
+    // ---- helpers ----
+
+    private void GivenStoredTimeSeries(params decimal[] values) =>
+        _snapshots.Setup(x => x.GetAsync<LiabilitiesTimeSeriesSnapshot>(_timeSeriesKey))
+            .ReturnsAsync(new LiabilitiesTimeSeriesSnapshot { UserId = 1, Currency = "PLN", StartDate = _start, EndDate = _end, Series = Points(values) });
+
+    private Task<SnapshotRefreshResult<TimeSeriesCardModel>> RefreshTimeSeries(
+        TimeSeriesCardModel? fresh,
+        Func<TimeSeriesCardModel, Task>? onSnapshotPainted = null) =>
+        CreateStore().RefreshTimeSeriesAsync(1, "PLN", _start, _end, new RefreshVersionGate(),
+            () => Task.FromResult(fresh), onSnapshotPainted);
+
+    private Task<SnapshotRefreshResult<DistributionCardModel>> RefreshDistribution(
+        DistributionCardModel? fresh,
+        Func<DistributionCardModel, Task>? onSnapshotPainted = null) =>
+        CreateStore().RefreshDistributionAsync(1, 2, _start, _end, new RefreshVersionGate(),
+            () => Task.FromResult(fresh), onSnapshotPainted);
+
+    private static TimeSeriesCardModel Series(params decimal[] values) => new(Points(values));
+
+    private static List<TimeSeriesModel> Points(params decimal[] values) =>
+        [.. values.Select((v, i) => new TimeSeriesModel(_start.AddDays(i), v))];
+
+    private static List<NameValueResult> Values(params (string Name, decimal Value)[] entries) =>
+        [.. entries.Select(e => new NameValueResult(e.Name, e.Value))];
+}

--- a/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Services/LiabilitiesSnapshotStoreTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Services/LiabilitiesSnapshotStoreTests.cs
@@ -92,7 +92,7 @@ public class LiabilitiesSnapshotStoreTests
         GivenStoredTimeSeries(1m, 2m);
         var store = CreateStore();
 
-        var result = await store.RefreshTimeSeriesAsync(1, "PLN", _start, _end, new RefreshVersionGate(),
+        var result = await store.RefreshTimeSeriesAsync(1, "PLN", _start, _end, new RefreshVersionGate(), claimedVersion: null,
             fetchAsync: () => throw new HttpRequestException());
 
         Assert.Equal(SnapshotRefreshOutcome.Failed, result.Outcome);
@@ -108,7 +108,7 @@ public class LiabilitiesSnapshotStoreTests
         var gate = new RefreshVersionGate();
         var store = CreateStore();
 
-        var result = await store.RefreshTimeSeriesAsync(1, "PLN", _start, _end, gate,
+        var result = await store.RefreshTimeSeriesAsync(1, "PLN", _start, _end, gate, claimedVersion: null,
             fetchAsync: () =>
             {
                 // A newer reload claims the gate mid-flight; this run must commit nothing.
@@ -118,6 +118,22 @@ public class LiabilitiesSnapshotStoreTests
 
         Assert.Equal(SnapshotRefreshOutcome.Superseded, result.Outcome);
         _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<LiabilitiesTimeSeriesSnapshot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefreshTimeSeries_ForwardsClaimedVersion_CallerGuardStaysCurrent()
+    {
+        // Regression: the card pre-claims a version and guards its post-run state with IsCurrent(claimedVersion).
+        // If the store let the coordinator claim a *newer* version instead of forwarding the pre-claimed one,
+        // that guard would never match and the card's error/loading commit would be skipped.
+        GivenStoredTimeSeries(1m, 2m);
+        var gate = new RefreshVersionGate();
+        var claimed = gate.Claim();
+
+        await CreateStore().RefreshTimeSeriesAsync(1, "PLN", _start, _end, gate, claimed,
+            () => Task.FromResult<TimeSeriesCardModel?>(Series(1m, 3m)));
+
+        Assert.True(gate.IsCurrent(claimed));
     }
 
     // ---- distribution surface ----
@@ -165,6 +181,42 @@ public class LiabilitiesSnapshotStoreTests
         Assert.Equal(SnapshotRefreshOutcome.Refreshed, result.Outcome);
     }
 
+    [Fact]
+    public async Task RefreshDistribution_FetchFailureBehindSnapshot_KeepsPaintedSnapshot()
+    {
+        _snapshots.Setup(x => x.GetAsync<LiabilitiesDistributionSnapshot>(_distributionKey))
+            .ReturnsAsync(new LiabilitiesDistributionSnapshot { UserId = 1, CurrencyId = 2, TypeData = Values(("Loan", 5m)), AccountData = [] });
+        var store = CreateStore();
+
+        var result = await store.RefreshDistributionAsync(1, 2, _start, _end, new RefreshVersionGate(), claimedVersion: null,
+            fetchAsync: () => throw new HttpRequestException());
+
+        Assert.Equal(SnapshotRefreshOutcome.Failed, result.Outcome);
+        Assert.True(result.SnapshotPainted);
+        Assert.False(result.IsBlockingFailure);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<LiabilitiesDistributionSnapshot>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RefreshDistribution_SupersededBeforeCommit_DoesNotWrite()
+    {
+        _snapshots.Setup(x => x.GetAsync<LiabilitiesDistributionSnapshot>(_distributionKey))
+            .ReturnsAsync(new LiabilitiesDistributionSnapshot { UserId = 1, CurrencyId = 2, TypeData = Values(("Loan", 5m)), AccountData = [] });
+        var gate = new RefreshVersionGate();
+        var store = CreateStore();
+
+        var result = await store.RefreshDistributionAsync(1, 2, _start, _end, gate, claimedVersion: null,
+            fetchAsync: () =>
+            {
+                // A newer reload claims the gate mid-flight; this run must commit nothing.
+                gate.Claim();
+                return Task.FromResult<DistributionCardModel?>(new DistributionCardModel(Values(("Loan", 9m)), []));
+            });
+
+        Assert.Equal(SnapshotRefreshOutcome.Superseded, result.Outcome);
+        _snapshots.Verify(x => x.SetAsync(It.IsAny<string>(), It.IsAny<LiabilitiesDistributionSnapshot>()), Times.Never);
+    }
+
     // ---- helpers ----
 
     private void GivenStoredTimeSeries(params decimal[] values) =>
@@ -174,13 +226,13 @@ public class LiabilitiesSnapshotStoreTests
     private Task<SnapshotRefreshResult<TimeSeriesCardModel>> RefreshTimeSeries(
         TimeSeriesCardModel? fresh,
         Func<TimeSeriesCardModel, Task>? onSnapshotPainted = null) =>
-        CreateStore().RefreshTimeSeriesAsync(1, "PLN", _start, _end, new RefreshVersionGate(),
+        CreateStore().RefreshTimeSeriesAsync(1, "PLN", _start, _end, new RefreshVersionGate(), claimedVersion: null,
             () => Task.FromResult(fresh), onSnapshotPainted);
 
     private Task<SnapshotRefreshResult<DistributionCardModel>> RefreshDistribution(
         DistributionCardModel? fresh,
         Func<DistributionCardModel, Task>? onSnapshotPainted = null) =>
-        CreateStore().RefreshDistributionAsync(1, 2, _start, _end, new RefreshVersionGate(),
+        CreateStore().RefreshDistributionAsync(1, 2, _start, _end, new RefreshVersionGate(), claimedVersion: null,
             () => Task.FromResult(fresh), onSnapshotPainted);
 
     private static TimeSeriesCardModel Series(params decimal[] values) => new(Points(values));


### PR DESCRIPTION
## Summary

First per-component slice of #616. Applies the stale-while-revalidate UI-snapshot standard from #615 to the two **Liabilities-page** dashboard cards, which #616 explicitly carves out as their own group requiring separate snapshots and their existing separate API calls (no aggregate request).

Both cards now paint their last-rendered state instantly on re-navigation, always re-fetch in the background, and only repaint/re-persist when the rendered content actually changed — keeping the cached view visible if a refresh fails.

## Changes

**Added**
- `Features/Dashboard/Services/LiabilitiesSnapshotStore.cs` — thin store mirroring `AccountDetailsSnapshotStore`: owns the two per-surface snapshot keys and the snapshot↔render-model mapping, delegating the orchestration to `ISnapshotRefreshCoordinator`. Keys scoped to **user + preferred currency**, with the date range stored in the snapshot rather than the key (per the #615 standard).
- `Features/Dashboard/Models/LiabilitiesTimeSeriesSnapshot.cs` and `LiabilitiesDistributionSnapshot.cs` (`SnapshotBase`). Content equality reuses the existing `TimeSeriesCardModel` / `DistributionCardModel` render models, so metadata never counts as a change.
- `LiabilitiesSnapshotStoreTests.cs` — covers paint-before-fetch, unchanged→no write, changed→writes scoped key, refresh-failure preserves painted snapshot, read-failure evicts + loads fresh, superseded request cannot overwrite, and cross-user / cross-currency snapshot rejection.

**Changed**
- `LiabilitiesTimeSeriesCard.razor.cs` — routes `Reload()` through the store with its own `RefreshVersionGate`; existing error/retry state now shows only when nothing was painted.
- `LiabilitiesDistributionOverviewCard.razor.cs` — routes the **self-load** branch through the store; the dashboard-supplied `Model` branch is unchanged (the dashboard overview already snapshots that data).
- `ServiceCollectionExtension.cs` — registers `LiabilitiesSnapshotStore`.
- `CHANGELOG.md` — user-visible entry.

No new bulk/aggregate endpoint, card DTO, or page-wide cache is introduced; each card keeps calling its existing `LiabilitiesHttpClient` method(s).

## Scope

This advances #616 but does **not** close it. The remaining components (`FinancialInsightsCarousel`, `RecurringTransactionDetectorCard`, `TransactionLogCard`, `DiversificationProxyCard`, and the currency/bond/investment transaction-list charts) will follow as separate slices — see the [plan comment](https://github.com/avresial/FinanceManager/issues/616#issuecomment-5112386826). Intentionally omitting an auto-close keyword so merging this slice leaves the issue open.

Part of #616.

## Testing
- `dotnet build ./code/FinanceManager.slnx` — clean (0 warnings, warnings-as-errors).
- `dotnet format` — applied.
- Unit tests: 679 passed. Architecture tests: 9 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ogCfwBXpgtnhif9gAURLX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Liabilities dashboard charts now display previously loaded data immediately when revisiting the dashboard.
  * Data refreshes in the background to provide updated results without blocking the existing view.
  * Improved handling for currency, date-range, and user changes to prevent outdated results from replacing newer selections.

* **Bug Fixes**
  * Existing data remains visible when a background refresh fails.
  * Prevented mismatched or stale liabilities data from appearing across selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->