### PR TITLE
Add Twelve Data market data provider integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Twelve Data can now supply daily stock and ETF prices, latest quotes, and daily forex rates through the existing market-data fallback flows. Provider priority, timeout, enabled state, and per-minute/daily credit budgets are configurable under `TwelveData`; provider-specific symbols stay on instrument listings, existing observations remain idempotently skipped, and Alpha Vantage remains available as an alternative. #643
 - Currency exchange rates can now be sourced from two official, free providers alongside the existing ones: **NBP** (Narodowy Bank Polski) for PLN pairs and the **ECB** (European Central Bank) Data Portal for EUR pairs, with automatic cross rates between two currencies both quoted against EUR. They are consulted ahead of the general currency API and fall back cleanly, treating non-trading days as "no rate" rather than errors; each can be turned off via the `Nbp` / `Ecb` configuration sections. #642
 - A new **Subscriptions** inbox turns recurring charges into a managed list with stable identities, weekly through annual cadence detection, next expected charge dates, monthly and annual cost equivalents, price-increase warnings, and persisted mute, cancellation, and review flags. #306
 - Investment accounts now compare portfolio value with Polish inflation by default, or with any available investment selected in **Settings → Preferences**, across the account chart's full date range. #307

--- a/code/FinanceManager.Api/ApiConfigurationExtensions.cs
+++ b/code/FinanceManager.Api/ApiConfigurationExtensions.cs
@@ -65,6 +65,14 @@ public static class ApiConfigurationExtensions
             .Bind(configuration.GetSection("Eodhd"))
             .Validate(o => !string.IsNullOrWhiteSpace(o.BaseUrl), "Eodhd:BaseUrl must be configured.")
             .ValidateOnStart();
+        services.AddOptions<TwelveDataOptions>()
+            .Bind(configuration.GetSection(TwelveDataOptions.SectionName))
+            .Validate(o => !string.IsNullOrWhiteSpace(o.BaseUrl), "TwelveData:BaseUrl must be configured.")
+            .Validate(o => o.Priority >= 0, "TwelveData:Priority cannot be negative.")
+            .Validate(o => o.PerMinuteCreditLimit > 0, "TwelveData:PerMinuteCreditLimit must be greater than 0.")
+            .Validate(o => o.DailyCreditLimit > 0, "TwelveData:DailyCreditLimit must be greater than 0.")
+            .Validate(o => o.RequestTimeoutSeconds > 0, "TwelveData:RequestTimeoutSeconds must be greater than 0.")
+            .ValidateOnStart();
         services.AddOptions<NbpOptions>()
             .Bind(configuration.GetSection(NbpOptions.SectionName))
             .Validate(o => !string.IsNullOrWhiteSpace(o.BaseUrl), "Nbp:BaseUrl must be configured.")

--- a/code/FinanceManager.Api/appsettings.Development.json
+++ b/code/FinanceManager.Api/appsettings.Development.json
@@ -59,5 +59,13 @@
     "StockLookbackDays": 30,
     "CurrencyLookbackDays": 30
   },
+  "TwelveData": {
+    "BaseUrl": "https://api.twelvedata.com",
+    "Enabled": true,
+    "Priority": 200,
+    "PerMinuteCreditLimit": 8,
+    "DailyCreditLimit": 800,
+    "RequestTimeoutSeconds": 30
+  },
   "AllowedHosts": "*"
 }

--- a/code/FinanceManager.Api/appsettings.Production.json
+++ b/code/FinanceManager.Api/appsettings.Production.json
@@ -88,6 +88,14 @@
     "BaseUrl": "https://www.alphavantage.co/query",
     "OutputSize": "full"
   },
+  "TwelveData": {
+    "BaseUrl": "https://api.twelvedata.com",
+    "Enabled": true,
+    "Priority": 200,
+    "PerMinuteCreditLimit": 8,
+    "DailyCreditLimit": 800,
+    "RequestTimeoutSeconds": 30
+  },
   "Backfill": {
     "RunOnStartup": true,
     "StockPricesEnabled": true,

--- a/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
+++ b/code/FinanceManager.Application/Assets/Pricing/InvestmentPriceProvider.cs
@@ -230,31 +230,24 @@ public class InvestmentPriceProvider(
 
     private async Task TryFetchAndStoreAsync(AssetListing listing, DateTime start, DateTime end, CancellationToken ct)
     {
-        var symbol = listing.MarketDataSymbols
+        var symbols = listing.MarketDataSymbols
             .Where(s => s.IsEnabled)
-            .OrderByDescending(s => s.IsPrimary)
+            .OrderBy(s => priceSource.SupportsProviderSelection ? priceSource.GetPriority(s.Provider) : 0)
+            .ThenByDescending(s => s.IsPrimary)
             .ThenBy(s => s.Id)
-            .FirstOrDefault();
+            .ToList();
 
-        if (symbol is null)
+        if (symbols.Count == 0)
         {
             logger.LogDebug("Listing {ListingId} has no enabled market-data symbol; cannot fetch prices", listing.Id);
             return;
         }
 
-        // A symbol whose most recent attempt failed keeps failing for a while (bad symbol,
-        // rate-limited provider). Without a cooldown every chart request would re-run the whole
-        // provider fallback chain for it, adding external-call latency to each page load.
-        if (symbol.LastError is not null && DateTimeOffset.UtcNow - symbol.UpdatedAt < _failedFetchCooldown)
-        {
-            logger.LogDebug("Skipping price fetch for listing {ListingId}: last attempt failed at {UpdatedAt} and is within the cooldown", listing.Id, symbol.UpdatedAt);
-            return;
-        }
+        if (!priceSource.SupportsProviderSelection)
+            symbols = [symbols[0]];
 
-        // Key the lock by listing+symbol only: _fetchLocks is static and never evicts, so per-range
-        // keys would leak a SemaphoreSlim per requested window. Sharing one lock per symbol also
-        // serialises overlapping range fetches, which is what we want.
-        var fetchKey = $"INVEST_FETCH_{listing.Id}_{symbol.Id}";
+        // One lock per listing serialises every provider symbol for the same instrument.
+        var fetchKey = $"INVEST_FETCH_{listing.Id}";
         var fetchLock = _fetchLocks.GetOrAdd(fetchKey, _ => new SemaphoreSlim(1, 1));
         await fetchLock.WaitAsync(ct);
         try
@@ -264,52 +257,65 @@ public class InvestmentPriceProvider(
             if (!NeedsFetch(existing, start.Date, end.Date))
                 return;
 
-            var rawCurrencyName = string.IsNullOrWhiteSpace(symbol.Currency) ? listing.TradingCurrency : symbol.Currency;
-            var rawCurrency = await currencyRepository.GetOrAdd(rawCurrencyName, rawCurrencyName, ct);
-
-            IReadOnlyList<Domain.FinancialAccounts.Investments.Entities.StockPrice> prices;
-            try
+            foreach (var symbol in symbols)
             {
-                prices = await priceSource.GetDailySeries(symbol.Symbol, string.Empty, start, end, rawCurrency, ct);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                logger.LogWarning(ex, "Price fetch failed for listing {ListingId} symbol {Symbol}", listing.Id, symbol.Symbol);
-                await symbolRepository.RecordFetchResult(symbol.Id, null, ex.Message, ct);
-                return;
-            }
-
-            if (prices.Count == 0)
-            {
-                await symbolRepository.RecordFetchResult(symbol.Id, null, "No price data returned", ct);
-                return;
-            }
-
-            var normalizedCurrencyName = NormalizedCurrencyName(rawCurrencyName, listing.PriceMultiplier);
-            var quotes = new List<PriceQuote>(prices.Count);
-            foreach (var price in prices)
-            {
-                if (price.PricePerUnit <= 0) continue;
-
-                quotes.Add(new PriceQuote
+                if (symbol.LastError is not null && DateTimeOffset.UtcNow - symbol.UpdatedAt < _failedFetchCooldown)
                 {
-                    AssetListingId = listing.Id,
-                    MarketDataSymbolId = symbol.Id,
-                    Provider = symbol.Provider,
-                    Price = price.PricePerUnit * listing.PriceMultiplier,
-                    Currency = normalizedCurrencyName,
-                    PriceTime = DayStart(price.Date),
-                    QuoteType = PriceQuoteType.EndOfDay,
-                    RawPrice = price.PricePerUnit,
-                    RawCurrency = rawCurrencyName,
-                    FetchedAt = DateTimeOffset.UtcNow
-                });
-            }
+                    logger.LogDebug(
+                        "Skipping price fetch for listing {ListingId} provider {Provider}: last attempt failed at {UpdatedAt}.",
+                        listing.Id, symbol.Provider, symbol.UpdatedAt);
+                    continue;
+                }
 
-            if (quotes.Count > 0)
+                var rawCurrencyName = string.IsNullOrWhiteSpace(symbol.Currency) ? listing.TradingCurrency : symbol.Currency;
+                var rawCurrency = await currencyRepository.GetOrAdd(rawCurrencyName, rawCurrencyName, ct);
+
+                IReadOnlyList<Domain.FinancialAccounts.Investments.Entities.StockPrice> prices;
+                try
+                {
+                    prices = priceSource.SupportsProviderSelection
+                        ? await priceSource.GetDailySeries(symbol.Provider, symbol.Symbol, string.Empty, start, end, rawCurrency, ct)
+                        : await priceSource.GetDailySeries(symbol.Symbol, string.Empty, start, end, rawCurrency, ct);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    logger.LogWarning(ex, "Price fetch failed for listing {ListingId} provider {Provider} symbol {Symbol}",
+                        listing.Id, symbol.Provider, symbol.Symbol);
+                    await symbolRepository.RecordFetchResult(symbol.Id, null, ex.Message, ct);
+                    continue;
+                }
+
+                if (prices.Count == 0)
+                {
+                    await symbolRepository.RecordFetchResult(symbol.Id, null, "No price data returned", ct);
+                    continue;
+                }
+
+                var normalizedCurrencyName = NormalizedCurrencyName(rawCurrencyName, listing.PriceMultiplier);
+                var quotes = prices
+                    .Where(price => price.PricePerUnit > 0)
+                    .Select(price => new PriceQuote
+                    {
+                        AssetListingId = listing.Id,
+                        MarketDataSymbolId = symbol.Id,
+                        Provider = symbol.Provider,
+                        Price = price.PricePerUnit * listing.PriceMultiplier,
+                        Currency = normalizedCurrencyName,
+                        PriceTime = DayStart(price.Date),
+                        QuoteType = PriceQuoteType.EndOfDay,
+                        RawPrice = price.PricePerUnit,
+                        RawCurrency = rawCurrencyName,
+                        FetchedAt = DateTimeOffset.UtcNow
+                    })
+                    .ToList();
+
+                if (quotes.Count == 0)
+                    continue;
+
                 await priceQuoteRepository.UpsertRange(quotes, ct);
-
-            await symbolRepository.RecordFetchResult(symbol.Id, DateTimeOffset.UtcNow, null, ct);
+                await symbolRepository.RecordFetchResult(symbol.Id, DateTimeOffset.UtcNow, null, ct);
+                return;
+            }
         }
         finally
         {

--- a/code/FinanceManager.Application/Backfill/Currencies/CurrencyRateBackfillService.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/CurrencyRateBackfillService.cs
@@ -7,7 +7,7 @@ namespace FinanceManager.Application.Backfill.Currencies;
 
 /// <summary>
 /// Startup currency exchange-rate backfill. For each discovered pair it skips already-fresh pairs,
-/// calls Alpha Vantage <c>FX_DAILY</c> once for stale pairs, and inserts only the dates missing from
+/// calls the configured market-data fallback chain once for stale pairs, and inserts only the dates missing from
 /// the database. Provider calls are sequential (free-tier rate limits); a quota response stops the
 /// run early while every row inserted so far stays committed for the next startup to resume from.
 /// </summary>
@@ -68,7 +68,7 @@ public sealed class CurrencyRateBackfillService(
                 // rows remain committed and the next startup continues idempotently from here.
                 rateLimited = true;
                 logger.LogWarning(
-                    "Currency backfill hit the Alpha Vantage rate limit at pair {From}->{To}; stopping this run. " +
+                    "Currency backfill exhausted its provider quota at pair {From}->{To}; stopping this run. " +
                     "Inserted {Inserted} rows so far; remaining pairs resume on next start.",
                     pair.From, pair.To, inserted);
                 break;

--- a/code/FinanceManager.Application/Backfill/Currencies/FallbackFxDailySource.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/FallbackFxDailySource.cs
@@ -1,0 +1,28 @@
+namespace FinanceManager.Application.Backfill.Currencies;
+
+public sealed class FallbackFxDailySource(IReadOnlyList<IFxDailySource> sources) : IFxDailySource
+{
+    public string Name => "Fallback";
+    public int Priority => 0;
+
+    public async Task<FxDailyResult> GetDailyRatesAsync(
+        string fromCurrency,
+        string toCurrency,
+        CancellationToken cancellationToken = default)
+    {
+        var rateLimited = false;
+        var failed = false;
+        foreach (var source in sources.OrderBy(x => x.Priority))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var result = await source.GetDailyRatesAsync(fromCurrency, toCurrency, cancellationToken);
+            if (result.Status == FxDailyStatus.Ok)
+                return result;
+
+            rateLimited |= result.Status == FxDailyStatus.RateLimited;
+            failed |= result.Status == FxDailyStatus.Error;
+        }
+
+        return rateLimited ? FxDailyResult.RateLimited : failed ? FxDailyResult.Failed : FxDailyResult.Empty;
+    }
+}

--- a/code/FinanceManager.Application/Backfill/Currencies/IFxDailySource.cs
+++ b/code/FinanceManager.Application/Backfill/Currencies/IFxDailySource.cs
@@ -1,13 +1,16 @@
 namespace FinanceManager.Application.Backfill.Currencies;
 
 /// <summary>
-/// Fetches Alpha Vantage <c>FX_DAILY</c> series for a single currency pair. Separate from the
+/// Fetches a provider's daily series for a single currency pair. Separate from the
 /// generic exchange-rate providers because the startup backfill needs the whole date-keyed series
 /// in one call plus an explicit rate-limit signal, neither of which the per-date provider surface
 /// exposes.
 /// </summary>
 public interface IFxDailySource
 {
+    string Name => GetType().Name;
+    int Priority => int.MaxValue;
+
     /// <summary>
     /// One <c>FX_DAILY</c> request for <paramref name="fromCurrency"/> → <paramref name="toCurrency"/>.
     /// Never throws for provider-side failures; those come back as a non-<see cref="FxDailyStatus.Ok"/>

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Pricing/FallbackStockPriceSource.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Pricing/FallbackStockPriceSource.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Domain.Assets.Entities;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using Microsoft.Extensions.Logging;
@@ -14,12 +15,17 @@ public sealed class FallbackStockPriceSource(
     ILogger<FallbackStockPriceSource> logger) : IStockPriceSource
 {
     public string Name => "Fallback";
+    public int Priority => 0;
+    public bool SupportsProviderSelection => true;
+    public IReadOnlySet<AssetType> SupportedAssetTypes => sources.SelectMany(x => x.SupportedAssetTypes).ToHashSet();
+    public IReadOnlySet<string> SupportedIntervals => sources.SelectMany(x => x.SupportedIntervals).ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     public async Task<IReadOnlyList<StockPrice>> GetDailySeries(string symbol, string isin, DateTime start, DateTime end, Currency currency, CancellationToken ct = default)
     {
-        for (var i = 0; i < sources.Count; i++)
+        var ordered = sources.OrderBy(x => x.Priority).ToList();
+        for (var i = 0; i < ordered.Count; i++)
         {
-            var source = sources[i];
+            var source = ordered[i];
             ct.ThrowIfCancellationRequested();
 
             var prices = await source.GetDailySeries(symbol, isin, start, end, currency, ct);
@@ -35,6 +41,44 @@ public sealed class FallbackStockPriceSource(
 
         return [];
     }
+
+    public async Task<StockPrice?> GetLatestQuote(
+        string symbol,
+        string isin,
+        Currency currency,
+        CancellationToken ct = default)
+    {
+        foreach (var source in sources.OrderBy(x => x.Priority))
+        {
+            var quote = await source.GetLatestQuote(symbol, isin, currency, ct);
+            if (quote is not null)
+                return quote;
+        }
+
+        return null;
+    }
+
+    public Task<IReadOnlyList<StockPrice>> GetDailySeries(
+        MarketDataProvider provider,
+        string symbol,
+        string isin,
+        DateTime start,
+        DateTime end,
+        Currency currency,
+        CancellationToken ct = default)
+    {
+        var source = sources
+            .Where(x => x.Provider == provider)
+            .OrderBy(x => x.Priority)
+            .FirstOrDefault();
+
+        return source is null
+            ? Task.FromResult<IReadOnlyList<StockPrice>>([])
+            : source.GetDailySeries(symbol, isin, start, end, currency, ct);
+    }
+
+    public int GetPriority(MarketDataProvider provider) =>
+        sources.Where(x => x.Provider == provider).Select(x => x.Priority).DefaultIfEmpty(int.MaxValue).Min();
 
     // Strip CR/LF so an attacker-influenced symbol cannot forge log entries (log injection).
     private static string Sanitize(string value)

--- a/code/FinanceManager.Application/FinancialAccounts/Stock/Pricing/IStockPriceSource.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Stock/Pricing/IStockPriceSource.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Domain.Assets.Entities;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 
@@ -12,6 +13,11 @@ public interface IStockPriceSource
 {
     /// <summary>Short provider name used for logging and diagnostics (e.g. "AlphaVantage").</summary>
     string Name { get; }
+    MarketDataProvider? Provider => null;
+    int Priority => int.MaxValue;
+    IReadOnlySet<AssetType> SupportedAssetTypes => new HashSet<AssetType>();
+    IReadOnlySet<string> SupportedIntervals => new HashSet<string>();
+    bool SupportsProviderSelection => false;
 
     /// <summary>
     /// Fetches the daily close series for <paramref name="symbol"/> between
@@ -22,4 +28,27 @@ public interface IStockPriceSource
     /// <param name="symbol">The provider-recognised symbol (e.g. "AAPL", "CSPX.LON").</param>
     /// <param name="isin">ISIN to stamp on the returned prices; the canonical key downstream.</param>
     Task<IReadOnlyList<StockPrice>> GetDailySeries(string symbol, string isin, DateTime start, DateTime end, Currency currency, CancellationToken ct = default);
+
+    Task<IReadOnlyList<StockPrice>> GetDailySeries(
+        MarketDataProvider provider,
+        string symbol,
+        string isin,
+        DateTime start,
+        DateTime end,
+        Currency currency,
+        CancellationToken ct = default) =>
+        Provider == provider ? GetDailySeries(symbol, isin, start, end, currency, ct) : Task.FromResult<IReadOnlyList<StockPrice>>([]);
+
+    async Task<StockPrice?> GetLatestQuote(
+        string symbol,
+        string isin,
+        Currency currency,
+        CancellationToken ct = default)
+    {
+        var end = DateTime.UtcNow;
+        var prices = await GetDailySeries(symbol, isin, end.AddDays(-7), end, currency, ct);
+        return prices.MaxBy(x => x.Date);
+    }
+
+    int GetPriority(MarketDataProvider provider) => Provider == provider ? Priority : int.MaxValue;
 }

--- a/code/FinanceManager.Application/Shared/Options/TwelveDataOptions.cs
+++ b/code/FinanceManager.Application/Shared/Options/TwelveDataOptions.cs
@@ -1,0 +1,14 @@
+namespace FinanceManager.Application.Shared.Options;
+
+public sealed class TwelveDataOptions
+{
+    public const string SectionName = "TwelveData";
+
+    public string BaseUrl { get; set; } = "https://api.twelvedata.com";
+    public string ApiKey { get; set; } = string.Empty;
+    public bool Enabled { get; set; } = true;
+    public int Priority { get; set; } = 200;
+    public int PerMinuteCreditLimit { get; set; } = 8;
+    public int DailyCreditLimit { get; set; } = 800;
+    public int RequestTimeoutSeconds { get; set; } = 30;
+}

--- a/code/FinanceManager.Infrastructure/Features/Administration/Services/ExternalServiceConfigService.cs
+++ b/code/FinanceManager.Infrastructure/Features/Administration/Services/ExternalServiceConfigService.cs
@@ -12,7 +12,8 @@ internal sealed class ExternalServiceConfigService(
     IServiceScopeFactory scopeFactory,
     IOptions<StockApiOptions> stockApiDefaults,
     IOptions<OpenFigiOptions> openFigiDefaults,
-    IOptions<EodhdOptions> eodhdDefaults) : IExternalServiceConfigService
+    IOptions<EodhdOptions> eodhdDefaults,
+    IOptions<TwelveDataOptions> twelveDataDefaults) : IExternalServiceConfigService
 {
     private List<ExternalServiceConfiguration>? _cache;
     private readonly SemaphoreSlim _lock = new(1, 1);
@@ -88,6 +89,13 @@ internal sealed class ExternalServiceConfigService(
             BaseUrl = eodhdDefaults.Value.BaseUrl,
             ApiKey = eodhdDefaults.Value.ApiKey,
             IsEnabled = true,
+        },
+        "TwelveData" => new ExternalServiceConfiguration
+        {
+            ServiceName = "TwelveData",
+            BaseUrl = twelveDataDefaults.Value.BaseUrl,
+            ApiKey = twelveDataDefaults.Value.ApiKey,
+            IsEnabled = twelveDataDefaults.Value.Enabled,
         },
         _ => new ExternalServiceConfiguration { ServiceName = serviceName, IsEnabled = true },
     };

--- a/code/FinanceManager.Infrastructure/Features/Assets/Providers/AlphaVantageClient.cs
+++ b/code/FinanceManager.Infrastructure/Features/Assets/Providers/AlphaVantageClient.cs
@@ -1,6 +1,7 @@
 using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
 using FinanceManager.Application.Shared.ExternalServices;
 using FinanceManager.Application.Shared.Options;
+using FinanceManager.Domain.Assets.Entities;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
@@ -25,6 +26,8 @@ internal sealed class AlphaVantageClient(
     };
 
     public string Name => "AlphaVantage";
+    public MarketDataProvider? Provider => MarketDataProvider.AlphaVantage;
+    public int Priority => 100;
 
     public async Task<IReadOnlyList<TickerSearchMatch>> SearchTicker(string keywords, CancellationToken ct = default)
     {

--- a/code/FinanceManager.Infrastructure/Features/Assets/Providers/EodhdClient.cs
+++ b/code/FinanceManager.Infrastructure/Features/Assets/Providers/EodhdClient.cs
@@ -1,5 +1,6 @@
 using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
 using FinanceManager.Application.Shared.ExternalServices;
+using FinanceManager.Domain.Assets.Entities;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using Microsoft.Extensions.Logging;
@@ -25,6 +26,8 @@ internal sealed class EodhdClient(
     };
 
     public string Name => "Eodhd";
+    public MarketDataProvider? Provider => MarketDataProvider.Eodhd;
+    public int Priority => 300;
 
     public async Task<IReadOnlyList<StockPrice>> GetDailySeries(string symbol, string isin, DateTime start, DateTime end, Currency currency, CancellationToken ct = default)
     {

--- a/code/FinanceManager.Infrastructure/Features/Assets/Providers/TwelveDataClient.cs
+++ b/code/FinanceManager.Infrastructure/Features/Assets/Providers/TwelveDataClient.cs
@@ -1,0 +1,253 @@
+using FinanceManager.Application.Backfill.Currencies;
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Application.Shared.ExternalServices;
+using FinanceManager.Application.Shared.Options;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FinanceManager.Infrastructure.Features.Assets.Providers;
+
+internal sealed class TwelveDataClient(
+    HttpClient httpClient,
+    ILogger<TwelveDataClient> logger,
+    IOptions<TwelveDataOptions> options,
+    IExternalServiceConfigService configService,
+    TwelveDataCreditBudget budget) : IStockPriceSource, IFxDailySource
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
+    private static readonly IReadOnlySet<AssetType> _assetTypes = new HashSet<AssetType> { AssetType.Stock, AssetType.ETF };
+    private static readonly IReadOnlySet<string> _intervals = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "1day" };
+
+    public string Name => "TwelveData";
+    public MarketDataProvider? Provider => MarketDataProvider.TwelveData;
+    public int Priority => options.Value.Priority;
+    public IReadOnlySet<AssetType> SupportedAssetTypes => _assetTypes;
+    public IReadOnlySet<string> SupportedIntervals => _intervals;
+
+    public async Task<IReadOnlyList<StockPrice>> GetDailySeries(
+        string symbol,
+        string isin,
+        DateTime start,
+        DateTime end,
+        Currency currency,
+        CancellationToken ct = default)
+    {
+        var response = await GetTimeSeriesAsync(ToProviderSymbol(symbol), start, end, ct);
+        if (response.Status != RequestStatus.Ok || response.Body?.Values is null)
+            return [];
+
+        var prices = response.Body.Values
+            .Select(x => TryMapPrice(x, isin, currency))
+            .Where(x => x is not null && x.Date >= start.Date && x.Date <= end.Date)
+            .Cast<StockPrice>()
+            .ToList();
+
+        logger.LogInformation(
+            "Twelve Data returned {Returned} daily records for {Symbol} over {Start:yyyy-MM-dd}..{End:yyyy-MM-dd}.",
+            prices.Count, Sanitize(symbol), start, end);
+        return prices;
+    }
+
+    public async Task<StockPrice?> GetLatestQuote(
+        string symbol,
+        string isin,
+        Currency currency,
+        CancellationToken ct = default)
+    {
+        var providerSymbol = ToProviderSymbol(symbol);
+        var response = await SendAsync($"quote?{providerSymbol}&interval=1day", ct);
+        if (response.Status != RequestStatus.Ok)
+            return null;
+
+        var quote = JsonSerializer.Deserialize<TwelveDataQuoteResponse>(response.Content, _jsonOptions);
+        var close = ParseDecimal(quote?.Close);
+        if (!TryParseDate(quote?.Datetime, out var date) || close <= 0)
+            return null;
+
+        return new StockPrice { Isin = isin, Currency = currency, Date = date, PricePerUnit = close };
+    }
+
+    public async Task<FxDailyResult> GetDailyRatesAsync(
+        string fromCurrency,
+        string toCurrency,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(fromCurrency) || string.IsNullOrWhiteSpace(toCurrency))
+            return FxDailyResult.Empty;
+
+        var end = DateTime.UtcNow.Date;
+        var response = await GetTimeSeriesAsync(
+            $"symbol={Uri.EscapeDataString($"{fromCurrency}/{toCurrency}")}",
+            end.AddDays(-30),
+            end,
+            cancellationToken);
+
+        if (response.Status == RequestStatus.RateLimited)
+            return FxDailyResult.RateLimited;
+        if (response.Status == RequestStatus.Error)
+            return FxDailyResult.Failed;
+        if (response.Body?.Values is null)
+            return FxDailyResult.Empty;
+
+        var points = response.Body.Values
+            .Select(x => (Date: ParseDate(x.Datetime), Close: ParseDecimal(x.Close)))
+            .Where(x => x.Date is not null && x.Close > 0)
+            .ToDictionary(x => x.Date!.Value, x => x.Close);
+        return points.Count == 0 ? FxDailyResult.Empty : FxDailyResult.Success(points);
+    }
+
+    private async Task<TimeSeriesResult> GetTimeSeriesAsync(
+        string providerSymbol,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct)
+    {
+        var response = await SendAsync(
+            $"time_series?{providerSymbol}&interval=1day&start_date={start:yyyy-MM-dd}&end_date={end:yyyy-MM-dd}&outputsize=5000&order=ASC",
+            ct);
+        if (response.Status != RequestStatus.Ok)
+            return new(response.Status, null);
+
+        var body = JsonSerializer.Deserialize<TwelveDataTimeSeriesResponse>(response.Content, _jsonOptions);
+        if (string.Equals(body?.Status, "error", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogWarning("Twelve Data rejected {Symbol}: {Message}", Sanitize(providerSymbol), Sanitize(body?.Message ?? "unknown error"));
+            return new(RequestStatus.Error, body);
+        }
+
+        return new(RequestStatus.Ok, body);
+    }
+
+    private async Task<HttpResult> SendAsync(string pathAndQuery, CancellationToken ct)
+    {
+        var config = await configService.GetServiceAsync("TwelveData", ct);
+        if (!options.Value.Enabled || !config.IsEnabled || string.IsNullOrWhiteSpace(config.ApiKey))
+        {
+            logger.LogWarning("Twelve Data is disabled or its API key is missing.");
+            return new(RequestStatus.Error, string.Empty);
+        }
+
+        if (!budget.TryConsume())
+        {
+            logger.LogWarning("Twelve Data configured credit budget is exhausted; deferring request.");
+            return new(RequestStatus.RateLimited, string.Empty);
+        }
+
+        var url = $"{config.BaseUrl.TrimEnd('/')}/{pathAndQuery}";
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Authorization = new AuthenticationHeaderValue("apikey", config.ApiKey);
+            using var response = await httpClient.SendAsync(request, ct);
+            var content = await response.Content.ReadAsStringAsync(ct);
+            var creditsUsed = response.Headers.TryGetValues("api-credits-used", out var used) ? used.FirstOrDefault() : null;
+            var creditsLeft = response.Headers.TryGetValues("api-credits-left", out var left) ? left.FirstOrDefault() : null;
+            logger.LogDebug("Twelve Data request consumed credits; provider reports used {Used}, left {Left}.", creditsUsed, creditsLeft);
+
+            if (response.StatusCode == HttpStatusCode.TooManyRequests)
+                return new(RequestStatus.RateLimited, content);
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogWarning("Twelve Data request failed with status {StatusCode}.", response.StatusCode);
+                return new(RequestStatus.Error, content);
+            }
+
+            var error = JsonSerializer.Deserialize<TwelveDataErrorResponse>(content, _jsonOptions);
+            if (string.Equals(error?.Status, "error", StringComparison.OrdinalIgnoreCase))
+            {
+                var errorMessage = error?.Message;
+                var status = error?.Code == 429
+                    || errorMessage?.Contains("rate limit", StringComparison.OrdinalIgnoreCase) == true
+                    || errorMessage?.Contains("credits", StringComparison.OrdinalIgnoreCase) == true
+                    ? RequestStatus.RateLimited
+                    : RequestStatus.Error;
+                logger.LogWarning("Twelve Data rejected a request: {Message}", Sanitize(errorMessage ?? "unknown error"));
+                return new(status, content);
+            }
+
+            return new(RequestStatus.Ok, content);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Twelve Data request failed.");
+            return new(RequestStatus.Error, string.Empty);
+        }
+    }
+
+    private static string ToProviderSymbol(string symbol)
+    {
+        var parts = symbol.Trim().Split(':', 2, StringSplitOptions.TrimEntries);
+        var query = $"symbol={Uri.EscapeDataString(parts[0])}";
+        return parts.Length == 2 ? $"{query}&exchange={Uri.EscapeDataString(parts[1])}" : query;
+    }
+
+    private static StockPrice? TryMapPrice(TwelveDataValue value, string isin, Currency currency)
+    {
+        if (!TryParseDate(value.Datetime, out var date)) return null;
+        var close = ParseDecimal(value.Close);
+        return close <= 0 ? null : new StockPrice { Isin = isin, Currency = currency, Date = date, PricePerUnit = close };
+    }
+
+    private static DateTime? ParseDate(string? value) => TryParseDate(value, out var date) ? date : null;
+
+    private static bool TryParseDate(string? value, out DateTime date)
+    {
+        var ok = DateTime.TryParseExact(
+            value,
+            ["yyyy-MM-dd", "yyyy-MM-dd HH:mm:ss"],
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal,
+            out var parsed);
+        date = DateTime.SpecifyKind(parsed.Date, DateTimeKind.Utc);
+        return ok;
+    }
+
+    private static decimal ParseDecimal(string? value) =>
+        decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed) ? parsed : 0m;
+
+    private static string Sanitize(string value) => value.Replace("\r", string.Empty).Replace("\n", string.Empty);
+
+    private enum RequestStatus { Ok, RateLimited, Error }
+    private readonly record struct HttpResult(RequestStatus Status, string Content);
+    private readonly record struct TimeSeriesResult(RequestStatus Status, TwelveDataTimeSeriesResponse? Body);
+
+    private sealed class TwelveDataTimeSeriesResponse
+    {
+        public string? Status { get; set; }
+        public string? Message { get; set; }
+        public List<TwelveDataValue>? Values { get; set; }
+    }
+
+    private sealed class TwelveDataValue
+    {
+        public string? Datetime { get; set; }
+        public string? Close { get; set; }
+    }
+
+    private sealed class TwelveDataQuoteResponse
+    {
+        [JsonPropertyName("datetime")]
+        public string? Datetime { get; set; }
+        [JsonPropertyName("close")]
+        public string? Close { get; set; }
+    }
+
+    private sealed class TwelveDataErrorResponse
+    {
+        public int Code { get; set; }
+        public string? Message { get; set; }
+        public string? Status { get; set; }
+    }
+}

--- a/code/FinanceManager.Infrastructure/Features/Assets/Providers/TwelveDataClient.cs
+++ b/code/FinanceManager.Infrastructure/Features/Assets/Providers/TwelveDataClient.cs
@@ -67,7 +67,17 @@ internal sealed class TwelveDataClient(
         if (response.Status != RequestStatus.Ok)
             return null;
 
-        var quote = JsonSerializer.Deserialize<TwelveDataQuoteResponse>(response.Content, _jsonOptions);
+        TwelveDataQuoteResponse? quote;
+        try
+        {
+            quote = JsonSerializer.Deserialize<TwelveDataQuoteResponse>(response.Content, _jsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Twelve Data returned unparseable quote content for {Symbol}.", Sanitize(providerSymbol));
+            return null;
+        }
+
         var close = ParseDecimal(quote?.Close);
         if (!TryParseDate(quote?.Datetime, out var date) || close <= 0)
             return null;
@@ -116,7 +126,17 @@ internal sealed class TwelveDataClient(
         if (response.Status != RequestStatus.Ok)
             return new(response.Status, null);
 
-        var body = JsonSerializer.Deserialize<TwelveDataTimeSeriesResponse>(response.Content, _jsonOptions);
+        TwelveDataTimeSeriesResponse? body;
+        try
+        {
+            body = JsonSerializer.Deserialize<TwelveDataTimeSeriesResponse>(response.Content, _jsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Twelve Data returned unparseable time series content for {Symbol}.", Sanitize(providerSymbol));
+            return new(RequestStatus.Error, null);
+        }
+
         if (string.Equals(body?.Status, "error", StringComparison.OrdinalIgnoreCase))
         {
             logger.LogWarning("Twelve Data rejected {Symbol}: {Message}", Sanitize(providerSymbol), Sanitize(body?.Message ?? "unknown error"));

--- a/code/FinanceManager.Infrastructure/Features/Assets/Providers/TwelveDataCreditBudget.cs
+++ b/code/FinanceManager.Infrastructure/Features/Assets/Providers/TwelveDataCreditBudget.cs
@@ -1,0 +1,38 @@
+using FinanceManager.Application.Shared.Options;
+using Microsoft.Extensions.Options;
+
+namespace FinanceManager.Infrastructure.Features.Assets.Providers;
+
+internal sealed class TwelveDataCreditBudget(IOptions<TwelveDataOptions> options)
+{
+    private readonly Lock _lock = new();
+    private readonly Queue<DateTimeOffset> _minuteCredits = new();
+    private DateOnly _day = DateOnly.FromDateTime(DateTime.UtcNow);
+    private int _dailyCredits;
+
+    public bool TryConsume() => TryConsume(DateTimeOffset.UtcNow);
+
+    internal bool TryConsume(DateTimeOffset now)
+    {
+        lock (_lock)
+        {
+            var today = DateOnly.FromDateTime(now.UtcDateTime);
+            if (_day != today)
+            {
+                _day = today;
+                _dailyCredits = 0;
+            }
+
+            while (_minuteCredits.TryPeek(out var usedAt) && now - usedAt >= TimeSpan.FromMinutes(1))
+                _minuteCredits.Dequeue();
+
+            var limits = options.Value;
+            if (_dailyCredits >= limits.DailyCreditLimit || _minuteCredits.Count >= limits.PerMinuteCreditLimit)
+                return false;
+
+            _dailyCredits++;
+            _minuteCredits.Enqueue(now);
+            return true;
+        }
+    }
+}

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Providers/AlphaVantageFxClient.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Providers/AlphaVantageFxClient.cs
@@ -24,6 +24,9 @@ internal sealed class AlphaVantageFxClient(
         PropertyNameCaseInsensitive = true
     };
 
+    public string Name => "AlphaVantage";
+    public int Priority => 100;
+
     public async Task<FxDailyResult> GetDailyRatesAsync(string fromCurrency, string toCurrency, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(fromCurrency) || string.IsNullOrWhiteSpace(toCurrency))

--- a/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
@@ -5,6 +5,7 @@ using FinanceManager.Application.Insights.Generation;
 using FinanceManager.Application.Labels.Setter;
 using FinanceManager.Application.Labels.Suggestions;
 using FinanceManager.Application.Shared.ExternalServices;
+using FinanceManager.Application.Shared.Options;
 using FinanceManager.Domain.Administration.Logging;
 using FinanceManager.Domain.Administration.Monitoring;
 using FinanceManager.Domain.Assets.Repositories;
@@ -50,6 +51,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace FinanceManager.Infrastructure;
 
@@ -60,12 +62,14 @@ public static class ServiceCollectionExtension
         services.AddSingleton<IExternalServiceConfigService, ExternalServiceConfigService>();
         services.AddHttpClient<IAlphaVantageClient, AlphaVantageClient>();
         services.AddHttpClient<EodhdClient>();
-        // Daily-price fetches go through a fallback chain: Alpha Vantage first, then EODHD when the
-        // primary is rate-limited, unentitled, or has no data. AlphaVantageClient also implements
-        // IStockPriceSource, so reuse the same singleton-per-scope instance the typed client resolves.
+        services.AddSingleton<TwelveDataCreditBudget>();
+        services.AddHttpClient<TwelveDataClient>((sp, client) =>
+            client.Timeout = TimeSpan.FromSeconds(sp.GetRequiredService<IOptions<TwelveDataOptions>>().Value.RequestTimeoutSeconds));
+        // Daily-price fetches use each provider's configured priority and provider-specific symbol.
         services.AddScoped<IStockPriceSource>(sp => new FallbackStockPriceSource(
             [
                 (IStockPriceSource)sp.GetRequiredService<IAlphaVantageClient>(),
+                sp.GetRequiredService<TwelveDataClient>(),
                 sp.GetRequiredService<EodhdClient>()
             ],
             sp.GetRequiredService<ILogger<FallbackStockPriceSource>>()));
@@ -79,7 +83,12 @@ public static class ServiceCollectionExtension
         services.AddHttpClient<ICurrencyExchangeRateProvider, EcbCurrencyExchangeRateProvider>(client =>
             client.Timeout = TimeSpan.FromSeconds(15));
         services.AddHttpClient<ICurrencyExchangeRateProvider, FawazAhmedCurrencyApiClient>();
-        services.AddHttpClient<IFxDailySource, AlphaVantageFxClient>();
+        services.AddHttpClient<AlphaVantageFxClient>();
+        services.AddScoped<IFxDailySource>(sp => new FallbackFxDailySource(
+        [
+            sp.GetRequiredService<AlphaVantageFxClient>(),
+            sp.GetRequiredService<TwelveDataClient>()
+        ]));
         services.AddHttpClient<IInflationIndexProvider, EurostatInflationIndexProvider>(client =>
             client.BaseAddress = new Uri("https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/"));
 

--- a/code/FinanceManager.Tests.Integration/Features/Assets/TwelveDataRegistrationTests.cs
+++ b/code/FinanceManager.Tests.Integration/Features/Assets/TwelveDataRegistrationTests.cs
@@ -1,0 +1,85 @@
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Application.Shared.ExternalServices;
+using FinanceManager.Application.Shared.Options;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.Shared.ExternalServices.Entities;
+using FinanceManager.Infrastructure;
+using FinanceManager.Infrastructure.Features.Assets.Providers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Features.Assets;
+
+[Trait("Category", "Integration")]
+public class TwelveDataRegistrationTests
+{
+    [Fact]
+    public async Task ProviderChain_ResolvesTwelveDataAndUsesMockedHttpResponse()
+    {
+        var handler = new MockHttpMessageHandler("""
+            {
+              "values": [{ "datetime": "2024-01-15", "close": "188.25" }],
+              "status": "ok"
+            }
+            """);
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddOptions();
+        services.Configure<TwelveDataOptions>(_ => { });
+        services.AddInfrastructureApi();
+        services.RemoveAll<IExternalServiceConfigService>();
+        services.AddSingleton<IExternalServiceConfigService>(new StubConfigService());
+        services.AddHttpClient<TwelveDataClient>().ConfigurePrimaryHttpMessageHandler(() => handler);
+
+        await using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var source = scope.ServiceProvider.GetRequiredService<TwelveDataClient>();
+        var chain = scope.ServiceProvider.GetRequiredService<IStockPriceSource>();
+
+        Assert.True(chain.SupportsProviderSelection);
+        Assert.Equal(200, chain.GetPriority(MarketDataProvider.TwelveData));
+
+        var result = await source.GetDailySeries(
+            "AAPL",
+            "US0378331005",
+            new DateTime(2024, 1, 1),
+            new DateTime(2024, 1, 31),
+            new Currency(1, "USD", "$"),
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(handler.LastRequestUri);
+        Assert.Equal(188.25m, Assert.Single(result).PricePerUnit);
+    }
+
+    private sealed class StubConfigService : IExternalServiceConfigService
+    {
+        private static readonly ExternalServiceConfiguration _config = new()
+        {
+            ServiceName = "TwelveData",
+            BaseUrl = "https://api.twelvedata.com",
+            ApiKey = "test-key",
+            IsEnabled = true
+        };
+
+        public ValueTask<ExternalServiceConfiguration> GetServiceAsync(string serviceName, CancellationToken ct = default) =>
+            ValueTask.FromResult(_config);
+
+        public ValueTask<IReadOnlyList<ExternalServiceConfiguration>> GetAllServicesAsync(CancellationToken ct = default) =>
+            ValueTask.FromResult<IReadOnlyList<ExternalServiceConfiguration>>([_config]);
+
+        public Task SaveServiceAsync(ExternalServiceConfiguration config, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class MockHttpMessageHandler(string response) : HttpMessageHandler
+    {
+        public Uri? LastRequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK) { Content = new StringContent(response) });
+        }
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Backfill/FallbackFxDailySourceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Backfill/FallbackFxDailySourceTests.cs
@@ -1,0 +1,40 @@
+using FinanceManager.Application.Backfill.Currencies;
+
+namespace FinanceManager.Tests.Unit.Application.Backfill;
+
+[Trait("Category", "Unit")]
+public class FallbackFxDailySourceTests
+{
+    [Fact]
+    public async Task UsesConfiguredPriorityAndFallsBack()
+    {
+        var secondary = new FakeSource("Secondary", 200, FxDailyResult.Success(new Dictionary<DateTime, decimal>
+        {
+            [new DateTime(2024, 1, 1)] = 1.1m
+        }));
+        var primary = new FakeSource("Primary", 100, FxDailyResult.Empty);
+        var source = new FallbackFxDailySource([secondary, primary]);
+
+        var result = await source.GetDailyRatesAsync("EUR", "USD", TestContext.Current.CancellationToken);
+
+        Assert.Equal(FxDailyStatus.Ok, result.Status);
+        Assert.Equal(1, primary.CallCount);
+        Assert.Equal(1, secondary.CallCount);
+    }
+
+    private sealed class FakeSource(string name, int priority, FxDailyResult result) : IFxDailySource
+    {
+        public string Name => name;
+        public int Priority => priority;
+        public int CallCount { get; private set; }
+
+        public Task<FxDailyResult> GetDailyRatesAsync(
+            string fromCurrency,
+            string toCurrency,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceProviderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Assets/InvestmentPriceProviderTests.cs
@@ -117,6 +117,52 @@ public class InvestmentPriceProviderTests
     }
 
     [Fact]
+    public async Task GetPricePerUnit_UsesProviderPriorityAndFallsBackToItsOwnSymbol()
+    {
+        var asOf = new DateTime(2024, 6, 3);
+        var listing = Listing();
+        listing.MarketDataSymbols.Add(new MarketDataSymbol
+        {
+            Id = 200,
+            AssetListingId = 10,
+            Provider = MarketDataProvider.TwelveData,
+            Symbol = "CSPX:LSE",
+            IsEnabled = true
+        });
+        _listingRepository.Setup(x => x.Get(10, It.IsAny<CancellationToken>())).ReturnsAsync(listing);
+        _priceSource.SetupGet(x => x.SupportsProviderSelection).Returns(true);
+        _priceSource.Setup(x => x.GetPriority(MarketDataProvider.TwelveData)).Returns(50);
+        _priceSource.Setup(x => x.GetPriority(MarketDataProvider.AlphaVantage)).Returns(100);
+        _priceSource
+            .Setup(x => x.GetDailySeries(
+                MarketDataProvider.TwelveData,
+                "CSPX:LSE",
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<Currency>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _priceSource
+            .Setup(x => x.GetDailySeries(
+                MarketDataProvider.AlphaVantage,
+                "CSPX.LON",
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<Currency>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([Price(200m, asOf)]);
+
+        var result = await CreateSut().GetPricePerUnitAsync(10, _usd, asOf, TestContext.Current.CancellationToken);
+
+        Assert.Equal(200m, result);
+        var stored = Assert.Single(_priceQuoteRepository.All);
+        Assert.Equal(MarketDataProvider.AlphaVantage, stored.Provider);
+        Assert.Equal(100, stored.MarketDataSymbolId);
+    }
+
+    [Fact]
     public async Task GetPricePerUnit_NormalisesGbxWithMultiplier_AndConvertsToTarget()
     {
         var asOf = new DateTime(2024, 6, 3);

--- a/code/FinanceManager.Tests.Unit/Application/Services/Stocks/FallbackStockPriceSourceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Stocks/FallbackStockPriceSourceTests.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Domain.Assets.Entities;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using Microsoft.Extensions.Logging;
@@ -59,6 +60,32 @@ public class FallbackStockPriceSourceTests
         Assert.Equal(1, fallback.CallCount);
     }
 
+    [Fact]
+    public async Task UsesPriorityAndOnlyCallsProviderMatchingTheSymbol()
+    {
+        var twelveData = new FakeSource(
+            "TwelveData", [Price(200m)], MarketDataProvider.TwelveData, priority: 50);
+        var alphaVantage = new FakeSource(
+            "AlphaVantage", [Price(100m)], MarketDataProvider.AlphaVantage, priority: 100);
+        var sut = Create(alphaVantage, twelveData);
+
+        var prioritized = await sut.GetDailySeries(
+            "AAPL", "US0378331005", _start, _end, _usd, TestContext.Current.CancellationToken);
+        var providerSpecific = await sut.GetDailySeries(
+            MarketDataProvider.AlphaVantage,
+            "AAPL",
+            "US0378331005",
+            _start,
+            _end,
+            _usd,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(200m, Assert.Single(prioritized).PricePerUnit);
+        Assert.Equal(100m, Assert.Single(providerSpecific).PricePerUnit);
+        Assert.Equal(1, alphaVantage.CallCount);
+        Assert.Equal(1, twelveData.CallCount);
+    }
+
     private static StockPrice Price(decimal value) => new()
     {
         Isin = "US0378331005",
@@ -67,9 +94,15 @@ public class FallbackStockPriceSourceTests
         Date = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc)
     };
 
-    private sealed class FakeSource(string name, IReadOnlyList<StockPrice> result) : IStockPriceSource
+    private sealed class FakeSource(
+        string name,
+        IReadOnlyList<StockPrice> result,
+        MarketDataProvider? provider = null,
+        int priority = int.MaxValue) : IStockPriceSource
     {
         public string Name => name;
+        public MarketDataProvider? Provider => provider;
+        public int Priority => priority;
         public int CallCount { get; private set; }
 
         public Task<IReadOnlyList<StockPrice>> GetDailySeries(string symbol, string isin, DateTime start, DateTime end, Currency currency, CancellationToken ct = default)

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Features/Assets/Providers/TwelveDataClientTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Features/Assets/Providers/TwelveDataClientTests.cs
@@ -1,0 +1,143 @@
+using FinanceManager.Application.Shared.ExternalServices;
+using FinanceManager.Application.Shared.Options;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.Shared.ExternalServices.Entities;
+using FinanceManager.Infrastructure.Features.Assets.Providers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System.Net;
+
+namespace FinanceManager.Tests.Unit.Infrastructure.Features.Assets.Providers;
+
+[Trait("Category", "Unit")]
+public class TwelveDataClientTests
+{
+    private static readonly Currency _usd = new(1, "USD", "$");
+    private static readonly DateTime _start = new(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime _end = new(2024, 1, 31, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task GetDailySeries_MapsDailyPricesAndExchange()
+    {
+        var handler = new MockHttpMessageHandler("""
+            {
+              "meta": { "type": "ETF" },
+              "values": [
+                { "datetime": "2024-01-02", "close": "95.50" },
+                { "datetime": "2024-02-01", "close": "99.00" }
+              ],
+              "status": "ok"
+            }
+            """);
+        var client = CreateClient(handler);
+
+        var result = await client.GetDailySeries(
+            "CSPX:LSE", "IE00B5BMR087", _start, _end, _usd, TestContext.Current.CancellationToken);
+
+        var price = Assert.Single(result);
+        Assert.Equal(95.50m, price.PricePerUnit);
+        Assert.Equal("IE00B5BMR087", price.Isin);
+        Assert.Contains("symbol=CSPX", handler.LastRequestUri!.Query);
+        Assert.Contains("exchange=LSE", handler.LastRequestUri.Query);
+        Assert.Contains("interval=1day", handler.LastRequestUri.Query);
+        Assert.Equal("apikey test-key", handler.LastAuthorization);
+        Assert.DoesNotContain("test-key", handler.LastRequestUri.Query);
+        Assert.Contains(AssetType.ETF, client.SupportedAssetTypes);
+        Assert.Contains("1day", client.SupportedIntervals);
+    }
+
+    [Fact]
+    public async Task GetLatestQuote_MapsQuote()
+    {
+        var client = CreateClient(new MockHttpMessageHandler(
+            """{ "symbol": "AAPL", "datetime": "2024-01-15", "close": "188.25" }"""));
+
+        var result = await client.GetLatestQuote(
+            "AAPL", "US0378331005", _usd, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(188.25m, result.PricePerUnit);
+        Assert.Equal(new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc), result.Date);
+    }
+
+    [Fact]
+    public async Task GetDailyRatesAsync_MapsForexPair()
+    {
+        var handler = new MockHttpMessageHandler("""
+            {
+              "values": [{ "datetime": "2024-01-15", "close": "1.095" }],
+              "status": "ok"
+            }
+            """);
+        var client = CreateClient(handler);
+
+        var result = await client.GetDailyRatesAsync("EUR", "USD", TestContext.Current.CancellationToken);
+
+        Assert.Equal(1.095m, Assert.Single(result.Points).Value);
+        Assert.Contains("symbol=EUR%2FUSD", handler.LastRequestUri!.Query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetDailyRatesAsync_ReturnsRateLimitedFor429()
+    {
+        var client = CreateClient(new MockHttpMessageHandler("{}", HttpStatusCode.TooManyRequests));
+
+        var result = await client.GetDailyRatesAsync("EUR", "USD", TestContext.Current.CancellationToken);
+
+        Assert.Equal(FinanceManager.Application.Backfill.Currencies.FxDailyStatus.RateLimited, result.Status);
+    }
+
+    [Fact]
+    public async Task GetDailyRatesAsync_ReturnsRateLimitedForApiErrorBody()
+    {
+        var client = CreateClient(new MockHttpMessageHandler(
+            """{ "code": 429, "message": "API credits limit reached", "status": "error" }"""));
+
+        var result = await client.GetDailyRatesAsync("EUR", "USD", TestContext.Current.CancellationToken);
+
+        Assert.Equal(FinanceManager.Application.Backfill.Currencies.FxDailyStatus.RateLimited, result.Status);
+    }
+
+    private static TwelveDataClient CreateClient(MockHttpMessageHandler handler)
+    {
+        var options = Options.Create(new TwelveDataOptions());
+        var config = new ExternalServiceConfiguration
+        {
+            ServiceName = "TwelveData",
+            BaseUrl = "https://api.twelvedata.com",
+            ApiKey = "test-key",
+            IsEnabled = true
+        };
+        return new TwelveDataClient(
+            new HttpClient(handler),
+            NullLogger<TwelveDataClient>.Instance,
+            options,
+            new StubConfigService(config),
+            new TwelveDataCreditBudget(options));
+    }
+
+    private sealed class StubConfigService(ExternalServiceConfiguration config) : IExternalServiceConfigService
+    {
+        public ValueTask<ExternalServiceConfiguration> GetServiceAsync(string serviceName, CancellationToken ct = default) =>
+            ValueTask.FromResult(config);
+
+        public ValueTask<IReadOnlyList<ExternalServiceConfiguration>> GetAllServicesAsync(CancellationToken ct = default) =>
+            ValueTask.FromResult<IReadOnlyList<ExternalServiceConfiguration>>([config]);
+
+        public Task SaveServiceAsync(ExternalServiceConfiguration config, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class MockHttpMessageHandler(string response, HttpStatusCode statusCode = HttpStatusCode.OK) : HttpMessageHandler
+    {
+        public Uri? LastRequestUri { get; private set; }
+        public string? LastAuthorization { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri;
+            LastAuthorization = request.Headers.Authorization?.ToString();
+            return Task.FromResult(new HttpResponseMessage(statusCode) { Content = new StringContent(response) });
+        }
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Features/Assets/Providers/TwelveDataClientTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Features/Assets/Providers/TwelveDataClientTests.cs
@@ -62,6 +62,28 @@ public class TwelveDataClientTests
     }
 
     [Fact]
+    public async Task GetLatestQuote_ReturnsNullForInvalidResponseShape()
+    {
+        var client = CreateClient(new MockHttpMessageHandler("""{ "close": {} }"""));
+
+        var result = await client.GetLatestQuote(
+            "AAPL", "US0378331005", _usd, TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetDailySeries_ReturnsEmptyForInvalidResponseShape()
+    {
+        var client = CreateClient(new MockHttpMessageHandler("""{ "values": {} }"""));
+
+        var result = await client.GetDailySeries(
+            "AAPL", "US0378331005", _start, _end, _usd, TestContext.Current.CancellationToken);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
     public async Task GetDailyRatesAsync_MapsForexPair()
     {
         var handler = new MockHttpMessageHandler("""

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Features/Assets/Providers/TwelveDataCreditBudgetTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Features/Assets/Providers/TwelveDataCreditBudgetTests.cs
@@ -1,0 +1,27 @@
+using FinanceManager.Application.Shared.Options;
+using FinanceManager.Infrastructure.Features.Assets.Providers;
+using Microsoft.Extensions.Options;
+
+namespace FinanceManager.Tests.Unit.Infrastructure.Features.Assets.Providers;
+
+[Trait("Category", "Unit")]
+public class TwelveDataCreditBudgetTests
+{
+    [Fact]
+    public void EnforcesMinuteAndDailyLimitsAndResetsAtUtcBoundaries()
+    {
+        var budget = new TwelveDataCreditBudget(Options.Create(new TwelveDataOptions
+        {
+            PerMinuteCreditLimit = 2,
+            DailyCreditLimit = 3
+        }));
+        var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+        Assert.True(budget.TryConsume(now));
+        Assert.True(budget.TryConsume(now));
+        Assert.False(budget.TryConsume(now));
+        Assert.True(budget.TryConsume(now.AddMinutes(1)));
+        Assert.False(budget.TryConsume(now.AddMinutes(2)));
+        Assert.True(budget.TryConsume(now.AddDays(1)));
+    }
+}


### PR DESCRIPTION
## Summary

- add Twelve Data daily stock, ETF, latest quote, and forex retrieval
- select providers deterministically using configured priority and provider-specific symbols
- enforce shared per-minute and daily credit budgets with explicit rate-limit handling
- retain Alpha Vantage and EODHD as fallbacks

## Impact

Twelve Data can now supplement or replace Alpha Vantage in price and currency backfills without duplicating stored observations. The API key is sent in the authorization header and remains outside committed configuration.

## Validation

- `dotnet format ./code/FinanceManager.slnx`
- `dotnet build ./code/FinanceManager.slnx`
- 792 unit tests passed
- 9 architecture tests passed
- 4 focused integration tests passed

Closes #643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Twelve Data as a market-data provider for stock prices, quotes, and currency rates.
  * Added configurable provider priorities and automatic fallback when a source is unavailable or returns no data.
  * Added credit-limit and request-timeout configuration for Twelve Data.
  * Improved price and currency backfills with prioritized multi-provider sourcing.

* **Bug Fixes**
  * Added validation for required provider settings and usage limits during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->