### PR TITLE
Unify investment search and atomic transaction import (#651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Investment transactions now search existing and external instruments together and add external master data only when the transaction saves successfully. #651
 - Twelve Data can now supply daily stock and ETF prices, latest quotes, and daily forex rates through the existing market-data fallback flows. Provider priority, timeout, enabled state, and per-minute/daily credit budgets are configurable under `TwelveData`; provider-specific symbols stay on instrument listings, existing observations remain idempotently skipped, and Alpha Vantage remains available as an alternative. #643
 - Currency exchange rates can now be sourced from two official, free providers alongside the existing ones: **NBP** (Narodowy Bank Polski) for PLN pairs and the **ECB** (European Central Bank) Data Portal for EUR pairs, with automatic cross rates between two currencies both quoted against EUR. They are consulted ahead of the general currency API and fall back cleanly, treating non-trading days as "no rate" rather than errors; each can be turned off via the `Nbp` / `Ecb` configuration sections. #642
 - A new **Subscriptions** inbox turns recurring charges into a managed list with stable identities, weekly through annual cadence detection, next expected charge dates, monthly and annual cost equivalents, price-increase warnings, and persisted mute, cancellation, and review flags. #306

--- a/code/FinanceManager.Api/Features/FinancialAccounts/Investments/Controllers/InvestmentTransactionController.cs
+++ b/code/FinanceManager.Api/Features/FinancialAccounts/Investments/Controllers/InvestmentTransactionController.cs
@@ -1,4 +1,7 @@
 using FinanceManager.Api.Shared.Helpers;
+using FinanceManager.Application.FinancialAccounts.Investments.Discovery;
+using FinanceManager.Application.FinancialAccounts.Investments.Transactions;
+using FinanceManager.Domain.Assets.Discovery;
 using FinanceManager.Domain.Assets.Dtos;
 using FinanceManager.Domain.Assets.Repositories;
 using FinanceManager.Domain.Assets.Services;
@@ -21,8 +24,10 @@ namespace FinanceManager.Api.Features.FinancialAccounts.Investments.Controllers;
 public class InvestmentTransactionController(
     IAccountRepository<InvestmentAccount> accountRepository,
     IInvestmentTransactionRepository transactionRepository,
+    IInvestmentTransactionService transactionService,
     ICacheInvalidator dashboardCacheInvalidator,
     IAssetListingRepository assetListingRepository,
+    IInvestmentInstrumentSearchService instrumentSearchService,
     IInvestmentPriceProvider priceProvider,
     ILogger<InvestmentTransactionController> logger) : ControllerBase
 {
@@ -108,16 +113,23 @@ public class InvestmentTransactionController(
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     public async Task<IActionResult> Add(AddInvestmentTransactionRequest request, CancellationToken cancellationToken = default)
     {
-        if (!IsValid(request.AssetListingId, request.Quantity, request.UnitPrice, request.Currency, request.TradeDate))
-            return BadRequest("Invalid input parameters.");
-
         var account = await accountRepository.Get(request.AccountId);
         if (account is null) return NotFound();
         if (!ApiAuthenticationHelper.IsAccountOwner(User, account.UserId)) return Forbid();
 
-        var result = await transactionRepository.Add(request.ToEntity(account.UserId), cancellationToken);
-        await dashboardCacheInvalidator.InvalidateUser(account.UserId);
-        return Ok(result.ToDto());
+        try
+        {
+            return Ok(await transactionService.AddAsync(request, account.UserId, cancellationToken));
+        }
+        catch (InvestmentTransactionCommandException ex)
+        {
+            return Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Could not save the transaction.",
+                detail: ex.Message,
+                type: $"https://financemanager.dev/problems/{ex.Code}",
+                extensions: new Dictionary<string, object?> { ["code"] = ex.Code });
+        }
     }
 
     [HttpPut("Update")]
@@ -168,6 +180,18 @@ public class InvestmentTransactionController(
         maxResults = Math.Clamp(maxResults, 1, 20);
         var listings = await assetListingRepository.SearchAsync(q, maxResults, cancellationToken);
         return Ok(listings.Select(x => new InstrumentSearchResultDto(x.Id, x.Ticker, x.ExchangeName, x.TradingCurrency)).ToList());
+    }
+
+    [HttpGet("SearchInstruments")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<InvestmentInstrumentOptionDto>))]
+    public async Task<IActionResult> SearchInstruments(
+        [FromQuery] string? q,
+        [FromQuery] int maxResults = 20,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(q)) return Ok(Array.Empty<InvestmentInstrumentOptionDto>());
+        maxResults = Math.Clamp(maxResults, 1, 50);
+        return Ok(await instrumentSearchService.SearchAsync(q, maxResults, cancellationToken));
     }
 
     [HttpGet("Listing/{listingId:long}")]

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInstrumentImportService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInstrumentImportService.cs
@@ -6,4 +6,6 @@ public interface IInstrumentImportService
 {
     Task<InstrumentImportPreviewDto> GetImportPreviewAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default);
     Task<ImportedInstrumentDto> ImportAsync(ImportInstrumentCommand command, CancellationToken ct = default);
+    Task ValidateForTransactionAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default);
+    Task<ImportedInstrumentDto> ImportValidatedAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default);
 }

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInstrumentImportService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInstrumentImportService.cs
@@ -6,6 +6,9 @@ public interface IInstrumentImportService
 {
     Task<InstrumentImportPreviewDto> GetImportPreviewAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default);
     Task<ImportedInstrumentDto> ImportAsync(ImportInstrumentCommand command, CancellationToken ct = default);
+    /// Strictly validate provider data before starting the transaction's database operation.
     Task ValidateForTransactionAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default);
+
+    /// Revalidates the provider symbol defensively, then persists the already validated instrument.
     Task<ImportedInstrumentDto> ImportValidatedAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default);
 }

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInvestmentInstrumentSearchService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/IInvestmentInstrumentSearchService.cs
@@ -1,0 +1,15 @@
+using FinanceManager.Domain.Assets.Discovery;
+
+namespace FinanceManager.Application.FinancialAccounts.Investments.Discovery;
+
+public interface IInvestmentInstrumentSearchService
+{
+    Task<IReadOnlyList<InvestmentInstrumentOptionDto>> SearchAsync(
+        string query,
+        int maxResults,
+        CancellationToken cancellationToken = default);
+
+    Task<InstrumentDiscoveryResultDto?> ResolveExternalResultAsync(
+        string resultId,
+        CancellationToken cancellationToken = default);
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InstrumentImportException.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InstrumentImportException.cs
@@ -1,0 +1,7 @@
+namespace FinanceManager.Application.FinancialAccounts.Investments.Discovery;
+
+public sealed class InstrumentImportException(string code, string message, Exception? innerException = null)
+    : Exception(message, innerException)
+{
+    public string Code { get; } = code;
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InstrumentImportService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InstrumentImportService.cs
@@ -32,15 +32,34 @@ public sealed class InstrumentImportService(
 
     public async Task<ImportedInstrumentDto> ImportAsync(ImportInstrumentCommand command, CancellationToken ct = default)
     {
-        var instrument = command.Instrument;
-        ValidateImport(instrument);
+        ValidateImport(command.Instrument);
+        return await PersistAsync(command.Instrument, strict: false, ct);
+    }
+
+    public async Task ValidateForTransactionAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default)
+    {
+        ValidateTransactionImport(instrument);
+        await ValidateSymbolAsync(instrument, ct, strict: true);
+    }
+
+    public Task<ImportedInstrumentDto> ImportValidatedAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default)
+    {
+        ValidateTransactionImport(instrument);
+        return PersistAsync(instrument, strict: true, ct);
+    }
+
+    private async Task<ImportedInstrumentDto> PersistAsync(
+        InstrumentDiscoveryResultDto instrument,
+        bool strict,
+        CancellationToken ct)
+    {
         var warnings = ImportWarnings(instrument).ToList();
         var (asset, listing, symbol) = await FindExistingAsync(instrument, ct);
         var createdAsset = asset is null;
         asset ??= await assetRepository.Add(new Asset
         {
             Name = instrument.DisplayName,
-            Type = ParseAssetType(instrument.SecurityType),
+            Type = ParseAssetType(instrument.SecurityType, defaultToStock: strict),
             Isin = instrument.Isin,
             ShareClassFigi = instrument.ShareClassFigi,
             CompositeFigi = instrument.CompositeFigi,
@@ -62,7 +81,7 @@ public sealed class InstrumentImportService(
         var createdSymbol = symbol is null && !string.IsNullOrWhiteSpace(instrument.ProviderSymbol);
         if (createdSymbol)
         {
-            var error = await ValidateSymbolAsync(instrument, ct);
+            var error = strict ? null : await ValidateSymbolAsync(instrument, ct);
             if (error is not null) warnings.Add(error);
             symbol = await symbolRepository.Add(new MarketDataSymbol
             {
@@ -142,18 +161,37 @@ public sealed class InstrumentImportService(
         return (asset, listing, symbol);
     }
 
-    private async Task<string?> ValidateSymbolAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct)
+    private async Task<string?> ValidateSymbolAsync(
+        InstrumentDiscoveryResultDto instrument,
+        CancellationToken ct,
+        bool strict = false)
     {
         try
         {
             var prices = await alphaVantageClient.GetDailySeries(instrument.ProviderSymbol!, DateTime.UtcNow.AddDays(-10), DateTime.UtcNow,
                 new Currency { ShortName = instrument.TradingCurrency! }, ct);
-            return prices.Any(x => x.PricePerUnit > 0) ? null : "Alpha Vantage returned no positive recent price; the symbol was saved disabled.";
+            if (prices.Any(x => x.PricePerUnit > 0)) return null;
+            if (strict)
+                throw new InstrumentImportException(
+                    "market_data_symbol_invalid",
+                    "Alpha Vantage could not validate the selected market-data symbol. No asset or transaction was created.");
+
+            return "Alpha Vantage returned no positive recent price; the symbol was saved disabled.";
+        }
+        catch (InstrumentImportException) when (strict)
+        {
+            throw;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             var sanitizedSymbol = instrument.ProviderSymbol?.Replace("\r", string.Empty).Replace("\n", string.Empty);
             logger.LogWarning(ex, "Alpha Vantage validation failed for {Symbol}", sanitizedSymbol);
+            if (strict)
+                throw new InstrumentImportException(
+                    "provider_unavailable",
+                    "Alpha Vantage could not validate the selected market-data symbol. No asset or transaction was created.",
+                    ex);
+
             return "Alpha Vantage validation failed; the symbol was saved disabled.";
         }
     }
@@ -172,13 +210,39 @@ public sealed class InstrumentImportService(
             throw new ArgumentException("Only stocks and ETFs can be imported.");
     }
 
+    private static void ValidateTransactionImport(InstrumentDiscoveryResultDto instrument)
+    {
+        if (!HasRequiredImportData(instrument))
+            throw new InstrumentImportException(
+                "instrument_not_found",
+                "The selected instrument is missing a name, ticker, exchange, or trading currency.");
+        if (string.IsNullOrWhiteSpace(instrument.ProviderSymbol))
+            throw new InstrumentImportException(
+                "market_data_symbol_invalid",
+                "The selected instrument has no usable market-data symbol. No asset or transaction was created.");
+        if (!string.IsNullOrWhiteSpace(instrument.SecurityType)
+            && ParseAssetType(instrument.SecurityType) is AssetType.Other)
+            throw new InstrumentImportException(
+                "instrument_import_failed",
+                "Only stocks and ETFs can be added to an investment transaction.");
+
+        if (instrument.Warnings.Any(w =>
+                w.Contains("ambiguous", StringComparison.OrdinalIgnoreCase)
+                || w.Contains("not confirmed", StringComparison.OrdinalIgnoreCase)
+                || w.Contains("differs", StringComparison.OrdinalIgnoreCase)))
+            throw new InstrumentImportException(
+                "instrument_ambiguous",
+                "The selected instrument could not be resolved to a specific exchange and currency.");
+    }
+
     private static bool HasRequiredImportData(InstrumentDiscoveryResultDto instrument) =>
         !string.IsNullOrWhiteSpace(instrument.DisplayName) && !string.IsNullOrWhiteSpace(instrument.Ticker)
         && !string.IsNullOrWhiteSpace(instrument.ExchangeMic) && !string.IsNullOrWhiteSpace(instrument.TradingCurrency);
 
-    private static AssetType ParseAssetType(string? securityType) =>
+    private static AssetType ParseAssetType(string? securityType, bool defaultToStock = false) =>
         securityType?.Contains("ETF", StringComparison.OrdinalIgnoreCase) == true ? AssetType.ETF
         : securityType?.Contains("Equity", StringComparison.OrdinalIgnoreCase) == true || securityType?.Contains("Stock", StringComparison.OrdinalIgnoreCase) == true ? AssetType.Stock
+        : defaultToStock && string.IsNullOrWhiteSpace(securityType) ? AssetType.Stock
         : AssetType.Other;
 }
 

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InstrumentImportService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InstrumentImportService.cs
@@ -42,10 +42,11 @@ public sealed class InstrumentImportService(
         await ValidateSymbolAsync(instrument, ct, strict: true);
     }
 
-    public Task<ImportedInstrumentDto> ImportValidatedAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default)
+    public async Task<ImportedInstrumentDto> ImportValidatedAsync(InstrumentDiscoveryResultDto instrument, CancellationToken ct = default)
     {
         ValidateTransactionImport(instrument);
-        return PersistAsync(instrument, strict: true, ct);
+        await ValidateSymbolAsync(instrument, ct, strict: true);
+        return await PersistAsync(instrument, strict: true, ct);
     }
 
     private async Task<ImportedInstrumentDto> PersistAsync(
@@ -56,7 +57,7 @@ public sealed class InstrumentImportService(
         var warnings = ImportWarnings(instrument).ToList();
         var (asset, listing, symbol) = await FindExistingAsync(instrument, ct);
         var createdAsset = asset is null;
-        asset ??= await assetRepository.Add(new Asset
+        asset ??= await assetRepository.Upsert(new Asset
         {
             Name = instrument.DisplayName,
             Type = ParseAssetType(instrument.SecurityType, defaultToStock: strict),
@@ -67,7 +68,7 @@ public sealed class InstrumentImportService(
         }, ct);
 
         var createdListing = listing is null;
-        listing ??= await listingRepository.Add(new AssetListing
+        listing ??= await listingRepository.Upsert(new AssetListing
         {
             AssetId = asset.Id,
             Ticker = instrument.Ticker.Trim().ToUpperInvariant(),
@@ -83,7 +84,7 @@ public sealed class InstrumentImportService(
         {
             var error = strict ? null : await ValidateSymbolAsync(instrument, ct);
             if (error is not null) warnings.Add(error);
-            symbol = await symbolRepository.Add(new MarketDataSymbol
+            symbol = await symbolRepository.Upsert(new MarketDataSymbol
             {
                 AssetListingId = listing.Id,
                 Provider = MarketDataProvider.AlphaVantage,
@@ -220,11 +221,10 @@ public sealed class InstrumentImportService(
             throw new InstrumentImportException(
                 "market_data_symbol_invalid",
                 "The selected instrument has no usable market-data symbol. No asset or transaction was created.");
-        if (!string.IsNullOrWhiteSpace(instrument.SecurityType)
-            && ParseAssetType(instrument.SecurityType) is AssetType.Other)
+        if (ParseAssetType(instrument.SecurityType) is AssetType.Other)
             throw new InstrumentImportException(
                 "instrument_import_failed",
-                "Only stocks and ETFs can be added to an investment transaction.");
+                "The selected instrument's asset type could not be determined; only stocks and ETFs can be added to an investment transaction.");
 
         if (instrument.Warnings.Any(w =>
                 w.Contains("ambiguous", StringComparison.OrdinalIgnoreCase)

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InvestmentInstrumentDiscoveryService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InvestmentInstrumentDiscoveryService.cs
@@ -55,7 +55,7 @@ public sealed partial class InvestmentInstrumentDiscoveryService(
         var listings = await SafeOpenFigi(() => openFigiClient.MapByIsinAsync(isin, ct), nameof(SearchByIsinAsync));
 
         return listings
-            .Select(of => BuildFromOpenFigi(of, providerSymbol: null, avQuoteCurrency: null, isinOverride: isin))
+            .Select(of => BuildFromOpenFigi(of, providerSymbol: null, avQuoteCurrency: null, avSecurityType: null, isinOverride: isin))
             .ToList();
     }
 
@@ -67,10 +67,13 @@ public sealed partial class InvestmentInstrumentDiscoveryService(
         if (string.IsNullOrWhiteSpace(baseTicker))
             return [];
 
+        var isTickerQuery = !baseTicker.Any(char.IsWhiteSpace);
         var openFigiExchCode = brokerSymbol.TryLookupExchange()?.OpenFigiExchCode;
 
         var avTask = SafeAlphaVantage(() => alphaVantageClient.SearchTicker(baseTicker, ct));
-        var ofTask = SafeOpenFigi(() => openFigiClient.MapByTickerAsync(baseTicker, openFigiExchCode, ct), nameof(SearchByTickerOrNameAsync));
+        var ofTask = isTickerQuery
+            ? SafeOpenFigi(() => openFigiClient.MapByTickerAsync(baseTicker, openFigiExchCode, ct), nameof(SearchByTickerOrNameAsync))
+            : Task.FromResult<IReadOnlyList<OpenFigiListing>>([]);
         await Task.WhenAll(avTask, ofTask);
 
         return Merge(baseTicker, avTask.Result, ofTask.Result);
@@ -98,7 +101,7 @@ public sealed partial class InvestmentInstrumentDiscoveryService(
             if (av is not null)
                 consumedAvSymbols.Add(av.Symbol);
 
-            var dto = BuildFromOpenFigi(of, av?.Symbol, av?.Currency, isinOverride: null);
+            var dto = BuildFromOpenFigi(of, av?.Symbol, av?.Currency, av?.Type, isinOverride: null);
             var key = DedupeKey(dto);
             if (seen.Add(key))
                 results.Add(dto);
@@ -148,6 +151,7 @@ public sealed partial class InvestmentInstrumentDiscoveryService(
         OpenFigiListing of,
         string? providerSymbol,
         string? avQuoteCurrency,
+        string? avSecurityType,
         string? isinOverride)
     {
         var (mic, exchangeName, exchangeCode) = ResolveVenue(of.ExchCode);
@@ -183,6 +187,7 @@ public sealed partial class InvestmentInstrumentDiscoveryService(
             ShareClassFigi = of.ShareClassFigi,
             CompositeFigi = of.CompositeFigi,
             Isin = isinOverride ?? of.Isin,
+            SecurityType = avSecurityType,
             ProviderSymbol = providerSymbol,
             ConfidenceScore = confidence,
             Warnings = warnings,
@@ -204,7 +209,7 @@ public sealed partial class InvestmentInstrumentDiscoveryService(
         {
             Source = "AlphaVantage",
             DisplayName = av.Name,
-            Ticker = string.IsNullOrWhiteSpace(baseTicker) ? av.Symbol : baseTicker,
+            Ticker = baseTicker.Any(char.IsWhiteSpace) ? av.Symbol : baseTicker,
             ExchangeMic = mic,
             ExchangeName = exchangeName,
             ExchangeCode = exchangeCode,

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InvestmentInstrumentSearchService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Discovery/InvestmentInstrumentSearchService.cs
@@ -1,0 +1,102 @@
+using FinanceManager.Domain.Assets.Discovery;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace FinanceManager.Application.FinancialAccounts.Investments.Discovery;
+
+public sealed class InvestmentInstrumentSearchService(
+    IAssetListingRepository listingRepository,
+    IInvestmentInstrumentDiscoveryService discoveryService,
+    IMemoryCache cache) : IInvestmentInstrumentSearchService
+{
+    private static readonly TimeSpan _resultTtl = TimeSpan.FromMinutes(15);
+    private const string _cachePrefix = "INVESTMENT_INSTRUMENT_RESULT_";
+
+    public async Task<IReadOnlyList<InvestmentInstrumentOptionDto>> SearchAsync(
+        string query,
+        int maxResults,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(query) || maxResults <= 0)
+            return [];
+
+        maxResults = Math.Clamp(maxResults, 1, 50);
+        var localListings = await listingRepository.SearchAsync(query, maxResults, cancellationToken);
+        var results = localListings.Select(ToExistingOption).ToList();
+        if (results.Count >= maxResults)
+            return results;
+
+        var externalResults = await discoveryService.SearchAsync(query, cancellationToken);
+        foreach (var external in externalResults.OrderByDescending(x => x.ConfidenceScore))
+        {
+            if (localListings.Any(listing => MatchesExisting(listing, external)))
+                continue;
+
+            var resultId = Guid.NewGuid().ToString("N");
+            cache.Set(CacheKey(resultId), external, _resultTtl);
+            results.Add(new InvestmentInstrumentOptionDto
+            {
+                ResultId = resultId,
+                Source = InstrumentOptionSource.External,
+                ExternalInstrument = external,
+                Ticker = external.Ticker,
+                DisplayName = external.DisplayName,
+                ExchangeMic = external.ExchangeMic,
+                ExchangeName = external.ExchangeName ?? external.ExchangeMic ?? string.Empty,
+                TradingCurrency = external.TradingCurrency ?? string.Empty,
+                Isin = external.Isin,
+                Warnings = external.Warnings
+            });
+
+            if (results.Count == maxResults)
+                break;
+        }
+
+        return results;
+    }
+
+    public Task<InstrumentDiscoveryResultDto?> ResolveExternalResultAsync(
+        string resultId,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (string.IsNullOrWhiteSpace(resultId)
+            || !cache.TryGetValue(CacheKey(resultId), out InstrumentDiscoveryResultDto? instrument))
+            return Task.FromResult<InstrumentDiscoveryResultDto?>(null);
+
+        return Task.FromResult(instrument);
+    }
+
+    private static InvestmentInstrumentOptionDto ToExistingOption(AssetListing listing) => new()
+    {
+        ResultId = $"listing:{listing.Id}",
+        Source = InstrumentOptionSource.Existing,
+        AssetListingId = listing.Id,
+        Ticker = listing.Ticker,
+        DisplayName = listing.Asset?.Name ?? listing.Ticker,
+        ExchangeMic = listing.ExchangeMic,
+        ExchangeName = listing.ExchangeName,
+        TradingCurrency = listing.TradingCurrency,
+        Isin = listing.Asset?.Isin
+    };
+
+    private static bool MatchesExisting(AssetListing listing, InstrumentDiscoveryResultDto external)
+    {
+        if (!string.IsNullOrWhiteSpace(external.ListingFigi)
+            && string.Equals(listing.ListingFigi, external.ListingFigi, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (!string.IsNullOrWhiteSpace(external.ProviderSymbol)
+            && listing.MarketDataSymbols.Any(symbol =>
+                symbol.Provider == MarketDataProvider.AlphaVantage
+                && string.Equals(symbol.Symbol, external.ProviderSymbol, StringComparison.OrdinalIgnoreCase)))
+            return true;
+
+        return string.Equals(listing.Ticker, external.Ticker, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(listing.ExchangeMic, external.ExchangeMic, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(listing.TradingCurrency, external.TradingCurrency, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string CacheKey(string resultId) => $"{_cachePrefix}{resultId}";
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Transactions/IInvestmentTransactionService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Transactions/IInvestmentTransactionService.cs
@@ -1,0 +1,11 @@
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+
+namespace FinanceManager.Application.FinancialAccounts.Investments.Transactions;
+
+public interface IInvestmentTransactionService
+{
+    Task<InvestmentTransactionDto> AddAsync(
+        AddInvestmentTransactionRequest request,
+        long userId,
+        CancellationToken cancellationToken = default);
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Transactions/InvestmentTransactionCommandException.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Transactions/InvestmentTransactionCommandException.cs
@@ -1,0 +1,7 @@
+namespace FinanceManager.Application.FinancialAccounts.Investments.Transactions;
+
+public sealed class InvestmentTransactionCommandException(string code, string message, Exception? innerException = null)
+    : Exception(message, innerException)
+{
+    public string Code { get; } = code;
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Transactions/InvestmentTransactionService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Transactions/InvestmentTransactionService.cs
@@ -1,11 +1,13 @@
 using FinanceManager.Application.FinancialAccounts.Investments.Discovery;
 using FinanceManager.Application.Shared.Persistence;
 using FinanceManager.Domain.Assets.Discovery;
+using FinanceManager.Domain.Assets.Entities;
 using FinanceManager.Domain.Assets.Repositories;
 using FinanceManager.Domain.Dashboard.Services;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
 using Microsoft.Extensions.Logging;
+using System.Collections.Concurrent;
 
 namespace FinanceManager.Application.FinancialAccounts.Investments.Transactions;
 
@@ -18,7 +20,7 @@ public sealed class InvestmentTransactionService(
     ICacheInvalidator cacheInvalidator,
     ILogger<InvestmentTransactionService> logger) : IInvestmentTransactionService
 {
-    private static readonly SemaphoreSlim _externalAddGate = new(1, 1);
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> _externalAddGates = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<InvestmentTransactionDto> AddAsync(
         AddInvestmentTransactionRequest request,
@@ -55,13 +57,16 @@ public sealed class InvestmentTransactionService(
                 "The selected instrument no longer exists. Search for it again.");
         }
 
+        var externalGate = external
+            ? _externalAddGates.GetOrAdd(GetExternalGateKey(instrument!), static _ => new(1, 1))
+            : null;
         var gateTaken = false;
         try
         {
-            if (external)
+            if (externalGate is not null)
             {
-                // ponytail: process-wide gate; use a distributed lock if imports run across multiple API instances.
-                await _externalAddGate.WaitAsync(cancellationToken);
+                // ponytail: process-local keyed gates plus database upserts; use a distributed lock if throughput or deployment scale requires it.
+                await externalGate.WaitAsync(cancellationToken);
                 gateTaken = true;
             }
 
@@ -121,7 +126,15 @@ public sealed class InvestmentTransactionService(
                 return result;
             }, cancellationToken);
 
-            await cacheInvalidator.InvalidateUser((int)userId, cancellationToken);
+            try
+            {
+                await cacheInvalidator.InvalidateUser((int)userId, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                logger.LogWarning(ex, "Transaction {TransactionId} was saved, but cache invalidation for user {UserId} failed", result.Id, userId);
+            }
+
             return result;
         }
         catch (InvestmentTransactionCommandException)
@@ -141,9 +154,12 @@ public sealed class InvestmentTransactionService(
         finally
         {
             if (gateTaken)
-                _externalAddGate.Release();
+                externalGate!.Release();
         }
     }
+
+    private static string GetExternalGateKey(InstrumentDiscoveryResultDto instrument) =>
+        $"{MarketDataProvider.AlphaVantage}:{instrument.ProviderSymbol!.Trim().ToUpperInvariant()}";
 
     private static void ValidateRequest(AddInvestmentTransactionRequest request)
     {

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Transactions/InvestmentTransactionService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Transactions/InvestmentTransactionService.cs
@@ -1,0 +1,164 @@
+using FinanceManager.Application.FinancialAccounts.Investments.Discovery;
+using FinanceManager.Application.Shared.Persistence;
+using FinanceManager.Domain.Assets.Discovery;
+using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.Dashboard.Services;
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Application.FinancialAccounts.Investments.Transactions;
+
+public sealed class InvestmentTransactionService(
+    IAssetListingRepository listingRepository,
+    IInvestmentTransactionRepository transactionRepository,
+    IInvestmentInstrumentSearchService instrumentSearchService,
+    IInstrumentImportService instrumentImportService,
+    IAtomicOperation atomicOperation,
+    ICacheInvalidator cacheInvalidator,
+    ILogger<InvestmentTransactionService> logger) : IInvestmentTransactionService
+{
+    private static readonly SemaphoreSlim _externalAddGate = new(1, 1);
+
+    public async Task<InvestmentTransactionDto> AddAsync(
+        AddInvestmentTransactionRequest request,
+        long userId,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateRequest(request);
+
+        var external = !string.IsNullOrWhiteSpace(request.ExternalInstrumentResultId);
+        InstrumentDiscoveryResultDto? instrument = null;
+        if (external)
+        {
+            instrument = await instrumentSearchService.ResolveExternalResultAsync(
+                request.ExternalInstrumentResultId!, cancellationToken);
+            if (instrument is null)
+                throw new InvestmentTransactionCommandException(
+                    "instrument_result_expired",
+                    "The external search result expired. Search for the instrument again.");
+
+            try
+            {
+                // Provider validation is deliberately completed before the database transaction starts.
+                await instrumentImportService.ValidateForTransactionAsync(instrument, cancellationToken);
+            }
+            catch (InstrumentImportException ex)
+            {
+                throw new InvestmentTransactionCommandException(ex.Code, ex.Message, ex);
+            }
+        }
+        else if (await listingRepository.Get(request.AssetListingId!.Value, cancellationToken) is null)
+        {
+            throw new InvestmentTransactionCommandException(
+                "instrument_not_found",
+                "The selected instrument no longer exists. Search for it again.");
+        }
+
+        var gateTaken = false;
+        try
+        {
+            if (external)
+            {
+                // ponytail: process-wide gate; use a distributed lock if imports run across multiple API instances.
+                await _externalAddGate.WaitAsync(cancellationToken);
+                gateTaken = true;
+            }
+
+            var result = await atomicOperation.ExecuteAsync(async transactionCancellationToken =>
+            {
+                long listingId;
+                if (instrument is not null)
+                {
+                    ImportedInstrumentDto imported;
+                    try
+                    {
+                        imported = await instrumentImportService.ImportValidatedAsync(instrument, transactionCancellationToken);
+                    }
+                    catch (InstrumentImportException ex)
+                    {
+                        throw new InvestmentTransactionCommandException(ex.Code, ex.Message, ex);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        throw new InvestmentTransactionCommandException(
+                            "instrument_import_failed",
+                            "The instrument could not be imported. No asset or transaction was created.",
+                            ex);
+                    }
+
+                    listingId = imported.AssetListingId;
+                }
+                else
+                {
+                    listingId = request.AssetListingId!.Value;
+                }
+
+                InvestmentTransactionDto result;
+                try
+                {
+                    var transaction = await transactionRepository.Add(
+                        request.ToEntity(userId, listingId),
+                        transactionCancellationToken);
+                    var saved = await transactionRepository.Get(transaction.Id, transactionCancellationToken);
+                    if (saved is null)
+                        throw new InvalidOperationException("The created transaction could not be reloaded.");
+
+                    result = saved.ToDto();
+                }
+                catch (InvestmentTransactionCommandException)
+                {
+                    throw;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    throw new InvestmentTransactionCommandException(
+                        "transaction_creation_failed",
+                        "The transaction could not be saved. No imported instrument data was kept.",
+                        ex);
+                }
+
+                return result;
+            }, cancellationToken);
+
+            await cacheInvalidator.InvalidateUser((int)userId, cancellationToken);
+            return result;
+        }
+        catch (InvestmentTransactionCommandException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(ex, "Failed to add investment transaction for account {AccountId}", request.AccountId);
+            throw new InvestmentTransactionCommandException(
+                external ? "instrument_import_failed" : "transaction_creation_failed",
+                external
+                    ? "The instrument could not be imported. No asset or transaction was created."
+                    : "The transaction could not be saved.",
+                ex);
+        }
+        finally
+        {
+            if (gateTaken)
+                _externalAddGate.Release();
+        }
+    }
+
+    private static void ValidateRequest(AddInvestmentTransactionRequest request)
+    {
+        var hasListing = request.AssetListingId is > 0;
+        var hasExternal = !string.IsNullOrWhiteSpace(request.ExternalInstrumentResultId);
+        if (hasListing == hasExternal || request.AssetListingId is 0)
+            throw new InvestmentTransactionCommandException(
+                "instrument_source_invalid",
+                "Select exactly one existing or external instrument.");
+
+        if (request.Quantity <= 0m || request.UnitPrice < 0m
+            || string.IsNullOrWhiteSpace(request.Currency)
+            || request.TradeDate == default)
+            throw new InvestmentTransactionCommandException(
+                "transaction_creation_failed",
+                "Invalid transaction details.");
+    }
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Registration.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Registration.cs
@@ -19,6 +19,7 @@ using FinanceManager.Application.FinancialAccounts.Investments.Assets;
 using FinanceManager.Application.FinancialAccounts.Investments.Balance;
 using FinanceManager.Application.FinancialAccounts.Investments.Discovery;
 using FinanceManager.Application.FinancialAccounts.Investments.Seeders;
+using FinanceManager.Application.FinancialAccounts.Investments.Transactions;
 using FinanceManager.Application.FinancialAccounts.Investments.Valuation;
 using FinanceManager.Application.FinancialAccounts.Shared.Csv;
 using FinanceManager.Application.FinancialAccounts.Shared.Exports;
@@ -77,7 +78,9 @@ internal static class Registration
                 .AddScoped<IInvestmentValuationService, InvestmentValuationService>()
                 .AddScoped<IInvestmentTransactionValuationService, InvestmentTransactionValuationService>()
                 .AddScoped<IInvestmentInstrumentDiscoveryService, InvestmentInstrumentDiscoveryService>()
+                .AddScoped<IInvestmentInstrumentSearchService, InvestmentInstrumentSearchService>()
                 .AddScoped<IInstrumentImportService, InstrumentImportService>()
+                .AddScoped<IInvestmentTransactionService, InvestmentTransactionService>()
                 .AddScoped<IBondUnrealizedGainLossCalculator, BondUnrealizedGainLossCalculator>()
                 .AddScoped<IBondService, BondService>();
 

--- a/code/FinanceManager.Application/Shared/Persistence/IAtomicOperation.cs
+++ b/code/FinanceManager.Application/Shared/Persistence/IAtomicOperation.cs
@@ -1,0 +1,6 @@
+namespace FinanceManager.Application.Shared.Persistence;
+
+public interface IAtomicOperation
+{
+    Task<T> ExecuteAsync<T>(Func<CancellationToken, Task<T>> operation, CancellationToken cancellationToken = default);
+}

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentTransactionForm.razor
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentTransactionForm.razor
@@ -1,21 +1,36 @@
 @namespace FinanceManager.Components.Features.FinancialAccounts.Components.InvestmentAccountComponents
-@using FinanceManager.Domain.Assets.Dtos
+@using FinanceManager.Domain.Assets.Discovery
 @using FinanceManager.Domain.FinancialAccounts.Investments.Entities
 
 <MudOverlay Visible="@Visible" DarkBackground="true" ZIndex="1300">
     <MudPaper Class="pa-5" Style="width: min(460px, 92vw);" role="dialog" aria-modal="true" aria-label="@(_editingId is null ? "Add transaction" : "Edit transaction")">
         <MudText Typo="Typo.h6" Class="mb-3">@(_editingId is null ? "Add transaction" : "Edit transaction")</MudText>
         <MudStack Spacing="3">
-            <MudAutocomplete T="InstrumentSearchResultDto" Label="Instrument"
+            <MudAutocomplete T="InvestmentInstrumentOptionDto" Label="Instrument"
                              Value="_selectedInstrument"
                              ValueChanged="OnInstrumentSelectedAsync"
                              SearchFunc="SearchInstrumentsAsync"
-                             ToStringFunc="@(dto => dto is null ? string.Empty : $"{dto.Ticker} — {dto.ExchangeName}")"
+                             ToStringFunc="@(dto => dto is null ? string.Empty : $"{dto.Ticker} — {dto.DisplayName}")"
                              MinCharacters="1" DebounceInterval="300" ResetValueOnEmptyText="true"
-                             CoerceText="false" Dense="true" />
-            @if (_editingId is null)
+                             CoerceText="false" Dense="true">
+                <ItemTemplate Context="option">
+                    <MudStack Spacing="0">
+                        <MudText Typo="Typo.body2">@option.Ticker — @option.DisplayName</MudText>
+                        <MudText Typo="Typo.caption">@option.ExchangeName (@option.ExchangeMic) · @option.TradingCurrency · @GetSourceLabel(option.Source)</MudText>
+                        @if (!string.IsNullOrWhiteSpace(option.Isin))
+                        {
+                            <MudText Typo="Typo.caption">ISIN: @option.Isin</MudText>
+                        }
+                    </MudStack>
+                </ItemTemplate>
+            </MudAutocomplete>
+            @if (_selectedInstrument?.Source == InstrumentOptionSource.External)
             {
-                <InstrumentImport ButtonText="Can't find it? Import instrument" Imported="OnInstrumentImportedAsync" />
+                <MudAlert Severity="Severity.Info" Dense="true">This instrument will be added when the transaction is saved.</MudAlert>
+            }
+            @if (_error is not null)
+            {
+                <MudAlert Severity="Severity.Error" Dense="true">@_error</MudAlert>
             }
             <MudSelect T="InvestmentTransactionType" Label="Type" @bind-Value="_formType" Dense="true">
                 <MudSelectItem T="InvestmentTransactionType" Value="InvestmentTransactionType.Buy">Buy</MudSelectItem>
@@ -23,7 +38,7 @@
             </MudSelect>
             <MudNumericField T="decimal" Label="Units" @bind-Value="_formQuantity" Min="0" Step="0.0001M" />
             <MudTextField T="string" Label="Unit price" Value="@(_selectedInstrument is null ? string.Empty : _formUnitPrice.ToString("N2"))" ReadOnly="true" Disabled="true" />
-            @if (_noPriceAvailable && _selectedInstrument is not null)
+            @if (_noPriceAvailable && _selectedInstrument?.Source == InstrumentOptionSource.Existing)
             {
                 <MudAlert Severity="Severity.Info" Dense="true">No price data found for this instrument. You can still save the transaction — the unit price will be recalculated once a price quote is available.</MudAlert>
             }

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentTransactionForm.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentTransactionForm.razor.cs
@@ -73,7 +73,10 @@ public partial class InvestmentTransactionForm : ComponentBase
     private bool HasInstrument => _selectedInstrument is { Source: InstrumentOptionSource.Existing, AssetListingId: > 0 }
         || _selectedInstrument is { Source: InstrumentOptionSource.External, ResultId: not null and not "" };
 
-    private bool CanSave => HasInstrument && _formQuantity > 0 && _formUnitPrice >= 0
+    private bool IsUnsupportedExternalEdit => _editingId is not null
+        && _selectedInstrument?.Source == InstrumentOptionSource.External;
+
+    private bool CanSave => !IsUnsupportedExternalEdit && HasInstrument && _formQuantity > 0 && _formUnitPrice >= 0
         && _formTradeDate is not null && !string.IsNullOrWhiteSpace(_formCurrency);
 
     private async Task CloseAsync() => await VisibleChanged.InvokeAsync(false);
@@ -143,7 +146,10 @@ public partial class InvestmentTransactionForm : ComponentBase
         if (string.IsNullOrWhiteSpace(value)) return [];
         try
         {
-            return await TransactionHttpClient.SearchInstrumentsAsync(value, cancellationToken: cancellationToken);
+            var results = await TransactionHttpClient.SearchInstrumentsAsync(value, cancellationToken: cancellationToken);
+            return _editingId is null
+                ? results
+                : results.Where(x => x.Source == InstrumentOptionSource.Existing);
         }
         catch (Exception ex)
         {
@@ -154,6 +160,13 @@ public partial class InvestmentTransactionForm : ComponentBase
 
     private async Task SaveAsync()
     {
+        if (IsUnsupportedExternalEdit)
+        {
+            _error = "External instruments cannot replace an existing instrument while editing.";
+            Snackbar.Add(_error, Severity.Error);
+            return;
+        }
+
         if (!CanSave) return;
         _saving = true;
         _error = null;

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentTransactionForm.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentTransactionForm.razor.cs
@@ -1,6 +1,5 @@
 using FinanceManager.Components.Features.FinancialAccounts.HttpClients;
 using FinanceManager.Domain.Assets.Discovery;
-using FinanceManager.Domain.Assets.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using Microsoft.AspNetCore.Components;
@@ -24,7 +23,7 @@ public partial class InvestmentTransactionForm : ComponentBase
     private bool _wasVisible;
     private long? _initializedTransactionId;
     private long? _editingId;
-    private InstrumentSearchResultDto? _selectedInstrument;
+    private InvestmentInstrumentOptionDto? _selectedInstrument;
     private long _formListingId;
     private InvestmentTransactionType _formType = InvestmentTransactionType.Buy;
     private decimal _formQuantity = 1m;
@@ -35,6 +34,7 @@ public partial class InvestmentTransactionForm : ComponentBase
     private string? _formNotes;
     private bool _saving;
     private bool _noPriceAvailable;
+    private string? _error;
 
     protected override void OnParametersSet()
     {
@@ -48,9 +48,16 @@ public partial class InvestmentTransactionForm : ComponentBase
     {
         _initializedTransactionId = Transaction?.Id;
         _editingId = Transaction?.Id;
-        _selectedInstrument = Transaction is null
-            ? null
-            : new InstrumentSearchResultDto(Transaction.AssetListingId, Transaction.Ticker, Transaction.ExchangeName, Transaction.Currency);
+        _selectedInstrument = Transaction is null ? null : new InvestmentInstrumentOptionDto
+        {
+            ResultId = $"listing:{Transaction.AssetListingId}",
+            Source = InstrumentOptionSource.Existing,
+            AssetListingId = Transaction.AssetListingId,
+            Ticker = Transaction.Ticker,
+            DisplayName = Transaction.Ticker,
+            ExchangeName = Transaction.ExchangeName,
+            TradingCurrency = Transaction.Currency
+        };
         _formListingId = Transaction?.AssetListingId ?? 0;
         _formType = Transaction?.Type ?? InvestmentTransactionType.Buy;
         _formQuantity = Transaction?.Quantity ?? 1m;
@@ -60,17 +67,22 @@ public partial class InvestmentTransactionForm : ComponentBase
         _formFee = Transaction?.Fee;
         _formNotes = Transaction?.Notes;
         _noPriceAvailable = false;
+        _error = null;
     }
 
-    private bool CanSave => _formListingId > 0 && _formQuantity > 0 && _formUnitPrice >= 0
+    private bool HasInstrument => _selectedInstrument is { Source: InstrumentOptionSource.Existing, AssetListingId: > 0 }
+        || _selectedInstrument is { Source: InstrumentOptionSource.External, ResultId: not null and not "" };
+
+    private bool CanSave => HasInstrument && _formQuantity > 0 && _formUnitPrice >= 0
         && _formTradeDate is not null && !string.IsNullOrWhiteSpace(_formCurrency);
 
     private async Task CloseAsync() => await VisibleChanged.InvokeAsync(false);
 
-    private async Task OnInstrumentSelectedAsync(InstrumentSearchResultDto? dto)
+    private async Task OnInstrumentSelectedAsync(InvestmentInstrumentOptionDto? dto)
     {
         _selectedInstrument = dto;
         _noPriceAvailable = false;
+        _error = null;
         if (dto is null)
         {
             _formListingId = 0;
@@ -79,9 +91,18 @@ public partial class InvestmentTransactionForm : ComponentBase
             return;
         }
 
-        _formListingId = dto.ListingId;
-        _formCurrency = dto.Currency;
-        await RefreshFormPriceAsync();
+        _formCurrency = dto.TradingCurrency;
+        if (dto.AssetListingId is long listingId)
+        {
+            _formListingId = listingId;
+            await RefreshFormPriceAsync();
+        }
+        else
+        {
+            _formListingId = 0;
+            _formUnitPrice = 0m;
+            _noPriceAvailable = true;
+        }
     }
 
     private async Task OnTradeDateChangedAsync(DateTime? value)
@@ -92,7 +113,7 @@ public partial class InvestmentTransactionForm : ComponentBase
 
     private async Task RefreshFormPriceAsync()
     {
-        if (_selectedInstrument is null || _formTradeDate is not DateTime tradeDate)
+        if (_selectedInstrument?.AssetListingId is not long listingId || _formTradeDate is not DateTime tradeDate)
         {
             _formUnitPrice = 0m;
             return;
@@ -100,7 +121,7 @@ public partial class InvestmentTransactionForm : ComponentBase
 
         try
         {
-            var priceInfo = await TransactionHttpClient.GetListingPriceAsync(_selectedInstrument.ListingId, DateOnly.FromDateTime(tradeDate));
+            var priceInfo = await TransactionHttpClient.GetListingPriceAsync(listingId, DateOnly.FromDateTime(tradeDate));
             if (priceInfo?.LatestPrice is decimal price)
                 _formUnitPrice = price;
             else
@@ -111,18 +132,18 @@ public partial class InvestmentTransactionForm : ComponentBase
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Failed to fetch price for listing {ListingId}", _selectedInstrument.ListingId);
+            Logger.LogError(ex, "Failed to fetch price for listing {ListingId}", listingId);
             _formUnitPrice = 0m;
             _noPriceAvailable = true;
         }
     }
 
-    private async Task<IEnumerable<InstrumentSearchResultDto>> SearchInstrumentsAsync(string value, CancellationToken cancellationToken)
+    private async Task<IEnumerable<InvestmentInstrumentOptionDto>> SearchInstrumentsAsync(string value, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(value)) return [];
         try
         {
-            return await TransactionHttpClient.SearchListingsAsync(value);
+            return await TransactionHttpClient.SearchInstrumentsAsync(value, cancellationToken: cancellationToken);
         }
         catch (Exception ex)
         {
@@ -131,17 +152,11 @@ public partial class InvestmentTransactionForm : ComponentBase
         }
     }
 
-    private async Task OnInstrumentImportedAsync(ImportedInstrumentDto imported)
-    {
-        await OnInstrumentSelectedAsync(new InstrumentSearchResultDto(
-            imported.AssetListingId, imported.Ticker, imported.ExchangeName, imported.TradingCurrency));
-        Snackbar.Add(imported.Warnings.Count == 0 ? "Instrument imported." : $"Instrument imported with {imported.Warnings.Count} warning(s).", Severity.Success);
-    }
-
     private async Task SaveAsync()
     {
         if (!CanSave) return;
         _saving = true;
+        _error = null;
         try
         {
             var tradeDate = DateOnly.FromDateTime(_formTradeDate!.Value);
@@ -149,11 +164,21 @@ public partial class InvestmentTransactionForm : ComponentBase
                 ? await TransactionHttpClient.UpdateAsync(new UpdateInvestmentTransactionRequest(
                     id, AccountId, _formListingId, _formType, _formQuantity, _formUnitPrice, _formCurrency, tradeDate, _formFee, _formNotes))
                 : await TransactionHttpClient.AddAsync(new AddInvestmentTransactionRequest(
-                    AccountId, _formListingId, _formType, _formQuantity, _formUnitPrice, _formCurrency, tradeDate, _formFee, _formNotes)) is not null;
+                    AccountId,
+                    _selectedInstrument?.Source == InstrumentOptionSource.Existing ? _formListingId : null,
+                    _formType,
+                    _formQuantity,
+                    _formUnitPrice,
+                    _formCurrency,
+                    tradeDate,
+                    _formFee,
+                    _formNotes,
+                    _selectedInstrument?.Source == InstrumentOptionSource.External ? _selectedInstrument.ResultId : null)) is not null;
 
             if (!ok)
             {
-                Snackbar.Add("Could not save the transaction.", Severity.Error);
+                _error = "Could not save the transaction.";
+                Snackbar.Add(_error, Severity.Error);
                 return;
             }
 
@@ -163,11 +188,17 @@ public partial class InvestmentTransactionForm : ComponentBase
         catch (Exception ex)
         {
             Logger.LogError(ex, "Failed to save investment transaction for account {AccountId}", AccountId);
-            Snackbar.Add("Could not save the transaction.", Severity.Error);
+            _error = ex is HttpRequestException && !string.IsNullOrWhiteSpace(ex.Message)
+                ? ex.Message
+                : "Could not save the transaction.";
+            Snackbar.Add(_error, Severity.Error);
         }
         finally
         {
             _saving = false;
         }
     }
+
+    private static string GetSourceLabel(InstrumentOptionSource source) =>
+        source == InstrumentOptionSource.Existing ? "Existing" : "External";
 }

--- a/code/FinanceManager.Components/Features/FinancialAccounts/HttpClients/InvestmentTransactionHttpClient.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/HttpClients/InvestmentTransactionHttpClient.cs
@@ -1,7 +1,9 @@
+using FinanceManager.Domain.Assets.Discovery;
 using FinanceManager.Domain.Assets.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 
 namespace FinanceManager.Components.Features.FinancialAccounts.HttpClients;
 
@@ -30,7 +32,8 @@ public class InvestmentTransactionHttpClient(HttpClient httpClient)
     public async Task<InvestmentTransactionDto?> AddAsync(AddInvestmentTransactionRequest request)
     {
         using var response = await httpClient.PostAsJsonAsync($"{httpClient.BaseAddress}api/InvestmentTransaction/Add", request);
-        if (!response.IsSuccessStatusCode) return null;
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException(await GetProblemDetailAsync(response));
         return await response.Content.ReadFromJsonAsync<InvestmentTransactionDto>();
     }
 
@@ -58,6 +61,18 @@ public class InvestmentTransactionHttpClient(HttpClient httpClient)
         return await response.Content.ReadFromJsonAsync<List<InstrumentSearchResultDto>>(cancellationToken) ?? [];
     }
 
+    public async Task<IReadOnlyList<InvestmentInstrumentOptionDto>> SearchInstrumentsAsync(
+        string query,
+        int maxResults = 20,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return [];
+        var url = $"{httpClient.BaseAddress}api/InvestmentTransaction/SearchInstruments?q={Uri.EscapeDataString(query)}&maxResults={maxResults}";
+        using var response = await httpClient.GetAsync(url, cancellationToken);
+        if (!response.IsSuccessStatusCode) return [];
+        return await response.Content.ReadFromJsonAsync<List<InvestmentInstrumentOptionDto>>(cancellationToken) ?? [];
+    }
+
     public async Task<InstrumentSearchResultDto?> GetListingAsync(long listingId)
     {
         using var response = await httpClient.GetAsync(
@@ -75,5 +90,23 @@ public class InvestmentTransactionHttpClient(HttpClient httpClient)
         using var response = await httpClient.GetAsync(url);
         if (!response.IsSuccessStatusCode) return null;
         return await response.Content.ReadFromJsonAsync<ListingPriceDto>();
+    }
+
+    private static async Task<string> GetProblemDetailAsync(HttpResponseMessage response)
+    {
+        try
+        {
+            var problem = await response.Content.ReadFromJsonAsync<JsonElement>();
+            if (problem.ValueKind == JsonValueKind.Object
+                && problem.TryGetProperty("detail", out var detail)
+                && detail.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(detail.GetString()))
+                return detail.GetString()!;
+        }
+        catch (JsonException)
+        {
+        }
+
+        return "Could not save the transaction.";
     }
 }

--- a/code/FinanceManager.Domain/Assets/Discovery/InstrumentOptionSource.cs
+++ b/code/FinanceManager.Domain/Assets/Discovery/InstrumentOptionSource.cs
@@ -1,0 +1,7 @@
+namespace FinanceManager.Domain.Assets.Discovery;
+
+public enum InstrumentOptionSource
+{
+    Existing,
+    External
+}

--- a/code/FinanceManager.Domain/Assets/Discovery/InvestmentInstrumentOptionDto.cs
+++ b/code/FinanceManager.Domain/Assets/Discovery/InvestmentInstrumentOptionDto.cs
@@ -1,0 +1,16 @@
+namespace FinanceManager.Domain.Assets.Discovery;
+
+public sealed record InvestmentInstrumentOptionDto
+{
+    public string ResultId { get; init; } = string.Empty;
+    public InstrumentOptionSource Source { get; init; }
+    public long? AssetListingId { get; init; }
+    public InstrumentDiscoveryResultDto? ExternalInstrument { get; init; }
+    public string Ticker { get; init; } = string.Empty;
+    public string DisplayName { get; init; } = string.Empty;
+    public string? ExchangeMic { get; init; }
+    public string ExchangeName { get; init; } = string.Empty;
+    public string TradingCurrency { get; init; } = string.Empty;
+    public string? Isin { get; init; }
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+}

--- a/code/FinanceManager.Domain/Assets/Discovery/InvestmentInstrumentOptionDto.cs
+++ b/code/FinanceManager.Domain/Assets/Discovery/InvestmentInstrumentOptionDto.cs
@@ -1,5 +1,6 @@
 namespace FinanceManager.Domain.Assets.Discovery;
 
+// Property-initializer syntax keeps optional fields readable at named object-initializer call sites.
 public sealed record InvestmentInstrumentOptionDto
 {
     public string ResultId { get; init; } = string.Empty;

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionDtos.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionDtos.cs
@@ -21,14 +21,15 @@ public record InvestmentTransactionDto(
 /// <summary>Request to add a new investment transaction. The owning user is derived from the account, not this payload.</summary>
 public record AddInvestmentTransactionRequest(
     int AccountId,
-    long AssetListingId,
+    long? AssetListingId,
     InvestmentTransactionType Type,
     decimal Quantity,
     decimal UnitPrice,
     string Currency,
     DateOnly TradeDate,
     decimal? Fee = null,
-    string? Notes = null);
+    string? Notes = null,
+    string? ExternalInstrumentResultId = null);
 
 /// <summary>Request to update an existing investment transaction. Account and owner are not reassigned.</summary>
 public record UpdateInvestmentTransactionRequest(

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionMappingExtensions.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionMappingExtensions.cs
@@ -19,12 +19,12 @@ public static class InvestmentTransactionMappingExtensions
         transaction.AssetListing?.Ticker ?? string.Empty,
         transaction.AssetListing?.ExchangeName ?? string.Empty);
 
-    /// <summary>Build a new entity from an add request, stamping the owning user resolved from the account.</summary>
-    public static InvestmentTransaction ToEntity(this AddInvestmentTransactionRequest request, long userId) => new()
+    /// <summary>Build a new entity from an add request after its instrument source was resolved.</summary>
+    public static InvestmentTransaction ToEntity(this AddInvestmentTransactionRequest request, long userId, long assetListingId) => new()
     {
         UserId = userId,
         AccountId = request.AccountId,
-        AssetListingId = request.AssetListingId,
+        AssetListingId = assetListingId,
         Type = request.Type,
         Quantity = request.Quantity,
         UnitPrice = request.UnitPrice,

--- a/code/FinanceManager.Infrastructure/Features/Assets/Repositories/AssetListingRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/Assets/Repositories/AssetListingRepository.cs
@@ -30,12 +30,18 @@ public class AssetListingRepository(AppDbContext context) : IAssetListingReposit
         if (string.IsNullOrWhiteSpace(query)) return [];
         var trimmed = query.Trim();
         // Tickers are stored uppercase; comparing directly against the uppercased input lets the index on Ticker be used.
-        // Exchange names are mixed-case so we use a LIKE pattern (case-sensitive on PG, insensitive on SQL Server by default).
+        // Exchange and asset text are mixed-case so we use LIKE patterns (case-sensitive on PG,
+        // insensitive on SQL Server by default).
         var upperTicker = trimmed.ToUpperInvariant();
         var likePattern = $"%{trimmed}%";
         return await context.AssetListings
             .AsNoTracking()
-            .Where(x => x.IsActive && (x.Ticker.StartsWith(upperTicker) || EF.Functions.Like(x.ExchangeName, likePattern)))
+            .Include(x => x.Asset)
+            .Include(x => x.MarketDataSymbols)
+            .Where(x => x.IsActive && (x.Ticker.StartsWith(upperTicker)
+                || EF.Functions.Like(x.ExchangeName, likePattern)
+                || EF.Functions.Like(x.Asset.Name, likePattern)
+                || EF.Functions.Like(x.Asset.Isin, likePattern)))
             .OrderByDescending(x => x.IsPrimaryListing)
             .ThenBy(x => x.Ticker)
             .Take(maxResults)

--- a/code/FinanceManager.Infrastructure/Features/Assets/Repositories/AssetListingRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/Assets/Repositories/AssetListingRepository.cs
@@ -29,19 +29,20 @@ public class AssetListingRepository(AppDbContext context) : IAssetListingReposit
     {
         if (string.IsNullOrWhiteSpace(query)) return [];
         var trimmed = query.Trim();
-        // Tickers are stored uppercase; comparing directly against the uppercased input lets the index on Ticker be used.
-        // Exchange and asset text are mixed-case so we use LIKE patterns (case-sensitive on PG,
-        // insensitive on SQL Server by default).
-        var upperTicker = trimmed.ToUpperInvariant();
-        var likePattern = $"%{trimmed}%";
+        var escapedQuery = trimmed.ToUpperInvariant()
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("%", "\\%", StringComparison.Ordinal)
+            .Replace("_", "\\_", StringComparison.Ordinal);
+        var tickerPattern = $"{escapedQuery}%";
+        var likePattern = $"%{escapedQuery}%";
         return await context.AssetListings
             .AsNoTracking()
             .Include(x => x.Asset)
             .Include(x => x.MarketDataSymbols)
-            .Where(x => x.IsActive && (x.Ticker.StartsWith(upperTicker)
-                || EF.Functions.Like(x.ExchangeName, likePattern)
-                || EF.Functions.Like(x.Asset.Name, likePattern)
-                || EF.Functions.Like(x.Asset.Isin, likePattern)))
+            .Where(x => x.IsActive && (EF.Functions.Like(x.Ticker.ToUpper(), tickerPattern, "\\")
+                || EF.Functions.Like(x.ExchangeName.ToUpper(), likePattern, "\\")
+                || EF.Functions.Like(x.Asset.Name.ToUpper(), likePattern, "\\")
+                || (x.Asset.Isin != null && EF.Functions.Like(x.Asset.Isin.ToUpper(), likePattern, "\\"))))
             .OrderByDescending(x => x.IsPrimaryListing)
             .ThenBy(x => x.Ticker)
             .Take(maxResults)
@@ -81,7 +82,19 @@ public class AssetListingRepository(AppDbContext context) : IAssetListingReposit
             return existing;
         }
 
-        return await Add(listing, cancellationToken);
+        try
+        {
+            return await Add(listing, cancellationToken);
+        }
+        catch (DbUpdateException)
+        {
+            context.Entry(listing).State = EntityState.Detached;
+            var concurrent = await context.AssetListings.FirstOrDefaultAsync(
+                x => x.Ticker == listing.Ticker && x.ExchangeMic == listing.ExchangeMic && x.TradingCurrency == listing.TradingCurrency,
+                cancellationToken);
+            if (concurrent is null) throw;
+            return concurrent;
+        }
     }
 
     public async Task<bool> Update(AssetListing listing, CancellationToken cancellationToken = default)

--- a/code/FinanceManager.Infrastructure/Features/Assets/Repositories/AssetRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/Assets/Repositories/AssetRepository.cs
@@ -43,12 +43,7 @@ public class AssetRepository(AppDbContext context) : IAssetRepository
     {
         // Identity is FIGI-centric: prefer matching an existing asset by ISIN when one is supplied,
         // otherwise fall back to the canonical share-class FIGI. Either key locates the same security.
-        Asset? existing = null;
-        if (!string.IsNullOrWhiteSpace(asset.Isin))
-            existing = await context.Assets.FirstOrDefaultAsync(x => x.Isin == asset.Isin, cancellationToken);
-
-        if (existing is null && !string.IsNullOrWhiteSpace(asset.ShareClassFigi))
-            existing = await context.Assets.FirstOrDefaultAsync(x => x.ShareClassFigi == asset.ShareClassFigi, cancellationToken);
+        var existing = await FindByIdentityAsync(asset, cancellationToken);
 
         if (existing is not null)
         {
@@ -75,7 +70,29 @@ public class AssetRepository(AppDbContext context) : IAssetRepository
             return existing;
         }
 
-        return await Add(asset, cancellationToken);
+        try
+        {
+            return await Add(asset, cancellationToken);
+        }
+        catch (DbUpdateException)
+        {
+            context.Entry(asset).State = EntityState.Detached;
+            existing = await FindByIdentityAsync(asset, cancellationToken);
+            if (existing is null) throw;
+            return existing;
+        }
+    }
+
+    private async Task<Asset?> FindByIdentityAsync(Asset asset, CancellationToken cancellationToken)
+    {
+        Asset? existing = null;
+        if (!string.IsNullOrWhiteSpace(asset.Isin))
+            existing = await context.Assets.FirstOrDefaultAsync(x => x.Isin == asset.Isin, cancellationToken);
+
+        if (existing is null && !string.IsNullOrWhiteSpace(asset.ShareClassFigi))
+            existing = await context.Assets.FirstOrDefaultAsync(x => x.ShareClassFigi == asset.ShareClassFigi, cancellationToken);
+
+        return existing;
     }
 
     public async Task<bool> Update(Asset asset, CancellationToken cancellationToken = default)

--- a/code/FinanceManager.Infrastructure/Features/Assets/Repositories/MarketDataSymbolRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/Assets/Repositories/MarketDataSymbolRepository.cs
@@ -55,7 +55,19 @@ public class MarketDataSymbolRepository(AppDbContext context) : IMarketDataSymbo
             return existing;
         }
 
-        return await Add(symbol, cancellationToken);
+        try
+        {
+            return await Add(symbol, cancellationToken);
+        }
+        catch (DbUpdateException)
+        {
+            context.Entry(symbol).State = EntityState.Detached;
+            var concurrent = await context.MarketDataSymbols.FirstOrDefaultAsync(
+                x => x.Provider == symbol.Provider && x.Symbol == symbol.Symbol,
+                cancellationToken);
+            if (concurrent is null) throw;
+            return concurrent;
+        }
     }
 
     public async Task<bool> RecordFetchResult(long id, DateTimeOffset? lastSuccessfulPriceFetchAt, string? lastError, CancellationToken cancellationToken = default)

--- a/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
@@ -6,6 +6,7 @@ using FinanceManager.Application.Labels.Setter;
 using FinanceManager.Application.Labels.Suggestions;
 using FinanceManager.Application.Shared.ExternalServices;
 using FinanceManager.Application.Shared.Options;
+using FinanceManager.Application.Shared.Persistence;
 using FinanceManager.Domain.Administration.Logging;
 using FinanceManager.Domain.Administration.Monitoring;
 using FinanceManager.Domain.Assets.Repositories;
@@ -44,6 +45,7 @@ using FinanceManager.Infrastructure.Features.Mcp.OAuth;
 using FinanceManager.Infrastructure.Features.MoneyFlow.Providers;
 using FinanceManager.Infrastructure.Persistence;
 using FinanceManager.Infrastructure.Shared.Ai;
+using FinanceManager.Infrastructure.Shared.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Caching.Hybrid;
@@ -99,6 +101,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<IAssetListingRepository, AssetListingRepository>()
                 .AddScoped<IMarketDataSymbolRepository, MarketDataSymbolRepository>()
                 .AddScoped<IInvestmentTransactionRepository, InvestmentTransactionRepository>()
+                .AddScoped<IAtomicOperation, EfAtomicOperation>()
                 .AddScoped<IPriceQuoteRepository, PriceQuoteRepository>()
                 .AddScoped<IFinancialAccountRepository, AccountRepository>()
                 .AddScoped<IUserRepository, UserRepository>()

--- a/code/FinanceManager.Infrastructure/Shared/Persistence/EfAtomicOperation.cs
+++ b/code/FinanceManager.Infrastructure/Shared/Persistence/EfAtomicOperation.cs
@@ -1,0 +1,27 @@
+using FinanceManager.Application.Shared.Persistence;
+using FinanceManager.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Infrastructure.Shared.Persistence;
+
+public sealed class EfAtomicOperation(AppDbContext context) : IAtomicOperation
+{
+    public async Task<T> ExecuteAsync<T>(Func<CancellationToken, Task<T>> operation, CancellationToken cancellationToken = default)
+    {
+        if (!context.Database.IsRelational())
+            return await operation(cancellationToken);
+
+        await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            var result = await operation(cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+            return result;
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
+    }
+}

--- a/code/FinanceManager.Infrastructure/Shared/Persistence/EfAtomicOperation.cs
+++ b/code/FinanceManager.Infrastructure/Shared/Persistence/EfAtomicOperation.cs
@@ -20,7 +20,7 @@ public sealed class EfAtomicOperation(AppDbContext context) : IAtomicOperation
         }
         catch
         {
-            await transaction.RollbackAsync(cancellationToken);
+            await transaction.RollbackAsync(CancellationToken.None);
             throw;
         }
     }

--- a/code/FinanceManager.Tests.Integration/Features/FinancialAccounts/Investments/Controllers/InvestmentTransactionControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Features/FinancialAccounts/Investments/Controllers/InvestmentTransactionControllerTests.cs
@@ -1,7 +1,11 @@
+using FinanceManager.Application.FinancialAccounts.Stock.Pricing;
+using FinanceManager.Application.FinancialAccounts.Stock.Resolution;
 using FinanceManager.Application.Identity.Users;
 using FinanceManager.Components.Features.FinancialAccounts.HttpClients;
+using FinanceManager.Domain.Assets.Discovery;
 using FinanceManager.Domain.Assets.Entities;
 using FinanceManager.Domain.Assets.Services;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Dtos;
@@ -26,6 +30,8 @@ public class InvestmentTransactionControllerTests(OptionsProvider optionsProvide
     private const int _testAccountId = 791;
     private const long _listingId = 5001;
     private readonly Mock<IInvestmentPriceProvider> _priceProvider = new();
+    private readonly Mock<IOpenFigiClient> _openFigiClient = new();
+    private readonly Mock<IAlphaVantageClient> _alphaVantageClient = new();
     private TestDatabase? _testDatabase;
 
     protected override void ConfigureServices(IServiceCollection services)
@@ -42,6 +48,8 @@ public class InvestmentTransactionControllerTests(OptionsProvider optionsProvide
         planVerifierMock.Setup(x => x.CanAddMoreEntries(_testUserId, It.IsAny<int>())).ReturnsAsync(true);
         services.AddSingleton(planVerifierMock.Object);
         services.AddSingleton(_priceProvider.Object);
+        services.AddSingleton(_openFigiClient.Object);
+        services.AddSingleton(_alphaVantageClient.Object);
     }
 
     private async Task SeedAccount()
@@ -139,6 +147,7 @@ public class InvestmentTransactionControllerTests(OptionsProvider optionsProvide
     public async Task Add_CreatesTransaction()
     {
         await SeedAccount();
+        await SeedListing();
         Authorize("testuser", _testUserId, UserRole.User);
         var client = new InvestmentTransactionHttpClient(Client);
 
@@ -153,6 +162,82 @@ public class InvestmentTransactionControllerTests(OptionsProvider optionsProvide
         Assert.NotNull(inDb);
         Assert.Equal(120m, inDb!.UnitPrice);
         Assert.Equal(_testUserId, inDb.UserId);
+    }
+
+    [Fact]
+    public async Task Add_WithExternalInstrument_CommitsInstrumentAndTransactionTogether()
+    {
+        await SeedAccount();
+        SetupExternalInstrument();
+        Authorize("testuser", _testUserId, UserRole.User);
+
+        var options = await Client.GetFromJsonAsync<List<InvestmentInstrumentOptionDto>>(
+            "api/InvestmentTransaction/SearchInstruments?q=CSPX",
+            TestContext.Current.CancellationToken);
+        var option = Assert.Single(options!);
+        Assert.Equal(InstrumentOptionSource.External, option.Source);
+
+        var request = new AddInvestmentTransactionRequest(
+            _testAccountId,
+            null,
+            InvestmentTransactionType.Buy,
+            2m,
+            100m,
+            "USD",
+            new DateOnly(2026, 1, 1),
+            ExternalInstrumentResultId: option.ResultId);
+        var response = await Client.PostAsJsonAsync(
+            "api/InvestmentTransaction/Add", request, TestContext.Current.CancellationToken);
+
+        response.EnsureSuccessStatusCode();
+        var transaction = await response.Content.ReadFromJsonAsync<InvestmentTransactionDto>(
+            TestContext.Current.CancellationToken);
+
+        Assert.NotNull(transaction);
+        Assert.True(transaction!.AssetListingId > 0);
+        Assert.Single(await _testDatabase!.Context.Assets.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Single(await _testDatabase.Context.AssetListings.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Single(await _testDatabase.Context.MarketDataSymbols.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Single(await _testDatabase.Context.InvestmentTransactions.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Add_WithInvalidExternalProviderResult_CreatesNoMasterData()
+    {
+        await SeedAccount();
+        SetupExternalInstrument();
+        _alphaVantageClient
+            .Setup(x => x.GetDailySeries(
+                "CSPX.LON",
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<Currency>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        Authorize("testuser", _testUserId, UserRole.User);
+
+        var options = await Client.GetFromJsonAsync<List<InvestmentInstrumentOptionDto>>(
+            "api/InvestmentTransaction/SearchInstruments?q=CSPX",
+            TestContext.Current.CancellationToken);
+        var request = new AddInvestmentTransactionRequest(
+            _testAccountId,
+            null,
+            InvestmentTransactionType.Buy,
+            2m,
+            100m,
+            "USD",
+            new DateOnly(2026, 1, 1),
+            ExternalInstrumentResultId: Assert.Single(options!).ResultId);
+        var response = await Client.PostAsJsonAsync(
+            "api/InvestmentTransaction/Add", request, TestContext.Current.CancellationToken);
+        var problem = await response.Content.ReadFromJsonAsync<Dictionary<string, object?>>(
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("market_data_symbol_invalid", problem!["code"]?.ToString());
+        Assert.Empty(await _testDatabase!.Context.Assets.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await _testDatabase.Context.AssetListings.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await _testDatabase.Context.InvestmentTransactions.ToListAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -283,6 +368,51 @@ public class InvestmentTransactionControllerTests(OptionsProvider optionsProvide
         var inDb = await _testDatabase!.Context.InvestmentTransactions
             .FirstOrDefaultAsync(x => x.Id == id, TestContext.Current.CancellationToken);
         Assert.Null(inDb);
+    }
+
+    private void SetupExternalInstrument()
+    {
+        _openFigiClient
+            .Setup(x => x.MapByTickerAsync("CSPX", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new OpenFigiListing(
+                    Isin: null,
+                    Ticker: "CSPX",
+                    Name: "iShares Core S&P 500 UCITS ETF",
+                    ExchCode: "LN",
+                    Currency: "USD",
+                    Figi: "BBG001",
+                    ShareClassFigi: "BBGSC")
+            ]);
+        _alphaVantageClient
+            .Setup(x => x.SearchTicker("CSPX", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new TickerSearchMatch
+                {
+                    Symbol = "CSPX.LON",
+                    Name = "iShares Core S&P 500 ETF",
+                    Type = "ETF",
+                    Region = "United Kingdom",
+                    Currency = "USD",
+                    MatchScore = 1m
+                }
+            ]);
+        _alphaVantageClient
+            .Setup(x => x.GetDailySeries(
+                "CSPX.LON",
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<Currency>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new StockPrice
+                {
+                    Isin = "CSPX.LON",
+                    PricePerUnit = 100m,
+                    Currency = new Currency(0, "USD", "USD"),
+                    Date = DateTime.UtcNow
+                }
+            ]);
     }
 
     public override void Dispose()

--- a/code/FinanceManager.Tests.Integration/Features/FinancialAccounts/Investments/Controllers/InvestmentTransactionControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Features/FinancialAccounts/Investments/Controllers/InvestmentTransactionControllerTests.cs
@@ -237,6 +237,7 @@ public class InvestmentTransactionControllerTests(OptionsProvider optionsProvide
         Assert.Equal("market_data_symbol_invalid", problem!["code"]?.ToString());
         Assert.Empty(await _testDatabase!.Context.Assets.ToListAsync(TestContext.Current.CancellationToken));
         Assert.Empty(await _testDatabase.Context.AssetListings.ToListAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(await _testDatabase.Context.MarketDataSymbols.ToListAsync(TestContext.Current.CancellationToken));
         Assert.Empty(await _testDatabase.Context.InvestmentTransactions.ToListAsync(TestContext.Current.CancellationToken));
     }
 

--- a/code/FinanceManager.Tests.Unit/Application/Services/Discovery/InstrumentImportServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Discovery/InstrumentImportServiceTests.cs
@@ -23,14 +23,14 @@ public class InstrumentImportServiceTests
         new(_avClientMock.Object, _assetRepositoryMock.Object, _listingRepositoryMock.Object,
             _symbolRepositoryMock.Object, _logger);
 
-    private static InstrumentDiscoveryResultDto Instrument() => new()
+    private static InstrumentDiscoveryResultDto Instrument(string securityType = "ETF") => new()
     {
         DisplayName = "iShares Core S&P 500 UCITS ETF",
         Ticker = "CSPX",
         ExchangeMic = "XLON",
         ExchangeCode = "LN",
         TradingCurrency = "USD",
-        SecurityType = "ETF",
+        SecurityType = securityType,
         ShareClassFigi = "BBGSC",
         ListingFigi = "BBG001",
         ProviderSymbol = "CSPX.LON"
@@ -64,11 +64,11 @@ public class InstrumentImportServiceTests
     public async Task ImportAsync_WhenValidationReturnsNoPrices_SavesDisabledSymbol()
     {
         _assetRepositoryMock.Setup(x => x.GetAll(It.IsAny<CancellationToken>())).ReturnsAsync([]);
-        _assetRepositoryMock.Setup(x => x.Add(It.IsAny<Asset>(), It.IsAny<CancellationToken>()))
+        _assetRepositoryMock.Setup(x => x.Upsert(It.IsAny<Asset>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((Asset asset, CancellationToken _) => { asset.Id = 1; return asset; });
-        _listingRepositoryMock.Setup(x => x.Add(It.IsAny<AssetListing>(), It.IsAny<CancellationToken>()))
+        _listingRepositoryMock.Setup(x => x.Upsert(It.IsAny<AssetListing>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((AssetListing listing, CancellationToken _) => { listing.Id = 2; return listing; });
-        _symbolRepositoryMock.Setup(x => x.Add(It.IsAny<MarketDataSymbol>(), It.IsAny<CancellationToken>()))
+        _symbolRepositoryMock.Setup(x => x.Upsert(It.IsAny<MarketDataSymbol>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((MarketDataSymbol symbol, CancellationToken _) => { symbol.Id = 3; return symbol; });
         _avClientMock.Setup(x => x.GetDailySeries("CSPX.LON", It.IsAny<DateTime>(), It.IsAny<DateTime>(),
             It.IsAny<FinanceManager.Domain.FinancialAccounts.Currencies.Entities.Currency>(), It.IsAny<CancellationToken>()))
@@ -78,8 +78,22 @@ public class InstrumentImportServiceTests
 
         Assert.True(result.CreatedMarketDataSymbol);
         Assert.Contains(result.Warnings, warning => warning.Contains("saved disabled", StringComparison.OrdinalIgnoreCase));
-        _symbolRepositoryMock.Verify(x => x.Add(It.Is<MarketDataSymbol>(symbol => !symbol.IsEnabled && symbol.LastError != null),
+        _symbolRepositoryMock.Verify(x => x.Upsert(It.Is<MarketDataSymbol>(symbol => !symbol.IsEnabled && symbol.LastError != null),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportValidatedAsync_WhenSecurityTypeIsUnknown_RejectsBeforePersistence()
+    {
+        var instrument = Instrument("Bond");
+
+        var exception = await Assert.ThrowsAsync<InstrumentImportException>(() =>
+            CreateService().ImportValidatedAsync(instrument, TestContext.Current.CancellationToken));
+
+        Assert.Equal("instrument_import_failed", exception.Code);
+        _assetRepositoryMock.Verify(x => x.Upsert(It.IsAny<Asset>(), It.IsAny<CancellationToken>()), Times.Never);
+        _avClientMock.Verify(x => x.GetDailySeries(
+            It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<FinanceManager.Domain.FinancialAccounts.Currencies.Entities.Currency>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Unit/Application/Services/Discovery/InvestmentInstrumentSearchServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Discovery/InvestmentInstrumentSearchServiceTests.cs
@@ -1,0 +1,69 @@
+using FinanceManager.Application.FinancialAccounts.Investments.Discovery;
+using FinanceManager.Domain.Assets.Discovery;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services.Discovery;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class InvestmentInstrumentSearchServiceTests
+{
+    private readonly Mock<IAssetListingRepository> _listingRepository = new();
+    private readonly Mock<IInvestmentInstrumentDiscoveryService> _discoveryService = new();
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+
+    [Fact]
+    public async Task SearchAsync_ReturnsLocalFirstAndDeduplicatesExternalListings()
+    {
+        var local = new AssetListing
+        {
+            Id = 7,
+            Ticker = "CSPX",
+            ExchangeMic = "XLON",
+            ExchangeName = "London Stock Exchange",
+            TradingCurrency = "USD",
+            ListingFigi = "BBG001",
+            Asset = new Asset { Name = "iShares Core S&P 500 UCITS ETF", Isin = "IE00B5BMR087" }
+        };
+        var duplicate = new InstrumentDiscoveryResultDto
+        {
+            Ticker = "CSPX",
+            DisplayName = "iShares Core S&P 500 UCITS ETF",
+            ExchangeMic = "XLON",
+            ExchangeName = "London Stock Exchange",
+            TradingCurrency = "USD",
+            ListingFigi = "BBG001",
+            ConfidenceScore = 1m
+        };
+        var external = new InstrumentDiscoveryResultDto
+        {
+            Ticker = "CSPX",
+            DisplayName = "iShares Core S&P 500 UCITS ETF",
+            ExchangeMic = "XETR",
+            ExchangeName = "Xetra",
+            TradingCurrency = "EUR",
+            ListingFigi = "BBG002",
+            ConfidenceScore = 0.8m
+        };
+        _listingRepository.Setup(x => x.SearchAsync("CSPX", 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([local]);
+        _discoveryService.Setup(x => x.SearchAsync("CSPX", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([duplicate, external]);
+
+        var results = await new InvestmentInstrumentSearchService(
+            _listingRepository.Object, _discoveryService.Object, _cache)
+            .SearchAsync("CSPX", 20, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(InstrumentOptionSource.Existing, results[0].Source);
+        Assert.Equal(InstrumentOptionSource.External, results[1].Source);
+        Assert.Equal("XETR", results[1].ExchangeMic);
+        Assert.NotEmpty(results[1].ResultId);
+        Assert.Equal(external, await new InvestmentInstrumentSearchService(
+            _listingRepository.Object, _discoveryService.Object, _cache)
+            .ResolveExternalResultAsync(results[1].ResultId, TestContext.Current.CancellationToken));
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/Transactions/InvestmentTransactionServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Transactions/InvestmentTransactionServiceTests.cs
@@ -1,0 +1,73 @@
+using FinanceManager.Application.FinancialAccounts.Investments.Discovery;
+using FinanceManager.Application.FinancialAccounts.Investments.Transactions;
+using FinanceManager.Application.Shared.Persistence;
+using FinanceManager.Domain.Assets.Discovery;
+using FinanceManager.Domain.Assets.Entities;
+using FinanceManager.Domain.Assets.Repositories;
+using FinanceManager.Domain.Dashboard.Services;
+using FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
+using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Services.Transactions;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class InvestmentTransactionServiceTests
+{
+    private readonly Mock<IAssetListingRepository> _listingRepository = new();
+    private readonly Mock<IInvestmentTransactionRepository> _transactionRepository = new();
+    private readonly Mock<IInvestmentInstrumentSearchService> _searchService = new();
+    private readonly Mock<IInstrumentImportService> _importService = new();
+    private readonly Mock<IAtomicOperation> _atomicOperation = new();
+    private readonly Mock<ICacheInvalidator> _cacheInvalidator = new();
+    private readonly ILogger<InvestmentTransactionService> _logger =
+        LoggerFactory.Create(_ => { }).CreateLogger<InvestmentTransactionService>();
+
+    [Fact]
+    public async Task AddAsync_ValidatesExternalInstrumentBeforeStartingAtomicOperation()
+    {
+        var instrument = new InstrumentDiscoveryResultDto
+        {
+            DisplayName = "CSPX",
+            Ticker = "CSPX",
+            ExchangeMic = "XLON",
+            TradingCurrency = "USD",
+            ProviderSymbol = "CSPX.LON",
+            SecurityType = "ETF"
+        };
+        _searchService.Setup(x => x.ResolveExternalResultAsync("result", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(instrument);
+        _importService.Setup(x => x.ValidateForTransactionAsync(instrument, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InstrumentImportException("provider_unavailable", "Provider unavailable."));
+
+        var service = CreateService();
+        var request = new AddInvestmentTransactionRequest(
+            1, null, InvestmentTransactionType.Buy, 1m, 100m, "USD", new DateOnly(2026, 1, 1),
+            ExternalInstrumentResultId: "result");
+
+        var exception = await Assert.ThrowsAsync<InvestmentTransactionCommandException>(() =>
+            service.AddAsync(request, 91, TestContext.Current.CancellationToken));
+
+        Assert.Equal("provider_unavailable", exception.Code);
+        _atomicOperation.Verify(
+            x => x.ExecuteAsync(
+                It.IsAny<Func<CancellationToken, Task<InvestmentTransactionDto>>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _transactionRepository.Verify(
+            x => x.Add(It.IsAny<InvestmentTransaction>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private InvestmentTransactionService CreateService() => new(
+        _listingRepository.Object,
+        _transactionRepository.Object,
+        _searchService.Object,
+        _importService.Object,
+        _atomicOperation.Object,
+        _cacheInvalidator.Object,
+        _logger);
+}


### PR DESCRIPTION
## Summary

- Unify investment transaction autocomplete across existing listings and external provider discovery.
- Resolve external choices through short-lived opaque result IDs instead of trusting client payloads.
- Validate account ownership, source selection, and provider data before saving.
- Persist external master data and the investment transaction atomically, with rollback and structured ProblemDetails errors.
- Keep the admin import workflow while deferring transaction-form imports until save.

## Why

Investment transactions previously used separate local search and immediate import flows, which could leave partial master data and did not give the save operation one atomic boundary.

## Validation

- `dotnet build ./code/FinanceManager.slnx --no-restore`
- `dotnet format ./code/FinanceManager.slnx --verify-no-changes --no-restore`
- 807 unit tests passed
- 302 integration tests passed
- Guest UI verification passed at desktop and mobile widths; no horizontal overflow or browser console errors

Closes #651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added investment instrument search with local and external results, richer metadata, duplicate removal, and result limits.
  * Investment transactions can now be created using externally discovered instruments.
  * Added validation and clear error reporting for invalid instruments and transaction requests.
  * External instruments are added atomically with their transactions.
* **Bug Fixes**
  * Improved investment searches to match names, exchanges, and ISINs.
  * Invalid external market data no longer creates partial records.
* **User Interface**
  * Enhanced instrument autocomplete details and added guidance for external instruments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->