### PR TITLE
Make the legacy-session probe test verify persistence

### DIFF
--- a/code/FinanceManager.Tests.Unit/Components/Features/Identity/Services/LoginServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Identity/Services/LoginServiceTests.cs
@@ -145,10 +145,18 @@ public class LoginServiceTests
         gate.SetResult();
         var handler = new GatedHandler(gate.Task, HttpStatusCode.OK);
         var localStorage = LegacyProbe(alreadyProbed: false);
-        var loginService = CreateLoginService(handler, CookieReader(sessionPresent: false), localStorage);
+        var cookieReader = CookieReader(sessionPresent: false);
 
-        await loginService.GetLoggedUser();
+        // First page load: nothing recorded yet, so the probe runs.
+        await CreateLoginService(handler, cookieReader, localStorage).GetLoggedUser();
+        Assert.Equal(1, handler.RequestCount);
 
+        // A second page load is a fresh LoginService over the same browser storage. Only the recorded flag can
+        // stop it probing again — the per-instance "already attempted" guard does not survive a reload, so
+        // asserting on one instance would prove nothing about the once-per-browser claim.
+        await CreateLoginService(handler, cookieReader, localStorage).GetLoggedUser();
+
+        Assert.Equal(1, handler.RequestCount);
         Mock.Get(localStorage).Verify(
             storage => storage.SetItemAsync("legacySessionProbed", true, It.IsAny<CancellationToken>()),
             Times.Once);
@@ -213,13 +221,20 @@ public class LoginServiceTests
             NullLogger<LoginService>.Instance);
     }
 
-    // The default across most tests is "migration already done", so the presence cookie alone decides.
+    // The default across most tests is "migration already done", so the presence cookie alone decides. The stored
+    // flag is stateful rather than fixed: recording the probe has to be observable to a later LoginService, since
+    // that -- not the per-instance "already attempted" flag -- is what makes the probe once-per-browser.
     private static ILocalStorageService LegacyProbe(bool alreadyProbed)
     {
+        var probed = alreadyProbed;
         var localStorage = new Mock<ILocalStorageService>();
         localStorage
             .Setup(storage => storage.ContainKeyAsync("legacySessionProbed", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(alreadyProbed);
+            .ReturnsAsync(() => probed);
+        localStorage
+            .Setup(storage => storage.SetItemAsync("legacySessionProbed", true, It.IsAny<CancellationToken>()))
+            .Callback(() => probed = true)
+            .Returns(ValueTask.CompletedTask);
 
         return localStorage.Object;
     }


### PR DESCRIPTION
Follow-up to #672, which merged before this could be included. Test-only; no behavioural change.

## Problem

`GetLoggedUser_RecordsTheLegacyProbeSoItRunsOnlyOncePerBrowser` called `GetLoggedUser` exactly once. Within a single `LoginService`, `_initialRefreshAttempted` already suppresses a second probe regardless of what is in local storage — so the test passed whether or not the probe was persisted, which is precisely the property it is named for. "Once per browser" spans page loads, and a reload constructs a fresh `LoginService`.

The migration logic this guards is the part of #672 that keeps pre-rollout sessions from being silently signed out, so a test that cannot fail on it is worth correcting.

## Change

The test now drives two `LoginService` instances over the same storage, so only the recorded flag can stop the second one refreshing. The local-storage double became stateful for the same reason — a fixed `ContainKeyAsync` result cannot observe the write, which would have left the new assertion just as hollow as the old one.

## Verification

Removing the `SetItemAsync` call from `HasProbedForLegacySession` now fails this test; before the change it passed. 855 unit tests pass, `dotnet format` produced no changes.

## Note on the other open review threads from #672

Two CodeRabbit comments are deliberately not addressed here:

- **"Do not refresh for a fresh signed-out browser profile."** Correct that a brand-new browser pays one probe on its first login-page load. The suggested fix needs a signal distinguishing a new profile from a legacy session, and the only candidate (`isThisFirstVisit`) is absent for users who arrived by deep link — keying on it would silently sign out exactly the sessions the probe protects. That trades a major bug back in to save two permits, once per browser, against a budget of ten per minute that one probe cannot exhaust. The probe is temporary: once all pre-#672 refresh tokens have expired it can be deleted outright, which removes the request entirely.
- **Primary constructor on `LoginService`.** Pre-existing style; converting would mix primary-constructor properties with the several fields that are not constructor parameters. Rated "low value" by the reviewer itself.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gxxt74KfES2DnMzuHTdywa)_