### PR TITLE
Fix develop build break and address PR #671 review comments

### DIFF
--- a/code/FinanceManager.Tests.Integration/Shared/ControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Shared/ControllerTests.cs
@@ -67,6 +67,11 @@ public abstract class ControllerTests : IClassFixture<OptionsProvider>, IDisposa
 
         if (!created)
         {
+            // The host already built its provider, so nothing registered here can reach it — this call is made
+            // purely for the side effects inside ConfigureServices that a reused host still needs per test
+            // instance: resetting shared mocks, and re-acquiring the fixture's TestDatabase. The scope makes that
+            // TestDatabase resolve to the very context the host was built with, so the discarded registrations
+            // would be identical to the live ones anyway. Cross-test data is prevented by the reset below.
             using (TestDatabase.UseDatabase(appKey))
                 ConfigureServices(new ServiceCollection());
         }

--- a/code/FinanceManager.Tests.Integration/TestDatabase.cs
+++ b/code/FinanceManager.Tests.Integration/TestDatabase.cs
@@ -11,18 +11,19 @@ internal sealed class TestDatabase : IDisposable
     private static readonly ConcurrentDictionary<string, InMemoryDatabaseRoot> _databaseRoots = [];
     private static readonly ConcurrentDictionary<string, AppDbContext> _sharedContexts = [];
     private static readonly AsyncLocal<string?> _scopedDatabaseName = new();
+    private readonly string _databaseName;
     private readonly bool _shared;
 
     public AppDbContext Context { get; }
 
     public TestDatabase()
     {
-        var databaseName = _scopedDatabaseName.Value
+        _databaseName = _scopedDatabaseName.Value
             ?? Guid.NewGuid().ToString();
         _shared = _scopedDatabaseName.Value is not null;
         Context = _shared
-            ? _sharedContexts.GetOrAdd(databaseName, static name => CreateContext(name))
-            : CreateContext(databaseName);
+            ? _sharedContexts.GetOrAdd(_databaseName, static name => CreateContext(name))
+            : CreateContext(_databaseName);
     }
 
     internal static IDisposable UseDatabase(string databaseName) => new DatabaseScope(databaseName);
@@ -37,6 +38,10 @@ internal sealed class TestDatabase : IDisposable
 
         Context.Database.EnsureDeleted();
         Context.Dispose();
+
+        // An isolated database is never reopened, so its root would otherwise sit in the static dictionary for the
+        // rest of the test run — one leaked root per test. Shared roots stay: their contexts outlive this instance.
+        _databaseRoots.TryRemove(_databaseName, out _);
         GC.SuppressFinalize(this);
     }
 

--- a/code/FinanceManager.Tests.Unit/Components/Features/Identity/Services/LoginServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Identity/Services/LoginServiceTests.cs
@@ -86,6 +86,7 @@ public class LoginServiceTests
             new CustomAuthenticationStateProvider(),
             httpClient,
             antiforgery.Object,
+            CookieReader(sessionPresent: false),
             NullLogger<LoginService>.Instance);
 
         var success = await loginService.Login(new UserSession


### PR DESCRIPTION
Test-only changes. `develop` currently does not build, which is what is failing CI on #671 — that PR's own diff is three files (CHANGELOG + the two nav components) and is not the cause.

## Changes

**Restore the unit-test build (blocking)**

`LoginServiceTests.Login_ClearsAntiforgeryToken` constructed `LoginService` without the `IBrowserCookieReader` argument, so `NullLogger<LoginService>.Instance` bound to the cookie-reader parameter and the build failed with `CS7036: There is no argument given that corresponds to the required parameter 'logger'`. This is a semantic merge conflict: #672 added the constructor parameter while #673 added this test against the older signature, and the two merged cleanly into a broken build. Passes `CookieReader(sessionPresent: false)` — the test asserts login clears the antiforgery token, so presence of a prior session is irrelevant to it.

**Address the two review threads on #671**

Both threads are marked outdated there because the files they point at reached `develop` via #658, but the findings still describe live code, so they are fixed here rather than dismissed.

- `TestDatabase` added an `InMemoryDatabaseRoot` to a static dictionary for every isolated (GUID-named) database and never removed it, retaining one root per isolated test database for the whole run. `Dispose` now removes the root it created. Shared roots are deliberately left in place, since their contexts outlive the disposing instance.
- `ControllerTests` calls `ConfigureServices(new ServiceCollection())` on the reused-host path, which reads like discarded registrations. The behaviour is intentional and is left unchanged: the call is made for the side effects a reused host still needs per test instance (resetting shared mocks, re-acquiring the fixture's `TestDatabase`), and the surrounding `TestDatabase.UseDatabase(appKey)` scope makes that `TestDatabase` resolve to the same context the host was built with, so the discarded registrations would duplicate the live ones. Cross-test data is prevented by the `EnsureDeleted`/`EnsureCreated` reset that follows. Added a comment recording this so the pattern is not re-flagged.

## Validation

- `dotnet build ./code/FinanceManager.slnx` — 0 warnings, 0 errors
- `dotnet format ./code/FinanceManager.slnx` — no changes
- `dotnet test --project ./FinanceManager.Tests.Unit/...` — 856 passed
- `dotnet test --project ./FinanceManager.Tests.Integration/...` — 303 passed

No changelog entry: all three changes are test-only with no user-visible effect. No UI change, so no screenshots.

https://claude.ai/code/session_01WgqctYpQkN876Srt7aTR3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgqctYpQkN876Srt7aTR3Q)_