### PR TITLE
Tune auth rate limit budget #669

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- Authentication rate-limit budget raised from 10 to 20 requests per 60-second window, reducing false positives for legitimate login and token-refresh traffic. #669
 - The Financial Insights card now uses available vertical space for insight messages instead of a fixed four-line clamp, while keeping the card height stable. #663
 - Moved the **Admin** navigation link next to **Settings** at the bottom of the menu.
 - The admin **AI Providers** page now works like **Service Keys**: every supported provider (OpenRouter, GitHub Models, Ollama, LM Studio) is always listed with a description and documentation link, and its base URL, timeout and API-key status are read from the saved configuration falling back to the app's own settings — so a key supplied through configuration shows the green "API key configured" mark straight away instead of the page reporting no providers. Providers are turned off with the enable switch rather than being added and deleted. #656

--- a/code/FinanceManager.Api/appsettings.Production.json
+++ b/code/FinanceManager.Api/appsettings.Production.json
@@ -63,7 +63,7 @@
       "WindowSeconds": 60
     },
     "Auth": {
-      "PermitLimit": 10,
+      "PermitLimit": 20,
       "WindowSeconds": 60
     },
     "ExternalProvider": {

--- a/code/FinanceManager.Application/Shared/Options/RateLimitingOptions.cs
+++ b/code/FinanceManager.Application/Shared/Options/RateLimitingOptions.cs
@@ -16,7 +16,7 @@ public sealed class RateLimitingOptions
     public RateLimitPolicyOptions Global { get; set; } = new() { PermitLimit = 100, WindowSeconds = 60 };
 
     /// <summary>Tighter limit for authentication endpoints (login, refresh, logout) to blunt brute-force attempts.</summary>
-    public RateLimitPolicyOptions Auth { get; set; } = new() { PermitLimit = 10, WindowSeconds = 60 };
+    public RateLimitPolicyOptions Auth { get; set; } = new() { PermitLimit = 20, WindowSeconds = 60 };
 
     /// <summary>Tighter limit for endpoints that fan out to paid/quota'd external providers (Alpha Vantage, OpenFIGI).</summary>
     public RateLimitPolicyOptions ExternalProvider { get; set; } = new() { PermitLimit = 30, WindowSeconds = 60 };


### PR DESCRIPTION
Closes #669

## Summary

- Raise the authentication rate-limit budget from 10 to 20 requests per 60-second window in the defaults and production configuration.
- Keep the account lockout guard unchanged at 5 failed attempts for 15 minutes.
- Document the user-facing change in the unreleased changelog.

## Why

The related auth-traffic fixes have landed, so the budget can be re-tuned with more headroom for legitimate login and token-refresh traffic while retaining the independent account lockout protection.

## Validation

- Focused integration tests: 3 passed, including the 429 and Retry-After assertions.
- FinanceManager.Application build passed with NuGet audit disabled for the network-restricted sandbox.
- Production JSON assertions and diff checks passed.
- Full unit suite: 855 passed, 6 unrelated existing culture/FX tests failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the allowed number of authentication requests per minute, reducing the chance of legitimate sign-ins being rate-limited.
  * Updated the production limit to match the new higher authentication threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->