### PR TITLE
fix: resolve #685 - Initialize dashboard date range to the last 31 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- The dashboard now opens on a rolling **last 31 days** range instead of the current calendar month, so its charts always show about a month of history even at the start of a month; the presets (This month / This quarter / This year) and custom date selection continue to work, and the initial state is shown as a custom range rather than highlighting This month. #685
 - Authentication rate-limit budget raised from 10 to 20 requests per 60-second window, reducing false positives for legitimate login and token-refresh traffic. #669
 - The Financial Insights card now uses available vertical space for insight messages instead of a fixed four-line clamp, while keeping the card height stable. #663
 - Moved the **Admin** navigation link next to **Settings** at the bottom of the menu.

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Dashboard.razor
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Dashboard.razor
@@ -3,6 +3,7 @@
 @using FinanceManager.Components.Features.Dashboard.Components.Cards.Liabilities
 @using FinanceManager.Components.Features.Dashboard.Components.Cards.TimeSeries
 @using FinanceManager.Components.Features.Dashboard.Models
+@using FinanceManager.Components.Shared.Helpers
 
 <MudContainer Class="py-2">
     <div class="d-flex justify-end mb-2">
@@ -150,4 +151,5 @@
     }
 </MudContainer>
 
-<DashboardDatePicker DateChanged=DateChanged StartingOption="ThisMonth" />
+<DashboardDatePicker DateChanged=DateChanged StartingOption="@DateRangeHelper.CustomRangeKey"
+                     InitialCustomStart="@StartDate" InitialCustomEnd="@EndDate" />

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Dashboard.razor.cs
@@ -61,7 +61,9 @@ public partial class Dashboard : ComponentBase
 
     protected override async Task OnInitializedAsync()
     {
-        var (Start, End) = DateRangeHelper.GetCurrentMonthRange();
+        // A rolling last-31-days window rather than the current calendar month, so charts always have
+        // ~a month of history — the current-month range is nearly empty on the 1st. #685
+        var (Start, End) = DateRangeHelper.GetLast31DaysRange(DateTime.UtcNow);
         StartDate = Start;
         EndDate = End;
 

--- a/code/FinanceManager.Components/Features/Dashboard/Components/DashboardDatePicker.razor
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/DashboardDatePicker.razor
@@ -44,12 +44,25 @@
     private MudDateRangePicker? _customDateRangePicker;
 
     [Parameter] public string StartingOption { get; set; } = "ThisMonth";
+
+    // When StartingOption is the custom key, these seed the displayed custom range so the picker
+    // reflects the active range on first paint instead of falling back to a preset highlight.
+    [Parameter] public DateTime? InitialCustomStart { get; set; }
+    [Parameter] public DateTime? InitialCustomEnd { get; set; }
     [Parameter] public required Action<(DateTime Start, DateTime End)> DateChanged { get; set; }
 
     protected override void OnInitialized()
     {
-        if (_presets.Any(p => p.Key == StartingOption))
+        if (StartingOption == DateRangeHelper.CustomRangeKey
+            && InitialCustomStart is DateTime start && InitialCustomEnd is DateTime end)
+        {
+            _selected = DateRangeHelper.CustomRangeKey;
+            _customRange = new DateRange(start.Date, end.Date);
+        }
+        else if (_presets.Any(p => p.Key == StartingOption))
+        {
             _selected = StartingOption;
+        }
     }
 
     private Task OpenCustomDateRangePicker() =>

--- a/code/FinanceManager.Components/Shared/Helpers/DateRangeHelper.cs
+++ b/code/FinanceManager.Components/Shared/Helpers/DateRangeHelper.cs
@@ -52,8 +52,8 @@ public static class DateRangeHelper
     /// A rolling window ending at <paramref name="now"/> that covers the last 31 calendar days,
     /// counting today — opened on 10 Aug this yields 11 Jul 00:00 (UTC) → now. Start is anchored to
     /// midnight so the first day buckets whole. Unlike <see cref="GetCurrentMonthRange"/> this always
-    /// carries ~a month of history regardless of the day of the month, so charts are not nearly empty
-    /// at month boundaries.
+    /// carries about a month of history regardless of the day of the month, so charts are not nearly
+    /// empty at month boundaries.
     /// </summary>
     public static (DateTime Start, DateTime End) GetLast31DaysRange(DateTime now)
     {

--- a/code/FinanceManager.Components/Shared/Helpers/DateRangeHelper.cs
+++ b/code/FinanceManager.Components/Shared/Helpers/DateRangeHelper.cs
@@ -48,6 +48,19 @@ public static class DateRangeHelper
         return (start, end);
     }
 
+    /// <summary>
+    /// A rolling window ending at <paramref name="now"/> that covers the last 31 calendar days,
+    /// counting today — opened on 10 Aug this yields 11 Jul 00:00 (UTC) → now. Start is anchored to
+    /// midnight so the first day buckets whole. Unlike <see cref="GetCurrentMonthRange"/> this always
+    /// carries ~a month of history regardless of the day of the month, so charts are not nearly empty
+    /// at month boundaries.
+    /// </summary>
+    public static (DateTime Start, DateTime End) GetLast31DaysRange(DateTime now)
+    {
+        var start = now.Date.AddDays(-30);
+        return (start, now);
+    }
+
     public static (DateTime Start, DateTime End) GetCurrentQuarterRange()
     {
         var now = DateTime.UtcNow;

--- a/code/FinanceManager.Tests.Unit/Components/Shared/Helpers/DateRangeHelperTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Shared/Helpers/DateRangeHelperTests.cs
@@ -58,6 +58,17 @@ public class DateRangeHelperTests
         Assert.Equal(start, range.Start);
     }
 
+    // The dashboard seeds a rolling 31-day window (counting today) anchored to midnight, so the
+    // start is 30 days before today and the end is exactly `now`.
+    [Fact]
+    public void GetLast31DaysRange_ReturnsMidnightStart30DaysBackAndNowEnd()
+    {
+        var range = DateRangeHelper.GetLast31DaysRange(_now);
+
+        Assert.Equal(new DateTime(2026, 6, 12, 0, 0, 0, DateTimeKind.Utc), range.Start);
+        Assert.Equal(_now, range.End);
+    }
+
     [Fact]
     public void GetExpandedStart_ReturnsOnlyOlderEntry()
     {


### PR DESCRIPTION
Closes #685

## What & why
The dashboard initialised its date range with `DateRangeHelper.GetCurrentMonthRange()` and rendered the picker with `StartingOption="ThisMonth"`. At the start of a month (especially the 1st) this leaves charts like net worth and cash flow nearly empty and incorrectly highlights **This month**.

This change seeds a rolling **last 31 days** window (counting today, anchored to midnight) so the dashboard always shows about a month of history regardless of the day of the month, and shows the initial state as a **custom** range instead of a preset.

## Changes
- **`DateRangeHelper.GetLast31DaysRange(DateTime now)`** — new testable helper returning `(now.Date.AddDays(-30), now)`.
- **`Dashboard.razor.cs`** — `OnInitializedAsync` uses `GetLast31DaysRange(DateTime.UtcNow)` instead of `GetCurrentMonthRange()`.
- **`DashboardDatePicker.razor`** — new `InitialCustomStart`/`InitialCustomEnd` parameters; when `StartingOption` is the custom key the picker marks the custom range as selected (no preset highlighted) and displays its `dd MMM – dd MMM` label.
- **`Dashboard.razor`** — passes `StartingOption="Custom"` plus the initial `StartDate`/`EndDate` to the picker.
- **`CHANGELOG.md`** — `Changed` entry under `[Unreleased]`.

The presets (This month / This quarter / This year) and manual custom selection are unchanged and keep working after initialisation.

## Testing
- `dotnet build ./code/FinanceManager.slnx` — succeeds, 0 warnings.
- `dotnet format --verify-no-changes` — clean.
- `dotnet test FinanceManager.Tests.Unit` — 869 passed, incl. a new `GetLast31DaysRange` case.
- Rendered on the guest account (mobile + desktop): the picker shows `12 Jul – 11 Aug` as an active custom range with no preset highlighted, and all charts span the rolling window.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kk61SdHhy5o9HEaG6dPopZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard date selection now defaults to a rolling 31-day range.
  * Custom dashboard date ranges can be initialized with specified start and end dates.
  * Date selections now use consistent date-only values for custom ranges.

* **Bug Fixes**
  * Improved dashboard date-picker initialization when custom dates are provided.

* **Tests**
  * Added coverage for rolling 31-day range calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->