### PR TITLE
Use dashboard initial time range on Assets and Liabilities pages #700

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- The **Assets** and **Liabilities** pages now open on the same rolling **last 31 days** range as the dashboard instead of the current calendar month, so all three views start on identical date boundaries and always show about a month of history; the presets (This month / This quarter / This year) and custom date selection continue to work. #700
 - The dashboard now opens on a rolling **last 31 days** range instead of the current calendar month, so its charts always show about a month of history even at the start of a month; the presets (This month / This quarter / This year) and custom date selection continue to work, and the initial state is shown as a custom range rather than highlighting This month. #685
 - Authentication rate-limit budget raised from 10 to 20 requests per 60-second window, reducing false positives for legitimate login and token-refresh traffic. #669
 - The Financial Insights card now uses available vertical space for insight messages instead of a fixed four-line clamp, while keeping the card height stable. #663

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Dashboard.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Dashboard.razor.cs
@@ -63,7 +63,8 @@ public partial class Dashboard : ComponentBase
     {
         // A rolling last-31-days window rather than the current calendar month, so charts always have
         // ~a month of history — the current-month range is nearly empty on the 1st. #685
-        var (Start, End) = DateRangeHelper.GetLast31DaysRange(DateTime.UtcNow);
+        // Shared with the Assets and Liabilities pages so the three cannot drift apart. #700
+        var (Start, End) = DateRangeHelper.GetDefaultOverviewRange(DateTime.UtcNow);
         StartDate = Start;
         EndDate = End;
 

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Pages/AssetsPage.razor
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Pages/AssetsPage.razor
@@ -1,5 +1,6 @@
 @page "/Assets"
 @using FinanceManager.Components.Features.Dashboard.Components.Cards.Assets
+@using FinanceManager.Components.Shared.Helpers
 
 <PageTitle>Assets</PageTitle>
 <MudContainer Class="py-2">
@@ -27,4 +28,5 @@
     </MudGrid>
 </MudContainer>
 
-<DashboardDatePicker DateChanged=DateChanged StartingOption="ThisMonth" />
+<DashboardDatePicker DateChanged=DateChanged StartingOption="@DateRangeHelper.CustomRangeKey"
+                     InitialCustomStart="@StartDate" InitialCustomEnd="@EndDate" />

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Pages/AssetsPage.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Pages/AssetsPage.razor.cs
@@ -12,7 +12,8 @@ public partial class AssetsPage : ComponentBase
 
     protected override void OnInitialized()
     {
-        var (Start, End) = DateRangeHelper.GetCurrentMonthRange();
+        // Same default range as the Dashboard, from the one shared entry point. #700
+        var (Start, End) = DateRangeHelper.GetDefaultOverviewRange(DateTime.UtcNow);
 
         StartDate = Start;
         EndDate = End;

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Pages/LiabilitiesPage.razor
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Pages/LiabilitiesPage.razor
@@ -1,5 +1,6 @@
 @page "/Liabilities"
 @using FinanceManager.Components.Features.Dashboard.Components.Cards.Liabilities
+@using FinanceManager.Components.Shared.Helpers
 
 <PageTitle>Liabilities</PageTitle>
 
@@ -16,4 +17,5 @@
 </MudContainer>
 
 
-<DashboardDatePicker DateChanged=DateChanged StartingOption="ThisMonth" />
+<DashboardDatePicker DateChanged=DateChanged StartingOption="@DateRangeHelper.CustomRangeKey"
+                     InitialCustomStart="@StartDate" InitialCustomEnd="@EndDate" />

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Pages/LiabilitiesPage.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Pages/LiabilitiesPage.razor.cs
@@ -11,7 +11,8 @@ public partial class LiabilitiesPage : ComponentBase
 
     protected override void OnInitialized()
     {
-        var (Start, End) = DateRangeHelper.GetCurrentMonthRange();
+        // Same default range as the Dashboard, from the one shared entry point. #700
+        var (Start, End) = DateRangeHelper.GetDefaultOverviewRange(DateTime.UtcNow);
 
         StartDate = Start;
         EndDate = End;

--- a/code/FinanceManager.Components/Shared/Helpers/DateRangeHelper.cs
+++ b/code/FinanceManager.Components/Shared/Helpers/DateRangeHelper.cs
@@ -61,6 +61,14 @@ public static class DateRangeHelper
         return (start, now);
     }
 
+    /// <summary>
+    /// The range the overview pages — Dashboard, Assets and Liabilities — open with. It names the
+    /// policy separately from the window it currently resolves to, so all three pages share one
+    /// entry point and changing the default stays a single edit here rather than three. #700
+    /// </summary>
+    public static (DateTime Start, DateTime End) GetDefaultOverviewRange(DateTime now) =>
+        GetLast31DaysRange(now);
+
     public static (DateTime Start, DateTime End) GetCurrentQuarterRange()
     {
         var now = DateTime.UtcNow;

--- a/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Pages/OverviewPagesInitialRangeTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Pages/OverviewPagesInitialRangeTests.cs
@@ -1,0 +1,47 @@
+using FinanceManager.Components.Features.Dashboard.Components.Pages;
+using System.Reflection;
+
+namespace FinanceManager.Tests.Unit.Components.Features.Dashboard.Components.Pages;
+
+[Trait("Category", "Unit")]
+public class OverviewPagesInitialRangeTests
+{
+    // The Assets and Liabilities pages must open on the window the Dashboard seeds — a rolling
+    // 31 days anchored to midnight — instead of the current calendar month, which is nearly
+    // empty at the start of a month. #700
+    [Fact]
+    public void AssetsPage_InitializesWithDefaultOverviewRange()
+    {
+        var page = new AssetsPage();
+
+        AssertDefaultOverviewRange(page, () => page.StartDate, () => page.EndDate);
+    }
+
+    [Fact]
+    public void LiabilitiesPage_InitializesWithDefaultOverviewRange()
+    {
+        var page = new LiabilitiesPage();
+
+        AssertDefaultOverviewRange(page, () => page.StartDate, () => page.EndDate);
+    }
+
+    private static void AssertDefaultOverviewRange(object page, Func<DateTime> startDate, Func<DateTime> endDate)
+    {
+        var before = DateTime.UtcNow;
+        Initialize(page);
+        var after = DateTime.UtcNow;
+
+        // Asserted as the relationship the shared helper defines rather than against a captured
+        // "now", so the expectation holds even if the clock crosses midnight mid-test.
+        Assert.InRange(endDate(), before, after);
+        Assert.Equal(endDate().Date.AddDays(-30), startDate());
+        Assert.Equal(DateTimeKind.Utc, startDate().Kind);
+    }
+
+    // The pages are never rendered here, so lifecycle is driven directly; OnInitialized is
+    // protected by ComponentBase's contract, hence the reflection.
+    private static void Initialize(object page) =>
+        page.GetType()
+            .GetMethod("OnInitialized", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(page, null);
+}

--- a/code/FinanceManager.Tests.Unit/Components/Shared/Helpers/DateRangeHelperTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Shared/Helpers/DateRangeHelperTests.cs
@@ -69,6 +69,14 @@ public class DateRangeHelperTests
         Assert.Equal(_now, range.End);
     }
 
+    // Dashboard, Assets and Liabilities all seed their initial range from this one entry point,
+    // so it must resolve to the same window for every caller. #700
+    [Fact]
+    public void GetDefaultOverviewRange_MatchesLast31DaysRange()
+    {
+        Assert.Equal(DateRangeHelper.GetLast31DaysRange(_now), DateRangeHelper.GetDefaultOverviewRange(_now));
+    }
+
     [Fact]
     public void GetExpandedStart_ReturnsOnlyOlderEntry()
     {


### PR DESCRIPTION
closes #700

## What changed

The Assets and Liabilities pages opened on the current calendar month while the Dashboard had already moved to a rolling last-31-days window (#685), so the three financial views could show different periods — and on the 1st of a month the Assets/Liabilities charts were nearly empty.

Both pages now seed the same range as the Dashboard, through one shared entry point.

- `DateRangeHelper.GetDefaultOverviewRange(now)` — new single entry point naming the *policy* ("the range overview pages open with") separately from the window it resolves to (`GetLast31DaysRange`). Changing the default is now one edit instead of three.
- `Dashboard`, `AssetsPage` and `LiabilitiesPage` all call it in their initialization, so the boundaries are identical (midnight-anchored start 30 days back, end = now).
- Both pages' `DashboardDatePicker` now mirrors the Dashboard's flow: `StartingOption="Custom"` seeded with the initial range, so the pill shows the active range (`15 Jul – 14 Aug`) instead of falsely highlighting **This month**.

Manual range selection is untouched — presets and the custom picker still drive `DateChanged` exactly as before.

## Tests

- `DateRangeHelperTests.GetDefaultOverviewRange_MatchesLast31DaysRange` — the shared entry point resolves to the same window for every caller.
- New `OverviewPagesInitialRangeTests` — Assets and Liabilities each initialize to a midnight-anchored start 30 days before an end pinned to "now".
- Full unit suite green (889 passed); `dotnet build` clean with warnings-as-errors; `dotnet format --verify-no-changes` clean.

## UI verification

Rendered on the guest demo account, mobile (430×920) and desktop (1280×1000). Both pages open on **15 Jul – 14 Aug** with the custom-range caption and a full month of chart history; clicking **This quarter** re-ranges the charts and highlights the preset as before.

## Changelog

Entry added under `[Unreleased] → Changed`.


---
_Generated by [Claude Code](https://claude.ai/code/session_019mKyba7ob8Hu5TaowxqhSK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard, Assets, and Liabilities pages now open with a consistent rolling 31-day overview.
  * Date pickers initialize with the selected overview dates, making the active range clearer.

* **Bug Fixes**
  * Improved consistency between displayed date-picker selections and the data shown on overview pages.

* **Tests**
  * Added coverage verifying default date ranges and date-picker initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->