### PR TITLE
Make date range picker compact #701

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- The dashboard, Assets, and Liabilities date-range picker now stays as one compact pill showing only the active preset or custom dates; opening it reveals the other presets and custom calendar without occupying persistent mobile screen space. #701
 - The dashboard now opens on a rolling **last 31 days** range instead of the current calendar month, so its charts always show about a month of history even at the start of a month; the presets (This month / This quarter / This year) and custom date selection continue to work, and the initial state is shown as a custom range rather than highlighting This month. #685
 - Authentication rate-limit budget raised from 10 to 20 requests per 60-second window, reducing false positives for legitimate login and token-refresh traffic. #669
 - The Financial Insights card now uses available vertical space for insight messages instead of a fixed four-line clamp, while keeping the card height stable. #663

--- a/code/FinanceManager.Components/Features/Dashboard/Components/DashboardDatePicker.razor
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/DashboardDatePicker.razor
@@ -1,30 +1,41 @@
 @using FinanceManager.Components.Shared.Helpers
 
-<MudPaper Elevation="3" Class="rounded-pill px-1 py-1" Style="right: 30px; position: fixed; bottom: 3vh; z-index: 2;">
-    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="0">
-        @foreach (var (key, label) in _presets)
-        {
-            <MudButton Variant="Variant.Text" Size="Size.Small" Class="rounded-pill px-3"
-                       Color="@(_selected == key ? Color.Primary : Color.Default)"
-                       Style="@($"font-weight: {(_selected == key ? 700 : 500)};")"
-                       OnClick="@(() => SelectPreset(key))">@label</MudButton>
-        }
+<div class="fm-dashboard-datepicker-container">
+    <MudPaper Elevation="3" Class="rounded-pill fm-dashboard-datepicker-pill">
+        <MudMenu Label="@CurrentDisplayLabel"
+                 AriaLabel="@($"Date range: {CurrentDisplayLabel}")"
+                 StartIcon="@Icons.Material.Filled.CalendarMonth"
+                 EndIcon="@Icons.Material.Filled.ArrowDropDown"
+                 Variant="Variant.Text"
+                 Color="Color.Default"
+                 Open="_isMenuOpen"
+                 OpenChanged="OnMenuOpenChanged"
+                 Dense="true"
+                 AnchorOrigin="Origin.TopRight"
+                 TransformOrigin="Origin.BottomRight"
+                 Class="fm-dashboard-datepicker-menu"
+                 PopoverClass="fm-dashboard-datepicker-popover"
+                 aria-expanded="@_isMenuOpen.ToString().ToLowerInvariant()">
+            <ChildContent>
+                @foreach (var (key, label) in _presets)
+                {
+                    <MudMenuItem OnClick="@(() => SelectPreset(key))"
+                                 Icon="@(_selected == key ? Icons.Material.Filled.Check : null)">
+                        <span class="@(_selected == key ? "fm-dashboard-datepicker-option-selected" : null)">@label</span>
+                    </MudMenuItem>
+                }
 
-        @if (_selected == DateRangeHelper.CustomRangeKey && _customRange is { Start: DateTime customStart, End: DateTime customEnd })
-        {
-            <MudText Typo="Typo.caption" Color="Color.Primary" Class="px-2"
-                     Style="font-weight: 700; white-space: nowrap;">
-                @customStart.ToString("dd MMM") &ndash; @customEnd.ToString("dd MMM")
-            </MudText>
-        }
+                <MudDivider />
+                <MudMenuItem OnClick="OpenCustomDateRangePicker"
+                             Icon="@(_selected == DateRangeHelper.CustomRangeKey ? Icons.Material.Filled.Check : Icons.Material.Filled.DateRange)">
+                    <span class="@(_selected == DateRangeHelper.CustomRangeKey ? "fm-dashboard-datepicker-option-selected" : null)">Custom range…</span>
+                </MudMenuItem>
+            </ChildContent>
+        </MudMenu>
+    </MudPaper>
+</div>
 
-        <MudIconButton Icon="@Icons.Material.Filled.CalendarMonth" Size="Size.Small"
-                       Color="@(_selected == DateRangeHelper.CustomRangeKey ? Color.Primary : Color.Default)"
-                       OnClick="OpenCustomDateRangePicker" aria-label="Select custom date range" />
-    </MudStack>
-</MudPaper>
-
-@* Hidden picker opened programmatically by the calendar icon; the Dialog variant matches
+@* Hidden picker opened programmatically by the Custom range option; the Dialog variant matches
    the custom-range picker on the account details pages. *@
 <div class="fm-dashboard-custom-range-picker">
     <MudDateRangePicker @ref="_customDateRangePicker" DateRange="_customRange" DateFormat="dd/MM/yyyy"
@@ -48,6 +59,7 @@
     private string _selected = "ThisMonth";
     private DateRange? _customRange;
     private MudDateRangePicker? _customDateRangePicker;
+    private bool _isMenuOpen;
 
     [Parameter] public string StartingOption { get; set; } = "ThisMonth";
 
@@ -56,6 +68,14 @@
     [Parameter] public DateTime? InitialCustomStart { get; set; }
     [Parameter] public DateTime? InitialCustomEnd { get; set; }
     [Parameter] public required Action<(DateTime Start, DateTime End)> DateChanged { get; set; }
+
+    private string CurrentDisplayLabel => _selected switch
+    {
+        DateRangeHelper.CustomRangeKey when _customRange is { Start: DateTime start, End: DateTime end } =>
+            $"{start:dd MMM} \u2013 {end:dd MMM}",
+        DateRangeHelper.CustomRangeKey => "Custom range",
+        _ => _presets.FirstOrDefault(preset => preset.Key == _selected).Label ?? "Select range"
+    };
 
     protected override void OnInitialized()
     {
@@ -73,6 +93,8 @@
 
     private Task OpenCustomDateRangePicker() =>
         _customDateRangePicker?.OpenAsync() ?? Task.CompletedTask;
+
+    private void OnMenuOpenChanged(bool isOpen) => _isMenuOpen = isOpen;
 
     private void SelectPreset(string key)
     {

--- a/code/FinanceManager.Components/Features/Dashboard/Components/DashboardDatePicker.razor
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/DashboardDatePicker.razor
@@ -72,7 +72,9 @@
     private string CurrentDisplayLabel => _selected switch
     {
         DateRangeHelper.CustomRangeKey when _customRange is { Start: DateTime start, End: DateTime end } =>
-            $"{start:dd MMM} \u2013 {end:dd MMM}",
+            start.Year == end.Year
+                ? $"{start:dd MMM} \u2013 {end:dd MMM yyyy}"
+                : $"{start:dd MMM yyyy} \u2013 {end:dd MMM yyyy}",
         DateRangeHelper.CustomRangeKey => "Custom range",
         _ => _presets.FirstOrDefault(preset => preset.Key == _selected).Label ?? "Select range"
     };

--- a/code/FinanceManager.Components/Features/Dashboard/Components/DashboardDatePicker.razor.css
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/DashboardDatePicker.razor.css
@@ -1,7 +1,42 @@
-/* The custom date-range picker is driven entirely by the calendar icon button and
-   opened programmatically as a dialog. Hide only its own inline input field so just
-   the icon acts as the trigger. The dialog overlay is rendered separately when opened
-   and is unaffected by this rule. */
+/* Keep the collapsed picker compact and inside the viewport, including safe areas. */
+.fm-dashboard-datepicker-container {
+    position: fixed;
+    right: 30px;
+    bottom: calc(3vh + env(safe-area-inset-bottom, 0px));
+    z-index: var(--mud-zindex-fab, 1050);
+    max-width: calc(100vw - 32px);
+}
+
+.fm-dashboard-datepicker-pill {
+    display: inline-flex;
+    max-width: 100%;
+    padding: 4px;
+}
+
+.fm-dashboard-datepicker-menu {
+    max-width: 100%;
+}
+
+.fm-dashboard-datepicker-menu ::deep .mud-button-root {
+    max-width: 100%;
+    border-radius: 9999px;
+    font-weight: 600;
+    text-transform: none;
+}
+
+.fm-dashboard-datepicker-menu ::deep .mud-button-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.fm-dashboard-datepicker-option-selected {
+    font-weight: 700;
+}
+
+/* The custom date-range picker is driven entirely by the menu option and
+   opened programmatically as a dialog. Hide its inline input field because the compact
+   menu option is the only visible trigger. The dialog overlay is rendered separately. */
 .fm-dashboard-custom-range-picker ::deep .mud-picker > .mud-input-control {
     display: none;
 }
@@ -16,7 +51,12 @@
 }
 
 @media (max-width: 959.98px) {
+    .fm-dashboard-datepicker-container {
+        right: max(16px, env(safe-area-inset-right, 0px));
+        bottom: calc(2vh + env(safe-area-inset-bottom, 0px));
+    }
+
     .fm-dashboard-datepicker-spacer {
-        height: calc(3vh + 56px + env(safe-area-inset-bottom, 0px));
+        height: calc(2vh + 56px + env(safe-area-inset-bottom, 0px));
     }
 }


### PR DESCRIPTION
Closes #701

## What changed

- Replaced the always-expanded date-range controls with one compact pill that shows only the active preset or custom date span.
- Added a responsive MudBlazor selector for This month, This quarter, This year, and the existing custom calendar dialog.
- Preserved the existing range calculations, inclusive custom end date, clamping, callback contract, and Dashboard/Assets/Liabilities reuse.
- Added safe-area-aware mobile positioning, viewport width constraints, selected-option emphasis, and an accessible trigger label/open state.
- Added the user-visible change to the changelog.

## Validation

- `dotnet format ./code/FinanceManager.slnx --verify-no-changes --verbosity minimal` — passed.
- `dotnet build ./code/FinanceManager.slnx --no-restore` — passed, 0 warnings/errors.
- `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --no-restore -- --output Normal` — 886 passed.
- Guest app at 430x920 and 1280x1000 — collapsed and expanded states rendered correctly; all four choices visible; preset selection updated and closed immediately; custom selection opened the calendar.
- Horizontal overflow check — 430/430 mobile and 1280/1280 desktop.
- Browser console errors — none.

## Risks

- Responsive checks cover the supported mobile and desktop widths, but not every device-specific safe-area shape.
- No new component-test dependency was introduced because this test project has no existing rendered-Razor harness; interaction coverage is from the real guest app plus the full unit/build gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned the dashboard date selector with a compact, pill-shaped dropdown.
  * Added clear selection indicators for presets and custom date ranges.
  * Improved responsive behavior, mobile positioning, safe-area handling, and label truncation.
  * Updated spacing and button styling for a more consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->