### PR TITLE
Optimize currency balance aggregation with linear passes

### DIFF
--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/Balance/CurrencyBalanceService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/Balance/CurrencyBalanceService.cs
@@ -53,7 +53,7 @@ public class CurrencyBalanceService(IFinancialAccountRepository financialAccount
     {
         if (end > DateTime.UtcNow) end = DateTime.UtcNow;
 
-        Dictionary<DateTime, decimal> result = [];
+        var result = InitializeDailyResult(start, end);
         var accountIdFilter = accountIds.Count > 0 ? accountIds.ToHashSet() : [];
 
         await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end))
@@ -61,17 +61,12 @@ public class CurrencyBalanceService(IFinancialAccountRepository financialAccount
             if (account?.Entries is null) continue;
             if (accountIdFilter.Count > 0 && !accountIdFilter.Contains(account.AccountId)) continue;
 
-            for (var date = end.Date; date >= start.Date; date = date.Add(-_oneDay))
+            foreach (var entry in account.Entries)
             {
-                if (!result.ContainsKey(date)) result.Add(date, 0);
+                var day = entry.PostingDate.Date;
+                if (day < start.Date || day > end.Date || !predicate(entry)) continue;
 
-                var entries = account.Get(date);
-                foreach (var entry in entries.Select(x => x as FinancialEntryBase).Where(x => x is not null))
-                {
-                    if (entry!.PostingDate.Date != date.Date) continue;
-                    if (!predicate(entry)) continue;
-                    result[date] += entry.ValueChange;
-                }
+                result[day] += entry.ValueChange;
             }
         }
 
@@ -82,23 +77,44 @@ public class CurrencyBalanceService(IFinancialAccountRepository financialAccount
     {
         if (end > DateTime.UtcNow) end = DateTime.UtcNow;
 
-        Dictionary<DateTime, decimal> result = [];
+        var result = InitializeDailyResult(start, end);
         var accountIdFilter = accountIds.Count > 0 ? accountIds.ToHashSet() : [];
 
         await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end))
         {
             if (accountIdFilter.Count > 0 && !accountIdFilter.Contains(account.AccountId)) continue;
 
-            for (var date = end.Date; date >= start.Date; date = date.Add(-_oneDay))
+            var orderedEntries = account.Entries.OrderBy(entry => entry.PostingDate).ToList();
+            var runningBalance = account.NextOlderEntry?.Value ?? 0;
+            var entryIndex = 0;
+
+            while (entryIndex < orderedEntries.Count && orderedEntries[entryIndex].PostingDate.Date < start.Date)
             {
-                if (!result.ContainsKey(date)) result.Add(date, 0);
+                runningBalance = orderedEntries[entryIndex].Value;
+                entryIndex++;
+            }
 
-                var entry = account.GetThisOrNextOlder(date);
-                if (entry is null) continue;
+            for (var date = start.Date; date <= end.Date; date = date.Add(_oneDay))
+            {
+                while (entryIndex < orderedEntries.Count && orderedEntries[entryIndex].PostingDate.Date <= date)
+                {
+                    runningBalance = orderedEntries[entryIndex].Value;
+                    entryIndex++;
+                }
 
-                result[date] += entry.Value;
+                result[date] += runningBalance;
             }
         }
+
+        return result;
+    }
+
+    private static Dictionary<DateTime, decimal> InitializeDailyResult(DateTime start, DateTime end)
+    {
+        Dictionary<DateTime, decimal> result = [];
+
+        for (var date = start.Date; date <= end.Date; date = date.Add(_oneDay))
+            result[date] = 0;
 
         return result;
     }

--- a/code/FinanceManager.Tests.Unit/Application/Services/BalanceServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/BalanceServiceTests.cs
@@ -151,4 +151,169 @@ public class CurrencyBalanceServiceTests
         Assert.Single(result);
         Assert.Equal(10, result.First().Value);
     }
+
+    [Fact]
+    public async Task GetClosingBalance_WithSparseEmptyDaysAndNextOlderEntry_CarriesForwardClosingBalanceAcrossGaps()
+    {
+        var userId = 1;
+        var start = new DateTime(2024, 1, 1);
+        var end = new DateTime(2024, 1, 7);
+        var nextOlder = new CurrencyAccountEntry(1, 0, start.AddDays(-1), 100, 100);
+        var account = new CurrencyAccount(
+            userId,
+            1,
+            "Currency Account 1",
+            [
+                new CurrencyAccountEntry(1, 1, start.AddDays(2), 150, 50),
+                new CurrencyAccountEntry(1, 2, start.AddDays(5), 180, 30)
+            ],
+            AccountLabel.Cash,
+            nextOlderEntry: nextOlder);
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                                       .Returns(new[] { account }.ToAsyncEnumerable());
+
+        var result = await _balanceService.GetClosingBalance(userId, DefaultCurrency.PLN, start, end);
+
+        Assert.Equal(7, result.Count);
+        Assert.Equal(100, result.Single(x => x.DateTime == start).Value);
+        Assert.Equal(100, result.Single(x => x.DateTime == start.AddDays(1)).Value);
+        Assert.Equal(150, result.Single(x => x.DateTime == start.AddDays(2)).Value);
+        Assert.Equal(150, result.Single(x => x.DateTime == start.AddDays(3)).Value);
+        Assert.Equal(150, result.Single(x => x.DateTime == start.AddDays(4)).Value);
+        Assert.Equal(180, result.Single(x => x.DateTime == start.AddDays(5)).Value);
+        Assert.Equal(180, result.Single(x => x.DateTime == start.AddDays(6)).Value);
+    }
+
+    [Fact]
+    public async Task GetClosingBalance_WithUnorderedAndMultipleSameDayEntries_PicksLatestChronologicalValue()
+    {
+        var userId = 1;
+        var start = new DateTime(2024, 1, 1);
+        var end = new DateTime(2024, 1, 2);
+        var account = new CurrencyAccount(
+            userId,
+            1,
+            "Currency Account 1",
+            [
+                new CurrencyAccountEntry(1, 1, start.AddHours(18), 120, 20),
+                new CurrencyAccountEntry(1, 2, start.AddDays(1).AddHours(10), 160, 40),
+                new CurrencyAccountEntry(1, 3, start.AddHours(9), 100, 100),
+                new CurrencyAccountEntry(1, 4, start.AddDays(1).AddHours(20), 190, 30),
+                new CurrencyAccountEntry(1, 5, start.AddDays(1).AddHours(14), 170, 10)
+            ],
+            AccountLabel.Cash);
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                                       .Returns(new[] { account }.ToAsyncEnumerable());
+
+        var result = await _balanceService.GetClosingBalance(userId, DefaultCurrency.PLN, start, end);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(120, result.Single(x => x.DateTime == start).Value);
+        Assert.Equal(190, result.Single(x => x.DateTime == start.AddDays(1)).Value);
+    }
+
+    [Fact]
+    public async Task GetClosingBalance_WithAccountIds_FiltersAccountsAndAggregates()
+    {
+        var userId = 1;
+        var start = new DateTime(2024, 1, 1);
+        var end = new DateTime(2024, 1, 2);
+        var firstAccount = new CurrencyAccount(
+            userId,
+            1,
+            "Currency Account 1",
+            [
+                new CurrencyAccountEntry(1, 1, start, 100, 100)
+            ],
+            AccountLabel.Cash);
+
+        var secondAccount = new CurrencyAccount(
+            userId,
+            2,
+            "Currency Account 2",
+            [
+                new CurrencyAccountEntry(2, 1, start, 50, 50)
+            ],
+            AccountLabel.Cash);
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                                       .Returns(new[] { firstAccount, secondAccount }.ToAsyncEnumerable());
+
+        var filteredResult = await _balanceService.GetClosingBalance(userId, DefaultCurrency.PLN, start, end, [2]);
+        var allResult = await _balanceService.GetClosingBalance(userId, DefaultCurrency.PLN, start, end, [1, 2]);
+
+        Assert.Equal(2, filteredResult.Count);
+        Assert.Equal(50, filteredResult.Single(x => x.DateTime == start).Value);
+        Assert.Equal(50, filteredResult.Single(x => x.DateTime == start.AddDays(1)).Value);
+
+        Assert.Equal(2, allResult.Count);
+        Assert.Equal(150, allResult.Single(x => x.DateTime == start).Value);
+        Assert.Equal(150, allResult.Single(x => x.DateTime == start.AddDays(1)).Value);
+    }
+
+    [Fact]
+    public async Task FlowAggregation_IgnoresOutOfRangeEntriesAndZeroFillsRange()
+    {
+        var userId = 1;
+        var start = new DateTime(2024, 1, 2);
+        var end = new DateTime(2024, 1, 5);
+        var account = new CurrencyAccount(
+            userId,
+            1,
+            "Currency Account 1",
+            [
+                new CurrencyAccountEntry(1, 1, start.AddDays(-2), 500, 500),
+                new CurrencyAccountEntry(1, 2, start.AddDays(1), 100, 100),
+                new CurrencyAccountEntry(1, 3, start.AddDays(1).AddHours(2), 70, -30),
+                new CurrencyAccountEntry(1, 4, start.AddDays(10), 300, 230)
+            ],
+            AccountLabel.Cash);
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                                       .Returns(new[] { account }.ToAsyncEnumerable());
+
+        var inflow = await _balanceService.GetInflow(userId, DefaultCurrency.PLN, start, end);
+        var outflow = await _balanceService.GetOutflow(userId, DefaultCurrency.PLN, start, end);
+        var netFlow = await _balanceService.GetNetCashFlow(userId, DefaultCurrency.PLN, start, end);
+
+        Assert.Equal(4, inflow.Count);
+        Assert.Equal(0, inflow.Single(x => x.DateTime == start).Value);
+        Assert.Equal(100, inflow.Single(x => x.DateTime == start.AddDays(1)).Value);
+        Assert.Equal(0, inflow.Single(x => x.DateTime == start.AddDays(2)).Value);
+        Assert.Equal(0, inflow.Single(x => x.DateTime == start.AddDays(3)).Value);
+
+        Assert.Equal(4, outflow.Count);
+        Assert.Equal(0, outflow.Single(x => x.DateTime == start).Value);
+        Assert.Equal(-30, outflow.Single(x => x.DateTime == start.AddDays(1)).Value);
+        Assert.Equal(0, outflow.Single(x => x.DateTime == start.AddDays(2)).Value);
+        Assert.Equal(0, outflow.Single(x => x.DateTime == start.AddDays(3)).Value);
+
+        Assert.Equal(4, netFlow.Count);
+        Assert.Equal(0, netFlow.Single(x => x.DateTime == start).Value);
+        Assert.Equal(70, netFlow.Single(x => x.DateTime == start.AddDays(1)).Value);
+        Assert.Equal(0, netFlow.Single(x => x.DateTime == start.AddDays(2)).Value);
+        Assert.Equal(0, netFlow.Single(x => x.DateTime == start.AddDays(3)).Value);
+    }
+
+    [Fact]
+    public async Task GetOutflow_WithAccountIds_FiltersAccounts()
+    {
+        var userId = 1;
+        var start = new DateTime(2024, 1, 1);
+        var firstAccount = new CurrencyAccount(userId, 1, "Currency Account 1", AccountLabel.Cash);
+        firstAccount.Add(new CurrencyAccountEntry(1, 1, start, -100, -100));
+
+        var secondAccount = new CurrencyAccount(userId, 2, "Currency Account 2", AccountLabel.Cash);
+        secondAccount.Add(new CurrencyAccountEntry(2, 1, start, -45, -45));
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<CurrencyAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                                       .Returns(new[] { firstAccount, secondAccount }.ToAsyncEnumerable());
+
+        var result = await _balanceService.GetOutflow(userId, DefaultCurrency.PLN, start, start, [2]);
+
+        Assert.Single(result);
+        Assert.Equal(-45, result.First().Value);
+    }
 }


### PR DESCRIPTION
Closes #704

## Summary
- replace repeated per-day entry scans with a single entry pass per currency account
- preserve zero-filled daily buckets, account filters, flow predicates, and closing-balance carry-forward
- sort closing-balance entries once and advance a cursor chronologically
- add regression coverage for sparse dates, unordered and same-day entries, account filters, and out-of-range entries

## Validation
- `dotnet build ./code/FinanceManager.slnx --no-restore --verbosity minimal` — passed, 0 warnings and 0 errors
- `dotnet format ./code/FinanceManager.slnx --verify-no-changes --no-restore --verbosity minimal` — passed
- Release unit test host — 894 passed, 0 failed
- Release integration test host filtered to `*MoneyFlowControllerTests` — 27 passed, 0 failed

## Risks
- Closing-balance aggregation depends on chronological entry ordering; the implementation sorts each account once and regression tests cover unordered and multiple same-day entries.
- No API contract or caller behavior changes are intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected daily balance calculations across dates with no transactions by carrying forward the latest known balance.
  * Ensured same-day transactions are processed chronologically.
  * Improved filtering by account and date range for balance, inflow, and outflow calculations.
  * Added zero-valued results for days without applicable activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->