### PR TITLE
Redesign investment holdings for responsive views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- Investment account holdings now use responsive, always-visible cards for instrument, market, type, units, current price, and current value, and the Top movers combined filter is shortened to **All**. #705
 - The account transactions toolbar is now a single compact row: **Add entry** and search collapse to icon buttons (search opens a panel directly below the toolbar), the category filter shows as a badged icon, and the date range moved off the chart into one dropdown labelled with the active range. All presets, custom ranges, filtering, searching, and add-entry actions behave as before. #706
 - The dashboard, Assets, and Liabilities date-range picker now stays as one compact pill showing only the active preset or custom dates; opening it reveals the other presets and custom calendar without occupying persistent mobile screen space. #701
 - The **Assets** and **Liabilities** pages now open on the same rolling **last 31 days** range as the dashboard instead of the current calendar month, so all three views start on identical date boundaries and always show about a month of history; the presets (This month / This quarter / This year) and custom date selection continue to work. #700

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
@@ -71,7 +71,7 @@ else
                         <AppreciationBreakdownCard CapitalValue="@_capitalValue" CurrentValue="@_currentValue"
                                                    Currency="@_currency.ShortName" Label="Asset appreciation" IsLoading="@_isChartLoading" />
 
-                        @HoldingsCard
+                        <InvestmentHoldingCard Holdings="@_holdings" />
 
                         <InvestmentAccountMoversCard TopEntries="@(_top5 ?? [])" BottomEntries="@(_bottom5 ?? [])" />
                     </MudStack>
@@ -95,7 +95,7 @@ else
                 <AppreciationBreakdownCard CapitalValue="@_capitalValue" CurrentValue="@_currentValue"
                                            Currency="@_currency.ShortName" Label="Asset appreciation" IsLoading="@_isChartLoading" />
 
-                @HoldingsCard
+                <InvestmentHoldingCard Holdings="@_holdings" />
 
                 <InvestmentAccountMoversCard TopEntries="@(_top5 ?? [])" BottomEntries="@(_bottom5 ?? [])" />
             </MudStack>
@@ -110,42 +110,3 @@ else
     <MudFab Color="Color.Primary" Size="Size.Medium" StartIcon="@Icons.Material.Filled.KeyboardArrowUp"
             aria-label="Scroll to top" />
 </MudScrollToTop>
-
-@code {
-    private RenderFragment HoldingsCard => __builder =>
-    {
-        <MudCard Outlined="true" Style="background-color: transparent;">
-            <MudCardHeader Class="py-2 px-4">
-                <CardHeaderContent><MudText Typo="Typo.subtitle2">Holdings</MudText></CardHeaderContent>
-            </MudCardHeader>
-            <MudCardContent Class="pa-0">
-                @if (_holdings.Count == 0)
-                {
-                    <MudAlert Severity="Severity.Info" Class="ma-4">No open holdings.</MudAlert>
-                }
-                else
-                {
-                    <MudSimpleTable Hover="true" Dense="true" Striped="true">
-                        <thead>
-                            <tr><th>Instrument</th><th class="text-right">Units</th><th class="text-right">Price</th><th class="text-right">Value</th></tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var h in _holdings)
-                            {
-                                <tr>
-                                    <td>
-                                        <MudText Typo="Typo.body2">@h.Ticker</MudText>
-                                        <MudText Typo="Typo.caption" Color="Color.Secondary">@h.ExchangeName</MudText>
-                                    </td>
-                                    <td class="text-right">@h.Quantity.ToString("N4")</td>
-                                    <td class="text-right">@h.LatestPrice.ToString("N2") @h.Currency</td>
-                                    <td class="text-right">@h.Value.ToString("N2") @h.Currency</td>
-                                </tr>
-                            }
-                        </tbody>
-                    </MudSimpleTable>
-                }
-            </MudCardContent>
-        </MudCard>
-    };
-}

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -418,7 +418,8 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
                 latest.Currency,
                 quantity,
                 latest.UnitPrice,
-                quantity * latest.UnitPrice));
+                quantity * latest.UnitPrice,
+                latest.AssetType));
         }
         return [.. rows.OrderByDescending(h => h.Value)];
     }

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentHoldingCard.razor
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentHoldingCard.razor
@@ -1,0 +1,66 @@
+@namespace FinanceManager.Components.Features.FinancialAccounts.Components.InvestmentAccountComponents
+@using FinanceManager.Components.Features.FinancialAccounts.Models
+@using FinanceManager.Domain.Assets.Entities
+
+<MudCard Outlined="true" Class="fm-holdings-card" Style="background-color: transparent;">
+    <MudCardHeader Class="py-2 px-4">
+        <CardHeaderContent>
+            <MudText Typo="Typo.subtitle2">Holdings</MudText>
+        </CardHeaderContent>
+    </MudCardHeader>
+    <MudCardContent Class="pa-0">
+        @if (Holdings.Count == 0)
+        {
+            <MudAlert Severity="Severity.Info" Class="ma-4">No open holdings.</MudAlert>
+        }
+        else
+        {
+            <div class="fm-holdings-list" role="list" aria-label="Holdings">
+                @foreach (var holding in Holdings)
+                {
+                    <article class="fm-holding-item pa-3" role="listitem" @key="holding.ListingId">
+                        <div class="fm-holding-header">
+                            <div class="fm-holding-title-group">
+                                <MudText Typo="Typo.subtitle2" Class="fm-holding-ticker">@holding.Ticker</MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary" Class="fm-holding-exchange">
+                                    Exchange · @(string.IsNullOrWhiteSpace(holding.ExchangeName) ? "Not specified" : holding.ExchangeName)
+                                </MudText>
+                            </div>
+                            <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Default"
+                                     Class="fm-holding-type-chip">
+                                @FormatAssetType(holding.AssetType)
+                            </MudChip>
+                        </div>
+
+                        <div class="fm-holding-grid mt-2">
+                            <div class="fm-holding-field">
+                                <MudText Typo="Typo.overline" Color="Color.Default" Class="fm-field-label">Units</MudText>
+                                <MudText Typo="Typo.body2" Class="fm-field-value fm-tabular">@holding.Quantity.ToString("N4")</MudText>
+                            </div>
+                            <div class="fm-holding-field">
+                                <MudText Typo="Typo.overline" Color="Color.Default" Class="fm-field-label">Current price</MudText>
+                                <MudText Typo="Typo.body2" Class="fm-field-value fm-tabular">@holding.LatestPrice.ToString("N2") @holding.Currency</MudText>
+                            </div>
+                            <div class="fm-holding-field">
+                                <MudText Typo="Typo.overline" Color="Color.Default" Class="fm-field-label">Current value</MudText>
+                                <MudText Typo="Typo.body2" Class="fm-field-value fm-tabular">@holding.Value.ToString("N2") @holding.Currency</MudText>
+                            </div>
+                        </div>
+                    </article>
+                    <MudDivider />
+                }
+            </div>
+        }
+    </MudCardContent>
+</MudCard>
+
+@code {
+    [Parameter, EditorRequired] public IReadOnlyList<InvestmentHoldingModel> Holdings { get; set; } = [];
+
+    private static string FormatAssetType(AssetType type) => type switch
+    {
+        AssetType.MutualFund => "Mutual fund",
+        AssetType.ETF => "ETF",
+        _ => type.ToString()
+    };
+}

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentHoldingCard.razor.css
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentHoldingCard.razor.css
@@ -42,7 +42,6 @@
 .fm-field-label,
 .fm-field-value {
     overflow-wrap: anywhere;
-    word-break: break-word;
 }
 
 .fm-holding-ticker {

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentHoldingCard.razor.css
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentHoldingCard.razor.css
@@ -1,0 +1,85 @@
+.fm-holdings-card,
+.fm-holdings-list,
+.fm-holding-item {
+    box-sizing: border-box;
+    max-width: 100%;
+    min-width: 0;
+    width: 100%;
+}
+
+.fm-holdings-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.fm-holdings-list > hr:last-child {
+    display: none;
+}
+
+.fm-holding-item {
+    display: flex;
+    flex-direction: column;
+}
+
+.fm-holding-header {
+    align-items: flex-start;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: space-between;
+    min-width: 0;
+}
+
+.fm-holding-title-group {
+    display: flex;
+    flex: 1 1 10rem;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.fm-holding-ticker,
+.fm-holding-exchange,
+.fm-field-label,
+.fm-field-value {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.fm-holding-ticker {
+    font-weight: 600;
+}
+
+.fm-holding-type-chip {
+    align-self: flex-start;
+    flex-shrink: 0;
+    margin: 0;
+}
+
+.fm-holding-grid {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    min-width: 0;
+    width: 100%;
+}
+
+.fm-holding-field {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.fm-field-label {
+    line-height: 1.2;
+    margin-bottom: 0.125rem;
+}
+
+.fm-field-value {
+    line-height: 1.3;
+}
+
+@media (max-width: 320px) {
+    .fm-holding-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/TransactionHistory/InvestmentAccountMoversCard.razor
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/TransactionHistory/InvestmentAccountMoversCard.razor
@@ -10,7 +10,7 @@
                 <MudToggleGroup T="MoverMode" Value="_mode" ValueChanged="OnModeChanged"
                                 SelectionMode="SelectionMode.SingleSelection" Color="Color.Primary"
                                 Outlined="true" Dense="true">
-                    <MudToggleItem Value="@MoverMode.Combined" Text="Combined" />
+                    <MudToggleItem Value="@MoverMode.Combined" Text="All" />
                     <MudToggleItem Value="@MoverMode.Top" Text="Top" />
                     <MudToggleItem Value="@MoverMode.Bottom" Text="Bottom" />
                 </MudToggleGroup>

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Models/InvestmentHoldingModel.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Models/InvestmentHoldingModel.cs
@@ -1,3 +1,5 @@
+using FinanceManager.Domain.Assets.Entities;
+
 namespace FinanceManager.Components.Features.FinancialAccounts.Models;
 
 public sealed record InvestmentHoldingModel(
@@ -7,4 +9,5 @@ public sealed record InvestmentHoldingModel(
     string Currency,
     decimal Quantity,
     decimal LatestPrice,
-    decimal Value);
+    decimal Value,
+    AssetType AssetType = AssetType.Other);

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionDtos.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionDtos.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Domain.Assets.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 
 namespace FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
@@ -16,7 +17,8 @@ public record InvestmentTransactionDto(
     decimal? Fee,
     string? Notes,
     string Ticker = "",
-    string ExchangeName = "");
+    string ExchangeName = "",
+    AssetType AssetType = AssetType.Other);
 
 /// <summary>Request to add a new investment transaction. The owning user is derived from the account, not this payload.</summary>
 public record AddInvestmentTransactionRequest(

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionMappingExtensions.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Dtos/InvestmentTransactionMappingExtensions.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Domain.Assets.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 
 namespace FinanceManager.Domain.FinancialAccounts.Investments.Dtos;
@@ -17,7 +18,8 @@ public static class InvestmentTransactionMappingExtensions
         transaction.Fee,
         transaction.Notes,
         transaction.AssetListing?.Ticker ?? string.Empty,
-        transaction.AssetListing?.ExchangeName ?? string.Empty);
+        transaction.AssetListing?.ExchangeName ?? string.Empty,
+        transaction.AssetListing?.Asset?.Type ?? AssetType.Other);
 
     /// <summary>Build a new entity from an add request after its instrument source was resolved.</summary>
     public static InvestmentTransaction ToEntity(this AddInvestmentTransactionRequest request, long userId, long assetListingId) => new()

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Investments/Repositories/InvestmentTransactionRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Investments/Repositories/InvestmentTransactionRepository.cs
@@ -10,11 +10,13 @@ public class InvestmentTransactionRepository(AppDbContext context) : IInvestment
     public Task<InvestmentTransaction?> Get(long id, CancellationToken cancellationToken = default) =>
         context.InvestmentTransactions
             .Include(x => x.AssetListing)
+            .ThenInclude(x => x.Asset)
             .FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
 
     public async Task<IReadOnlyList<InvestmentTransaction>> GetByAccount(int accountId, CancellationToken cancellationToken = default) =>
         await context.InvestmentTransactions.AsNoTracking()
             .Include(x => x.AssetListing)
+            .ThenInclude(x => x.Asset)
             .Where(x => x.AccountId == accountId)
             .OrderBy(x => x.TradeDate).ThenBy(x => x.Id)
             .ToListAsync(cancellationToken);

--- a/code/FinanceManager.Tests.Integration/Features/FinancialAccounts/Investments/Controllers/InvestmentTransactionControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Features/FinancialAccounts/Investments/Controllers/InvestmentTransactionControllerTests.cs
@@ -75,6 +75,17 @@ public class InvestmentTransactionControllerTests(OptionsProvider optionsProvide
     private async Task SeedListing()
     {
         if (_testDatabase is null) return;
+        if (!await _testDatabase.Context.Assets.AnyAsync(a => a.Id == 1, TestContext.Current.CancellationToken))
+        {
+            _testDatabase.Context.Assets.Add(new Asset
+            {
+                Id = 1,
+                Name = "iShares Core S&P 500 UCITS ETF",
+                Type = AssetType.ETF
+            });
+            await _testDatabase.Context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        }
+
         if (await _testDatabase.Context.AssetListings.AnyAsync(l => l.Id == _listingId, TestContext.Current.CancellationToken)) return;
         _testDatabase.Context.AssetListings.Add(new AssetListing
         {
@@ -278,6 +289,18 @@ public class InvestmentTransactionControllerTests(OptionsProvider optionsProvide
         var transactions = await client.GetByAccountAsync(_testAccountId);
 
         Assert.Equal(2, transactions.Count);
+    }
+
+    [Fact]
+    public async Task GetByAccount_ReturnsAssetType()
+    {
+        await SeedTransaction(InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10));
+        Authorize("testuser", _testUserId, UserRole.User);
+        var client = new InvestmentTransactionHttpClient(Client);
+
+        var transaction = Assert.Single(await client.GetByAccountAsync(_testAccountId));
+
+        Assert.Equal(AssetType.ETF, transaction.AssetType);
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Integration/Features/FinancialAccounts/Investments/Controllers/InvestmentValuationControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Features/FinancialAccounts/Investments/Controllers/InvestmentValuationControllerTests.cs
@@ -70,6 +70,12 @@ public class InvestmentValuationControllerTests(OptionsProvider optionsProvider)
         var context = _testDatabase!.Context;
 
         context.Currencies.Add(new Currency(_usdCurrencyId, "USD", "$"));
+        context.Assets.Add(new Asset
+        {
+            Id = 1,
+            Name = "iShares Core S&P 500 UCITS ETF",
+            Type = AssetType.ETF
+        });
         context.AssetListings.Add(new AssetListing
         {
             Id = _listingId,


### PR DESCRIPTION
Closes #705

## Summary
- replace the investment holdings table with responsive, always-visible holding cards
- show ticker, exchange, asset type, units, current price, and current value
- pass asset type through the transaction DTO/repository path and rename the Top movers combined filter to All

## Validation
- `dotnet format ./code --verify-no-changes --verbosity diagnostic` (0 files changed)
- `dotnet build ./code/FinanceManager.slnx --no-restore --verbosity minimal` (0 warnings, 0 errors)
- unit tests: 894 passed, 0 failed
- integration tests: 306 passed, 0 failed
- focused transaction integration tests: 15 passed, 0 failed
- focused valuation integration tests: 10 passed, 0 failed
- rendered guest account at 430x920 and 1280x1000; no document, drawer, or holdings-card horizontal overflow

## Risks
- asset type loading adds an Asset include to the transaction detail/account queries; other hot read paths are unchanged
- UI verification used the seeded guest investment account in the local development host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Investment holdings now display asset types, including ETFs and mutual funds.
  * Holdings are presented in a responsive card layout with clearer details for units, prices, and values.
  * Empty investment accounts now show a dedicated empty-state message.
* **UI Improvements**
  * Updated the transaction history filter label from “Combined” to “All.”
  * Improved holdings layout for smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->