### PR TITLE
Refine transaction toolbar search and custom date selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- The account transactions toolbar now places the search button as its first control on the left, and the date-range dropdown displays a calendar icon when a custom date range is active. #712
 - Investment account holdings now use responsive, always-visible cards for instrument, market, type, units, current price, and current value, and the Top movers combined filter is shortened to **All**. #705
 - The account transactions toolbar is now a single compact row: **Add entry** and search collapse to icon buttons (search opens a panel directly below the toolbar), the category filter shows as a badged icon, and the date range moved off the chart into one dropdown labelled with the active range. All presets, custom ranges, filtering, searching, and add-entry actions behave as before. #706
 - The dashboard, Assets, and Liabilities date-range picker now stays as one compact pill showing only the active preset or custom dates; opening it reveals the other presets and custom calendar without occupying persistent mobile screen space. #701

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbar.razor
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbar.razor
@@ -3,6 +3,14 @@
     @* overflow-x is the safety valve for viewports narrower than the controls: the row scrolls
        itself instead of pushing the page into horizontal overflow. *@
     <div class="d-flex align-center" style="@($"min-height: 40px; overflow-x: auto; gap: {(IsMobile ? "2px" : "8px")};")">
+        @* Search — collapsed to an icon; the input lives in the panel below *@
+        <MudIconButton Icon="@(_isSearchExpanded ? Icons.Material.Filled.SearchOff : Icons.Material.Filled.Search)"
+                       Size="Size.Small" Color="@(_isSearchExpanded || !string.IsNullOrWhiteSpace(SearchText) ? Color.Primary : Color.Default)"
+                       OnClick="ToggleSearch" Style="flex-shrink: 0;"
+                       aria-label="@(_isSearchExpanded ? "Hide search" : "Search transactions")"
+                       title="@(_isSearchExpanded ? "Hide search" : "Search transactions")"
+                       aria-expanded="@_isSearchExpanded" aria-controls="@_searchPanelId" />
+
         @* Income / Expense toggle group *@
         <MudToggleGroup T="TxFilter?" Value="ActiveFilter" ValueChanged="ActiveFilterChanged"
                         SelectionMode="SelectionMode.ToggleSelection" Color="Color.Default" Dense="true" Size="Size.Small" Outlined
@@ -54,9 +62,16 @@
             <ActivatorContent>
                 <MudButton Variant="Variant.Outlined" Color="Color.Default" Size="Size.Small"
                            EndIcon="@Icons.Material.Filled.KeyboardArrowDown" OnClick="ToggleRangeMenu"
-                           aria-label="@($"Date range: {RangeButtonText}")" aria-haspopup="menu"
+                           aria-label="@RangeButtonAccessibleText" title="@RangeButtonAccessibleText" aria-haspopup="menu"
                            Class="fm-range-button">
-                    @RangeButtonText
+                    @if (IsCustomRange)
+                    {
+                        <MudIcon Icon="@Icons.Material.Filled.CalendarMonth" Size="Size.Small" />
+                    }
+                    else
+                    {
+                        @RangeButtonText
+                    }
                 </MudButton>
             </ActivatorContent>
             <ChildContent>
@@ -82,14 +97,6 @@
         </MudMenu>
 
         <MudSpacer />
-
-        @* Search — collapsed to an icon; the input lives in the panel below *@
-        <MudIconButton Icon="@(_isSearchExpanded ? Icons.Material.Filled.SearchOff : Icons.Material.Filled.Search)"
-                       Size="Size.Small" Color="@(_isSearchExpanded || !string.IsNullOrWhiteSpace(SearchText) ? Color.Primary : Color.Default)"
-                       OnClick="ToggleSearch" Style="flex-shrink: 0;"
-                       aria-label="@(_isSearchExpanded ? "Hide search" : "Search transactions")"
-                       title="@(_isSearchExpanded ? "Hide search" : "Search transactions")"
-                       aria-expanded="@_isSearchExpanded" aria-controls="@_searchPanelId" />
 
         @* Add entry split button — plus icon + Import / Export / Manage in the dropdown *@
         <MudButtonGroup Variant="Variant.Outlined" Color="Color.Default" Size="Size.Small" Style="flex-shrink: 0;">

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbar.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbar.razor.cs
@@ -56,20 +56,45 @@ public partial class AccountHistoryToolbar : ComponentBase
     };
 
     /// <summary>
-    /// Label on the date-range dropdown: the preset key, or the picked days for a custom range
-    /// so the button still says which window is on screen.
+    /// True when the active selection is the custom range, whether or not dates are present.
+    /// Custom-state checks must use this rather than comparing <see cref="RangeButtonText"/>
+    /// values, which may render the short form on mobile or when dates are missing.
     /// </summary>
-    private string RangeButtonText
+    internal bool IsCustomRange => SelectedRange == CustomRangeKey;
+
+    /// <summary>
+    /// Label on the date-range dropdown: the exact preset key, or the picked days for a custom
+    /// range so the button still says which window is on screen.
+    /// </summary>
+    internal string RangeButtonText
     {
         get
         {
-            if (SelectedRange != CustomRangeKey) return SelectedRange;
+            if (!IsCustomRange) return SelectedRange;
             if (CustomDateRange is not { Start: DateTime start, End: DateTime end }) return "Custom";
 
             // A dated label is ~45px wider than the phone row can spare once the type filter,
             // category, search and add controls have taken their share, so mobile keeps the
             // short form — the picked days are still shown in the picker and the change card.
             return IsMobile ? "Custom" : $"{start:dd/MM} – {end:dd/MM}";
+        }
+    }
+
+    /// <summary>
+    /// Accessible description of the active date range. Presets keep their exact label; a
+    /// complete custom range spells out both dates so a screen reader hears the window; a
+    /// custom selection without dates falls back to an honest "custom range" rather than
+    /// inventing one.
+    /// </summary>
+    internal string RangeButtonAccessibleText
+    {
+        get
+        {
+            if (!IsCustomRange) return $"Date range: {SelectedRange}";
+
+            return CustomDateRange is { Start: DateTime start, End: DateTime end }
+                ? $"Date range: {start:dd/MM/yyyy} to {end:dd/MM/yyyy}"
+                : "Date range: custom range";
         }
     }
 

--- a/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbarTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbarTests.cs
@@ -1,0 +1,147 @@
+using FinanceManager.Components.Features.FinancialAccounts.Components.Shared;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace FinanceManager.Tests.Unit.Components.Features.FinancialAccounts.Components.Shared;
+
+[Trait("Category", "Unit")]
+public class AccountHistoryToolbarTests
+{
+    private static readonly DateTime _customStart = new(2026, 1, 5);
+    private static readonly DateTime _customEnd = new(2026, 6, 15);
+
+    [Theory]
+    [InlineData("Month")]
+    [InlineData("1M")]
+    [InlineData("3M")]
+    [InlineData("6M")]
+    [InlineData("YTD")]
+    public void IsCustomRange_IsFalse_ForEachPresetRange(string preset)
+    {
+        var toolbar = CreateToolbar(selectedRange: preset);
+
+        Assert.False(toolbar.IsCustomRange);
+    }
+
+    [Theory]
+    [InlineData("Month")]
+    [InlineData("1M")]
+    [InlineData("3M")]
+    [InlineData("6M")]
+    [InlineData("YTD")]
+    public void RangeButtonText_ReturnsExactPresetLabel_ForEachPresetRange(string preset)
+    {
+        var toolbar = CreateToolbar(selectedRange: preset);
+
+        Assert.Equal(preset, toolbar.RangeButtonText);
+    }
+
+    [Theory]
+    [InlineData("Month")]
+    [InlineData("1M")]
+    [InlineData("3M")]
+    [InlineData("6M")]
+    [InlineData("YTD")]
+    public void RangeButtonAccessibleText_KeepsExactPresetLabel_ForEachPresetRange(string preset)
+    {
+        var toolbar = CreateToolbar(selectedRange: preset);
+
+        Assert.Equal($"Date range: {preset}", toolbar.RangeButtonAccessibleText);
+    }
+
+    [Fact]
+    public void IsCustomRange_IsTrue_WhenCustomRangeIsSelected()
+    {
+        var toolbar = CreateToolbar(
+            selectedRange: AccountHistoryToolbar.CustomRangeKey,
+            customDateRange: new DateRange(_customStart, _customEnd));
+
+        Assert.True(toolbar.IsCustomRange);
+    }
+
+    [Fact]
+    public void IsCustomRange_IsTrue_WhenCustomRangeIsSelectedButDatesAreMissing()
+    {
+        var toolbar = CreateToolbar(selectedRange: AccountHistoryToolbar.CustomRangeKey);
+
+        Assert.True(toolbar.IsCustomRange);
+    }
+
+    [Fact]
+    public void RangeButtonAccessibleText_SpellsOutBothDates_WhenCustomRangeIsComplete()
+    {
+        var toolbar = CreateToolbar(
+            selectedRange: AccountHistoryToolbar.CustomRangeKey,
+            customDateRange: new DateRange(_customStart, _customEnd));
+
+        Assert.Equal("Date range: 05/01/2026 to 15/06/2026", toolbar.RangeButtonAccessibleText);
+    }
+
+    [Fact]
+    public void RangeButtonText_KeepsShortDatedForm_WhenCustomRangeIsComplete()
+    {
+        var toolbar = CreateToolbar(
+            selectedRange: AccountHistoryToolbar.CustomRangeKey,
+            customDateRange: new DateRange(_customStart, _customEnd));
+
+        Assert.Equal("05/01 – 15/06", toolbar.RangeButtonText);
+    }
+
+    [Fact]
+    public void RangeButtonText_UsesShortForm_WhenCustomRangeIsCompleteAndMobile()
+    {
+        var toolbar = CreateToolbar(
+            selectedRange: AccountHistoryToolbar.CustomRangeKey,
+            customDateRange: new DateRange(_customStart, _customEnd),
+            isMobile: true);
+
+        Assert.Equal("Custom", toolbar.RangeButtonText);
+    }
+
+    [Fact]
+    public void RangeButtonAccessibleText_FallsBackToHonestCustom_WhenCustomDatesAreMissing()
+    {
+        var toolbar = CreateToolbar(selectedRange: AccountHistoryToolbar.CustomRangeKey);
+
+        Assert.Equal("Date range: custom range", toolbar.RangeButtonAccessibleText);
+    }
+
+    [Fact]
+    public void RangeButtonAccessibleText_FallsBackToHonestCustom_WhenOnlyOneCustomDateIsPresent()
+    {
+        var toolbar = CreateToolbar(
+            selectedRange: AccountHistoryToolbar.CustomRangeKey,
+            customDateRange: new DateRange(_customStart, end: null));
+
+        Assert.Equal("Date range: custom range", toolbar.RangeButtonAccessibleText);
+    }
+
+    [Fact]
+    public void RangeButtonText_FallsBackToCustom_WhenCustomDatesAreMissing()
+    {
+        var toolbar = CreateToolbar(selectedRange: AccountHistoryToolbar.CustomRangeKey);
+
+        Assert.Equal("Custom", toolbar.RangeButtonText);
+    }
+
+    private static AccountHistoryToolbar CreateToolbar(
+        string? selectedRange = null,
+        DateRange? customDateRange = null,
+        bool isMobile = false)
+    {
+        var parameters = new Dictionary<string, object?>
+        {
+            [nameof(AccountHistoryToolbar.CustomDateRange)] = customDateRange,
+            [nameof(AccountHistoryToolbar.IsMobile)] = isMobile
+        };
+
+        if (selectedRange is not null)
+            parameters[nameof(AccountHistoryToolbar.SelectedRange)] = selectedRange;
+
+#pragma warning disable BL0005 // Required component parameter is intentionally seeded before renderer-free unit assertions.
+        var toolbar = new AccountHistoryToolbar { AccountId = 1 };
+#pragma warning restore BL0005
+        ParameterView.FromDictionary(parameters).SetParameterProperties(toolbar);
+        return toolbar;
+    }
+}


### PR DESCRIPTION
Closes #712

## Summary
- move the existing transaction search action to the far-left toolbar position without changing expand/collapse behavior
- show a calendar icon for active custom ranges while keeping preset labels unchanged
- expose the selected custom dates through the range control accessible name and tooltip
- add focused regression coverage and an Unreleased changelog entry

## Validation
- `dotnet format ./code --verify-no-changes --no-restore --verbosity diagnostic` — passed, 0 files formatted
- `dotnet build ./code/FinanceManager.slnx --no-restore` — passed, 0 warnings, 0 errors
- focused `AccountHistoryToolbarTests` — 23 passed
- unit tests under `en_US.UTF-8` — 917 passed
- integration tests with `UseInMemoryDatabase=true` — 306 passed
- default Polish locale — 911 passed, 6 pre-existing unrelated culture-sensitive failures reproduced
- guest-account rendering at 430x920 and 1280x1000 — search is first, custom range shows the calendar icon, accessible dates are present, custom picker remains reachable, preset `3M` label is retained, and neither toolbar nor page overflows

## Orchestration
Parallel disjoint scopes from base `84d9401a`:
- Antigravity / `gemini-3.7-flash-medium`: Razor markup and changelog; scoped diff/format checks passed
- LM Studio / `qwen/qwen3.8-27b`: code-behind and focused tests; scoped diff passed, worker validation was interrupted after an unauthorized restore, so all validation above is coordinator-owned

## Risks
Low. The existing search callbacks, range menu, and custom picker are unchanged; this alters control order and custom-range presentation only. No migration or dependency change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen-reader labels for account history date-range controls.
  * Added clearer accessible descriptions for preset, complete custom, incomplete custom, and undated ranges.

* **UI Improvements**
  * Moved the search toggle to the beginning of the toolbar.
  * Added a calendar icon for custom date ranges while preserving existing range display behavior.

* **Bug Fixes**
  * Improved detection and presentation of custom date-range selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->