### PR TITLE
Add bUnit component tests (#707)

### DIFF
--- a/code/Directory.Packages.props
+++ b/code/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
     <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.4.6" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="bunit" Version="2.9.0" />
     <PackageVersion Include="TngTech.ArchUnitNET.xUnitV3" Version="0.13.3" />
     <PackageVersion Include="Blazor-ApexCharts" Version="7.0.0" />
     <PackageVersion Include="Blazored.LocalStorage" Version="4.5.0" />

--- a/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCardTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Cards/Assets/InvestmentPaycheckEstimatorCardTests.cs
@@ -1,37 +1,49 @@
+using Blazored.LocalStorage;
+using Bunit;
 using FinanceManager.Components.Features.Dashboard.Components.Cards.Assets;
+using FinanceManager.Components.Features.Dashboard.Services;
+using FinanceManager.Components.Features.MoneyFlow.HttpClients;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Domain.Identity.Services;
 using FinanceManager.Domain.MoneyFlow.Entities;
-using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MudBlazor;
+using MudBlazor.Services;
 
 namespace FinanceManager.Tests.Unit.Components.Features.Dashboard.Components.Cards.Assets;
 
 [Trait("Category", "Unit")]
 public class InvestmentPaycheckEstimatorCardTests
 {
-    // GetUninitializedObject skips the constructor and all field initializers, so the
-    // injected cache service stays null. Any call that tried to fetch fresh data would
-    // therefore throw a NullReferenceException — a passing test proves the rate change
-    // recomputed the paycheck purely from data already held by the card.
-    private static InvestmentPaycheckEstimatorCard CreateCard(InvestmentPaycheckEstimate estimate, decimal rate)
+    private static InvestmentPaycheckEstimatorCard RenderCard(BunitContext context, InvestmentPaycheckEstimate estimate, decimal rate)
     {
-        var card = (InvestmentPaycheckEstimatorCard)RuntimeHelpers.GetUninitializedObject(typeof(InvestmentPaycheckEstimatorCard));
+        var cut = context.Render<InvestmentPaycheckEstimatorCard>();
+        Assert.Contains("Investment paycheck", cut.Markup);
+        var card = cut.Instance;
         card._estimate = estimate;
         card._annualWithdrawalRate = rate;
         return card;
     }
 
     [Fact]
-    public void MonthlyPaycheck_ComputesLocallyFromInvestableValueAndRate()
+    public async Task MonthlyPaycheck_ComputesLocallyFromInvestableValueAndRate()
     {
-        var card = CreateCard(new InvestmentPaycheckEstimate { InvestableAssetsValue = 120_000m }, 0.04m);
+        await using var context = CreateContext();
+        var card = RenderCard(context, new InvestmentPaycheckEstimate { InvestableAssetsValue = 120_000m }, 0.04m);
 
         // 120000 * 0.04 / 12 = 400
         Assert.Equal(400m, card.MonthlyPaycheck);
     }
 
     [Fact]
-    public void OnPresetSelected_RecalculatesPaycheckLocally_WithoutFetching()
+    public async Task OnPresetSelected_RecalculatesPaycheckLocally_WithoutFetching()
     {
-        var card = CreateCard(new InvestmentPaycheckEstimate { InvestableAssetsValue = 120_000m }, 0.04m);
+        await using var context = CreateContext();
+        var card = RenderCard(context, new InvestmentPaycheckEstimate { InvestableAssetsValue = 120_000m }, 0.04m);
 
         card.OnPresetSelected(0.05m);
 
@@ -41,9 +53,10 @@ public class InvestmentPaycheckEstimatorCardTests
     }
 
     [Fact]
-    public void OnRateChanged_RecalculatesPaycheckLocally_WithoutFetching()
+    public async Task OnRateChanged_RecalculatesPaycheckLocally_WithoutFetching()
     {
-        var card = CreateCard(new InvestmentPaycheckEstimate { InvestableAssetsValue = 240_000m }, 0.04m);
+        await using var context = CreateContext();
+        var card = RenderCard(context, new InvestmentPaycheckEstimate { InvestableAssetsValue = 240_000m }, 0.04m);
 
         card.OnRateChanged(0.03m);
 
@@ -53,9 +66,10 @@ public class InvestmentPaycheckEstimatorCardTests
     }
 
     [Fact]
-    public void ReplacementRatio_DerivesFromLocalPaycheckAndAverageSalary()
+    public async Task ReplacementRatio_DerivesFromLocalPaycheckAndAverageSalary()
     {
-        var card = CreateCard(new InvestmentPaycheckEstimate
+        await using var context = CreateContext();
+        var card = RenderCard(context, new InvestmentPaycheckEstimate
         {
             InvestableAssetsValue = 120_000m,
             SalaryMonthsUsed = 3,
@@ -67,9 +81,10 @@ public class InvestmentPaycheckEstimatorCardTests
     }
 
     [Fact]
-    public void ReplacementRatio_TracksRateChangesLocally()
+    public async Task ReplacementRatio_TracksRateChangesLocally()
     {
-        var card = CreateCard(new InvestmentPaycheckEstimate
+        await using var context = CreateContext();
+        var card = RenderCard(context, new InvestmentPaycheckEstimate
         {
             InvestableAssetsValue = 120_000m,
             SalaryMonthsUsed = 3,
@@ -83,11 +98,12 @@ public class InvestmentPaycheckEstimatorCardTests
     }
 
     [Fact]
-    public void MonthlyPaycheck_And_ReplacementRatio_RoundToServerPrecision()
+    public async Task MonthlyPaycheck_And_ReplacementRatio_RoundToServerPrecision()
     {
         // Matches InvestmentPaycheckEstimatorService: paycheck rounded to 2 decimals,
         // ratio rounded to 4 decimals from that rounded paycheck.
-        var card = CreateCard(new InvestmentPaycheckEstimate
+        await using var context = CreateContext();
+        var card = RenderCard(context, new InvestmentPaycheckEstimate
         {
             InvestableAssetsValue = 100_000m,
             SalaryMonthsUsed = 3,
@@ -101,10 +117,35 @@ public class InvestmentPaycheckEstimatorCardTests
     }
 
     [Fact]
-    public void ReplacementRatio_IsNull_WhenNoSalaryData()
+    public async Task ReplacementRatio_IsNull_WhenNoSalaryData()
     {
-        var card = CreateCard(new InvestmentPaycheckEstimate { InvestableAssetsValue = 120_000m }, 0.04m);
+        await using var context = CreateContext();
+        var card = RenderCard(context, new InvestmentPaycheckEstimate { InvestableAssetsValue = 120_000m }, 0.04m);
 
         Assert.Null(card.ReplacementRatio);
+    }
+
+    private static BunitContext CreateContext()
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddLogging();
+        context.Services.AddMudServices();
+
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(service => service.GetCurrencyAsync()).ReturnsAsync(DefaultCurrency.PLN);
+        context.Services.AddSingleton(settings.Object);
+
+        var login = new Mock<ILoginService>();
+        login.Setup(service => service.GetLoggedUser()).ReturnsAsync((UserSession?)null);
+        context.Services.AddSingleton(login.Object);
+
+        context.Services.AddSingleton(new InvestmentPaycheckEstimateCacheService(
+            Mock.Of<ILocalStorageService>(),
+            new MemoryCache(new MemoryCacheOptions()),
+            new AssetsHttpClient(new HttpClient()),
+            NullLogger<InvestmentPaycheckEstimateCacheService>.Instance));
+
+        return context;
     }
 }

--- a/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Cards/Assets/InvestmentRateCardTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Cards/Assets/InvestmentRateCardTests.cs
@@ -1,6 +1,18 @@
+using Blazored.LocalStorage;
+using Bunit;
 using FinanceManager.Components.Features.Dashboard.Components.Cards.Assets;
+using FinanceManager.Components.Features.Dashboard.Services;
+using FinanceManager.Components.Features.MoneyFlow.HttpClients;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Domain.Identity.Services;
 using FinanceManager.Domain.MoneyFlow.Entities;
-using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MudBlazor;
+using MudBlazor.Services;
 
 namespace FinanceManager.Tests.Unit.Components.Features.Dashboard.Components.Cards.Assets;
 
@@ -12,7 +24,9 @@ public class InvestmentRateCardTests
     {
         var january = new InvestmentRate { Start = new DateTime(2026, 1, 1) };
         var february = new InvestmentRate { Start = new DateTime(2026, 2, 1) };
-        var card = CreateCard(new DateTime(2026, 2, 20, 0, 0, 0, DateTimeKind.Utc));
+        using var context = CreateContext();
+        var card = RenderCard(context);
+        card.AsOfDate = new DateTime(2026, 2, 20, 0, 0, 0, DateTimeKind.Utc);
         card.MonthlyInvestmentRates = [january, february];
 
         Assert.True(card.SelectMonth(0));
@@ -29,7 +43,9 @@ public class InvestmentRateCardTests
         // the average — otherwise it reads as if the salary had already been received.
         var june = new InvestmentRate { Start = new DateTime(2026, 6, 1), Salary = 9456.88m, InvestmentsChange = 4000m };
         var july = new InvestmentRate { Start = new DateTime(2026, 7, 1), Salary = 0m, InvestmentsChange = 5523.17m };
-        var card = CreateCard(new DateTime(2026, 7, 20, 0, 0, 0, DateTimeKind.Utc));
+        using var context = CreateContext();
+        var card = RenderCard(context);
+        card.AsOfDate = new DateTime(2026, 7, 20, 0, 0, 0, DateTimeKind.Utc);
         card.MonthlyInvestmentRates = [june, july];
 
         card.BuildDerivedState();
@@ -44,7 +60,9 @@ public class InvestmentRateCardTests
     public void BuildDerivedState_CurrentMonthWithSalary_ReportsRate()
     {
         var july = new InvestmentRate { Start = new DateTime(2026, 7, 1), Salary = 10_000m, InvestmentsChange = 5000m };
-        var card = CreateCard(new DateTime(2026, 7, 20, 0, 0, 0, DateTimeKind.Utc));
+        using var context = CreateContext();
+        var card = RenderCard(context);
+        card.AsOfDate = new DateTime(2026, 7, 20, 0, 0, 0, DateTimeKind.Utc);
         card.MonthlyInvestmentRates = [july];
 
         card.BuildDerivedState();
@@ -54,12 +72,34 @@ public class InvestmentRateCardTests
         Assert.Equal(50m, card.Series[0].Percentage);
     }
 
-    // The component is never rendered here, so field initialisers and injected dependencies are not
-    // needed — only the state the derived-value calculations read.
-    private static InvestmentRateCard CreateCard(DateTime asOfDate)
+    private static InvestmentRateCard RenderCard(BunitContext context)
     {
-        var card = (InvestmentRateCard)RuntimeHelpers.GetUninitializedObject(typeof(InvestmentRateCard));
-        card.AsOfDate = asOfDate;
-        return card;
+        var cut = context.Render<InvestmentRateCard>();
+        Assert.Contains("Investment rate", cut.Markup);
+        return cut.Instance;
+    }
+
+    private static BunitContext CreateContext()
+    {
+        var context = new BunitContext();
+        context.JSInterop.Mode = JSRuntimeMode.Loose;
+        context.Services.AddLogging();
+        context.Services.AddMudServices();
+
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(service => service.GetCurrencyAsync()).ReturnsAsync(DefaultCurrency.PLN);
+        context.Services.AddSingleton(settings.Object);
+
+        var login = new Mock<ILoginService>();
+        login.Setup(service => service.GetLoggedUser()).ReturnsAsync((UserSession?)null);
+        context.Services.AddSingleton(login.Object);
+
+        context.Services.AddSingleton(new InvestmentRateCacheService(
+            Mock.Of<ILocalStorageService>(),
+            new MemoryCache(new MemoryCacheOptions()),
+            new MoneyFlowHttpClient(new HttpClient()),
+            NullLogger<InvestmentRateCacheService>.Instance));
+
+        return context;
     }
 }

--- a/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Pages/OverviewPagesInitialRangeTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/Dashboard/Components/Pages/OverviewPagesInitialRangeTests.cs
@@ -1,5 +1,10 @@
+using Bunit;
+using FinanceManager.Components.Features.Dashboard.Components;
+using FinanceManager.Components.Features.Dashboard.Components.Cards;
+using FinanceManager.Components.Features.Dashboard.Components.Cards.Assets;
+using FinanceManager.Components.Features.Dashboard.Components.Cards.Liabilities;
+using FinanceManager.Components.Features.Dashboard.Components.Cards.TimeSeries;
 using FinanceManager.Components.Features.Dashboard.Components.Pages;
-using System.Reflection;
 
 namespace FinanceManager.Tests.Unit.Components.Features.Dashboard.Components.Pages;
 
@@ -12,25 +17,28 @@ public class OverviewPagesInitialRangeTests
     [Fact]
     public void AssetsPage_InitializesWithDefaultOverviewRange()
     {
-        var page = new AssetsPage();
+        using var context = CreateContext();
+        var before = DateTime.UtcNow;
+        var cut = context.Render<AssetsPage>();
+        var after = DateTime.UtcNow;
 
-        AssertDefaultOverviewRange(page, () => page.StartDate, () => page.EndDate);
+        AssertDefaultOverviewRange(before, after, () => cut.Instance.StartDate, () => cut.Instance.EndDate);
+        Assert.Contains("mud-container", cut.Markup);
     }
 
     [Fact]
     public void LiabilitiesPage_InitializesWithDefaultOverviewRange()
     {
-        var page = new LiabilitiesPage();
-
-        AssertDefaultOverviewRange(page, () => page.StartDate, () => page.EndDate);
-    }
-
-    private static void AssertDefaultOverviewRange(object page, Func<DateTime> startDate, Func<DateTime> endDate)
-    {
+        using var context = CreateContext();
         var before = DateTime.UtcNow;
-        Initialize(page);
+        var cut = context.Render<LiabilitiesPage>();
         var after = DateTime.UtcNow;
 
+        AssertDefaultOverviewRange(before, after, () => cut.Instance.StartDate, () => cut.Instance.EndDate);
+    }
+
+    private static void AssertDefaultOverviewRange(DateTime before, DateTime after, Func<DateTime> startDate, Func<DateTime> endDate)
+    {
         // Asserted as the relationship the shared helper defines rather than against a captured
         // "now", so the expectation holds even if the clock crosses midnight mid-test.
         Assert.InRange(endDate(), before, after);
@@ -38,10 +46,17 @@ public class OverviewPagesInitialRangeTests
         Assert.Equal(DateTimeKind.Utc, startDate().Kind);
     }
 
-    // The pages are never rendered here, so lifecycle is driven directly; OnInitialized is
-    // protected by ComponentBase's contract, hence the reflection.
-    private static void Initialize(object page) =>
-        page.GetType()
-            .GetMethod("OnInitialized", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .Invoke(page, null);
+    private static BunitContext CreateContext()
+    {
+        var context = new BunitContext();
+        context.ComponentFactories.AddStub<AssetsTimeSeriesCard>();
+        context.ComponentFactories.AddStub<AssetsDistributionOverviewCard>();
+        context.ComponentFactories.AddStub<InvestmentPaycheckEstimatorCard>();
+        context.ComponentFactories.AddStub<InvestmentRateCard>();
+        context.ComponentFactories.AddStub<DiversificationProxyCard>();
+        context.ComponentFactories.AddStub<LiabilitiesTimeSeriesCard>();
+        context.ComponentFactories.AddStub<LiabilitiesDistributionOverviewCard>();
+        context.ComponentFactories.AddStub<DashboardDatePicker>();
+        return context;
+    }
 }

--- a/code/FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj
+++ b/code/FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj
@@ -12,6 +12,7 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
+		<PackageReference Include="bunit" />
 		<PackageReference Include="coverlet.collector">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>


### PR DESCRIPTION
Closes #707

## Summary
- add bUnit 2.9.0 via central package management to the unit test project
- render the investment card tests through BunitContext with MudBlazor service/JS harnesses
- render the overview pages through bUnit and stub unrelated child cards
- remove uninitialized-object and lifecycle-reflection test setup while preserving assertions

## Validation
- `dotnet restore ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --verbosity normal --disable-parallel` — passed
- `dotnet format ./FinanceManager.slnx --verify-no-changes --verbosity minimal` — passed
- `dotnet build ./FinanceManager.slnx --configuration Release --no-restore --verbosity minimal` — passed, 0 warnings, 0 errors
- `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --configuration Release --no-restore -- --output Normal` — passed, 917/917

The host default `pl-PL` locale reproduces six unrelated pre-existing culture-sensitive unit failures; the complete suite is green under `en_US.UTF-8`. No production code changes and no subagents were used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved dashboard component test coverage by validating components through realistic rendered UI scenarios.
  * Added verification for investment calculations, rate changes, replacement ratios, rounding, missing salary data, and initial date ranges.
  * Centralized test setup for required services and rendering dependencies.
* **Chores**
  * Added bUnit support for unit testing with a centrally managed package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->