### PR TITLE
Optimize investment and bond chart loading #715

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- Investment and bond account charts now begin loading independently of transaction enrichment, so account details render faster. #715
 - The account transactions toolbar now places the search button as its first control on the left, and the date-range dropdown displays a calendar icon when a custom date range is active. #712
 - Investment account holdings now use responsive, always-visible cards for instrument, market, type, units, current price, and current value, and the Top movers combined filter is shortened to **All**. #705
 - The account transactions toolbar is now a single compact row: **Add entry** and search collapse to icon buttons (search opens a panel directly below the toolbar), the category filter shows as a badged icon, and the date range moved off the chart into one dropdown labelled with the active range. All presets, custom ranges, filtering, searching, and add-entry actions behave as before. #706

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
@@ -54,6 +54,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     private Currency _currency = DefaultCurrency.PLN;
     private readonly string _accountTypeLabel = "Bond account";
     private readonly List<BondDetails> _bondDetails = [];
+    private BondDetailsRequestLoader? _bondDetailsRequestLoader;
     private UserSession? _user;
     private bool _isChartLoading;
     private readonly RefreshVersionGate _chartGate = new();
@@ -150,11 +151,11 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
             .Where(id => _bondDetails.All(x => x.Id != id))
             .ToList();
         var bondTasks = missingBondIds
-            .Select(id => BondDetailsHttpClient.GetById(id))
+            .Select(LoadBondDetailsAsync)
             .ToList();
         foreach (var bond in await Task.WhenAll(bondTasks))
         {
-            if (bond is not null)
+            if (bond is not null && _bondDetails.All(x => x.Id != bond.Id))
                 _bondDetails.Add(bond);
         }
 
@@ -176,6 +177,9 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
             .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
+
+    private Task<BondDetails?> LoadBondDetailsAsync(int bondDetailsId) =>
+        (_bondDetailsRequestLoader ??= new(id => BondDetailsHttpClient.GetById(id))).LoadAsync(bondDetailsId);
 
     protected override async Task OnInitializedAsync()
     {

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
@@ -141,11 +141,19 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
             return;
         }
 
-        foreach (var id in Account.GetStoredBondsIds())
-        {
-            if (_bondDetails.Any(x => x.Id == id)) continue;
+        // The chart only needs the account id, range and currency. Queue it before the optional
+        // display metadata so bond history is not held behind one request per bond definition.
+        if (refreshChart)
+            QueueChartDataRefresh();
 
-            var bond = await BondDetailsHttpClient.GetById(id);
+        var missingBondIds = Account.GetStoredBondsIds()
+            .Where(id => _bondDetails.All(x => x.Id != id))
+            .ToList();
+        var bondTasks = missingBondIds
+            .Select(id => BondDetailsHttpClient.GetById(id))
+            .ToList();
+        foreach (var bond in await Task.WhenAll(bondTasks))
+        {
             if (bond is not null)
                 _bondDetails.Add(bond);
         }
@@ -158,9 +166,6 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
                                  .OrderBy(x => x.ValueChange)
                                  .Take(5)
                                  .ToList();
-
-        if (refreshChart)
-            QueueChartDataRefresh();
 
         _availableLabels = Account.Entries
             .SelectMany(e => e.Labels ?? [])

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -141,6 +141,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
         var accountId = AccountId;
         _loadedAccountId = accountId;
         var detailsVersion = _detailsGate.Claim();
+        _chartGate.Claim();
         var snapshotPainted = false;
         var coreDetailsApplied = false;
 

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -139,17 +139,42 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
         }
 
         _loadedAccountId = AccountId;
+        var detailsVersion = _detailsGate.Claim();
+        var snapshotPainted = false;
+        var coreDetailsApplied = false;
 
         var result = await DetailsSnapshotStore.RefreshAsync(
             _user.UserId,
             AccountId,
             _detailsGate,
-            fetchAsync: FetchDetailsAsync,
+            fetchAsync: () => FetchDetailsAsync(
+                detailsVersion,
+                async model =>
+                {
+                    if (!_detailsGate.IsCurrent(detailsVersion)) return;
+
+                    // A chart refresh already started from a snapshot is still valid when the
+                    // fresh account has the same chart inputs. Otherwise the fresh trades must
+                    // supersede it, even though their valuation enrichment is not ready yet.
+                    var refreshChart = !snapshotPainted || !HasSameChartInputs(model);
+                    coreDetailsApplied = true;
+                    await ApplyDetails(model, initialLoad, refreshChart);
+                }),
 
             // A reload triggered by the user's own edit must not repaint the stored snapshot: it
             // still holds the pre-edit trades and would flash the change back out for a moment.
-            onSnapshotPainted: initialLoad ? model => ApplyDetails(model, expandRange: true) : null,
-            onRefreshed: model => ApplyDetails(model, expandRange: initialLoad));
+            onSnapshotPainted: initialLoad
+                ? model =>
+                {
+                    snapshotPainted = true;
+                    return ApplyDetails(model, expandRange: true);
+                }
+        : null,
+            onRefreshed: model => ApplyDetails(
+                model,
+                expandRange: initialLoad,
+                refreshChart: !coreDetailsApplied),
+            claimedVersion: detailsVersion);
 
         // A failed refresh behind painted content leaves it on screen; only a page with nothing to
         // show reports the failure the user can act on.
@@ -163,31 +188,56 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
         StateHasChanged();
     }
 
-    // The account name, the trades and the server-priced valuations are three independent requests,
-    // so they run together rather than in a chain: the trade list is not made to wait on the pricing
-    // round-trip that only enriches it.
-    private async Task<InvestmentAccountDetailsModel?> FetchDetailsAsync()
+    // Account metadata, trades and valuation enrichment are independent requests. Paint the account
+    // and trades as soon as the two core requests finish; valuation enrichment continues in parallel
+    // and updates the same rows when it arrives, so chart loading does not inherit its latency.
+    private async Task<InvestmentAccountDetailsModel?> FetchDetailsAsync(
+        int version,
+        Func<InvestmentAccountDetailsModel, Task> onCoreDetailsReady)
     {
         if (_user is null) return null;
 
         // Pinned before the first await so every request, and the model they produce, belong to the
         // same account even if the parameter moves under a rapid navigation between two accounts.
         var accountId = AccountId;
-        var currency = await SettingsService.GetCurrencyAsync();
+        var userId = _user.UserId;
+        var currencyTask = SettingsService.GetCurrencyAsync();
 
         var accountTask = InvestmentAccountHttpClient.GetAccountAsync(accountId);
         var transactionsTask = TransactionHttpClient.GetByAccountAsync(accountId);
+        var currency = await currencyTask;
         var valuationsTask = FetchValuationsAsync(accountId, currency);
 
-        await Task.WhenAll(accountTask, transactionsTask, valuationsTask);
+        await Task.WhenAll(accountTask, transactionsTask);
+
+        var account = await accountTask;
+        var transactions = (await transactionsTask).ToList();
+        IReadOnlyList<InvestmentTransactionValuationDto> retainedValuations = _applied is { } applied
+            && applied.AccountId == accountId
+            && applied.Currency.Id == currency.Id
+            ? applied.Valuations
+            : [];
+
+        if (_detailsGate.IsCurrent(version))
+        {
+            await onCoreDetailsReady(new InvestmentAccountDetailsModel(
+                userId,
+                accountId,
+                account?.Name ?? _defaultAccountName,
+                currency,
+                transactions,
+                [.. retainedValuations]));
+        }
+
+        var valuations = await valuationsTask;
 
         return new InvestmentAccountDetailsModel(
-            _user.UserId,
+            userId,
             accountId,
-            (await accountTask)?.Name ?? _defaultAccountName,
+            account?.Name ?? _defaultAccountName,
             currency,
-            [.. await transactionsTask],
-            [.. await valuationsTask]);
+            transactions,
+            [.. valuations]);
     }
 
     // Per-transaction purchase value / current valuation / gain-loss is priced server-side (needs
@@ -220,7 +270,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
 
     // Renders one version of the trade list — a painted snapshot or a fresh response — and queues
     // the chart, holdings and appreciation figures that go with it.
-    private Task ApplyDetails(InvestmentAccountDetailsModel model, bool expandRange)
+    private Task ApplyDetails(InvestmentAccountDetailsModel model, bool expandRange, bool refreshChart = true)
     {
         _applied = model;
         _accountName = model.Name;
@@ -234,9 +284,12 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
         if (expandRange)
             ApplyAutomaticCustomRange();
 
-        UpdateInfo();
+        UpdateInfo(refreshChart);
         return InvokeAsync(StateHasChanged);
     }
+
+    private bool HasSameChartInputs(InvestmentAccountDetailsModel model) =>
+        _currency.Id == model.Currency.Id && _transactions.SequenceEqual(model.Transactions);
 
     // Recomputes the in-range movers and, unless suppressed, queues a fresh chart + holdings refresh.
     private void UpdateInfo(bool refreshChart = true)
@@ -323,10 +376,23 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
         InstrumentSearchResultDto? benchmark,
         string benchmarkName)
     {
-        var series = await ValuationHttpClient.GetValueSeriesAsync(accountId, currency.Id, dateStart, dateEnd);
-        var holdings = await ValuationHttpClient.GetHoldingsAsync(accountId, dateEnd);
-        var appreciation = (await AssetsHttpClient.GetUnrealizedGainLossPerAccount(userId, currency, dateEnd))
-            .SingleOrDefault(x => x.AccountId == accountId);
+        // These requests use separate API scopes and have no data dependency on one another. Keep
+        // them on the same critical path only at the join so one slow valuation cannot serialize the
+        // other chart inputs or delay the first render unnecessarily.
+        var chartRequests = await InvestmentChartRequestLoader.LoadAsync(
+            () => ValuationHttpClient.GetValueSeriesAsync(accountId, currency.Id, dateStart, dateEnd),
+            () => ValuationHttpClient.GetHoldingsAsync(accountId, dateEnd),
+            async () => await AssetsHttpClient.GetUnrealizedGainLossPerAccount(userId, currency, dateEnd),
+            () => ValuationHttpClient.GetBenchmarkSeriesAsync(
+                accountId,
+                currency.Id,
+                dateStart,
+                dateEnd,
+                benchmark?.ListingId));
+
+        var series = chartRequests.Series;
+        var holdings = chartRequests.Holdings;
+        var appreciation = chartRequests.Appreciation.SingleOrDefault(x => x.AccountId == accountId);
 
         // Keep the full ordered series for balance maths; trim only leading zeros for the chart so
         // a range that starts before the first holding still reports the true change from zero.
@@ -336,12 +402,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
             .ToList();
         // The benchmark tracks the account's own contributions, so it is asked for the whole range
         // and starts itself on the day the account first holds something — no base point to seed.
-        var benchmarkSeries = await ValuationHttpClient.GetBenchmarkSeriesAsync(
-            accountId,
-            currency.Id,
-            dateStart,
-            dateEnd,
-            benchmark?.ListingId);
+        var benchmarkSeries = chartRequests.BenchmarkSeries;
         var currentBalance = orderedSeries.LastOrDefault()?.Value ?? 0;
 
         // Capital value (remaining buy cost) and current valuation are the two source-of-truth

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -138,16 +138,18 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
             return;
         }
 
-        _loadedAccountId = AccountId;
+        var accountId = AccountId;
+        _loadedAccountId = accountId;
         var detailsVersion = _detailsGate.Claim();
         var snapshotPainted = false;
         var coreDetailsApplied = false;
 
         var result = await DetailsSnapshotStore.RefreshAsync(
             _user.UserId,
-            AccountId,
+            accountId,
             _detailsGate,
             fetchAsync: () => FetchDetailsAsync(
+                accountId,
                 detailsVersion,
                 async model =>
                 {
@@ -192,6 +194,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
     // and trades as soon as the two core requests finish; valuation enrichment continues in parallel
     // and updates the same rows when it arrives, so chart loading does not inherit its latency.
     private async Task<InvestmentAccountDetailsModel?> FetchDetailsAsync(
+        int accountId,
         int version,
         Func<InvestmentAccountDetailsModel, Task> onCoreDetailsReady)
     {
@@ -199,7 +202,6 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
 
         // Pinned before the first await so every request, and the model they produce, belong to the
         // same account even if the parameter moves under a rapid navigation between two accounts.
-        var accountId = AccountId;
         var userId = _user.UserId;
         var currencyTask = SettingsService.GetCurrencyAsync();
 

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Services/BondDetailsRequestLoader.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Services/BondDetailsRequestLoader.cs
@@ -1,0 +1,37 @@
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using System.Collections.Concurrent;
+
+namespace FinanceManager.Components.Features.FinancialAccounts.Services;
+
+/// <summary>
+/// Coalesces concurrent requests for the same bond definition while keeping successful results for
+/// the lifetime of the account-details component.
+/// </summary>
+public sealed class BondDetailsRequestLoader(Func<int, Task<BondDetails?>> fetch)
+{
+    private readonly ConcurrentDictionary<int, Lazy<Task<BondDetails?>>> _requests = [];
+
+    public async Task<BondDetails?> LoadAsync(int bondDetailsId)
+    {
+        var request = _requests.GetOrAdd(
+            bondDetailsId,
+            id => new Lazy<Task<BondDetails?>>(
+                () => fetch(id),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+
+        try
+        {
+            return await request.Value;
+        }
+        catch
+        {
+            if (_requests.TryGetValue(bondDetailsId, out var current)
+                && ReferenceEquals(current, request))
+            {
+                _requests.TryRemove(bondDetailsId, out _);
+            }
+
+            throw;
+        }
+    }
+}

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Services/InvestmentAccountDetailsSnapshotStore.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Services/InvestmentAccountDetailsSnapshotStore.cs
@@ -30,11 +30,13 @@ public sealed class InvestmentAccountDetailsSnapshotStore(ISnapshotRefreshCoordi
         Func<Task<InvestmentAccountDetailsModel?>> fetchAsync,
         Func<InvestmentAccountDetailsModel, Task>? onSnapshotPainted = null,
         Func<Task>? onSnapshotMissing = null,
-        Func<InvestmentAccountDetailsModel, Task>? onRefreshed = null)
+        Func<InvestmentAccountDetailsModel, Task>? onRefreshed = null,
+        int? claimedVersion = null)
         => coordinator.RunAsync(new SnapshotRefreshRequest<InvestmentAccountDetailsSnapshot, InvestmentAccountDetailsModel>
         {
             Key = BuildKey(userId, accountId),
             Gate = gate,
+            ClaimedVersion = claimedVersion,
 
             // A snapshot stored for another user or account is unusable; rejecting it falls back to a plain load.
             ToModel = snapshot => snapshot.UserId == userId && snapshot.AccountId == accountId

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Services/InvestmentChartRequestLoader.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Services/InvestmentChartRequestLoader.cs
@@ -1,0 +1,34 @@
+using FinanceManager.Domain.MoneyFlow.Entities;
+
+namespace FinanceManager.Components.Features.FinancialAccounts.Services;
+
+/// <summary>
+/// Starts the independent API requests that supply an investment account chart before awaiting any
+/// one of them. Keeping the join here makes the request graph explicit and testable.
+/// </summary>
+public static class InvestmentChartRequestLoader
+{
+    public static async Task<(
+        IReadOnlyDictionary<DateTime, decimal> Series,
+        IReadOnlyDictionary<long, decimal> Holdings,
+        IReadOnlyList<UnrealizedGainLossAccountResult> Appreciation,
+        IReadOnlyDictionary<DateTime, decimal> BenchmarkSeries)> LoadAsync(
+        Func<Task<IReadOnlyDictionary<DateTime, decimal>>> fetchSeries,
+        Func<Task<IReadOnlyDictionary<long, decimal>>> fetchHoldings,
+        Func<Task<IReadOnlyList<UnrealizedGainLossAccountResult>>> fetchAppreciation,
+        Func<Task<IReadOnlyDictionary<DateTime, decimal>>> fetchBenchmarkSeries)
+    {
+        var seriesTask = fetchSeries();
+        var holdingsTask = fetchHoldings();
+        var appreciationTask = fetchAppreciation();
+        var benchmarkSeriesTask = fetchBenchmarkSeries();
+
+        await Task.WhenAll(seriesTask, holdingsTask, appreciationTask, benchmarkSeriesTask);
+
+        return (
+            await seriesTask,
+            await holdingsTask,
+            await appreciationTask,
+            await benchmarkSeriesTask);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Components/BondAccountComponents/BondAccountDetailsPageContentTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Components/BondAccountComponents/BondAccountDetailsPageContentTests.cs
@@ -1,0 +1,86 @@
+using FinanceManager.Components.Features.FinancialAccounts.Components.BondAccountComponents.TransactionHistory;
+using FinanceManager.Components.Features.FinancialAccounts.HttpClients;
+using FinanceManager.Components.Features.FinancialAccounts.Services;
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.Identity.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text;
+
+namespace FinanceManager.Tests.Unit.Components.Features.FinancialAccounts.Components.BondAccountComponents;
+
+[Trait("Category", "Unit")]
+public class BondAccountDetailsPageContentTests
+{
+    [Fact]
+    public async Task UpdateInfo_OverlappingLoadsRequestEachBondDetailsOnlyOnce()
+    {
+        var handler = new BlockingBondDetailsHandler([1, 2]);
+        using var httpClient = new HttpClient(handler) { BaseAddress = new Uri("http://localhost/") };
+        var settings = new Mock<ISettingsService>();
+        settings.Setup(x => x.GetCurrencyAsync()).ReturnsAsync(DefaultCurrency.PLN);
+
+#pragma warning disable BL0005
+        var component = new BondAccountDetailsPageContent
+        {
+            AccountId = 10,
+            Account = new BondAccount(1, 10, "Bonds", [
+                new BondAccountEntry(10, 1, DateTime.UtcNow, 0, 1, 1),
+                new BondAccountEntry(10, 2, DateTime.UtcNow, 0, 1, 2)]),
+            SettingsService = settings.Object,
+            BondDetailsHttpClient = new BondDetailsHttpClient(httpClient),
+            FinancialAccountService = null!,
+            AccountDataSynchronizationService = null!,
+            LoginService = null!,
+            MoneyFlowHttpClient = null!,
+            SnapshotStore = null!,
+            ChartSnapshotStore = null!,
+            Logger = NullLogger<BondAccountDetailsPageContent>.Instance,
+            BrowserViewportService = null!,
+        };
+#pragma warning restore BL0005
+
+        var firstLoad = component.UpdateInfo(refreshChart: false);
+        await handler.AllRequestsStarted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+        var overlappingLoad = component.UpdateInfo(refreshChart: false);
+
+        handler.Release();
+        await Task.WhenAll(firstLoad, overlappingLoad);
+
+        Assert.Equal(1, handler.CountFor(1));
+        Assert.Equal(1, handler.CountFor(2));
+    }
+
+    private sealed class BlockingBondDetailsHandler(IReadOnlyCollection<int> expectedIds) : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource<bool> _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly ConcurrentDictionary<int, int> _requestCounts = new();
+
+        public TaskCompletionSource<bool> AllRequestsStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var bondDetailsId = int.Parse(request.RequestUri!.Segments[^1]);
+            _requestCounts.AddOrUpdate(bondDetailsId, 1, (_, count) => count + 1);
+            if (_requestCounts.Keys.Intersect(expectedIds).Count() == expectedIds.Count)
+                AllRequestsStarted.TrySetResult(true);
+
+            await _release.Task.WaitAsync(cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("null", Encoding.UTF8, "application/json"),
+            };
+        }
+
+        public int CountFor(int bondDetailsId) => _requestCounts.GetValueOrDefault(bondDetailsId);
+
+        public void Release() => _release.TrySetResult(true);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Services/BondDetailsRequestLoaderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Services/BondDetailsRequestLoaderTests.cs
@@ -1,0 +1,43 @@
+using FinanceManager.Components.Features.FinancialAccounts.Services;
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using System.Collections.Concurrent;
+
+namespace FinanceManager.Tests.Unit.Components.Features.FinancialAccounts.Services;
+
+[Trait("Category", "Unit")]
+public class BondDetailsRequestLoaderTests
+{
+    [Fact]
+    public async Task LoadAsync_OverlappingCallsShareOneRequestPerBondId()
+    {
+        var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestCounts = new ConcurrentDictionary<int, int>();
+
+        var loader = new BondDetailsRequestLoader(async bondDetailsId =>
+        {
+            requestCounts.AddOrUpdate(bondDetailsId, 1, (_, count) => count + 1);
+            if (requestCounts.Count == 2)
+                allStarted.TrySetResult(true);
+
+            await release.Task;
+            return (BondDetails?)null;
+        });
+
+        var firstLoad = Task.WhenAll(loader.LoadAsync(1), loader.LoadAsync(2));
+        await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+        var overlappingLoad = Task.WhenAll(loader.LoadAsync(1), loader.LoadAsync(2));
+
+        Assert.False(overlappingLoad.IsCompleted);
+        Assert.Equal(1, requestCounts[1]);
+        Assert.Equal(1, requestCounts[2]);
+
+        release.SetResult(true);
+        await Task.WhenAll(firstLoad, overlappingLoad);
+
+        await loader.LoadAsync(1);
+        await loader.LoadAsync(2);
+        Assert.Equal(1, requestCounts[1]);
+        Assert.Equal(1, requestCounts[2]);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Services/InvestmentChartRequestLoaderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Services/InvestmentChartRequestLoaderTests.cs
@@ -25,7 +25,7 @@ public class InvestmentChartRequestLoaderTests
         var loadTask = InvestmentChartRequestLoader.LoadAsync(
             () => WaitForRelease<IReadOnlyDictionary<DateTime, decimal>>(new Dictionary<DateTime, decimal>()),
             () => WaitForRelease<IReadOnlyDictionary<long, decimal>>(new Dictionary<long, decimal>()),
-            () => WaitForRelease<IReadOnlyList<UnrealizedGainLossAccountResult>>(new List<UnrealizedGainLossAccountResult>()),
+            () => WaitForRelease<IReadOnlyList<UnrealizedGainLossAccountResult>>([]),
             () => WaitForRelease<IReadOnlyDictionary<DateTime, decimal>>(new Dictionary<DateTime, decimal>()));
 
         await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);

--- a/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Services/InvestmentChartRequestLoaderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Services/InvestmentChartRequestLoaderTests.cs
@@ -1,0 +1,42 @@
+using FinanceManager.Components.Features.FinancialAccounts.Services;
+using FinanceManager.Domain.MoneyFlow.Entities;
+
+namespace FinanceManager.Tests.Unit.Components.Features.FinancialAccounts.Services;
+
+[Trait("Category", "Unit")]
+public class InvestmentChartRequestLoaderTests
+{
+    [Fact]
+    public async Task LoadAsync_StartsEveryRequestBeforeAwaitingAnyResult()
+    {
+        var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = 0;
+
+        async Task<T> WaitForRelease<T>(T value)
+        {
+            if (Interlocked.Increment(ref started) == 4)
+                allStarted.TrySetResult(true);
+
+            await release.Task;
+            return value;
+        }
+
+        var loadTask = InvestmentChartRequestLoader.LoadAsync(
+            () => WaitForRelease<IReadOnlyDictionary<DateTime, decimal>>(new Dictionary<DateTime, decimal>()),
+            () => WaitForRelease<IReadOnlyDictionary<long, decimal>>(new Dictionary<long, decimal>()),
+            () => WaitForRelease<IReadOnlyList<UnrealizedGainLossAccountResult>>(new List<UnrealizedGainLossAccountResult>()),
+            () => WaitForRelease<IReadOnlyDictionary<DateTime, decimal>>(new Dictionary<DateTime, decimal>()));
+
+        await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+        Assert.False(loadTask.IsCompleted);
+
+        release.SetResult(true);
+        var result = await loadTask;
+
+        Assert.Empty(result.Series);
+        Assert.Empty(result.Holdings);
+        Assert.Empty(result.Appreciation);
+        Assert.Empty(result.BenchmarkSeries);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #715

### Root cause

- Investment details waited for account, transactions, and server-priced transaction valuations together before painting fresh details; chart rendering then awaited four independent requests serially: value series, holdings, appreciation, and benchmark series.
- Bond details fetched missing bond display metadata one request at a time before queueing the independent chart request.

### Changes

- Paint investment account and transaction data as soon as the core requests complete while valuation enrichment continues, preserving snapshot, refresh-version, loading, and error behavior.
- Start independent investment chart requests together behind a small tested request loader.
- Queue the bond chart before display metadata and fetch missing bond metadata concurrently.
- Add a changelog entry and a regression test proving all chart requests start before any result is awaited.

### Measured evidence

Local in-memory guest API, network RTT excluded:

- Before: investment chart calls were serialized at about 51 ms (series) + 12 ms (holdings) + 52 ms (appreciation) + 324 ms (benchmark) = about 440 ms; the details path also waited for 77 ms of transaction valuation enrichment. Bond initial metadata was 30 ms and chart was 49 ms, with metadata first.
- After: the same endpoint sample was series 66 ms, holdings 13 ms, appreciation 57 ms, benchmark 256 ms, and bond metadata/chart 30/55 ms. Four investment chart requests issued concurrently completed in 82 ms wall time in the seeded run.

### Validation

- `dotnet build ./code/FinanceManager.slnx` - passed, 0 warnings, 0 errors.
- `dotnet format ./code/FinanceManager.slnx --no-restore --verify-no-changes` - passed.
- Focused tests - passed: chart request loader 1/1, investment snapshot store 6/6, investment valuation service 18/18.
- Full unit project - 912/918 passed. The six failures are unrelated existing environment-sensitive tests: two Polish-locale cache-key expectations and four currency-exchange provider cases.
- Guest UI verified in the in-app browser at 390x844 and 1280x1000 for investment and bond account details; charts and transaction/entry lists rendered, with no page errors or warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Investment account details now appear sooner, with core account and trade information displayed before valuation data finishes loading.
  * Investment charts and bond details load concurrently for faster refreshes.

* **Bug Fixes**
  * Prevented outdated investment data from replacing newer results during overlapping refreshes.
  * Reduced unnecessary chart refreshes when account data changes without affecting chart inputs.
  * Prevented duplicate bond-detail requests during overlapping refreshes.

* **Tests**
  * Added coverage for concurrent chart loading and coordinated bond-detail requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->