### PR TITLE
Preserve external dependency identity in resilience logs #718

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- Admin logs for resilient external requests now retain a safe provider, host, method, path, and operation identity; generic resilience entries no longer persist raw exception text or duplicate uncontextualized failures. #718
 - Returning after a long break now restores the last compatible dashboard and account-chart state immediately, then refreshes it in the background instead of losing it to date-based snapshot keys. #691
 - On mobile, the fixed date-range picker at the bottom of the dashboard, assets, and liabilities pages no longer permanently hides the last page content. Those pages now reserve enough bottom space (including the device safe-area inset) for content to scroll fully clear of the picker, while desktop and tablet-wide layouts are unchanged. #688
 - Expected cancellation during imports and provider calls is now separated from genuine failures, and exchange-rate ranges report transport failures on the affected dates. #681

--- a/code/FinanceManager.Tests.Unit/ServiceDefaults/ExternalDependencyLoggingHandlerTests.cs
+++ b/code/FinanceManager.Tests.Unit/ServiceDefaults/ExternalDependencyLoggingHandlerTests.cs
@@ -159,6 +159,196 @@ public class ExternalDependencyLoggingHandlerTests
         Assert.DoesNotContain("secret-value", retryLog.Message);
     }
 
+    [Fact]
+    public async Task AddServiceDefaults_HttpClientFactory_PollyRecordsAreReplacedBySafeRequestRecords()
+    {
+        var entries = new List<LogRecord>();
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+        builder.Logging.AddProvider(new RecordingLoggerProvider(entries));
+        builder.AddServiceDefaults();
+        builder.Services.AddHttpClient("external")
+            .ConfigurePrimaryHttpMessageHandler(() => new SequenceHandler(
+                new HttpResponseMessage(HttpStatusCode.GatewayTimeout),
+                new HttpResponseMessage(HttpStatusCode.OK)));
+
+        using var host = builder.Build();
+        var clientFactory = host.Services.GetRequiredService<IHttpClientFactory>();
+        using var client = clientFactory.CreateClient("external");
+
+        using var response = await client.GetAsync(
+            "https://api.twelvedata.com/time_series?apikey=secret-value",
+            TestContext.Current.CancellationToken);
+
+        var resilienceLogs = entries
+            .Where(entry => entry.Message.StartsWith("Execution attempt.", StringComparison.Ordinal)
+                || entry.Message.StartsWith("Resilience event occurred.", StringComparison.Ordinal))
+            .ToList();
+        var retryLog = Assert.Single(
+            entries,
+            entry => entry.Message.StartsWith("External dependency retry", StringComparison.Ordinal));
+
+        Assert.Empty(resilienceLogs);
+        Assert.Contains("Operation: Twelve Data GET api.twelvedata.com", retryLog.Message);
+        Assert.Contains("Service: Twelve Data", retryLog.Message);
+        Assert.Contains("Path: /time_series", retryLog.Message);
+        Assert.DoesNotContain("secret-value", retryLog.Message);
+    }
+
+    [Fact]
+    public async Task AddServiceDefaults_HttpClientFactory_Terminal504LogsSafeRequestIdentity()
+    {
+        var entries = new List<LogRecord>();
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+        builder.Logging.AddProvider(new RecordingLoggerProvider(entries));
+        builder.AddServiceDefaults();
+        builder.Services.AddHttpClient("external")
+            .ConfigurePrimaryHttpMessageHandler(() => new StubHandler(_ =>
+                new HttpResponseMessage(HttpStatusCode.GatewayTimeout)));
+
+        using var host = builder.Build();
+        var clientFactory = host.Services.GetRequiredService<IHttpClientFactory>();
+        using var client = clientFactory.CreateClient("external");
+
+        using var response = await client.GetAsync(
+            "https://api.twelvedata.com/time_series?apikey=secret-value",
+            TestContext.Current.CancellationToken);
+
+        var terminalLog = Assert.Single(
+            entries,
+            entry => entry.Message.StartsWith("External dependency request returned", StringComparison.Ordinal));
+
+        Assert.Equal(HttpStatusCode.GatewayTimeout, response.StatusCode);
+        Assert.Contains("Operation: Twelve Data GET api.twelvedata.com", terminalLog.Message);
+        Assert.Contains("Service: Twelve Data", terminalLog.Message);
+        Assert.Contains("Host: api.twelvedata.com", terminalLog.Message);
+        Assert.Contains("Method: GET", terminalLog.Message);
+        Assert.Contains("Path: /time_series", terminalLog.Message);
+        Assert.Contains("Result: 504", terminalLog.Message);
+        Assert.DoesNotContain("secret-value", terminalLog.Message);
+    }
+
+    [Fact]
+    public async Task AddServiceDefaults_HttpClientFactory_TimeoutLogUsesSafeOperationKey()
+    {
+        var entries = new List<LogRecord>();
+        var builder = Host.CreateApplicationBuilder();
+        builder.Configuration["HttpClientResilience:AttemptTimeoutSeconds"] = "1";
+        builder.Configuration["HttpClientResilience:TotalRequestTimeoutSeconds"] = "1";
+        builder.Logging.ClearProviders();
+        builder.Logging.AddProvider(new RecordingLoggerProvider(entries));
+        builder.AddServiceDefaults();
+        builder.Services.AddHttpClient("external")
+            .ConfigurePrimaryHttpMessageHandler(() => new CancellationAwareHandler());
+
+        using var host = builder.Build();
+        var clientFactory = host.Services.GetRequiredService<IHttpClientFactory>();
+        using var client = clientFactory.CreateClient("external");
+
+        await Assert.ThrowsAnyAsync<Exception>(() => client.GetAsync(
+            "https://api.twelvedata.com/time_series?apikey=secret-value",
+            TestContext.Current.CancellationToken));
+
+        var timeoutLogs = entries
+            .Where(entry => entry.Message.StartsWith("External dependency timeout", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(timeoutLogs);
+        Assert.All(timeoutLogs, log =>
+        {
+            Assert.Contains("Operation: Twelve Data GET api.twelvedata.com", log.Message);
+            Assert.Contains("Service: Twelve Data", log.Message);
+            Assert.Contains("Path: /time_series", log.Message);
+            Assert.DoesNotContain("secret-value", log.Message);
+        });
+    }
+
+    [Fact]
+    public async Task AddServiceDefaults_HttpClientFactory_TransportFailureRecordsRedactExceptionSecrets()
+    {
+        var entries = new List<LogRecord>();
+        var builder = Host.CreateApplicationBuilder();
+        builder.Logging.ClearProviders();
+        builder.Logging.AddProvider(new RecordingLoggerProvider(entries));
+        builder.AddServiceDefaults();
+        builder.Services.AddHttpClient("external")
+            .ConfigurePrimaryHttpMessageHandler(() => new TransportFailureHandler());
+
+        using var host = builder.Build();
+        var clientFactory = host.Services.GetRequiredService<IHttpClientFactory>();
+        using var client = clientFactory.CreateClient("external");
+
+        await Assert.ThrowsAnyAsync<Exception>(() => client.GetAsync(
+            "https://api.openfigi.com/v3/mapping?apiKey=query-secret",
+            TestContext.Current.CancellationToken));
+
+        var capturedText = string.Join(
+            Environment.NewLine,
+            entries.SelectMany(entry => new[] { entry.Message, entry.Exception?.ToString() ?? string.Empty }));
+
+        Assert.False(capturedText.Contains("query-secret", StringComparison.Ordinal), capturedText);
+        Assert.False(capturedText.Contains("exception-secret", StringComparison.Ordinal), capturedText);
+
+        var resilienceLogs = entries
+            .Where(entry => entry.Message.StartsWith("Execution attempt.", StringComparison.Ordinal)
+                || entry.Message.StartsWith("Resilience event occurred.", StringComparison.Ordinal))
+            .ToList();
+
+        var retryLogs = entries
+            .Where(entry => entry.Message.StartsWith("External dependency retry", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Empty(resilienceLogs);
+        Assert.NotEmpty(retryLogs);
+        Assert.All(retryLogs, log =>
+        {
+            Assert.Contains("Operation: OpenFIGI GET api.openfigi.com", log.Message);
+            Assert.DoesNotContain("query-secret", log.Message);
+            Assert.DoesNotContain("exception-secret", log.Message);
+        });
+    }
+
+    [Fact]
+    public async Task SendAsync_NonSuccessResponse_RedactsSecretAssignmentsInPath()
+    {
+        var logger = new RecordingLogger<ExternalDependencyLoggingHandler>();
+        using var handler = new ExternalDependencyLoggingHandler(logger)
+        {
+            InnerHandler = new StubHandler(_ => new HttpResponseMessage(HttpStatusCode.BadRequest))
+        };
+        using var client = new HttpClient(handler);
+
+        using var response = await client.GetAsync(
+            "https://api.openfigi.com/v3/mapping/token=path-secret?apiKey=query-secret",
+            TestContext.Current.CancellationToken);
+
+        var log = Assert.Single(logger.Entries);
+        Assert.Contains("Path: /v3/mapping/token=[REDACTED]", log.Message);
+        Assert.DoesNotContain("path-secret", log.Message);
+        Assert.DoesNotContain("query-secret", log.Message);
+    }
+
+    private sealed class CancellationAwareHandler : HttpMessageHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+
+    private sealed class TransportFailureHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromException<HttpResponseMessage>(new HttpRequestException(
+                "Request https://api.openfigi.com/v3/mapping?apiKey=exception-secret failed with Authorization: Bearer exception-secret"));
+    }
+
     private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(

--- a/code/ServiceDefaults/Extensions.cs
+++ b/code/ServiceDefaults/Extensions.cs
@@ -28,6 +28,10 @@ public static class Extensions
     {
         builder.ConfigureOpenTelemetry();
 
+        // Polly's built-in log payload includes raw exception messages and the original exception.
+        // Request-scoped callbacks below provide the redacted admin-visible records; metrics remain enabled.
+        builder.Logging.AddFilter("Polly", LogLevel.None);
+
         builder.AddDefaultHealthChecks();
 
         builder.Services.AddTransient<ExternalDependencyLoggingHandler>();
@@ -62,7 +66,8 @@ public static class Extensions
                             : args.Outcome.Exception?.GetType().Name ?? "unknown";
 
                         logger.LogWarning(
-                            "External dependency retry. Service: {Service}; Host: {Host}; Method: {Method}; Path: {Path}; Result: {Result}; Attempt: {Attempt}; Execution Time: {ExecutionTimeMs}ms; Retry Delay: {RetryDelayMs}ms.",
+                            "External dependency retry. Operation: {Operation}; Service: {Service}; Host: {Host}; Method: {Method}; Path: {Path}; Result: {Result}; Attempt: {Attempt}; Execution Time: {ExecutionTimeMs}ms; Retry Delay: {RetryDelayMs}ms.",
+                            ExternalDependencyLogging.GetOperationKey(request),
                             ExternalDependencyLogging.GetService(request),
                             ExternalDependencyLogging.GetHost(request),
                             ExternalDependencyLogging.GetMethod(request),
@@ -101,7 +106,8 @@ public static class Extensions
         var request = args.Context.GetRequestMessage();
 
         logger.LogWarning(
-            "External dependency timeout. Service: {Service}; Host: {Host}; Method: {Method}; Path: {Path}; Timeout Type: {TimeoutType}; Timeout: {TimeoutMs}ms.",
+            "External dependency timeout. Operation: {Operation}; Service: {Service}; Host: {Host}; Method: {Method}; Path: {Path}; Timeout Type: {TimeoutType}; Timeout: {TimeoutMs}ms.",
+            ExternalDependencyLogging.GetOperationKey(request),
             ExternalDependencyLogging.GetService(request),
             ExternalDependencyLogging.GetHost(request),
             ExternalDependencyLogging.GetMethod(request),

--- a/code/ServiceDefaults/ExternalDependencyLogging.cs
+++ b/code/ServiceDefaults/ExternalDependencyLogging.cs
@@ -54,9 +54,14 @@ internal static class ExternalDependencyLogging
     public static string GetMethod(HttpRequestMessage? request) =>
         request?.Method.Method ?? "UNKNOWN";
 
+    // Keep the operation key useful for resilience telemetry without including
+    // request-specific values such as query strings, paths, or correlation IDs.
+    public static string GetOperationKey(HttpRequestMessage? request) =>
+        $"{GetService(request)} {GetMethod(request)} {GetHost(request)}";
+
     // Query strings are intentionally excluded because provider URLs can contain API keys.
     public static string GetPath(HttpRequestMessage? request) =>
-        request?.RequestUri?.AbsolutePath ?? "(unknown)";
+        RedactText(request?.RequestUri?.AbsolutePath ?? "(unknown)");
 
     public static bool IsExpectedNotFound(HttpRequestMessage? request, HttpStatusCode statusCode)
     {

--- a/code/ServiceDefaults/ExternalDependencyLoggingHandler.cs
+++ b/code/ServiceDefaults/ExternalDependencyLoggingHandler.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Polly;
 
 namespace ServiceDefaults;
 
@@ -12,6 +13,19 @@ public sealed class ExternalDependencyLoggingHandler(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
+        var resilienceContext = request.GetResilienceContext();
+        var ownsResilienceContext = resilienceContext is null;
+
+        if (ownsResilienceContext)
+        {
+            resilienceContext = ResilienceContextPool.Shared.Get(
+                ExternalDependencyLogging.GetOperationKey(request),
+                cancellationToken);
+            request.SetResilienceContext(resilienceContext);
+        }
+
+        resilienceContext!.SetRequestMessage(request);
+
         try
         {
             var response = await base.SendAsync(request, cancellationToken);
@@ -24,7 +38,8 @@ public sealed class ExternalDependencyLoggingHandler(
 
                 logger.Log(
                     logLevel,
-                    "External dependency request returned a non-success response. Service: {Service}; Host: {Host}; Method: {Method}; Path: {Path}; Result: {StatusCode}; Reason: {ReasonPhrase}.",
+                    "External dependency request returned a non-success response. Operation: {Operation}; Service: {Service}; Host: {Host}; Method: {Method}; Path: {Path}; Result: {StatusCode}; Reason: {ReasonPhrase}.",
+                    ExternalDependencyLogging.GetOperationKey(request),
                     ExternalDependencyLogging.GetService(request),
                     ExternalDependencyLogging.GetHost(request),
                     ExternalDependencyLogging.GetMethod(request),
@@ -44,13 +59,22 @@ public sealed class ExternalDependencyLoggingHandler(
         {
             logger.LogError(
                 ExternalDependencyLogging.RedactException(exception),
-                "External dependency request failed. Service: {Service}; Host: {Host}; Method: {Method}; Path: {Path}.",
+                "External dependency request failed. Operation: {Operation}; Service: {Service}; Host: {Host}; Method: {Method}; Path: {Path}.",
+                ExternalDependencyLogging.GetOperationKey(request),
                 ExternalDependencyLogging.GetService(request),
                 ExternalDependencyLogging.GetHost(request),
                 ExternalDependencyLogging.GetMethod(request),
                 ExternalDependencyLogging.GetPath(request));
 
             throw;
+        }
+        finally
+        {
+            if (ownsResilienceContext)
+            {
+                request.SetResilienceContext(null!);
+                ResilienceContextPool.Shared.Return(resilienceContext!);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Attach a pooled Polly context with a safe provider/method/host operation identity before the shared resilience pipeline runs.
- Include that operation identity in retry, timeout, and terminal external-dependency records, with path redaction retained.
- Disable Polly built-in logging because its exception payload can expose raw request secrets; the redacted request-scoped records remain available and resilience metrics stay enabled.
- Add deterministic 504, timeout, transport-failure, operation-identity, and redaction regression coverage.

## Validation

- Full unit suite: 925/925 passed under `LC_ALL=en_US.UTF-8`.
- Full integration suite: 309/309 passed under `LC_ALL=en_US.UTF-8`.
- `dotnet build ./code/FinanceManager.slnx`: passed with 0 warnings and 0 errors.
- `dotnet format ./code/FinanceManager.slnx` and `dotnet format ./code --verify-no-changes --verbosity diagnostic`: passed.

The default `C.UTF-8` unit run has six unrelated pre-existing culture-sensitive failures; the complete suite passes under the stable English validation culture.

Closes #718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external service error and retry logging with consistent operation details.
  * Suppressed unsafe resilience logs that could expose raw exception information.
  * Redacted sensitive values in request paths, query strings, and exception messages.
  * Enhanced logging for timeouts, transport failures, and gateway errors while preserving useful diagnostic context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->