### PR TITLE
Add read-only maintenance log history

### DIFF
--- a/.claude/skills/fm-maintenance/SKILL.md
+++ b/.claude/skills/fm-maintenance/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: fm-maintenance
+description: Guide for AI agents using FinanceManager maintenance endpoints, including X-Maintenance-Key authentication, the price-backfill trigger, and bounded read-only log diagnostics.
+---
+
+# FMMaintenanceSkill
+
+Use this skill for authorized maintenance automation and incident investigation. The maintenance
+surface is deliberately narrow: it provides the existing price-backfill trigger and a read-only
+log-history query. Never use the maintenance key as a substitute for user or administrator access.
+
+## Authentication
+
+Send the maintenance key only in this header:
+
+```http
+X-Maintenance-Key: <MAINTENANCE_KEY>
+```
+
+The application validates the key against its hashed database key or configured fallback. Keys are
+never returned by maintenance endpoints, accepted in URLs, or written to logs. Use only
+`<MAINTENANCE_KEY>` and `<BASE_URL>` placeholders in scripts and documentation.
+
+## Endpoints
+
+### Trigger backfill
+
+`POST /api/PriceBackfill` queues the weekly closing-price backfill and returns `202 Accepted`.
+It has no request body and is the only maintenance write-like operation. Do not call it while
+investigating logs unless the operational task actually requires a backfill.
+
+### Query logs
+
+`GET /api/maintenance/logs` is strictly read-only. It returns the existing `PagedLogEntriesDto`:
+`items` and `totalCount`. Each item contains `id`, `timestampUtc`, `level`, `category`, `message`,
+`exception`, `eventId`, and `eventName` when available. Results are newest first.
+
+Supported query parameters:
+
+| Parameter | Default | Constraint |
+|---|---:|---|
+| `skip` | `0` | Non-negative number of matching entries to skip |
+| `take` | `25` | Must be between `1` and `200` |
+| `fromUtc` | none | Inclusive UTC timestamp lower bound |
+| `toUtc` | none | Inclusive UTC timestamp upper bound |
+| `level` | none | Exact `Trace`, `Debug`, `Information`, `Warning`, `Error`, or `Critical` level (case-insensitive) |
+| `search` | none | Text matched against message, category, exception, or event name |
+
+Keep the time window and `take` small first, then advance `skip` when `totalCount` exceeds the
+page. Use ISO 8601 UTC values such as `2026-08-27T04:00:00Z`.
+
+## Investigation workflow
+
+1. Choose the incident window in UTC.
+2. Request a small `Warning` or `Error` page for that window.
+3. Add `search` terms for the provider, operation, or category.
+4. Inspect `message`, `exception`, and event identity fields; redact sensitive values before sharing.
+5. Page through additional results with `skip` only when needed.
+6. Trigger `POST /api/PriceBackfill` separately only when remediation calls for it.
+
+Example requests (placeholders are intentional):
+
+```bash
+curl -s -G "<BASE_URL>/api/maintenance/logs" \
+  -H "X-Maintenance-Key: <MAINTENANCE_KEY>" \
+  --data-urlencode "fromUtc=2026-08-27T04:00:00Z" \
+  --data-urlencode "toUtc=2026-08-27T05:00:00Z" \
+  --data-urlencode "level=Error" \
+  --data-urlencode "take=25"
+```
+
+```bash
+curl -s -X POST "<BASE_URL>/api/PriceBackfill" \
+  -H "X-Maintenance-Key: <MAINTENANCE_KEY>"
+```
+
+## Responses and guardrails
+
+- `200 OK`: log query succeeded.
+- `202 Accepted`: backfill request was accepted.
+- `400 Bad Request`: invalid level, time range, search length, or pagination bounds.
+- `401 Unauthorized`: key is missing or invalid.
+- `404 Not Found`: no maintenance key is configured; the route is intentionally masked.
+- `429 Too Many Requests`: maintenance rate limit was exceeded; back off before retrying.
+
+Only the documented GET query and backfill POST are available. Do not attempt log deletion,
+mutation, configuration, admin, or unrelated write endpoints with this credential. Never place
+the key in query parameters, command-line arguments that may be captured, logs, responses, or
+committed files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Authorized maintenance workers can now query bounded, read-only application log history with time, level, and text filters. #722
 - External dependency failures now identify the provider and redacted request path in application logs; admins can copy individual log details or export the currently open log page as JSON for sharing with an agent.
 - Investment transactions now search existing and external instruments together and add external master data only when the transaction saves successfully. #651
 - Twelve Data can now supply daily stock and ETF prices, latest quotes, and daily forex rates through the existing market-data fallback flows. Provider priority, timeout, enabled state, and per-minute/daily credit budgets are configurable under `TwelveData`; provider-specific symbols stay on instrument listings, existing observations remain idempotently skipped, and Alpha Vantage remains available as an alternative. #643

--- a/code/FinanceManager.Api/Features/Maintenance/Controllers/MaintenanceLogsController.cs
+++ b/code/FinanceManager.Api/Features/Maintenance/Controllers/MaintenanceLogsController.cs
@@ -1,0 +1,102 @@
+using FinanceManager.Application.Shared.Maintenance;
+using FinanceManager.Domain.Administration.Logging;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace FinanceManager.Api.Features.Maintenance.Controllers;
+
+[Route("api/maintenance/logs")]
+[ApiController]
+[Tags("Maintenance")]
+[EnableRateLimiting(RateLimitingServiceCollectionExtension.AuthPolicy)]
+public class MaintenanceLogsController(
+    IMaintenanceKeyService maintenanceKeyService,
+    ILogEntryRepository repository,
+    ILogger<MaintenanceLogsController> logger) : ControllerBase
+{
+    private const int _defaultTake = 25;
+    private const int _maxTake = 200;
+    private const int _maxSearchLength = 256;
+
+    [AllowAnonymous]
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PagedLogEntriesDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Get(
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = _defaultTake,
+        [FromQuery] string? level = null,
+        [FromQuery] DateTime? fromUtc = null,
+        [FromQuery] DateTime? toUtc = null,
+        [FromQuery] string? search = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (!await maintenanceKeyService.IsConfiguredAsync(cancellationToken))
+            return NotFound();
+
+        if (!Request.Headers.TryGetValue(PriceBackfillController.ApiKeyHeader, out var providedKey) ||
+            !await maintenanceKeyService.ValidateAsync(providedKey.ToString(), cancellationToken))
+        {
+            logger.LogWarning("Maintenance log read rejected: missing or invalid maintenance key.");
+            return Unauthorized();
+        }
+
+        if (skip < 0) return BadRequest("skip must be non-negative.");
+        if (take <= 0) return BadRequest("take must be greater than zero.");
+        if (take > _maxTake) return BadRequest($"take must be {_maxTake} or less.");
+        if (fromUtc > toUtc) return BadRequest("fromUtc must not be later than toUtc.");
+        if (search?.Length > _maxSearchLength)
+            return BadRequest($"search must be {_maxSearchLength} characters or fewer.");
+        if (!TryParseLevel(level, out var levels)) return BadRequest("level is not supported.");
+
+        var (items, total) = await repository.GetPaged(
+            skip,
+            take,
+            levels,
+            fromUtc,
+            toUtc,
+            search,
+            cancellationToken);
+
+        return Ok(new PagedLogEntriesDto(items.Select(Map).ToList(), total));
+    }
+
+    private static bool TryParseLevel(string? level, out IReadOnlyCollection<LogSeverity>? levels)
+    {
+        levels = level?.ToLowerInvariant() switch
+        {
+            null or "" => null,
+            "trace" => [LogSeverity.Trace],
+            "debug" => [LogSeverity.Debug],
+            "information" or "info" => [LogSeverity.Information],
+            "warning" or "warn" => [LogSeverity.Warning],
+            "error" => [LogSeverity.Error],
+            "critical" => [LogSeverity.Critical],
+            _ => null,
+        };
+
+        return string.IsNullOrWhiteSpace(level) ||
+            level.Equals("trace", StringComparison.OrdinalIgnoreCase) ||
+            level.Equals("debug", StringComparison.OrdinalIgnoreCase) ||
+            level.Equals("information", StringComparison.OrdinalIgnoreCase) ||
+            level.Equals("info", StringComparison.OrdinalIgnoreCase) ||
+            level.Equals("warning", StringComparison.OrdinalIgnoreCase) ||
+            level.Equals("warn", StringComparison.OrdinalIgnoreCase) ||
+            level.Equals("error", StringComparison.OrdinalIgnoreCase) ||
+            level.Equals("critical", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static LogEntryDto Map(LogEntry entry) =>
+        new(
+            entry.Id,
+            entry.TimestampUtc,
+            entry.Level,
+            entry.Category,
+            entry.Message,
+            entry.Exception,
+            entry.EventId,
+            entry.EventName);
+}

--- a/code/FinanceManager.Domain/Administration/Logging/ILogEntryRepository.cs
+++ b/code/FinanceManager.Domain/Administration/Logging/ILogEntryRepository.cs
@@ -14,5 +14,14 @@ public interface ILogEntryRepository
         IReadOnlyCollection<LogSeverity>? levels = null,
         CancellationToken cancellationToken = default);
 
+    Task<(List<LogEntry> Items, int TotalCount)> GetPaged(
+        int skip,
+        int take,
+        IReadOnlyCollection<LogSeverity>? levels,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        string? search,
+        CancellationToken cancellationToken = default);
+
     Task<int> DeleteOlderThan(DateTime cutoffUtc, CancellationToken cancellationToken = default);
 }

--- a/code/FinanceManager.Infrastructure/Features/Administration/Repositories/LogEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/Administration/Repositories/LogEntryRepository.cs
@@ -31,11 +31,34 @@ public class LogEntryRepository(AppDbContext context) : ILogEntryRepository
         int skip,
         int take,
         IReadOnlyCollection<LogSeverity>? levels = null,
+        CancellationToken cancellationToken = default) =>
+        await GetPaged(skip, take, levels, fromUtc: null, toUtc: null, search: null, cancellationToken);
+
+    public async Task<(List<LogEntry> Items, int TotalCount)> GetPaged(
+        int skip,
+        int take,
+        IReadOnlyCollection<LogSeverity>? levels,
+        DateTime? fromUtc,
+        DateTime? toUtc,
+        string? search,
         CancellationToken cancellationToken = default)
     {
         var query = context.LogEntries.AsNoTracking();
         if (levels is { Count: > 0 })
             query = query.Where(e => levels.Contains(e.Level));
+        if (fromUtc is DateTime from)
+            query = query.Where(e => e.TimestampUtc >= from);
+        if (toUtc is DateTime to)
+            query = query.Where(e => e.TimestampUtc <= to);
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var normalizedSearch = search.Trim().ToLower();
+            query = query.Where(e =>
+                e.Message.ToLower().Contains(normalizedSearch) ||
+                e.Category.ToLower().Contains(normalizedSearch) ||
+                (e.Exception != null && e.Exception.ToLower().Contains(normalizedSearch)) ||
+                (e.EventName != null && e.EventName.ToLower().Contains(normalizedSearch)));
+        }
 
         var total = await query.CountAsync(cancellationToken);
         var items = await query

--- a/code/FinanceManager.Tests.Integration/Features/Maintenance/Controllers/MaintenanceLogsControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Features/Maintenance/Controllers/MaintenanceLogsControllerTests.cs
@@ -1,0 +1,96 @@
+using FinanceManager.Application.Shared.Maintenance;
+using FinanceManager.Application.Shared.Options;
+using FinanceManager.Domain.Administration.Logging;
+using FinanceManager.Tests.Integration.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Net;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Features.Maintenance.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public class MaintenanceLogsControllerTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider)
+{
+    private const string _maintenanceKey = "integration-test-maintenance-key";
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        services.PostConfigure<MaintenanceOptions>(options => options.ApiKey = _maintenanceKey);
+
+        var repositoryMock = new Mock<ILogEntryRepository>();
+        repositoryMock
+            .Setup(x => x.GetPaged(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<IReadOnlyCollection<LogSeverity>?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((
+                [new LogEntry
+                {
+                    Id = 7,
+                    TimestampUtc = DateTime.UtcNow,
+                    Level = LogSeverity.Error,
+                    Category = "MaintenanceTest",
+                    Message = "A provider failure",
+                    Exception = "TimeoutException",
+                    EventId = 100,
+                    EventName = "ProviderFailure"
+                }],
+                1));
+        services.AddSingleton(repositoryMock.Object);
+    }
+
+    [Fact]
+    public async Task Get_WithValidKey_ReturnsPagedLogEntries()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "api/maintenance/logs?level=Error&take=10");
+        request.Headers.Add("X-Maintenance-Key", _maintenanceKey);
+
+        var response = await Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains("A provider failure", content, StringComparison.Ordinal);
+        Assert.Contains("TimeoutException", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Get_WithoutKeyHeader_ReturnsUnauthorized()
+    {
+        var response = await Client.GetAsync("api/maintenance/logs", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_WithWrongKey_ReturnsUnauthorized()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "api/maintenance/logs");
+        request.Headers.Add("X-Maintenance-Key", "wrong-key");
+
+        var response = await Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+}
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public class MaintenanceLogsControllerUnconfiguredTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider)
+{
+    [Fact]
+    public async Task Get_WithoutConfiguredKey_ReturnsNotFound()
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "api/maintenance/logs");
+        request.Headers.Add("X-Maintenance-Key", "any-key");
+
+        var response = await Client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Api/Features/Maintenance/Controllers/MaintenanceLogsControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Features/Maintenance/Controllers/MaintenanceLogsControllerTests.cs
@@ -1,0 +1,194 @@
+using FinanceManager.Api.Features.Maintenance.Controllers;
+using FinanceManager.Application.Shared.Maintenance;
+using FinanceManager.Domain.Administration.Logging;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Api.Features.Maintenance.Controllers;
+
+[Trait("Category", "Unit")]
+public class MaintenanceLogsControllerTests
+{
+    private const string _validKey = "fmk_test-maintenance-key";
+
+    private readonly Mock<IMaintenanceKeyService> _keyService = new();
+    private readonly Mock<ILogEntryRepository> _repository = new();
+
+    private MaintenanceLogsController CreateController(string? providedKey)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (providedKey is not null)
+            httpContext.Request.Headers[PriceBackfillController.ApiKeyHeader] = providedKey;
+
+        return new MaintenanceLogsController(
+            _keyService.Object,
+            _repository.Object,
+            NullLogger<MaintenanceLogsController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+    }
+
+    private void SetupConfiguredKey()
+    {
+        _keyService.Setup(x => x.IsConfiguredAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _keyService
+            .Setup(x => x.ValidateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string key, CancellationToken _) => key == _validKey);
+    }
+
+    [Fact]
+    public async Task Get_WhenNoMaintenanceKeyIsConfigured_ReturnsNotFoundWithoutReadingLogs()
+    {
+        _keyService.Setup(x => x.IsConfiguredAsync(It.IsAny<CancellationToken>())).ReturnsAsync(false);
+
+        var result = await CreateController(_validKey).Get(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.IsType<NotFoundResult>(result);
+        _repository.Verify(
+            x => x.GetPaged(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<IReadOnlyCollection<LogSeverity>?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("wrong-key")]
+    public async Task Get_WhenKeyIsMissingOrInvalid_ReturnsUnauthorizedWithoutReadingLogs(string? providedKey)
+    {
+        SetupConfiguredKey();
+
+        var result = await CreateController(providedKey).Get(cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.IsType<UnauthorizedResult>(result);
+        _repository.Verify(
+            x => x.GetPaged(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<IReadOnlyCollection<LogSeverity>?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Get_WithValidKey_PassesFiltersAndMapsPagedResults()
+    {
+        SetupConfiguredKey();
+        var fromUtc = new DateTime(2026, 8, 27, 4, 0, 0, DateTimeKind.Utc);
+        var toUtc = fromUtc.AddHours(1);
+        var entry = new LogEntry
+        {
+            Id = 42,
+            TimestampUtc = fromUtc.AddMinutes(5),
+            Level = LogSeverity.Error,
+            Category = "Provider",
+            Message = "Provider failed",
+            Exception = "TimeoutException",
+            EventId = 7,
+            EventName = "ProviderFailure"
+        };
+        _repository
+            .Setup(x => x.GetPaged(
+                10,
+                5,
+                It.IsAny<IReadOnlyCollection<LogSeverity>?>(),
+                fromUtc,
+                toUtc,
+                "provider",
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(([entry], 11));
+
+        var result = await CreateController(_validKey).Get(
+            skip: 10,
+            take: 5,
+            level: "error",
+            fromUtc: fromUtc,
+            toUtc: toUtc,
+            search: "provider",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var paged = Assert.IsType<PagedLogEntriesDto>(ok.Value);
+        Assert.Equal(11, paged.TotalCount);
+        var mapped = Assert.Single(paged.Items);
+        Assert.Equal(entry.Id, mapped.Id);
+        Assert.Equal(entry.Exception, mapped.Exception);
+        Assert.Equal(entry.EventName, mapped.EventName);
+        _repository.Verify(
+            x => x.GetPaged(
+                10,
+                5,
+                It.Is<IReadOnlyCollection<LogSeverity>?>(levels =>
+                    levels != null && levels.Count == 1 && levels.Contains(LogSeverity.Error)),
+                fromUtc,
+                toUtc,
+                "provider",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData(-1, 25, null)]
+    [InlineData(0, 0, null)]
+    [InlineData(0, 201, null)]
+    [InlineData(0, 25, "verbose")]
+    public async Task Get_WhenQueryIsInvalid_ReturnsBadRequest(int skip, int take, string? level)
+    {
+        SetupConfiguredKey();
+
+        var result = await CreateController(_validKey).Get(
+            skip: skip,
+            take: take,
+            level: level,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        _repository.Verify(
+            x => x.GetPaged(
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                It.IsAny<IReadOnlyCollection<LogSeverity>?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<DateTime?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Get_WhenTimeRangeIsReversed_ReturnsBadRequest()
+    {
+        SetupConfiguredKey();
+
+        var result = await CreateController(_validKey).Get(
+            fromUtc: DateTime.UtcNow,
+            toUtc: DateTime.UtcNow.AddMinutes(-1),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Get_WhenSearchIsTooLong_ReturnsBadRequest()
+    {
+        SetupConfiguredKey();
+
+        var result = await CreateController(_validKey).Get(
+            search: new string('x', 257),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Features/Administration/Repositories/LogEntryRepositoryTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Features/Administration/Repositories/LogEntryRepositoryTests.cs
@@ -1,0 +1,63 @@
+using FinanceManager.Domain.Administration.Logging;
+using FinanceManager.Infrastructure.Features.Administration.Repositories;
+using FinanceManager.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Tests.Unit.Infrastructure.Features.Administration.Repositories;
+
+[Collection("Infrastructure")]
+[Trait("Category", "Unit")]
+public class LogEntryRepositoryTests
+{
+    [Fact]
+    public async Task GetPaged_AppliesFiltersAndReturnsNewestFirst()
+    {
+        await using var context = CreateContext();
+        var baseTime = new DateTime(2026, 8, 27, 1, 0, 0, DateTimeKind.Utc);
+        context.LogEntries.AddRange(
+            new LogEntry { Id = 1, TimestampUtc = baseTime, Level = LogSeverity.Warning, Category = "Provider", Message = "old Alpha" },
+            new LogEntry { Id = 2, TimestampUtc = baseTime.AddHours(1), Level = LogSeverity.Warning, Category = "Provider", Message = "new Alpha" },
+            new LogEntry { Id = 3, TimestampUtc = baseTime.AddHours(2), Level = LogSeverity.Error, Category = "Provider", Message = "error Alpha" },
+            new LogEntry { Id = 4, TimestampUtc = baseTime.AddHours(3), Level = LogSeverity.Warning, Category = "Provider", Message = "new Beta" });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var repository = new LogEntryRepository(context);
+        var (items, total) = await repository.GetPaged(
+            skip: 0,
+            take: 10,
+            levels: [LogSeverity.Warning],
+            fromUtc: baseTime.AddMinutes(30),
+            toUtc: baseTime.AddHours(3),
+            search: "alpha",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, total);
+        var item = Assert.Single(items);
+        Assert.Equal(2, item.Id);
+    }
+
+    [Fact]
+    public async Task GetPaged_PaginatesAfterOrderingByTimestampAndId()
+    {
+        await using var context = CreateContext();
+        var timestamp = new DateTime(2026, 8, 27, 1, 0, 0, DateTimeKind.Utc);
+        context.LogEntries.AddRange(
+            new LogEntry { Id = 1, TimestampUtc = timestamp },
+            new LogEntry { Id = 2, TimestampUtc = timestamp },
+            new LogEntry { Id = 3, TimestampUtc = timestamp.AddHours(1) });
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var (items, total) = await new LogEntryRepository(context).GetPaged(
+            skip: 1,
+            take: 1,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(3, total);
+        Assert.Equal(2, Assert.Single(items).Id);
+    }
+
+    private static AppDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+}

--- a/docs/codebase/INTEGRATIONS.md
+++ b/docs/codebase/INTEGRATIONS.md
@@ -15,6 +15,7 @@
 | Ollama | Local/remote AI endpoint | Final AI fallback provider | No auth detected in code | Medium | `code\FinanceManager.Infrastructure\Services\Ai\OllamaChatClient.cs`, `code\FinanceManager.Api\appsettings.json` |
 | SignalR hub (`/hubs/currency-import`) | Realtime transport | Import job progress/events between API and browser | JWT via query-string token handling | Medium | `code\FinanceManager.Api\Program.cs` |
 | MCP/OAuth (`/mcp`, `/connect/*`) | Stateless MCP transport and OAuth authorization server | Gives configured AI clients owner-isolated read access to Finance Manager data | OpenIddict authorization code, refresh token, resource, and `mcp` scope validation | High | `code\FinanceManager.Api\Mcp`, `code\FinanceManager.Api\Controllers\McpOAuthController.cs`, `docs\deployment.md` |
+| Maintenance API (`/api/PriceBackfill`, `/api/maintenance/logs`) | Dedicated maintenance & diagnostics HTTP API | Operational triggering (price backfill) and read-only runtime log inspection for incident diagnostics | API key via `X-Maintenance-Key` request header (hashed in database / configuration fallback) | Medium | `code\FinanceManager.Api\Features\Maintenance\Controllers\PriceBackfillController.cs`, `code\FinanceManager.Application\Shared\Maintenance\*`, `.claude\skills\fm-maintenance\SKILL.md` |
 | Browser local/session storage | Browser-side storage | Persist user session and login state | Same-origin browser storage | Medium | `code\FinanceManager\Program.cs`, `code\FinanceManager.Components\Services\LoginService.cs` |
 
 ### 2) Data Stores
@@ -31,6 +32,7 @@
 
 - Credential sources: appsettings files, environment variables (notably `FINANCE_MANAGER_DB_KEY` and optional OTLP endpoint), ASP.NET User Secrets (`UserSecretsId`), and runtime options sections
 - Hardcoding checks: development/test JWT signing keys and a development SQL Server connection string are committed in `appsettings.*`; external AI/stock API keys are present as config slots but blank in the checked-in config
+- Maintenance API key (`X-Maintenance-Key`): Database-managed keys are stored as hashes; an optional configuration fallback can also be supplied. Maintenance endpoints enforce header-only validation, never accept keys in query strings, never echo or return keys in responses, and keys must never be logged.
 - Rotation or lifecycle notes: MCP OAuth signing/encryption certificate storage and disruptive rotation are documented in `docs\deployment.md`; a general rotation runbook for the other application secrets is still `[TODO]`
 
 ### 4) Reliability and Failure Behavior
@@ -39,11 +41,13 @@
 - Timeout policy: `HttpClientResilience` timeouts are configurable in appsettings and applied in `ServiceDefaults`; OpenRouter timeout is separately configurable in `OpenRouterOptions`
 - Circuit-breaker or fallback behavior: HTTP circuit-breaker sampling is configured in `ServiceDefaults`; AI calls are wired through a fallback chain in config and DI; stock price reads first check repository/cache before hitting Alpha Vantage
 - Fawaz currency data is free, requires no API key, and has no provider request-rate limit. It is published as daily date-versioned npm packages beginning on `2024-03-02`; earlier dates return `OutOfRange` without an HTTP request so another configured provider can resolve them.
+- Maintenance endpoints (`/api/PriceBackfill`, `/api/maintenance/logs`): Protected by rate limiting, returning `429 Too Many Requests` on violation. When unconfigured, endpoints return `404 Not Found` to mask their existence. Read-only log queries use bounded `skip`/`take` pagination (`take` max 200), UTC range/level/text filters, and newest-first ordering.
 
 ### 5) Observability for Integrations
 
 - Logging around external calls: yes, in stock, currency, and AI client wrappers
 - Metrics/tracing coverage: yes, service defaults enable OpenTelemetry logging, metrics, tracing, and optional OTLP export
+- Dedicated read-only maintenance log inspection: `GET /api/maintenance/logs` provides authorized maintenance workers with structured, bounded query access to runtime logs. It accepts `skip`, `take`, `fromUtc`, `toUtc`, `level`, and `search`; responses contain `items` and `totalCount`, and never contain maintenance keys.
 - Missing visibility gaps: client-side typed HTTP clients mostly log locally or return defaults, and no repo-level dashboard/alert configuration was found
 
 ### 6) Evidence
@@ -52,7 +56,10 @@
 - `code\FinanceManager.Infrastructure\Services\Stocks\AlphaVantageClient.cs`
 - `code\FinanceManager.Infrastructure\Features\FinancialAccounts\Currencies\Providers\FawazAhmedCurrencyApiClient.cs`
 - `code\FinanceManager.Infrastructure\Services\Ai\ServiceCollectionExtension.cs`
+- `code\FinanceManager.Api\Features\Maintenance\Controllers\PriceBackfillController.cs`
+- `code\FinanceManager.Application\Shared\Maintenance\MaintenanceKeyService.cs`
 - `code\FinanceManager.Api\appsettings.json`
 - `code\FinanceManager.Api\appsettings.Development.json`
 - `code\ServiceDefaults\Extensions.cs`
 - `code\AppHost\AppHost.cs`
+- `.claude\skills\fm-maintenance\SKILL.md`


### PR DESCRIPTION
Closes #722

## Summary
- add a dedicated maintenance-key-protected GET /api/maintenance/logs endpoint
- support bounded pagination, UTC ranges, exact log levels, case-insensitive text search, and newest-first ordering
- document FMMaintenanceSkill and maintenance API integration/security guidance
- preserve the existing admin log repository contract while adding filtered queries

## Validation
- LC_ALL=en_US.UTF-8 dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --no-restore (938 passed)
- LC_ALL=en_US.UTF-8 dotnet test --project ./FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj --no-restore (313 passed)
- LC_ALL=en_US.UTF-8 dotnet test --project ./FinanceManager.Tests.Architecture/FinanceManager.Tests.Architecture.csproj --no-restore (9 passed)
- dotnet build ./FinanceManager.slnx --configuration Release --no-restore (0 warnings/errors)
- dotnet format ./FinanceManager.slnx --verify-no-changes --verbosity minimal
- dotnet format style ./code --verify-no-changes --diagnostics IDE1006 --severity error
- git diff --check

## Risk
The endpoint exposes existing structured log fields to callers who possess the existing maintenance key; it adds no write/admin capability and does not expose credentials.