### PR TITLE
Align account history toolbar button styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- Account transaction toolbar controls now share a consistent height, and the search button matches their outlined styling. #726
 - External provider retries are now bounded and degraded outcomes remain distinct from caller cancellation after transient failures. #719
 - Admin logs for resilient external requests now retain a safe provider, host, method, path, and operation identity; generic resilience entries no longer persist raw exception text or duplicate uncontextualized failures. #718
 - Returning after a long break now restores the last compatible dashboard and account-chart state immediately, then refreshes it in the background instead of losing it to date-based snapshot keys. #691

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbar.razor
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbar.razor
@@ -6,7 +6,7 @@
         @* Search — collapsed to an icon; the input lives in the panel below *@
         <MudIconButton Icon="@(_isSearchExpanded ? Icons.Material.Filled.SearchOff : Icons.Material.Filled.Search)"
                        Size="Size.Small" Color="@(_isSearchExpanded || !string.IsNullOrWhiteSpace(SearchText) ? Color.Primary : Color.Default)"
-                       OnClick="ToggleSearch" Style="flex-shrink: 0;"
+                       OnClick="ToggleSearch" Class="fm-toolbar-search-button" Style="flex-shrink: 0;"
                        aria-label="@(_isSearchExpanded ? "Hide search" : "Search transactions")"
                        title="@(_isSearchExpanded ? "Hide search" : "Search transactions")"
                        aria-expanded="@_isSearchExpanded" aria-controls="@_searchPanelId" />

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbar.razor.css
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbar.razor.css
@@ -19,10 +19,16 @@
     box-sizing: border-box;
 }
 
-.fm-tx-toolbar ::deep .mud-toggle-item,
+.fm-tx-toolbar ::deep .mud-toggle-group,
 .fm-tx-toolbar ::deep .fm-range-button,
-.fm-tx-toolbar ::deep .mud-button-group-root > .mud-button-root {
+.fm-tx-toolbar ::deep .mud-button-group-root {
     height: var(--fm-toolbar-control-height);
+    box-sizing: border-box;
+}
+
+.fm-tx-toolbar ::deep .mud-toggle-item,
+.fm-tx-toolbar ::deep .mud-button-group-root > .mud-button-root {
+    height: 100%;
     box-sizing: border-box;
 }
 

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbar.razor.css
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountHistoryToolbar.razor.css
@@ -5,6 +5,27 @@
     color: var(--mud-palette-text-secondary) !important;
 }
 
+/* Keep every compact toolbar action the same height. MudBlazor gives small icon,
+   toggle, regular, and grouped buttons slightly different padding by default. */
+.fm-tx-toolbar {
+    --fm-toolbar-control-height: 32px;
+}
+
+.fm-tx-toolbar ::deep .fm-toolbar-search-button {
+    width: var(--fm-toolbar-control-height);
+    height: var(--fm-toolbar-control-height);
+    border: 1px solid var(--mud-palette-lines-inputs);
+    border-radius: var(--mud-default-borderradius);
+    box-sizing: border-box;
+}
+
+.fm-tx-toolbar ::deep .mud-toggle-item,
+.fm-tx-toolbar ::deep .fm-range-button,
+.fm-tx-toolbar ::deep .mud-button-group-root > .mud-button-root {
+    height: var(--fm-toolbar-control-height);
+    box-sizing: border-box;
+}
+
 ::deep .mud-button-group-outlined .mud-button-root,
 ::deep .mud-toggle-group-outlined {
     border-color: var(--mud-palette-lines-inputs) !important;


### PR DESCRIPTION
## Summary

- normalize the compact account-history toolbar controls to a shared 32px height
- add a theme-aware outline to the search button
- document the user-visible fix in the changelog

## Validation

- `dotnet format ./code/FinanceManager.slnx --no-restore`
- `dotnet build ./code/FinanceManager.slnx`
- `LC_ALL=en_US.UTF-8 dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --no-build` (962 passed)
- rendered Bond account on the guest account at 390x844 and 1280x1000
- verified search, filter, range, and split add controls all compute to 32px high

Closes #726


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the heights of compact account history toolbar controls for a more consistent appearance.
  * Added a bordered, rounded style to the toolbar’s search button.
  * Preserved the search button’s existing click behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->