### PR TITLE
Add capital contribution series to investment and bond charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Investment and bond account charts now show cumulative user-paid capital alongside account value and the selected benchmark, including range-start carry-over, withdrawals, same-day events, and historical currency conversion. #729
 - Every card on the dashboard, account, admin, and welcome pages now carries an information icon that shows a short tooltip explaining what the card is about, on hover or keyboard focus. #730
 - Authorized maintenance workers can now query bounded, read-only application log history with time, level, and text filters. #722
 - External dependency failures now identify the provider and redacted request path in application logs; admins can copy individual log details or export the currently open log page as JSON for sharing with an agent.

--- a/code/FinanceManager.Api/Features/MoneyFlow/Controllers/MoneyFlowController.cs
+++ b/code/FinanceManager.Api/Features/MoneyFlow/Controllers/MoneyFlowController.cs
@@ -63,6 +63,18 @@ public class MoneyFlowController(INetWorthService netWorthService, ILabelsValueS
             : await balanceService.GetNetCashFlow(userId, currency, start, end));
     }
 
+    [HttpGet("GetCapital/{userId:int}/{currencyId:int}/{start:DateTime}/{end:DateTime}/{step:long?}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<TimeSeriesModel>))]
+    public async Task<IActionResult> GetCapital(int userId, int currencyId, DateTime start, DateTime end, long? step = null, [FromQuery] List<int>? accountIds = null, CancellationToken cancellationToken = default)
+    {
+        if (!ApiAuthenticationHelper.IsAuthenticatedUser(User, userId)) return Forbid();
+
+        var currency = await currencyRepository.GetCurrencies(cancellationToken).SingleAsync(x => x.Id == currencyId, cancellationToken);
+        return Ok(accountIds is { Count: > 0 }
+            ? await balanceService.GetCapital(userId, currency, start, end, accountIds)
+            : await balanceService.GetCapital(userId, currency, start, end));
+    }
+
     [HttpGet("GetClosingBalance/{userId:int}/{currencyId:int}/{start:DateTime}/{end:DateTime}/{step:long?}")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<TimeSeriesModel>))]
     public async Task<IActionResult> GetClosingBalance(int userId, int currencyId, DateTime start, DateTime end, long? step = null, [FromQuery] List<int>? accountIds = null, CancellationToken cancellationToken = default)

--- a/code/FinanceManager.Application/FinancialAccounts/BalanceService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/BalanceService.cs
@@ -26,6 +26,12 @@ public class BalanceService(IEnumerable<IBalanceServiceTyped> typedBalanceServic
     public Task<List<TimeSeriesModel>> GetNetCashFlow(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds) =>
         Aggregate(service => service.GetNetCashFlow(userId, currency, start, end, accountIds));
 
+    public Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end) =>
+        Aggregate(service => service.GetCapital(userId, currency, start, end));
+
+    public Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds) =>
+        Aggregate(service => service.GetCapital(userId, currency, start, end, accountIds));
+
     public Task<List<TimeSeriesModel>> GetClosingBalance(int userId, Currency currency, DateTime start, DateTime end) =>
         Aggregate(service => service.GetClosingBalance(userId, currency, start, end));
 

--- a/code/FinanceManager.Application/FinancialAccounts/Bond/Balance/BondBalanceService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Bond/Balance/BondBalanceService.cs
@@ -1,7 +1,9 @@
+using FinanceManager.Application.FinancialAccounts.Shared;
 using FinanceManager.Application.Shared;
 using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
 using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
 using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Shared.Services;
 using FinanceManager.Domain.Identity.Repositories;
@@ -10,7 +12,10 @@ using FinanceManager.Domain.MoneyFlow.Entities;
 
 namespace FinanceManager.Application.FinancialAccounts.Bond.Balance;
 
-internal class BondBalanceService(IFinancialAccountRepository financialAccountRepository, IBondDetailsRepository bondDetailsRepository) : IBalanceServiceTyped
+internal class BondBalanceService(
+    IFinancialAccountRepository financialAccountRepository,
+    IBondDetailsRepository bondDetailsRepository,
+    ICurrencyExchangeService currencyExchangeService) : IBalanceServiceTyped
 {
     public Task<List<TimeSeriesModel>> GetInflow(int userId, Currency currency, DateTime start, DateTime end) =>
         GetInflow(userId, currency, start, end, []);
@@ -29,6 +34,93 @@ internal class BondBalanceService(IFinancialAccountRepository financialAccountRe
 
     public Task<List<TimeSeriesModel>> GetNetCashFlow(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds) =>
         AggregateByDay(userId, start, end, _ => true, accountIds);
+
+    public Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end) =>
+        GetCapital(userId, currency, start, end, []);
+
+    public async Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds)
+    {
+        if (end > DateTime.UtcNow) end = DateTime.UtcNow;
+        if (start == default || end == default || end.Date < start.Date) return [];
+
+        var accountIdFilter = accountIds.Count > 0 ? accountIds.ToHashSet() : [];
+        var bondDetails = await bondDetailsRepository.GetAllAsync().ToDictionaryAsync(x => x.Id);
+        List<BondCapitalFlow> flows = [];
+
+        await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, start, end))
+        {
+            if (account is null) continue;
+            if (accountIdFilter.Count > 0 && !accountIdFilter.Contains(account.AccountId)) continue;
+
+            // GetAccounts carries only the latest pre-range row per bond. Its running Value is the
+            // number of units already held, which seeds the visible range without treating accrued
+            // interest as user-paid capital.
+            var boundaryEntries = account.NextOlderEntries.Values
+                .Concat(account.Entries.Where(entry => entry.PostingDate.Date < start.Date))
+                .GroupBy(entry => entry.BondDetailsId)
+                .Select(group => group.OrderByDescending(entry => entry.PostingDate).ThenByDescending(entry => entry.EntryId).First());
+
+            foreach (var entry in boundaryEntries)
+            {
+                if (!bondDetails.TryGetValue(entry.BondDetailsId, out var details))
+                    throw new InvalidOperationException($"Bond capital requires details for bond id {entry.BondDetailsId}.");
+
+                flows.Add(new BondCapitalFlow(
+                    start.Date,
+                    entry.Value * details.UnitValue,
+                    details.Currency));
+            }
+
+            foreach (var entry in account.Entries.Where(entry =>
+                         entry.PostingDate.Date >= start.Date && entry.PostingDate.Date <= end.Date))
+            {
+                if (!bondDetails.TryGetValue(entry.BondDetailsId, out var details))
+                    throw new InvalidOperationException($"Bond capital requires details for bond id {entry.BondDetailsId}.");
+
+                // ValueChange is the cash-like unit movement. Interest changes Value through the
+                // bond pricing model and therefore never changes contributed capital.
+                flows.Add(new BondCapitalFlow(
+                    entry.PostingDate.Date,
+                    entry.ValueChange * details.UnitValue,
+                    details.Currency));
+            }
+        }
+
+        if (flows.Count == 0) return [];
+
+        var ratesByCurrency = new Dictionary<string, IReadOnlyDictionary<DateTime, decimal>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var group in flows.GroupBy(flow => flow.Currency.ShortName, StringComparer.OrdinalIgnoreCase))
+        {
+            ratesByCurrency[group.Key] = await CurrencyRateSeries.LoadAsync(
+                currencyExchangeService,
+                group.First().Currency,
+                currency,
+                start.Date,
+                end.Date);
+        }
+
+        Dictionary<DateTime, decimal> dailyDeltas = [];
+        foreach (var flow in flows)
+        {
+            if (!ratesByCurrency.TryGetValue(flow.Currency.ShortName, out var rates)
+                || !CurrencyRateSeries.TryGet(rates, flow.Date, out var rate))
+                continue;
+
+            dailyDeltas[flow.Date] = dailyDeltas.GetValueOrDefault(flow.Date) + flow.Amount * rate;
+        }
+
+        Dictionary<DateTime, decimal> cumulative = [];
+        decimal capital = 0m;
+        for (var date = start.Date; date <= end.Date; date = date.AddDays(1))
+        {
+            capital += dailyDeltas.GetValueOrDefault(date);
+            cumulative[date] = capital;
+        }
+
+        return TimeBucketService.Get(cumulative.Select(x => (x.Key, x.Value)))
+                                .Select(bucket => new TimeSeriesModel(bucket.Date, bucket.Objects.Last()))
+                                .ToList();
+    }
 
     public Task<List<TimeSeriesModel>> GetClosingBalance(int userId, Currency currency, DateTime start, DateTime end) =>
         GetClosingBalance(userId, currency, start, end, []);
@@ -92,4 +184,6 @@ internal class BondBalanceService(IFinancialAccountRepository financialAccountRe
                                 .Select(bucket => new TimeSeriesModel(bucket.Date, bucket.Objects.Sum()))
                                 .ToList();
     }
+
+    private sealed record BondCapitalFlow(DateTime Date, decimal Amount, Currency Currency);
 }

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/Balance/CurrencyBalanceService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/Balance/CurrencyBalanceService.cs
@@ -40,6 +40,14 @@ public class CurrencyBalanceService(IFinancialAccountRepository financialAccount
         return BucketToSeries(result);
     }
 
+    // Capital is meaningful only for investment and bond account histories. Currency account
+    // entries remain ordinary money-flow records and must not be counted on an account-value chart.
+    public Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end) =>
+        Task.FromResult(new List<TimeSeriesModel>());
+
+    public Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds) =>
+        Task.FromResult(new List<TimeSeriesModel>());
+
     public Task<List<TimeSeriesModel>> GetClosingBalance(int userId, Currency currency, DateTime start, DateTime end) =>
         GetClosingBalance(userId, currency, start, end, []);
 

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Balance/InvestmentBalanceService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Balance/InvestmentBalanceService.cs
@@ -48,6 +48,49 @@ internal class InvestmentBalanceService(
     public Task<List<TimeSeriesModel>> GetNetCashFlow(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds) =>
         Task.FromResult(new List<TimeSeriesModel>());
 
+    public Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end) =>
+        GetCapital(userId, currency, start, end, []);
+
+    public async Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds)
+    {
+        if (end > DateTime.UtcNow) end = DateTime.UtcNow;
+        if (start == default || end == default || end.Date < start.Date) return [];
+
+        var accountIdFilter = accountIds.Count > 0 ? accountIds.ToHashSet() : [];
+        List<int> investmentAccountIds = [];
+
+        await foreach (var account in financialAccountRepository.GetAccounts<InvestmentAccount>(userId, start, end))
+        {
+            if (account is null) continue;
+            if (accountIdFilter.Count > 0 && !accountIdFilter.Contains(account.AccountId)) continue;
+
+            investmentAccountIds.Add(account.AccountId);
+        }
+
+        if (investmentAccountIds.Count == 0) return [];
+
+        var seriesByAccount = await investmentValuationService.GetCapitalSeriesAsync(
+            investmentAccountIds, currency, start.Date, end.Date);
+        if (seriesByAccount.Count == 0) return [];
+
+        Dictionary<DateTime, decimal> values = [];
+        for (var date = start.Date; date <= end.Date; date = date.AddDays(1))
+            values[date] = 0m;
+
+        foreach (var series in seriesByAccount.Values)
+        {
+            foreach (var (date, value) in series)
+            {
+                if (values.ContainsKey(date.Date))
+                    values[date.Date] += value;
+            }
+        }
+
+        return TimeBucketService.Get(values.OrderBy(x => x.Key).Select(x => (x.Key, x.Value)))
+                                .Select(bucket => new TimeSeriesModel(bucket.Date, bucket.Objects.Last()))
+                                .ToList();
+    }
+
     public Task<List<TimeSeriesModel>> GetClosingBalance(int userId, Currency currency, DateTime start, DateTime end) =>
         GetClosingBalance(userId, currency, start, end, []);
 

--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
@@ -1,5 +1,7 @@
+using FinanceManager.Application.FinancialAccounts.Shared;
 using FinanceManager.Domain.Assets.Services;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Investments.Services;
@@ -23,7 +25,8 @@ namespace FinanceManager.Application.FinancialAccounts.Investments.Valuation;
 internal class InvestmentValuationService(
     IInvestmentTransactionRepository transactionRepository,
     IInvestmentPriceProvider priceProvider,
-    IInflationIndexProvider inflationIndexProvider) : IInvestmentValuationService
+    IInflationIndexProvider inflationIndexProvider,
+    ICurrencyExchangeService currencyExchangeService) : IInvestmentValuationService
 {
     public async Task<IReadOnlyDictionary<long, decimal>> GetHoldingsAsOfAsync(int accountId, DateOnly asOf, CancellationToken ct = default)
     {
@@ -144,6 +147,37 @@ internal class InvestmentValuationService(
         return result;
     }
 
+    public async Task<IReadOnlyDictionary<int, IReadOnlyDictionary<DateTime, decimal>>> GetCapitalSeriesAsync(
+        IReadOnlyCollection<int> accountIds,
+        Currency targetCurrency,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default)
+    {
+        var result = new Dictionary<int, IReadOnlyDictionary<DateTime, decimal>>();
+        if (accountIds.Count == 0 || start == default || end == default || end < start)
+            return result;
+
+        var transactions = await transactionRepository.GetByAccounts(accountIds, ct);
+        var endDate = end.Date;
+        var capitalFlows = transactions
+            .Where(transaction => transaction.TradeDate.ToDateTime(TimeOnly.MinValue) <= endDate)
+            .Select(ToCapitalFlow)
+            .Where(flow => flow.Amount != 0m)
+            .ToList();
+        if (capitalFlows.Count == 0) return result;
+
+        var ratesByCurrency = await LoadCapitalRatesAsync(capitalFlows, targetCurrency, endDate, ct);
+        foreach (var accountGroup in capitalFlows.GroupBy(flow => flow.AccountId))
+        {
+            var series = BuildCapitalSeries(accountGroup, targetCurrency, ratesByCurrency, start.Date, endDate);
+            if (series.Count > 0)
+                result[accountGroup.Key] = series;
+        }
+
+        return result;
+    }
+
     // Fold one account's transactions against the shared per-listing price series: carry each
     // listing's holding forward across days without a trade and value it at that day's price.
     private static Dictionary<DateTime, decimal> BuildAccountSeries(
@@ -192,6 +226,99 @@ internal class InvestmentValuationService(
 
         return result;
     }
+
+    private async Task<Dictionary<string, IReadOnlyDictionary<DateTime, decimal>>> LoadCapitalRatesAsync(
+        IReadOnlyCollection<InvestmentCapitalFlow> flows,
+        Currency targetCurrency,
+        DateTime endDate,
+        CancellationToken ct)
+    {
+        Dictionary<string, IReadOnlyDictionary<DateTime, decimal>> ratesByCurrency =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var currencyGroup in flows.GroupBy(flow => flow.Currency, StringComparer.OrdinalIgnoreCase))
+        {
+            var firstDate = currencyGroup.Min(flow => flow.Date);
+            var sourceCurrency = new Currency(0, currencyGroup.Key, currencyGroup.Key);
+            ratesByCurrency[currencyGroup.Key] = await CurrencyRateSeries.LoadAsync(
+                currencyExchangeService, sourceCurrency, targetCurrency, firstDate, endDate);
+        }
+
+        return ratesByCurrency;
+    }
+
+    private static Dictionary<DateTime, decimal> BuildCapitalSeries(
+        IEnumerable<InvestmentCapitalFlow> accountFlows,
+        Currency targetCurrency,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<DateTime, decimal>> ratesByCurrency,
+        DateTime startDate,
+        DateTime endDate)
+    {
+        Dictionary<DateTime, decimal> dailyDeltas = [];
+        decimal openingCapital = 0m;
+
+        foreach (var flow in accountFlows)
+        {
+            var convertedAmount = ConvertCapitalFlow(flow, targetCurrency, ratesByCurrency);
+            if (convertedAmount is not decimal amount) continue;
+
+            if (flow.Date < startDate)
+                openingCapital += amount;
+            else if (flow.Date <= endDate)
+                dailyDeltas[flow.Date] = dailyDeltas.GetValueOrDefault(flow.Date) + amount;
+        }
+
+        Dictionary<DateTime, decimal> result = [];
+        var capital = openingCapital;
+        for (var date = startDate; date <= endDate; date = date.AddDays(1))
+        {
+            capital += dailyDeltas.GetValueOrDefault(date);
+            result[date] = capital;
+        }
+
+        return result;
+    }
+
+    private static decimal? ConvertCapitalFlow(
+        InvestmentCapitalFlow flow,
+        Currency targetCurrency,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<DateTime, decimal>> ratesByCurrency)
+    {
+        if (string.Equals(flow.Currency, targetCurrency.ShortName, StringComparison.OrdinalIgnoreCase))
+            return flow.Amount;
+
+        return ratesByCurrency.TryGetValue(flow.Currency, out var rates)
+            && CurrencyRateSeries.TryGet(rates, flow.Date, out var rate)
+            && rate > 0m
+                ? flow.Amount * rate
+                : null;
+    }
+
+    private static InvestmentCapitalFlow ToCapitalFlow(InvestmentTransaction transaction)
+    {
+        var gross = transaction.Quantity * transaction.UnitPrice;
+        var fee = transaction.Fee ?? 0m;
+        var amount = transaction.Type switch
+        {
+            // The new investment model has no separate deposit/transfer rows. Buy/Sell are the
+            // persisted cash-impact records, while an unknown future type must not add capital.
+            InvestmentTransactionType.Buy => gross + fee,
+            InvestmentTransactionType.Sell => -(gross - fee),
+            _ => 0m
+        };
+
+        var currency = transaction.Currency.Trim();
+        var isMinorQuote = DefaultCurrency.MinorQuoteUnits.TryGetValue(currency, out var majorCurrency);
+        var multiplier = isMinorQuote ? transaction.AssetListing?.PriceMultiplier ?? 0.01m : 1m;
+
+        return new InvestmentCapitalFlow(
+            transaction.AccountId,
+            transaction.TradeDate.ToDateTime(TimeOnly.MinValue).Date,
+            amount * multiplier,
+            isMinorQuote ? majorCurrency! : currency);
+    }
+
+    private sealed record InvestmentCapitalFlow(int AccountId, DateTime Date, decimal Amount, string Currency);
 
     public async Task<IReadOnlyDictionary<DateTime, decimal>> GetBenchmarkSeriesAsync(
         long? assetListingId,

--- a/code/FinanceManager.Application/FinancialAccounts/Shared/CurrencyRateSeries.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Shared/CurrencyRateSeries.cs
@@ -1,0 +1,61 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
+
+namespace FinanceManager.Application.FinancialAccounts.Shared;
+
+/// <summary>
+/// Loads a historical FX range once and carries known rates across non-publishing days. Chart
+/// calculations use this instead of resolving a rate for every transaction or day.
+/// </summary>
+internal static class CurrencyRateSeries
+{
+    public static async Task<Dictionary<DateTime, decimal>> LoadAsync(
+        ICurrencyExchangeService exchangeService,
+        Currency fromCurrency,
+        Currency toCurrency,
+        DateTime start,
+        DateTime end)
+    {
+        var startDate = start.Date;
+        var endDate = end.Date;
+        if (startDate > endDate) return [];
+
+        if (string.Equals(fromCurrency.ShortName, toCurrency.ShortName, StringComparison.OrdinalIgnoreCase))
+        {
+            var sameCurrency = new Dictionary<DateTime, decimal>();
+            for (var date = startDate; date <= endDate; date = date.AddDays(1))
+                sameCurrency[date] = 1m;
+
+            return sameCurrency;
+        }
+
+        var rates = await exchangeService.GetExchangeRateAsync(fromCurrency, toCurrency, startDate, endDate);
+        var knownRates = rates
+            .Where(x => x.Value is > 0m)
+            .ToDictionary(x => x.Date.Date, x => x.Value!.Value);
+        if (knownRates.Count == 0) return knownRates;
+
+        // FX providers do not publish on every calendar day. Use the last known rate for the
+        // trailing gaps and the first known rate for a range that starts before publication.
+        decimal? carried = null;
+        for (var date = startDate; date <= endDate; date = date.AddDays(1))
+        {
+            if (knownRates.TryGetValue(date, out var rate))
+                carried = rate;
+            else if (carried is decimal previousRate)
+                knownRates[date] = previousRate;
+        }
+
+        var firstRate = knownRates.OrderBy(x => x.Key).First().Value;
+        for (var date = startDate; date <= endDate && !knownRates.ContainsKey(date); date = date.AddDays(1))
+            knownRates[date] = firstRate;
+
+        return knownRates;
+    }
+
+    public static bool TryGet(
+        IReadOnlyDictionary<DateTime, decimal> rates,
+        DateTime date,
+        out decimal rate) =>
+        rates.TryGetValue(date.Date, out rate);
+}

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor
@@ -12,7 +12,7 @@ else if (IsLoading || AccountHistoryState.HasTransactionHistory(Account))
                         <AccountDetailsHero AccountName="@Account.Name" AccountTypeLabel="@_accountTypeLabel" Currency="@_currency.ShortName"
                         Balance="@_currentBalance" BalanceChange="@_balanceChange" BalanceChangePercent="@_balanceChangePercent"
                         SelectedRange="@_selectedRange" IsChartLoading="@_isChartLoading"
-                        ChartData="@ChartData" IsMobile="@_isMobile" />
+                        ChartData="@ChartData" CapitalData="@CapitalData" IsMobile="@_isMobile" />
 
     <MudContainer MaxWidth="MaxWidth.Large" Class="px-0">
         <MudGrid Spacing="3">

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
@@ -63,6 +63,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     public BondAccount? Account { get; set; }
     public string ErrorMessage { get; set; } = string.Empty;
     public List<TimeSeriesModel> ChartData { get; set; } = [];
+    public List<TimeSeriesModel> CapitalData { get; set; } = [];
 
     [Parameter] public required int AccountId { get; set; }
 
@@ -286,9 +287,14 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
                     version,
                     async () =>
                     {
-                        var series = (await MoneyFlowHttpClient.GetClosingBalance(userId, currency, dateStart, dateEnd, [accountId]))
+                        var balanceTask = MoneyFlowHttpClient.GetClosingBalance(userId, currency, dateStart, dateEnd, [accountId]);
+                        var capitalTask = MoneyFlowHttpClient.GetCapital(userId, currency, dateStart, dateEnd, [accountId]);
+                        await Task.WhenAll(balanceTask, capitalTask);
+
+                        var series = (await balanceTask)
                             .SkipWhile(x => x.Value == 0)
                             .ToList();
+                        var capitalSeries = await capitalTask;
                         var currentBalance = series.LastOrDefault()?.Value ?? 0;
                         var balanceChange = series.Count >= 2 ? series.Last().Value - series.First().Value : 0;
                         var startBalance = currentBalance - balanceChange;
@@ -299,7 +305,8 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
                             series,
                             currentBalance,
                             balanceChange,
-                            startBalance == 0 ? null : balanceChange / startBalance * 100m);
+                            startBalance == 0 ? null : balanceChange / startBalance * 100m,
+                            capitalSeries);
                     },
                     onSnapshotPainted: ApplyChartModel,
                     onSnapshotMissing: ShowChartLoading,
@@ -330,6 +337,8 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     {
         ChartData.Clear();
         ChartData.AddRange(model.Series);
+        CapitalData.Clear();
+        CapitalData.AddRange(model.CapitalSeries ?? []);
         _currentBalance = model.CurrentBalance;
         _balanceChange = model.BalanceChange;
         _balanceChangePercent = model.BalanceChangePercent;
@@ -340,6 +349,7 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
     private Task ShowChartLoading()
     {
         ChartData.Clear();
+        CapitalData.Clear();
         _isChartLoading = true;
         return InvokeAsync(StateHasChanged);
     }

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor
@@ -24,7 +24,7 @@ else
                         Balance="@_currentBalance" BalanceChange="@_balanceChange" BalanceChangePercent="@_balanceChangePercent"
                         ChangeLabel="Asset appreciation" ShowChangeRange="false" IsBalanceLoading="@_isChartLoading"
                         SelectedRange="@_selectedRange" IsChartLoading="@_isChartLoading"
-                        ChartData="@ChartData" BenchmarkData="@BenchmarkData" BenchmarkName="@_benchmarkName"
+                        ChartData="@ChartData" BenchmarkData="@BenchmarkData" CapitalData="@CapitalData" BenchmarkName="@_benchmarkName"
                         IsMobile="@_isMobile" />
 
     <MudContainer MaxWidth="MaxWidth.Large" Class="px-0">

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -35,6 +35,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
     [Inject] public required ILogger<InvestmentAccountDetailsPageContent> Logger { get; set; }
     [Inject] public required AccountChartSnapshotStore ChartSnapshotStore { get; set; }
     [Inject] public required InvestmentAccountDetailsSnapshotStore DetailsSnapshotStore { get; set; }
+    [Inject] public required MoneyFlowHttpClient MoneyFlowHttpClient { get; set; }
 
     private const string _defaultAccountName = "Investments";
     private const string _defaultBenchmarkName = "Polish inflation";
@@ -75,6 +76,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
     private decimal? _balanceChangePercent;
     public List<TimeSeriesModel> ChartData { get; set; } = [];
     public List<TimeSeriesModel> BenchmarkData { get; set; } = [];
+    public List<TimeSeriesModel> CapitalData { get; set; } = [];
     private string _benchmarkName = _defaultBenchmarkName;
 
     // Toolbar filter state.
@@ -391,7 +393,8 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
                 currency.Id,
                 dateStart,
                 dateEnd,
-                benchmark?.ListingId));
+                benchmark?.ListingId),
+            async () => await MoneyFlowHttpClient.GetCapital(userId, currency, dateStart, dateEnd, [accountId]));
 
         var series = chartRequests.Series;
         var holdings = chartRequests.Holdings;
@@ -426,7 +429,8 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
             currentValue,
             balanceChange,
             capitalValue == 0m ? null : balanceChange / capitalValue * 100m,
-            BuildHoldings(transactions, holdings, dateEnd));
+            BuildHoldings(transactions, holdings, dateEnd),
+            [.. chartRequests.CapitalSeries]);
     }
 
     // Only chart data is restored. The selected range and its dates stay owned by the user's
@@ -439,6 +443,8 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
         ChartData.AddRange(model.Series);
         BenchmarkData.Clear();
         BenchmarkData.AddRange(model.BenchmarkSeries);
+        CapitalData.Clear();
+        CapitalData.AddRange(model.CapitalSeries ?? []);
         _benchmarkName = model.BenchmarkName;
         _currentBalance = model.CurrentBalance;
         _capitalValue = model.CapitalValue;
@@ -454,6 +460,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
     {
         ChartData.Clear();
         BenchmarkData.Clear();
+        CapitalData.Clear();
         _isChartLoading = true;
         return InvokeAsync(StateHasChanged);
     }

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountDetailsHero.razor
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountDetailsHero.razor
@@ -90,6 +90,11 @@
                     <ApexPointSeries TItem="TimeSeriesModel" Items="BenchmarkData" Name="@BenchmarkName" SeriesType="SeriesType.Line"
                                      XValue="@(p => p.DateTime.ToLocalTime())" YValue="@(p => p.Value)" />
                 }
+                @if (CapitalData.Count > 0)
+                {
+                    <ApexPointSeries TItem="TimeSeriesModel" Items="CapitalData" Name="@CapitalSeriesName" SeriesType="SeriesType.Line"
+                                     XValue="@(p => p.DateTime.ToLocalTime())" YValue="@(p => p.Value)" />
+                }
             </ApexChart>
         }
     </div>

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountDetailsHero.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/Shared/AccountDetailsHero.razor.cs
@@ -30,6 +30,7 @@ public partial class AccountDetailsHero
     [Parameter] public bool IsBalanceLoading { get; set; }
     [Parameter] public List<TimeSeriesModel> ChartData { get; set; } = [];
     [Parameter] public List<TimeSeriesModel> BenchmarkData { get; set; } = [];
+    [Parameter] public List<TimeSeriesModel> CapitalData { get; set; } = [];
     [Parameter] public string BenchmarkName { get; set; } = "Benchmark";
     [Parameter] public bool IsMobile { get; set; }
 
@@ -43,6 +44,7 @@ public partial class AccountDetailsHero
 
     /// <summary>Legend/series name for the account's own balance series.</summary>
     public const string BalanceSeriesName = "Balance";
+    public const string CapitalSeriesName = "Capital";
 
     // The y-axis is scaled to the series actually on screen (see ApplyYScale), so the options
     // object is per-instance rather than a shared static one.
@@ -68,7 +70,8 @@ public partial class AccountDetailsHero
         // equal) and a renamed benchmark, which changes the legend without changing values.
         var points = ChartData
             .Select(p => (BalanceSeriesName, p.DateTime, p.Value))
-            .Concat(BenchmarkData.Select(p => (BenchmarkName, p.DateTime, p.Value)));
+            .Concat(BenchmarkData.Select(p => (BenchmarkName, p.DateTime, p.Value)))
+            .Concat(CapitalData.Select(p => (CapitalSeriesName, p.DateTime, p.Value)));
         if (!ReferenceEquals(_chart, _drawnChart))
         {
             // A freshly mounted chart instance (first render, or remounted after the loading
@@ -93,9 +96,9 @@ public partial class AccountDetailsHero
         var axis = _heroChartOptions.Yaxis?.FirstOrDefault();
         if (axis is null) return;
 
-        // The benchmark line is rebased onto the portfolio, so both series share one axis and
-        // the padded bounds have to span them together or the rebased line clips.
-        var values = ChartData.Concat(BenchmarkData).Select(p => (double)p.Value).ToList();
+        // The non-balance lines share the balance axis, so the padded bounds have to span every
+        // displayed series or a rebased benchmark/capital line can clip.
+        var values = ChartData.Concat(BenchmarkData).Concat(CapitalData).Select(p => (double)p.Value).ToList();
         if (values.Count == 0) return;
 
         var bounds = ChartHelper.AddYRangePadding(values.Min(), values.Max());
@@ -122,7 +125,7 @@ public partial class AccountDetailsHero
             // Same draw animation as the dashboard time-series cards.
             Animations = new Animations { Enabled = true, Speed = 400 },
         },
-        Colors = ["#ffab00", "#42a5f5"],
+        Colors = ["#ffab00", "#42a5f5", "#66bb6a"],
         Stroke = new Stroke { Curve = Curve.Smooth, Width = 2, LineCap = LineCap.Round },
         DataLabels = new DataLabels { Enabled = false },
         // Top-aligned so the legend does not compete with the x-axis label row below the plot.
@@ -134,14 +137,14 @@ public partial class AccountDetailsHero
             HorizontalAlign = ApexCharts.Align.Right,
         },
         // Fill types are matched to series by index. The balance area (index 0) fades out
-        // downwards; the benchmark line (index 1) must be solid, because ApexCharts strokes a
-        // line series with its fill — a gradient there renders the line invisible at the end
-        // where the gradient reaches zero opacity.
+        // downwards; the benchmark and capital lines (indices 1 and 2) must be solid, because
+        // ApexCharts strokes a line series with its fill — a gradient there renders the line
+        // invisible at the end where the gradient reaches zero opacity.
         Fill = new Fill
         {
-            Type = [FillType.Gradient, FillType.Solid],
+            Type = [FillType.Gradient, FillType.Solid, FillType.Solid],
             Gradient = new FillGradient { OpacityFrom = 0.45, OpacityTo = 0d, Stops = [0, 100] },
-            Opacity = [1d, 1d],
+            Opacity = [1d, 1d, 1d],
         },
         Grid = new Grid
         {
@@ -193,7 +196,14 @@ public partial class AccountDetailsHero
                 },
             },
         ],
-        Tooltip = new Tooltip { Enabled = false },
+        Tooltip = new Tooltip
+        {
+            Enabled = true,
+            Shared = true,
+            Intersect = false,
+            X = new TooltipX { Format = "dd MMM yyyy" },
+            Marker = new TooltipMarker { Show = true },
+        },
     };
 
     private string GetInitial() => string.IsNullOrWhiteSpace(AccountName) ? "?" : AccountName.Trim()[..1].ToUpperInvariant();

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Models/AccountChartModel.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Models/AccountChartModel.cs
@@ -9,4 +9,5 @@ public sealed record AccountChartModel(
     List<TimeSeriesModel> Series,
     decimal CurrentBalance,
     decimal BalanceChange,
-    decimal? BalanceChangePercent);
+    decimal? BalanceChangePercent,
+    List<TimeSeriesModel>? CapitalSeries = null);

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Models/InvestmentAccountChartModel.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Models/InvestmentAccountChartModel.cs
@@ -14,4 +14,5 @@ public sealed record InvestmentAccountChartModel(
     decimal CurrentValue,
     decimal BalanceChange,
     decimal? BalanceChangePercent,
-    List<InvestmentHoldingModel> Holdings);
+    List<InvestmentHoldingModel> Holdings,
+    List<TimeSeriesModel>? CapitalSeries = null);

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Services/InvestmentChartRequestLoader.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Services/InvestmentChartRequestLoader.cs
@@ -12,23 +12,27 @@ public static class InvestmentChartRequestLoader
         IReadOnlyDictionary<DateTime, decimal> Series,
         IReadOnlyDictionary<long, decimal> Holdings,
         IReadOnlyList<UnrealizedGainLossAccountResult> Appreciation,
-        IReadOnlyDictionary<DateTime, decimal> BenchmarkSeries)> LoadAsync(
+        IReadOnlyDictionary<DateTime, decimal> BenchmarkSeries,
+        IReadOnlyList<TimeSeriesModel> CapitalSeries)> LoadAsync(
         Func<Task<IReadOnlyDictionary<DateTime, decimal>>> fetchSeries,
         Func<Task<IReadOnlyDictionary<long, decimal>>> fetchHoldings,
         Func<Task<IReadOnlyList<UnrealizedGainLossAccountResult>>> fetchAppreciation,
-        Func<Task<IReadOnlyDictionary<DateTime, decimal>>> fetchBenchmarkSeries)
+        Func<Task<IReadOnlyDictionary<DateTime, decimal>>> fetchBenchmarkSeries,
+        Func<Task<IReadOnlyList<TimeSeriesModel>>> fetchCapitalSeries)
     {
         var seriesTask = fetchSeries();
         var holdingsTask = fetchHoldings();
         var appreciationTask = fetchAppreciation();
         var benchmarkSeriesTask = fetchBenchmarkSeries();
+        var capitalSeriesTask = fetchCapitalSeries();
 
-        await Task.WhenAll(seriesTask, holdingsTask, appreciationTask, benchmarkSeriesTask);
+        await Task.WhenAll(seriesTask, holdingsTask, appreciationTask, benchmarkSeriesTask, capitalSeriesTask);
 
         return (
             await seriesTask,
             await holdingsTask,
             await appreciationTask,
-            await benchmarkSeriesTask);
+            await benchmarkSeriesTask,
+            await capitalSeriesTask);
     }
 }

--- a/code/FinanceManager.Components/Features/MoneyFlow/HttpClients/MoneyFlowHttpClient.cs
+++ b/code/FinanceManager.Components/Features/MoneyFlow/HttpClients/MoneyFlowHttpClient.cs
@@ -36,6 +36,16 @@ public class MoneyFlowHttpClient(HttpClient httpClient)
         return result ?? [];
     }
 
+    public Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end) =>
+        GetCapital(userId, currency, start, end, []);
+
+    public async Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds)
+    {
+        string endpoint = AppendAccountIdsQuery($"{httpClient.BaseAddress}api/MoneyFlow/GetCapital/{userId}/{currency.Id}/{start:O}/{end:O}", accountIds);
+        var result = await httpClient.GetFromJsonAsync<List<TimeSeriesModel>>(endpoint);
+        return result ?? [];
+    }
+
     public async Task<decimal?> GetNetWorth(int userId, Currency currency, DateTime date)
     {
         var result = await httpClient.GetFromJsonAsync<decimal?>($"{httpClient.BaseAddress}api/MoneyFlow/GetNetWorth/{userId}/{currency.Id}/{date:O}");

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Services/IInvestmentValuationService.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Services/IInvestmentValuationService.cs
@@ -68,6 +68,19 @@ public interface IInvestmentValuationService
         CancellationToken ct = default);
 
     /// <summary>
+    /// Cumulative net cash paid into each investment account over [<paramref name="start"/>,
+    /// <paramref name="end"/>]. The current investment model stores Buy and Sell rows as its
+    /// account-level cash-impact records, so buys increase capital and sells reduce it. Activity
+    /// before the range is carried into the first visible point; no market prices are used.
+    /// </summary>
+    Task<IReadOnlyDictionary<int, IReadOnlyDictionary<DateTime, decimal>>> GetCapitalSeriesAsync(
+        IReadOnlyCollection<int> accountIds,
+        Currency targetCurrency,
+        DateTime start,
+        DateTime end,
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Daily value of a shadow portfolio that receives the same contributions as
     /// <paramref name="accountId"/> but invests them in the benchmark instead, in
     /// <paramref name="targetCurrency"/> over [<paramref name="start"/>, <paramref name="end"/>].

--- a/code/FinanceManager.Domain/FinancialAccounts/Shared/Services/IBalanceService.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Shared/Services/IBalanceService.cs
@@ -11,6 +11,8 @@ public interface IBalanceService
     Task<List<TimeSeriesModel>> GetOutflow(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds);
     Task<List<TimeSeriesModel>> GetNetCashFlow(int userId, Currency currency, DateTime start, DateTime end);
     Task<List<TimeSeriesModel>> GetNetCashFlow(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds);
+    Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end);
+    Task<List<TimeSeriesModel>> GetCapital(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds);
     Task<List<TimeSeriesModel>> GetClosingBalance(int userId, Currency currency, DateTime start, DateTime end);
     Task<List<TimeSeriesModel>> GetClosingBalance(int userId, Currency currency, DateTime start, DateTime end, IReadOnlyCollection<int> accountIds);
 }

--- a/code/FinanceManager.Tests.Integration/Features/MoneyFlow/Controllers/MoneyFlowControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Features/MoneyFlow/Controllers/MoneyFlowControllerTests.cs
@@ -596,6 +596,7 @@ public class MoneyFlowControllerTests(OptionsProvider optionsProvider) : Control
         now => $"api/MoneyFlow/GetInflow/2/{DefaultCurrency.USD.Id}/{now.AddDays(-7):O}/{now:O}",
         now => $"api/MoneyFlow/GetOutflow/2/{DefaultCurrency.USD.Id}/{now.AddDays(-7):O}/{now:O}",
         now => $"api/MoneyFlow/GetNetCashFlow/2/{DefaultCurrency.USD.Id}/{now.AddDays(-7):O}/{now:O}",
+        now => $"api/MoneyFlow/GetCapital/2/{DefaultCurrency.USD.Id}/{now.AddDays(-7):O}/{now:O}",
         now => $"api/MoneyFlow/GetClosingBalance/2/{DefaultCurrency.USD.Id}/{now.AddDays(-7):O}/{now:O}",
         now => $"api/MoneyFlow/GetLabelsValue?userId=2&start={now.AddDays(-7):O}&end={now:O}",
         now => $"api/MoneyFlow/GetInvestmentRate?userId=2&currencyId={DefaultCurrency.USD.Id}&start={now.AddDays(-7):O}&end={now:O}",
@@ -713,6 +714,25 @@ public class MoneyFlowControllerTests(OptionsProvider optionsProvider) : Control
         Assert.Equal(1000m, inflow.Sum(x => x.Value));
         Assert.Equal(-500m, outflow.Sum(x => x.Value));
         Assert.Equal(-500m, netCashFlow.Single(x => x.DateTime == day0.AddDays(1)).Value);
+    }
+
+    [Fact]
+    public async Task GetCapital_IncludesInvestmentAccountTrades()
+    {
+        var day0 = new DateTime(2024, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        await SeedCashAndInvestmentAccounts(day0);
+        Authorize("TestUser", 1, UserRole.User);
+
+        var result = await new MoneyFlowHttpClient(Client).GetCapital(
+            1,
+            DefaultCurrency.USD,
+            day0,
+            day0.AddDays(2),
+            [51]);
+
+        Assert.Equal(0m, result.Single(x => x.DateTime == day0).Value);
+        Assert.Equal(500m, result.Single(x => x.DateTime == day0.AddDays(1)).Value);
+        Assert.Equal(500m, result.Single(x => x.DateTime == day0.AddDays(2)).Value);
     }
 
     public override void Dispose()

--- a/code/FinanceManager.Tests.Unit/Api/Features/MoneyFlow/Controllers/MoneyFlowControllerTests.cs
+++ b/code/FinanceManager.Tests.Unit/Api/Features/MoneyFlow/Controllers/MoneyFlowControllerTests.cs
@@ -147,4 +147,19 @@ public class MoneyFlowControllerTests
         var returnValue = Assert.IsType<List<TimeSeriesModel>>(okResult.Value);
         Assert.Single(returnValue);
     }
+
+    [Fact]
+    public async Task GetCapital_ReturnsSingleElement()
+    {
+        DateTime startDate = new(2000, 1, 1);
+        DateTime endDate = new(2000, 2, 1);
+        List<int> accountIds = [7];
+        _mockBalanceService.Setup(repo => repo.GetCapital(_testUserId, DefaultCurrency.PLN, startDate, endDate, accountIds)).ReturnsAsync([new()]);
+
+        var result = await _controller.GetCapital(_testUserId, DefaultCurrency.PLN.Id, startDate, endDate, null, accountIds, TestContext.Current.CancellationToken);
+
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var returnValue = Assert.IsType<List<TimeSeriesModel>>(okResult.Value);
+        Assert.Single(returnValue);
+    }
 }

--- a/code/FinanceManager.Tests.Unit/Application/Services/BalanceAggregationServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/BalanceAggregationServiceTests.cs
@@ -30,6 +30,8 @@ public class BalanceAggregationServiceTests
         mock.Setup(x => x.GetOutflow(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<IReadOnlyCollection<int>>())).ReturnsAsync([]);
         mock.Setup(x => x.GetNetCashFlow(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>())).ReturnsAsync([]);
         mock.Setup(x => x.GetNetCashFlow(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<IReadOnlyCollection<int>>())).ReturnsAsync([]);
+        mock.Setup(x => x.GetCapital(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>())).ReturnsAsync([]);
+        mock.Setup(x => x.GetCapital(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<IReadOnlyCollection<int>>())).ReturnsAsync([]);
         mock.Setup(x => x.GetClosingBalance(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>())).ReturnsAsync([]);
         mock.Setup(x => x.GetClosingBalance(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<IReadOnlyCollection<int>>())).ReturnsAsync([]);
     }
@@ -44,6 +46,21 @@ public class BalanceAggregationServiceTests
                  .ReturnsAsync([new(date, 15)]);
 
         var result = await _balanceService.GetClosingBalance(1, DefaultCurrency.PLN, date, date);
+
+        Assert.Single(result);
+        Assert.Equal(25, result[0].Value);
+    }
+
+    [Fact]
+    public async Task GetCapital_AggregatesValuesFromTypedServices()
+    {
+        var date = new DateTime(2024, 1, 1);
+        _service1.Setup(x => x.GetCapital(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                 .ReturnsAsync([new(date, 10)]);
+        _service2.Setup(x => x.GetCapital(It.IsAny<int>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                 .ReturnsAsync([new(date, 15)]);
+
+        var result = await _balanceService.GetCapital(1, DefaultCurrency.PLN, date, date);
 
         Assert.Single(result);
         Assert.Equal(25, result[0].Value);

--- a/code/FinanceManager.Tests.Unit/Application/Services/BondBalanceServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/BondBalanceServiceTests.cs
@@ -2,6 +2,7 @@ using FinanceManager.Application.FinancialAccounts.Bond.Balance;
 using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
 using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
 using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
 using FinanceManager.Domain.Identity.Entities;
@@ -17,11 +18,15 @@ public class BondBalanceServiceTests
 {
     private readonly Mock<IFinancialAccountRepository> _financialAccountRepositoryMock = new();
     private readonly Mock<IBondDetailsRepository> _bondDetailsRepositoryMock = new();
+    private readonly Mock<ICurrencyExchangeService> _currencyExchangeServiceMock = new();
     private readonly BondBalanceService _service;
 
     public BondBalanceServiceTests()
     {
-        _service = new BondBalanceService(_financialAccountRepositoryMock.Object, _bondDetailsRepositoryMock.Object);
+        _service = new BondBalanceService(
+            _financialAccountRepositoryMock.Object,
+            _bondDetailsRepositoryMock.Object,
+            _currencyExchangeServiceMock.Object);
     }
 
     [Fact]
@@ -93,4 +98,76 @@ public class BondBalanceServiceTests
         Assert.Equal(10000, result.Single(x => x.DateTime == startDate).Value);
         Assert.Equal(-5000, result.Single(x => x.DateTime == endDate).Value);
     }
+
+    [Fact]
+    public async Task GetCapital_CarriesOpeningUnits_CombinesSameDayEntries_AndExcludesInterest()
+    {
+        var userId = 1;
+        DateTime startDate = new(2024, 1, 2);
+        DateTime endDate = new(2024, 1, 4);
+        var account = new BondAccount(userId, 1, "Bonds",
+        [
+            new BondAccountEntry(1, 1, new DateTime(2024, 1, 1), 10, 10, 1),
+            new BondAccountEntry(1, 2, startDate, 12, 2, 1),
+            new BondAccountEntry(1, 3, startDate, 13, 1, 1),
+            new BondAccountEntry(1, 4, new DateTime(2024, 1, 3), 8, -5, 1)
+        ], AccountLabel.Other);
+
+        var details = CreateDetails(startDate, endDate, DefaultCurrency.PLN);
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                                       .Returns(new[] { account }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).Returns(new[] { details }.ToAsyncEnumerable());
+
+        var result = await _service.GetCapital(userId, DefaultCurrency.PLN, startDate, endDate);
+
+        Assert.Equal(1_300m, result.Single(x => x.DateTime == startDate).Value);
+        Assert.Equal(800m, result.Single(x => x.DateTime == startDate.AddDays(1)).Value);
+        Assert.Equal(800m, result.Single(x => x.DateTime == endDate).Value);
+    }
+
+    [Fact]
+    public async Task GetCapital_ConvertsBondCashFlowsUsingHistoricalRates()
+    {
+        var userId = 1;
+        DateTime startDate = new(2024, 1, 2);
+        DateTime endDate = new(2024, 1, 3);
+        var account = new BondAccount(userId, 1, "Bonds",
+        [
+            new BondAccountEntry(1, 1, startDate, 10, 10, 1),
+            new BondAccountEntry(1, 2, endDate, 8, -2, 1)
+        ], AccountLabel.Other);
+        var details = CreateDetails(startDate, endDate, DefaultCurrency.USD);
+
+        _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                                       .Returns(new[] { account }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).Returns(new[] { details }.ToAsyncEnumerable());
+        _currencyExchangeServiceMock
+            .Setup(x => x.GetExchangeRateAsync(DefaultCurrency.USD, DefaultCurrency.PLN, startDate, endDate))
+            .ReturnsAsync([
+                (startDate, (decimal?)2m),
+                (endDate, (decimal?)3m)
+            ]);
+
+        var result = await _service.GetCapital(userId, DefaultCurrency.PLN, startDate, endDate);
+
+        Assert.Equal(2_000m, result.Single(x => x.DateTime == startDate).Value);
+        Assert.Equal(1_400m, result.Single(x => x.DateTime == endDate).Value);
+        _currencyExchangeServiceMock.Verify(
+            x => x.GetExchangeRateAsync(DefaultCurrency.USD, DefaultCurrency.PLN, startDate, endDate),
+            Times.Once);
+    }
+
+    private static BondDetails CreateDetails(DateTime startDate, DateTime endDate, Currency currency) =>
+        new(
+            "Bond",
+            "Issuer",
+            DateOnly.FromDateTime(startDate),
+            DateOnly.FromDateTime(endDate.AddYears(1)),
+            [new BondCalculationMethod { DateOperator = DateOperator.UntilDate, DateValue = endDate.AddYears(1).ToString("yyyy-MM-dd"), Rate = 0 }],
+            currency,
+            BondType.InflationBond,
+            100m)
+        {
+            Id = 1
+        };
 }

--- a/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentBalanceServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentBalanceServiceTests.cs
@@ -59,6 +59,47 @@ public class InvestmentBalanceServiceTests
     }
 
     [Fact]
+    public async Task GetCapital_AggregatesCapitalSeriesAcrossInvestmentAccounts()
+    {
+        DateTime start = new(2024, 1, 1);
+        DateTime end = new(2024, 1, 3);
+
+        var account1 = new InvestmentAccount(_userId, 10, "Investments A");
+        var account2 = new InvestmentAccount(_userId, 20, "Investments B");
+
+        _financialAccountRepository.Setup(repo => repo.GetAccounts<InvestmentAccount>(_userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                                   .Returns(new[] { account1, account2 }.ToAsyncEnumerable());
+
+        _valuationService.Setup(x => x.GetCapitalSeriesAsync(
+                It.Is<IReadOnlyCollection<int>>(a => a.Contains(10) && a.Contains(20)),
+                DefaultCurrency.PLN,
+                start.Date,
+                end.Date,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, IReadOnlyDictionary<DateTime, decimal>>
+            {
+                [10] = new Dictionary<DateTime, decimal>
+                {
+                    [start] = 100,
+                    [start.AddDays(1)] = 100,
+                    [end] = 150
+                },
+                [20] = new Dictionary<DateTime, decimal>
+                {
+                    [start] = 25,
+                    [start.AddDays(1)] = 30,
+                    [end] = 30
+                }
+            });
+
+        var result = await _service.GetCapital(_userId, DefaultCurrency.PLN, start, end);
+
+        Assert.Equal(125, result.Single(x => x.DateTime == start).Value);
+        Assert.Equal(130, result.Single(x => x.DateTime == start.AddDays(1)).Value);
+        Assert.Equal(180, result.Single(x => x.DateTime == end).Value);
+    }
+
+    [Fact]
     public async Task GetClosingBalance_RespectsAccountIdFilter()
     {
         DateTime start = new(2024, 1, 1);

--- a/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
@@ -1,6 +1,7 @@
 using FinanceManager.Application.FinancialAccounts.Investments.Valuation;
 using FinanceManager.Domain.Assets.Services;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
 using FinanceManager.Domain.MoneyFlow.Services;
@@ -17,20 +18,29 @@ public class InvestmentValuationServiceTests
     private readonly Mock<IInvestmentTransactionRepository> _transactionRepository = new();
     private readonly Mock<IInvestmentPriceProvider> _priceProvider = new();
     private readonly Mock<IInflationIndexProvider> _inflationIndexProvider = new();
+    private readonly Mock<ICurrencyExchangeService> _currencyExchangeService = new();
 
     private InvestmentValuationService CreateSut() =>
-        new(_transactionRepository.Object, _priceProvider.Object, _inflationIndexProvider.Object);
+        new(_transactionRepository.Object, _priceProvider.Object, _inflationIndexProvider.Object, _currencyExchangeService.Object);
 
-    private static InvestmentTransaction Tx(long listingId, InvestmentTransactionType type, decimal qty, DateOnly tradeDate, int accountId = _accountId) =>
+    private static InvestmentTransaction Tx(
+        long listingId,
+        InvestmentTransactionType type,
+        decimal qty,
+        DateOnly tradeDate,
+        int accountId = _accountId,
+        decimal unitPrice = 1m,
+        decimal? fee = null) =>
         new()
         {
             AccountId = accountId,
             AssetListingId = listingId,
             Type = type,
             Quantity = qty,
-            UnitPrice = 1m,
+            UnitPrice = unitPrice,
             Currency = "USD",
-            TradeDate = tradeDate
+            TradeDate = tradeDate,
+            Fee = fee
         };
 
     [Fact]
@@ -255,6 +265,82 @@ public class InvestmentValuationServiceTests
 
         // The listing shared by both accounts is priced once across the whole set.
         _priceProvider.Verify(x => x.GetPricePerUnitSeriesAsync(10, _usd, start, end, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCapitalSeries_AccumulatesBuysAndSells_CarriesOpeningCapital_AndCombinesSameDayFlows()
+    {
+        var start = new DateTime(2024, 1, 2);
+        var end = new DateTime(2024, 1, 4);
+        SetupTransactions(
+            Tx(1, InvestmentTransactionType.Buy, 10m, new DateOnly(2024, 1, 1), unitPrice: 10m, fee: 2m),
+            Tx(1, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 2), unitPrice: 10m, fee: 1m),
+            Tx(1, InvestmentTransactionType.Buy, 1m, new DateOnly(2024, 1, 2), unitPrice: 5m),
+            Tx(1, InvestmentTransactionType.Sell, 1m, new DateOnly(2024, 1, 3), unitPrice: 15m, fee: 1m));
+
+        var series = await CreateSut().GetCapitalSeriesAsync(
+            [_accountId], _usd, start, end, TestContext.Current.CancellationToken);
+
+        Assert.Equal(128m, series[_accountId][start]);
+        Assert.Equal(114m, series[_accountId][start.AddDays(1)]);
+        Assert.Equal(114m, series[_accountId][end]);
+        Assert.Equal(114m, series[_accountId][start.AddDays(2)]);
+    }
+
+    [Fact]
+    public async Task GetCapitalSeries_ConvertsEachCashFlowUsingOneHistoricalRateRange()
+    {
+        var start = new DateTime(2024, 1, 2);
+        var end = new DateTime(2024, 1, 3);
+        var eur = new Currency(2, "EUR", "€");
+        var transactions = new[]
+        {
+            Tx(1, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 2), unitPrice: 100m),
+            Tx(1, InvestmentTransactionType.Sell, 1m, new DateOnly(2024, 1, 3), unitPrice: 50m)
+        };
+        foreach (var transaction in transactions)
+            transaction.Currency = eur.ShortName;
+        SetupTransactions(transactions);
+
+        _currencyExchangeService
+            .Setup(x => x.GetExchangeRateAsync(
+                It.Is<Currency>(currency => currency.ShortName == "EUR"),
+                It.Is<Currency>(currency => currency.ShortName == "PLN"),
+                start,
+                end))
+            .ReturnsAsync([
+                (start, (decimal?)2m),
+                (end, (decimal?)3m)
+            ]);
+
+        var series = await CreateSut().GetCapitalSeriesAsync(
+            [_accountId], DefaultCurrency.PLN, start, end, TestContext.Current.CancellationToken);
+
+        Assert.Equal(400m, series[_accountId][start]);
+        Assert.Equal(250m, series[_accountId][end]);
+        _currencyExchangeService.Verify(
+            x => x.GetExchangeRateAsync(
+                It.Is<Currency>(currency => currency.ShortName == "EUR"),
+                It.Is<Currency>(currency => currency.ShortName == "PLN"),
+                start,
+                end),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetCapitalSeries_IgnoresUnknownFutureTransactionTypes()
+    {
+        var transactions = new[]
+        {
+            Tx(1, (InvestmentTransactionType)999, 5m, new DateOnly(2024, 1, 1), unitPrice: 100m)
+        };
+        SetupTransactions(transactions);
+
+        var series = await CreateSut().GetCapitalSeriesAsync(
+            [_accountId], _usd, new DateTime(2024, 1, 1), new DateTime(2024, 1, 2), TestContext.Current.CancellationToken);
+
+        Assert.Empty(series);
+        _currencyExchangeService.VerifyNoOtherCalls();
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Services/InvestmentChartRequestLoaderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Features/FinancialAccounts/Services/InvestmentChartRequestLoaderTests.cs
@@ -15,7 +15,7 @@ public class InvestmentChartRequestLoaderTests
 
         async Task<T> WaitForRelease<T>(T value)
         {
-            if (Interlocked.Increment(ref started) == 4)
+            if (Interlocked.Increment(ref started) == 5)
                 allStarted.TrySetResult(true);
 
             await release.Task;
@@ -26,7 +26,8 @@ public class InvestmentChartRequestLoaderTests
             () => WaitForRelease<IReadOnlyDictionary<DateTime, decimal>>(new Dictionary<DateTime, decimal>()),
             () => WaitForRelease<IReadOnlyDictionary<long, decimal>>(new Dictionary<long, decimal>()),
             () => WaitForRelease<IReadOnlyList<UnrealizedGainLossAccountResult>>([]),
-            () => WaitForRelease<IReadOnlyDictionary<DateTime, decimal>>(new Dictionary<DateTime, decimal>()));
+            () => WaitForRelease<IReadOnlyDictionary<DateTime, decimal>>(new Dictionary<DateTime, decimal>()),
+            () => WaitForRelease<IReadOnlyList<TimeSeriesModel>>([]));
 
         await allStarted.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         Assert.False(loadTask.IsCompleted);
@@ -38,5 +39,6 @@ public class InvestmentChartRequestLoaderTests
         Assert.Empty(result.Holdings);
         Assert.Empty(result.Appreciation);
         Assert.Empty(result.BenchmarkSeries);
+        Assert.Empty(result.CapitalSeries);
     }
 }


### PR DESCRIPTION
Closes #729

## Summary

- Add a cumulative Capital series to investment and bond account charts.
- Carry contributions and withdrawals from before the selected range into the visible series, combine same-day activity, and preserve existing Balance and benchmark series.
- Reuse historical currency conversion with one range lookup per source currency.
- Add the shared Capital legend/tooltip presentation and load capital data alongside the existing chart requests.
- Add backend, API, component, unit, integration, and architecture coverage.

## Validation

- `dotnet format ./code/FinanceManager.slnx --verify-no-changes`
- `dotnet build ./code/FinanceManager.slnx --no-restore` — 0 warnings, 0 errors
- Unit tests — 979 passed
- MoneyFlow integration tests — 29 passed
- Architecture tests — 9 passed
- Browser verification — investment and bond charts checked at 430x920 and 1280x1000, including the Capital tooltip

The current investment domain persists Buy/Sell rows rather than standalone deposit/withdrawal rows, so those existing cash-impact semantics define investment capital. Accrued bond interest is excluded from contributed capital.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added capital time-series data retrieval for selected date ranges, currencies, and accounts.
  - Bond and investment account charts now display capital alongside balances, holdings, and benchmarks.
  - Capital calculations account for opening positions, transactions, fees, and historical currency exchange rates.
  - Investment and bond capital data are loaded alongside existing chart data for a more complete account overview.

- **Bug Fixes**
  - Improved chart tooltips and scaling to support the additional capital series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->