### PR TITLE
Bound NBP exchange-rate range lookups #728

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- Historical exchange-rate range lookups now use bounded provider range requests, avoiding concurrent per-date NBP request bursts while preserving provider fallback and missing-day behavior. #728
 - Card explanations now open from card header labels with polished, viewport-aware tooltip surfaces and no standalone info icons. #730
 - Landing and welcome card titles now stay centered across their full header while remaining tooltip triggers. #730
 - The Investment paycheck card's detailed information panel is replaced by the standard card information tooltip. #730

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
@@ -261,8 +261,10 @@ internal class CurrencyExchangeService(
             .ToList();
         var usdToTarget = await ResolveDirectRangeAsync(usd, toCurrency, targetDates, statesByDate: statesByDate);
         var results = new Dictionary<DateTime, CurrencyExchangeRateResult>();
-        List<(DateTime Date, decimal Rate)> ratesToPersist = [];
 
+        // Keep derived USD-cross rates request-scoped. The point-resolution path does not persist
+        // derived pairs either, so a transient direct-provider failure can retry the authoritative
+        // pair instead of being shadowed by an approximation in storage.
         foreach (var date in dates)
         {
             var key = NormalizeDate(date);
@@ -282,11 +284,7 @@ internal class CurrencyExchangeService(
 
             var rate = fromResult.Value!.Value * targetResult.Value!.Value;
             results[key] = CurrencyExchangeRateResult.Success(rate);
-            ratesToPersist.Add((key, rate));
         }
-
-        if (ratesToPersist.Count > 0)
-            await exchangeRateRepository.AddRange(fromCurrency.ShortName, toCurrency.ShortName, ratesToPersist);
 
         return results;
     }

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
@@ -14,6 +14,10 @@ internal class CurrencyExchangeService(
     // are persisted, so successive requests keep narrowing the gap until the range is covered.
     private const int _maxProviderResolutionsPerCall = 60;
 
+    // Keep provider range calls bounded even when the selected missing dates are sparse. NBP uses
+    // the same window internally and its documented table-A limit is larger than this value.
+    private const int _maxProviderRangeDays = 180;
+
     public async Task<List<(DateTime Date, decimal? Value)>> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime dateStart, DateTime dateEnd)
     {
         if (dateStart == default || dateEnd == default) return [];
@@ -66,21 +70,47 @@ internal class CurrencyExchangeService(
                 ? missingDates
                 : missingDates.Take(_maxProviderResolutionsPerCall).ToList();
 
-            const int batchSize = 50;
-            for (var offset = 0; offset < toResolve.Count; offset += batchSize)
+            var directResults = await ResolveDirectRangeAsync(
+                fromCurrency,
+                toCurrency,
+                toResolve,
+                stored);
+            List<DateTime> unresolvedDirectDates = [];
+
+            foreach (var date in toResolve)
             {
-                var currentBatchSize = Math.Min(batchSize, toResolve.Count - offset);
-                List<Task<decimal?>> batchTasks = [];
-
-                for (var i = 0; i < currentBatchSize; i++)
+                var key = NormalizeDate(date);
+                var directResult = directResults[key];
+                if (directResult.IsSuccess)
                 {
-                    var date = toResolve[offset + i];
-                    batchTasks.Add(GetExchangeRateAsync(fromCurrency, toCurrency, date));
+                    rates.Add((date, directResult.Value));
                 }
+                else if (directResult.Status == CurrencyExchangeRateStatus.NotYetPublished)
+                {
+                    // The range API returns values only. Keep a current-day publication miss
+                    // unavailable rather than allowing the capped-tail carry-forward below to
+                    // turn it into a stale value.
+                    rates.Add((date, null));
+                }
+                else
+                {
+                    unresolvedDirectDates.Add(date);
+                }
+            }
 
-                var batchResults = await Task.WhenAll(batchTasks);
-                for (var i = 0; i < batchResults.Length; i++)
-                    rates.Add((toResolve[offset + i], batchResults[i]));
+            if (unresolvedDirectDates.Count > 0 && !IsUsd(fromCurrency) && !IsUsd(toCurrency))
+            {
+                var crossResults = await ResolveRangeViaUsdAsync(fromCurrency, toCurrency, unresolvedDirectDates);
+                foreach (var date in unresolvedDirectDates)
+                {
+                    var crossResult = crossResults[NormalizeDate(date)];
+                    rates.Add((date, crossResult.IsSuccess ? crossResult.Value : null));
+                }
+            }
+            else
+            {
+                foreach (var date in unresolvedDirectDates)
+                    rates.Add((date, null));
             }
 
             // Dates past the per-call resolution cap carry the nearest earlier known rate
@@ -110,6 +140,145 @@ internal class CurrencyExchangeService(
         }
 
         return rates.OrderBy(x => x.Date).ToList();
+    }
+
+    private async Task<Dictionary<DateTime, CurrencyExchangeRateResult>> ResolveDirectRangeAsync(
+        Currency fromCurrency,
+        Currency toCurrency,
+        IReadOnlyCollection<DateTime> dates,
+        IReadOnlyDictionary<(string From, string To, DateTime Date), decimal>? stored = null)
+    {
+        var orderedDates = dates
+            .Select(NormalizeDate)
+            .Distinct()
+            .OrderBy(date => date)
+            .ToList();
+        if (orderedDates.Count == 0) return [];
+
+        var normalizedFrom = Normalize(fromCurrency.ShortName);
+        var normalizedTo = Normalize(toCurrency.ShortName);
+        var existing = stored ?? await exchangeRateRepository.GetRange(
+            fromCurrency.ShortName,
+            toCurrency.ShortName,
+            orderedDates[0],
+            orderedDates[^1]) ?? new Dictionary<(string From, string To, DateTime Date), decimal>();
+        var results = new Dictionary<DateTime, CurrencyExchangeRateResult>();
+        var states = orderedDates.ToDictionary(date => date, _ => new ResolutionState());
+        List<DateTime> pendingDates = [];
+
+        foreach (var date in orderedDates)
+        {
+            var key = (normalizedFrom, normalizedTo, date);
+            if (existing.TryGetValue(key, out var rate))
+                results[date] = CurrencyExchangeRateResult.Success(rate);
+            else
+                pendingDates.Add(date);
+        }
+
+        List<(DateTime Date, decimal Rate)> ratesToPersist = [];
+        foreach (var provider in providers)
+        {
+            var unresolvedDates = pendingDates.Where(date => !results.ContainsKey(date)).ToList();
+            for (var offset = 0; offset < unresolvedDates.Count;)
+            {
+                var windowEnd = offset;
+                while (windowEnd + 1 < unresolvedDates.Count &&
+                       (unresolvedDates[windowEnd + 1] - unresolvedDates[offset]).Days < _maxProviderRangeDays)
+                {
+                    windowEnd++;
+                }
+
+                var windowStartDate = unresolvedDates[offset];
+                var windowEndDate = unresolvedDates[windowEnd];
+                var providerResults = await provider.GetExchangeRateAsync(
+                    fromCurrency,
+                    toCurrency,
+                    windowStartDate,
+                    windowEndDate);
+                var resultByDate = providerResults
+                    .GroupBy(x => NormalizeDate(x.Date))
+                    .ToDictionary(group => group.Key, group => group.Last().Result);
+
+                for (var index = offset; index <= windowEnd; index++)
+                {
+                    var date = unresolvedDates[index];
+                    if (results.ContainsKey(date) || !resultByDate.TryGetValue(date, out var providerResult))
+                        continue;
+
+                    if (providerResult.Status == CurrencyExchangeRateProviderStatus.OutOfRange)
+                    {
+                        states[date].OutOfRangeProviders.Add(provider);
+                        continue;
+                    }
+
+                    if (providerResult is { Status: CurrencyExchangeRateProviderStatus.Success, Value: decimal rate })
+                    {
+                        results[date] = CurrencyExchangeRateResult.Success(rate);
+                        ratesToPersist.Add((date, rate));
+                        continue;
+                    }
+
+                    states[date].Observe(providerResult, date);
+                }
+
+                offset = windowEnd + 1;
+            }
+        }
+
+        if (ratesToPersist.Count > 0)
+            await exchangeRateRepository.AddRange(fromCurrency.ShortName, toCurrency.ShortName, ratesToPersist);
+
+        foreach (var date in orderedDates)
+        {
+            if (!results.ContainsKey(date))
+                results[date] = states[date].Build(date);
+        }
+
+        return results;
+    }
+
+    private async Task<Dictionary<DateTime, CurrencyExchangeRateResult>> ResolveRangeViaUsdAsync(
+        Currency fromCurrency,
+        Currency toCurrency,
+        IReadOnlyCollection<DateTime> dates)
+    {
+        if (dates.Count == 0 || IsUsd(fromCurrency) || IsUsd(toCurrency)) return [];
+
+        var usd = DefaultCurrency.USD;
+        var fromToUsd = await ResolveDirectRangeAsync(fromCurrency, usd, dates);
+        var targetDates = dates
+            .Where(date => fromToUsd[NormalizeDate(date)].IsSuccess)
+            .ToList();
+        var usdToTarget = await ResolveDirectRangeAsync(usd, toCurrency, targetDates);
+        var results = new Dictionary<DateTime, CurrencyExchangeRateResult>();
+        List<(DateTime Date, decimal Rate)> ratesToPersist = [];
+
+        foreach (var date in dates)
+        {
+            var key = NormalizeDate(date);
+            var fromResult = fromToUsd[key];
+            if (!fromResult.IsSuccess)
+            {
+                results[key] = fromResult;
+                continue;
+            }
+
+            var targetResult = usdToTarget[key];
+            if (!targetResult.IsSuccess)
+            {
+                results[key] = targetResult;
+                continue;
+            }
+
+            var rate = fromResult.Value!.Value * targetResult.Value!.Value;
+            results[key] = CurrencyExchangeRateResult.Success(rate);
+            ratesToPersist.Add((key, rate));
+        }
+
+        if (ratesToPersist.Count > 0)
+            await exchangeRateRepository.AddRange(fromCurrency.ShortName, toCurrency.ShortName, ratesToPersist);
+
+        return results;
     }
 
     public async Task<decimal?> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date) =>

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/ExchangeRates/CurrencyExchangeService.cs
@@ -70,11 +70,13 @@ internal class CurrencyExchangeService(
                 ? missingDates
                 : missingDates.Take(_maxProviderResolutionsPerCall).ToList();
 
+            var statesByDate = toResolve.ToDictionary(date => NormalizeDate(date), _ => new ResolutionState());
             var directResults = await ResolveDirectRangeAsync(
                 fromCurrency,
                 toCurrency,
                 toResolve,
-                stored);
+                stored,
+                statesByDate);
             List<DateTime> unresolvedDirectDates = [];
 
             foreach (var date in toResolve)
@@ -100,7 +102,11 @@ internal class CurrencyExchangeService(
 
             if (unresolvedDirectDates.Count > 0 && !IsUsd(fromCurrency) && !IsUsd(toCurrency))
             {
-                var crossResults = await ResolveRangeViaUsdAsync(fromCurrency, toCurrency, unresolvedDirectDates);
+                var crossResults = await ResolveRangeViaUsdAsync(
+                    fromCurrency,
+                    toCurrency,
+                    unresolvedDirectDates,
+                    statesByDate);
                 foreach (var date in unresolvedDirectDates)
                 {
                     var crossResult = crossResults[NormalizeDate(date)];
@@ -146,7 +152,8 @@ internal class CurrencyExchangeService(
         Currency fromCurrency,
         Currency toCurrency,
         IReadOnlyCollection<DateTime> dates,
-        IReadOnlyDictionary<(string From, string To, DateTime Date), decimal>? stored = null)
+        IReadOnlyDictionary<(string From, string To, DateTime Date), decimal>? stored = null,
+        IReadOnlyDictionary<DateTime, ResolutionState>? statesByDate = null)
     {
         var orderedDates = dates
             .Select(NormalizeDate)
@@ -163,7 +170,7 @@ internal class CurrencyExchangeService(
             orderedDates[0],
             orderedDates[^1]) ?? new Dictionary<(string From, string To, DateTime Date), decimal>();
         var results = new Dictionary<DateTime, CurrencyExchangeRateResult>();
-        var states = orderedDates.ToDictionary(date => date, _ => new ResolutionState());
+        var states = statesByDate ?? orderedDates.ToDictionary(date => date, _ => new ResolutionState());
         List<DateTime> pendingDates = [];
 
         foreach (var date in orderedDates)
@@ -178,7 +185,9 @@ internal class CurrencyExchangeService(
         List<(DateTime Date, decimal Rate)> ratesToPersist = [];
         foreach (var provider in providers)
         {
-            var unresolvedDates = pendingDates.Where(date => !results.ContainsKey(date)).ToList();
+            var unresolvedDates = pendingDates
+                .Where(date => !results.ContainsKey(date) && !states[date].OutOfRangeProviders.Contains(provider))
+                .ToList();
             for (var offset = 0; offset < unresolvedDates.Count;)
             {
                 var windowEnd = offset;
@@ -240,16 +249,17 @@ internal class CurrencyExchangeService(
     private async Task<Dictionary<DateTime, CurrencyExchangeRateResult>> ResolveRangeViaUsdAsync(
         Currency fromCurrency,
         Currency toCurrency,
-        IReadOnlyCollection<DateTime> dates)
+        IReadOnlyCollection<DateTime> dates,
+        IReadOnlyDictionary<DateTime, ResolutionState> statesByDate)
     {
         if (dates.Count == 0 || IsUsd(fromCurrency) || IsUsd(toCurrency)) return [];
 
         var usd = DefaultCurrency.USD;
-        var fromToUsd = await ResolveDirectRangeAsync(fromCurrency, usd, dates);
+        var fromToUsd = await ResolveDirectRangeAsync(fromCurrency, usd, dates, statesByDate: statesByDate);
         var targetDates = dates
             .Where(date => fromToUsd[NormalizeDate(date)].IsSuccess)
             .ToList();
-        var usdToTarget = await ResolveDirectRangeAsync(usd, toCurrency, targetDates);
+        var usdToTarget = await ResolveDirectRangeAsync(usd, toCurrency, targetDates, statesByDate: statesByDate);
         var results = new Dictionary<DateTime, CurrencyExchangeRateResult>();
         List<(DateTime Date, decimal Rate)> ratesToPersist = [];
 

--- a/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
@@ -545,7 +545,7 @@ public class CurrencyExchangeServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task GetExchangeRateAsync_PartiallyStoredRange_UsesBulkReadThenPointResolutionForMissing()
+    public async Task GetExchangeRateAsync_PartiallyStoredRange_UsesBulkReadThenProviderRangeForMissing()
     {
         // Arrange
         var fromCurrency = new Currency(1, "USD", "$");
@@ -564,11 +564,6 @@ public class CurrencyExchangeServiceTests : IDisposable
         _exchangeRateRepositoryMock
             .Setup(x => x.GetRange("USD", "EUR", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(storedRates);
-
-        // Setup point Get to return null for direct, forcing provider call
-        _exchangeRateRepositoryMock
-            .Setup(x => x.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((decimal?)null);
 
         var jsonResponse = @"{""usd"": {""eur"": 0.915}}";
         SetupHttpResponse(HttpStatusCode.OK, jsonResponse);
@@ -589,10 +584,10 @@ public class CurrencyExchangeServiceTests : IDisposable
             x => x.GetRange("USD", "EUR", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
             Times.Once);
 
-        // Verify point Get was called for missing date resolution
+        // Range resolution uses the provider's bulk method, not one repository lookup per date.
         _exchangeRateRepositoryMock.Verify(
             x => x.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
-            Times.AtLeastOnce);
+            Times.Never);
 
         // Verify provider was called for missing date
         _httpMessageHandlerMock.Protected().Verify(
@@ -603,7 +598,7 @@ public class CurrencyExchangeServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task GetExchangeRateAsync_RangeWithManyMissingDates_CapsProviderCallsAndCarriesRatesForward()
+    public async Task GetExchangeRateAsync_RangeWithManyMissingDates_UsesBoundedRangeLookupAndCarriesRatesForward()
     {
         // Arrange: a 100-day range with only the first day stored, so 99 dates are missing —
         // more than the per-call provider resolution cap of 60.
@@ -621,14 +616,9 @@ public class CurrencyExchangeServiceTests : IDisposable
         _exchangeRateRepositoryMock
             .Setup(x => x.GetRange("USD", "EUR", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(storedRates);
-        _exchangeRateRepositoryMock
-            .Setup(x => x.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((decimal?)null);
-
-        var jsonResponse = @"{""usd"": {""eur"": 0.915}}";
-        SetupHttpResponse(HttpStatusCode.OK, jsonResponse);
-
-        var service = CreateService();
+        var provider = new RecordingRangeProvider(_ =>
+            new CurrencyExchangeRateProviderResult(CurrencyExchangeRateProviderStatus.Success, 0.915m));
+        var service = CreateService([provider]);
 
         // Act
         var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, dateStart, dateEnd);
@@ -638,12 +628,45 @@ public class CurrencyExchangeServiceTests : IDisposable
         Assert.All(result, x => Assert.NotNull(x.Value));
         Assert.Equal(0.915m, result[^1].Value);
 
-        // Only the first 60 missing dates may reach the external provider.
-        _httpMessageHandlerMock.Protected().Verify(
-            "SendAsync",
-            Times.Exactly(60),
-            ItExpr.IsAny<HttpRequestMessage>(),
-            ItExpr.IsAny<CancellationToken>());
+        // Only the first 60 missing dates reach a provider, through one bounded range call.
+        var rangeCall = Assert.Single(provider.RangeCalls);
+        Assert.Equal(dateStart.AddDays(1), rangeCall.Start);
+        Assert.Equal(dateStart.AddDays(60), rangeCall.End);
+        Assert.Equal(0, provider.SingleCallCount);
+    }
+
+    [Fact]
+    public async Task GetExchangeRateAsync_RangeUsesOrderedProviderFallbackAndPreservesMissingDays()
+    {
+        var fromCurrency = new Currency(1, "USD", "$");
+        var toCurrency = new Currency(2, "EUR", "€");
+        var dateStart = new DateTime(2024, 1, 5);
+        var dateEnd = dateStart.AddDays(6);
+        IReadOnlyDictionary<(string From, string To, DateTime Date), decimal> storedRates = new Dictionary<(string, string, DateTime), decimal>();
+
+        _exchangeRateRepositoryMock
+            .Setup(x => x.GetRange("USD", "EUR", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(storedRates);
+
+        var firstProvider = new RecordingRangeProvider(date =>
+            date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday
+                ? new(CurrencyExchangeRateProviderStatus.NotFound)
+                : new(CurrencyExchangeRateProviderStatus.Failed));
+        var secondProvider = new RecordingRangeProvider(date =>
+            date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday
+                ? new(CurrencyExchangeRateProviderStatus.NotFound)
+                : new(CurrencyExchangeRateProviderStatus.Success, 1m + (date - dateStart).Days / 100m));
+        var service = CreateService([firstProvider, secondProvider]);
+
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, dateStart, dateEnd);
+
+        Assert.Equal(
+            [1m, null, null, 1.03m, 1.04m, 1.05m, 1.06m],
+            result.Select(x => x.Value));
+        Assert.Single(firstProvider.RangeCalls);
+        Assert.Single(secondProvider.RangeCalls);
+        Assert.Equal(0, firstProvider.SingleCallCount);
+        Assert.Equal(0, secondProvider.SingleCallCount);
     }
 
     private CurrencyExchangeService CreateService()
@@ -676,6 +699,38 @@ public class CurrencyExchangeServiceTests : IDisposable
             Func<TState, Exception?, string> formatter) =>
             Levels.Add(logLevel);
     }
+
+    private sealed class RecordingRangeProvider(
+        Func<DateTime, CurrencyExchangeRateProviderResult> resultFactory) : ICurrencyExchangeRateProvider
+    {
+        public List<(DateTime Start, DateTime End)> RangeCalls { get; } = [];
+
+        public int SingleCallCount { get; private set; }
+
+        public Task<CurrencyExchangeRateProviderResult> GetExchangeRateAsync(Currency fromCurrency, Currency toCurrency, DateTime date)
+        {
+            SingleCallCount++;
+            return Task.FromException<CurrencyExchangeRateProviderResult>(
+                new InvalidOperationException("The range test provider must not receive point lookups."));
+        }
+
+        public Task<List<(DateTime Date, CurrencyExchangeRateProviderResult Result)>> GetExchangeRateAsync(
+            Currency fromCurrency,
+            Currency toCurrency,
+            DateTime dateStart,
+            DateTime dateEnd)
+        {
+            var start = dateStart.Date;
+            var end = dateEnd.Date;
+            RangeCalls.Add((start, end));
+            List<(DateTime Date, CurrencyExchangeRateProviderResult Result)> results = [];
+            for (var date = start; date <= end; date = date.AddDays(1))
+                results.Add((date, resultFactory(date)));
+
+            return Task.FromResult(results);
+        }
+    }
+
     public void Dispose() => _httpClient?.Dispose();
     private void SetupHttpResponse(HttpStatusCode statusCode, string content)
     {

--- a/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
@@ -636,6 +636,70 @@ public class CurrencyExchangeServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetExchangeRateAsync_RangeWithSparseMissingDates_UsesSeparateBoundedProviderWindows()
+    {
+        var fromCurrency = new Currency(1, "USD", "$");
+        var toCurrency = new Currency(2, "EUR", "€");
+        var dateStart = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var dateEnd = dateStart.AddDays(360);
+        var missingDates = new[] { dateStart, dateStart.AddDays(200) };
+        IReadOnlyDictionary<(string From, string To, DateTime Date), decimal> storedRates =
+            Enumerable.Range(0, (dateEnd - dateStart).Days + 1)
+                .Select(dayOffset => dateStart.AddDays(dayOffset))
+                .Where(date => !missingDates.Contains(date))
+                .ToDictionary(date => ("USD", "EUR", date), _ => 1m);
+
+        _exchangeRateRepositoryMock
+            .Setup(x => x.GetRange("USD", "EUR", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(storedRates);
+        var provider = new RecordingRangeProvider(_ =>
+            new CurrencyExchangeRateProviderResult(CurrencyExchangeRateProviderStatus.Success, 0.915m));
+        var service = CreateService([provider]);
+
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, dateStart, dateEnd);
+
+        Assert.Equal(361, result.Count);
+        Assert.Equal(0.915m, result[0].Value);
+        Assert.Equal(0.915m, result[200].Value);
+        Assert.Equal(
+            [
+                (dateStart, dateStart),
+                (dateStart.AddDays(200), dateStart.AddDays(200)),
+            ],
+            provider.RangeCalls);
+        Assert.Equal(0, provider.SingleCallCount);
+    }
+
+    [Fact]
+    public async Task GetExchangeRateAsync_Range_DoesNotForwardFillCurrentUtcDayPastResolutionCap()
+    {
+        var todayUtc = DateTime.UtcNow.Date;
+        var dateStart = todayUtc.AddDays(-61);
+        var fromCurrency = new Currency(1, "USD", "$");
+        var toCurrency = new Currency(2, "EUR", "€");
+        IReadOnlyDictionary<(string From, string To, DateTime Date), decimal> storedRates =
+            new Dictionary<(string, string, DateTime), decimal>
+            {
+                { ("USD", "EUR", dateStart), 0.92m },
+            };
+
+        _exchangeRateRepositoryMock
+            .Setup(x => x.GetRange("USD", "EUR", It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(storedRates);
+        var provider = new RecordingRangeProvider(_ =>
+            new CurrencyExchangeRateProviderResult(CurrencyExchangeRateProviderStatus.Success, 0.915m));
+        var service = CreateService([provider]);
+
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, dateStart, todayUtc);
+
+        Assert.Equal(62, result.Count);
+        Assert.Equal(0.915m, result[^2].Value);
+        Assert.Null(result[^1].Value);
+        Assert.Equal((dateStart.AddDays(1), todayUtc.AddDays(-1)), Assert.Single(provider.RangeCalls));
+        Assert.Equal(0, provider.SingleCallCount);
+    }
+
+    [Fact]
     public async Task GetExchangeRateAsync_RangeUsesOrderedProviderFallbackAndPreservesMissingDays()
     {
         var fromCurrency = new Currency(1, "USD", "$");
@@ -705,6 +769,43 @@ public class CurrencyExchangeServiceTests : IDisposable
         Assert.Equal(3, fallbackProvider.RangeCalls.Count);
         Assert.Equal(0, outOfRangeProvider.SingleCallCount);
         Assert.Equal(0, fallbackProvider.SingleCallCount);
+    }
+
+    [Fact]
+    public async Task GetExchangeRateAsync_RangeUsdCross_DoesNotPersistDerivedRateAfterDirectFailure()
+    {
+        var fromCurrency = new Currency(1, "GBP", "£");
+        var toCurrency = new Currency(2, "PLN", "zł");
+        var date = new DateTime(2024, 3, 15);
+        IReadOnlyDictionary<(string From, string To, DateTime Date), decimal> storedRates = new Dictionary<(string, string, DateTime), decimal>();
+
+        _exchangeRateRepositoryMock
+            .Setup(x => x.GetRange(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(storedRates);
+
+        var provider = new RecordingRangeProvider((from, to, _) =>
+            from.ShortName == "GBP" && to.ShortName == "PLN"
+                ? new(CurrencyExchangeRateProviderStatus.Failed)
+                : from.ShortName == "GBP" && to.ShortName == "USD"
+                    ? new(CurrencyExchangeRateProviderStatus.Success, 1.25m)
+                    : new(CurrencyExchangeRateProviderStatus.Success, 4m));
+        var service = CreateService([provider]);
+
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, date, date);
+
+        Assert.Equal(5m, Assert.Single(result).Value);
+        _exchangeRateRepositoryMock.Verify(
+            x => x.AddRange(
+                "GBP",
+                "PLN",
+                It.IsAny<IReadOnlyCollection<(DateTime Date, decimal Rate)>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     private CurrencyExchangeService CreateService()

--- a/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/CurrencyExchangeServiceTests.cs
@@ -669,6 +669,44 @@ public class CurrencyExchangeServiceTests : IDisposable
         Assert.Equal(0, secondProvider.SingleCallCount);
     }
 
+    [Fact]
+    public async Task GetExchangeRateAsync_RangeOutOfRangeProvider_IsNotRetriedForUsdCross()
+    {
+        var fromCurrency = new Currency(1, "GBP", "£");
+        var toCurrency = new Currency(2, "PLN", "zł");
+        var date = new DateTime(2024, 3, 15);
+        IReadOnlyDictionary<(string From, string To, DateTime Date), decimal> storedRates = new Dictionary<(string, string, DateTime), decimal>();
+
+        _exchangeRateRepositoryMock
+            .Setup(x => x.GetRange(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<DateTime>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(storedRates);
+
+        var outOfRangeProvider = new RecordingRangeProvider((from, to, _) =>
+            from.ShortName == "GBP" && to.ShortName == "PLN"
+                ? new(CurrencyExchangeRateProviderStatus.OutOfRange)
+                : new(CurrencyExchangeRateProviderStatus.Success, 1m));
+        var fallbackProvider = new RecordingRangeProvider((from, to, _) =>
+            from.ShortName == "GBP" && to.ShortName == "PLN"
+                ? new(CurrencyExchangeRateProviderStatus.NotFound)
+                : from.ShortName == "GBP" && to.ShortName == "USD"
+                    ? new(CurrencyExchangeRateProviderStatus.Success, 1.25m)
+                    : new(CurrencyExchangeRateProviderStatus.Success, 4m));
+        var service = CreateService([outOfRangeProvider, fallbackProvider]);
+
+        var result = await service.GetExchangeRateAsync(fromCurrency, toCurrency, date, date);
+
+        Assert.Equal(5m, Assert.Single(result).Value);
+        Assert.Single(outOfRangeProvider.RangeCalls);
+        Assert.Equal(3, fallbackProvider.RangeCalls.Count);
+        Assert.Equal(0, outOfRangeProvider.SingleCallCount);
+        Assert.Equal(0, fallbackProvider.SingleCallCount);
+    }
+
     private CurrencyExchangeService CreateService()
     {
         ICurrencyExchangeRateProvider[] providers = [CreateProvider()];
@@ -700,9 +738,18 @@ public class CurrencyExchangeServiceTests : IDisposable
             Levels.Add(logLevel);
     }
 
-    private sealed class RecordingRangeProvider(
-        Func<DateTime, CurrencyExchangeRateProviderResult> resultFactory) : ICurrencyExchangeRateProvider
+    private sealed class RecordingRangeProvider : ICurrencyExchangeRateProvider
     {
+        private readonly Func<Currency, Currency, DateTime, CurrencyExchangeRateProviderResult> _resultFactory;
+
+        public RecordingRangeProvider(Func<DateTime, CurrencyExchangeRateProviderResult> resultFactory)
+            : this((_, _, date) => resultFactory(date))
+        {
+        }
+
+        public RecordingRangeProvider(Func<Currency, Currency, DateTime, CurrencyExchangeRateProviderResult> resultFactory) =>
+            _resultFactory = resultFactory;
+
         public List<(DateTime Start, DateTime End)> RangeCalls { get; } = [];
 
         public int SingleCallCount { get; private set; }
@@ -725,7 +772,7 @@ public class CurrencyExchangeServiceTests : IDisposable
             RangeCalls.Add((start, end));
             List<(DateTime Date, CurrencyExchangeRateProviderResult Result)> results = [];
             for (var date = start; date <= end; date = date.AddDays(1))
-                results.Add((date, resultFactory(date)));
+                results.Add((date, _resultFactory(fromCurrency, toCurrency, date)));
 
             return Task.FromResult(results);
         }

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Features/FinancialAccounts/Currencies/Providers/NbpCurrencyExchangeRateProviderTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Features/FinancialAccounts/Currencies/Providers/NbpCurrencyExchangeRateProviderTests.cs
@@ -25,7 +25,7 @@ public class NbpCurrencyExchangeRateProviderTests
         {"table":"A","currency":"dolar amerykański","code":"USD","rates":[{"no":"1/A/NBP/2024","effectiveDate":"2024-01-02","mid":4.0000},{"no":"2/A/NBP/2024","effectiveDate":"2024-01-03","mid":4.1000}]}
         """;
 
-    private static NbpCurrencyExchangeRateProvider CreateProvider(MockHttpMessageHandler handler, bool enabled = true) =>
+    private static NbpCurrencyExchangeRateProvider CreateProvider(HttpMessageHandler handler, bool enabled = true) =>
         new(new HttpClient(handler),
             Options.Create(new NbpOptions { BaseUrl = "https://api.nbp.pl/api", Enabled = enabled }),
             NullLogger<NbpCurrencyExchangeRateProvider>.Instance);
@@ -129,6 +129,26 @@ public class NbpCurrencyExchangeRateProviderTests
     }
 
     [Fact]
+    public async Task Range_UsesSequentialRequestsWithinTheConfiguredChunkLimit()
+    {
+        var handler = new TrackingHttpMessageHandler();
+        var provider = CreateProvider(handler);
+
+        var results = await provider.GetExchangeRateAsync(_usd, _pln, _date, _date.AddDays(360));
+
+        Assert.Equal(361, results.Count);
+        Assert.Equal(3, handler.RequestUris.Count);
+        Assert.Equal(1, handler.MaxConcurrency);
+        Assert.Equal(
+            [
+                "/api/exchangerates/rates/a/USD/2024-01-02/2024-06-29/",
+                "/api/exchangerates/rates/a/USD/2024-06-30/2024-12-26/",
+                "/api/exchangerates/rates/a/USD/2024-12-27/2024-12-27/",
+            ],
+            handler.RequestUris.Select(uri => uri.AbsolutePath));
+    }
+
+    [Fact]
     public async Task Range_Disabled_PlnToPln_ReturnsNotFound_WithoutCallingApi()
     {
         var handler = new MockHttpMessageHandler(_ => Ok(_usdRangeResponse));
@@ -152,6 +172,37 @@ public class NbpCurrencyExchangeRateProviderTests
         {
             CallCount++;
             return Task.FromResult(responder(request));
+        }
+    }
+
+    private sealed class TrackingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly object _gate = new();
+        private int _activeRequests;
+
+        public List<Uri> RequestUris { get; } = [];
+
+        public int MaxConcurrency { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            lock (_gate)
+            {
+                RequestUris.Add(request.RequestUri!);
+                _activeRequests++;
+                MaxConcurrency = Math.Max(MaxConcurrency, _activeRequests);
+            }
+
+            try
+            {
+                await Task.Delay(1, cancellationToken);
+                return new(HttpStatusCode.OK) { Content = new StringContent(_usdMidResponse) };
+            }
+            finally
+            {
+                lock (_gate)
+                    _activeRequests--;
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #728

## Summary
- resolve missing historical rates through provider range APIs in bounded 180-day windows
- preserve provider ordering, fallback outcomes, inverse-rate reuse, direct-rate bulk persistence, and missing-day/current-day behavior
- carry per-date out-of-range provider state through USD fallback so unsupported providers are not retried
- keep NBP range requests sequential and covered by regression tests
- keep derived USD-cross rates request-scoped so transient direct-provider failures can retry authoritative pairs

## Validation
- `LC_ALL=en_US.UTF-8 dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj` (985 passed)
- `LC_ALL=en_US.UTF-8 dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --filter-class FinanceManager.Tests.Unit.Application.Services.CurrencyExchangeServiceTests` (29 passed)
- `LC_ALL=en_US.UTF-8 dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --filter-class FinanceManager.Tests.Unit.Infrastructure.Features.FinancialAccounts.Currencies.Providers.NbpCurrencyExchangeRateProviderTests` (10 passed)
- `LC_ALL=en_US.UTF-8 dotnet test --project ./FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj --filter-class FinanceManager.Tests.Integration.ServiceDefaults.NbpResilienceRegistrationTests` (3 passed)
- `dotnet build ./code/FinanceManager.slnx --no-restore` (0 warnings, 0 errors)
- `dotnet format ./code/FinanceManager.slnx --verify-no-changes`
- Remote workflow run #1207: build, unit, integration, architecture, code quality, security, and CodeRabbit checks green; publish/deploy skipped for PR