### PR TITLE
Optimize recent currency and bond transaction queries

### DIFF
--- a/code/FinanceManager.Application/Dashboard/TransactionLogService.cs
+++ b/code/FinanceManager.Application/Dashboard/TransactionLogService.cs
@@ -17,8 +17,8 @@ namespace FinanceManager.Application.Dashboard;
 /// account of every type (currency, bond, investment) and interleaving them into a
 /// single newest-first list. The underlying repositories share a scoped EF Core
 /// DbContext, which allows only one active query at a time — so each account stream
-/// is fully buffered before the per-account entry queries run, and everything is
-/// awaited sequentially.
+/// is fully buffered before the bounded entry queries run, and everything is awaited
+/// sequentially.
 /// </summary>
 public class TransactionLogService(
     ICurrencyAccountRepository<CurrencyAccount> currencyAccountRepository,
@@ -37,22 +37,39 @@ public class TransactionLogService(
 
         List<TransactionLogEntryDto> result = [];
 
-        foreach (var account in await BufferAccounts(currencyAccountRepository.GetAvailableAccounts(userId), cancellationToken))
+        var currencyAccounts = await BufferAccounts(currencyAccountRepository.GetAvailableAccounts(userId), cancellationToken);
+        if (currencyAccounts.Count != 0)
         {
-            var entries = await currencyEntryRepository.Get(account.AccountId, DateTime.MaxValue, count);
+            var currencyAccountNames = currencyAccounts.ToDictionary(a => a.AccountId, a => a.AccountName);
+            var entries = await currencyEntryRepository.GetMostRecentByAccounts(
+                [.. currencyAccountNames.Keys], count, cancellationToken);
+
             result.AddRange(entries.Select(e => new TransactionLogEntryDto(
-                account.AccountId, account.AccountName, AccountType.Currency, e.EntryId, e.PostingDate, e.ValueChange, GetCurrencyDescription(e))));
+                e.AccountId,
+                currencyAccountNames[e.AccountId],
+                AccountType.Currency,
+                e.EntryId,
+                e.PostingDate,
+                e.ValueChange,
+                GetCurrencyDescription(e))));
         }
 
-        foreach (var account in await BufferAccounts(bondAccountRepository.GetAvailableAccounts(userId), cancellationToken))
+        var bondAccounts = await BufferAccounts(bondAccountRepository.GetAvailableAccounts(userId), cancellationToken);
+        if (bondAccounts.Count != 0)
         {
-            var entries = await bondEntryRepository.Get(account.AccountId, DateTime.MaxValue, count);
-            foreach (var entry in entries)
-            {
-                var description = await GetBondDescription(entry, cancellationToken);
-                result.Add(new TransactionLogEntryDto(
-                    account.AccountId, account.AccountName, AccountType.Bond, entry.EntryId, entry.PostingDate, entry.ValueChange, description));
-            }
+            var bondAccountNames = bondAccounts.ToDictionary(a => a.AccountId, a => a.AccountName);
+            var entries = await bondEntryRepository.GetMostRecentByAccounts(
+                [.. bondAccountNames.Keys], count, cancellationToken);
+            var bondNames = await GetBondNames(entries, cancellationToken);
+
+            result.AddRange(entries.Select(e => new TransactionLogEntryDto(
+                e.AccountId,
+                bondAccountNames[e.AccountId],
+                AccountType.Bond,
+                e.EntryId,
+                e.PostingDate,
+                e.ValueChange,
+                bondNames.TryGetValue(e.BondDetailsId, out var name) && name is not null ? name : "Bond")));
         }
 
         Dictionary<int, string> investmentAccounts = [];
@@ -95,14 +112,23 @@ public class TransactionLogService(
     private static string GetInvestmentDescription(InvestmentTransaction transaction) =>
         $"{transaction.Type} {transaction.Quantity:0.####} {transaction.AssetListing?.Ticker}".TrimEnd();
 
-    private async Task<string> GetBondDescription(BondAccountEntry entry, CancellationToken cancellationToken)
+    private async Task<IReadOnlyDictionary<int, string?>> GetBondNames(
+        IReadOnlyList<BondAccountEntry> entries,
+        CancellationToken cancellationToken)
     {
-        if (!_bondNamesCache.TryGetValue(entry.BondDetailsId, out var name))
+        var missingIds = entries
+            .Select(entry => entry.BondDetailsId)
+            .Distinct()
+            .Where(id => !_bondNamesCache.ContainsKey(id))
+            .ToList();
+
+        if (missingIds.Count != 0)
         {
-            name = (await bondDetailsRepository.GetByIdAsync(entry.BondDetailsId, cancellationToken))?.Name;
-            _bondNamesCache[entry.BondDetailsId] = name;
+            var names = await bondDetailsRepository.GetNamesByIdsAsync(missingIds, cancellationToken);
+            foreach (var id in missingIds)
+                _bondNamesCache[id] = names.TryGetValue(id, out var name) ? name : null;
         }
 
-        return name ?? "Bond";
+        return _bondNamesCache;
     }
 }

--- a/code/FinanceManager.Domain/FinancialAccounts/Bond/Repositories/IBondDetailsRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Bond/Repositories/IBondDetailsRepository.cs
@@ -5,6 +5,11 @@ namespace FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
 public interface IBondDetailsRepository
 {
     Task<BondDetails?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Resolves bond names for a set of ids in one query. Missing ids are omitted so callers can retain
+    /// the dashboard's existing fallback description for deleted bond details.
+    /// </summary>
+    Task<IReadOnlyDictionary<int, string>> GetNamesByIdsAsync(IReadOnlyCollection<int> ids, CancellationToken cancellationToken = default);
     IAsyncEnumerable<BondDetails> GetAllAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<BondDetails>> GetByIssuerAsync(string issuer, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<string>> GetIssuersAsync(CancellationToken cancellationToken = default);

--- a/code/FinanceManager.Domain/FinancialAccounts/Shared/Repositories/IAccountEntryRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Shared/Repositories/IAccountEntryRepository.cs
@@ -23,7 +23,8 @@ public interface IAccountEntryRepository<T>
     Task<IReadOnlyList<T>> GetByIds(IReadOnlyCollection<int> entryIds, CancellationToken cancellationToken = default);
     /// <summary>
     /// Returns the most recent <paramref name="count"/> entries across the supplied accounts in one
-    /// bounded database query, ordered by posting date descending and entry id descending.
+    /// bounded database query, ordered by posting date descending and entry id descending. Implementations
+    /// may project the returned entities to the scalar fields needed by the recent-activity consumer.
     /// </summary>
     Task<IReadOnlyList<T>> GetMostRecentByAccounts(IReadOnlyCollection<int> accountIds, int count, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<T>> GetRecentUnlabelled(int count, CancellationToken cancellationToken = default);

--- a/code/FinanceManager.Domain/FinancialAccounts/Shared/Repositories/IAccountEntryRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Shared/Repositories/IAccountEntryRepository.cs
@@ -21,6 +21,11 @@ public interface IAccountEntryRepository<T>
     Task<(List<T> Entries, DateTime EffectiveStartDate)> GetEntriesWithMinimumCount(int accountId, DateTime startDate, DateTime endDate, int minimumEntryCount = 0);
     Task<T?> Get(int accountId, int entryId);
     Task<IReadOnlyList<T>> GetByIds(IReadOnlyCollection<int> entryIds, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Returns the most recent <paramref name="count"/> entries across the supplied accounts in one
+    /// bounded database query, ordered by posting date descending and entry id descending.
+    /// </summary>
+    Task<IReadOnlyList<T>> GetMostRecentByAccounts(IReadOnlyCollection<int> accountIds, int count, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<T>> GetRecentUnlabelled(int count, CancellationToken cancellationToken = default);
     Task<T?> GetYoungest(int accountId);
     Task<T?> GetNextYounger(int accountId, int entryId);

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondDetailsRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondDetailsRepository.cs
@@ -32,6 +32,19 @@ internal class BondDetailsRepository(AppDbContext context) : IBondDetailsReposit
     public async Task<BondDetails?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
         => await context.Bonds.Include(b => b.CalculationMethods).FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
 
+    public async Task<IReadOnlyDictionary<int, string>> GetNamesByIdsAsync(
+        IReadOnlyCollection<int> ids,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids.Count == 0)
+            return new Dictionary<int, string>();
+
+        return await context.Bonds
+            .AsNoTracking()
+            .Where(b => ids.Contains(b.Id))
+            .ToDictionaryAsync(b => b.Id, b => b.Name, cancellationToken);
+    }
+
     public async Task<IReadOnlyList<BondDetails>> GetByIssuerAsync(string issuer, CancellationToken cancellationToken = default)
         => await context.Bonds.Include(b => b.CalculationMethods).Where(x => x.Issuer == issuer).ToListAsync(cancellationToken);
 

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondEntryRepository.cs
@@ -10,6 +10,10 @@ namespace FinanceManager.Infrastructure.Features.FinancialAccounts.Bond.Reposito
 
 public class BondEntryRepository(AppDbContext context) : IBondAccountEntryRepository<BondAccountEntry>
 {
+    // SQL Server permits at most 2,100 parameters per command. Keep room for the Take parameter and
+    // future predicates when a user has an unusually large number of accounts.
+    private const int _maxAccountIdsPerQuery = 2_000;
+
     private readonly BondEntryValueCalculator _valueCalculator = new(context);
     public Task<bool> Add(BondAccountEntry entry, bool recalculate) =>
         Add(entry, recalculate, CancellationToken.None);
@@ -476,13 +480,25 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
         if (accountIds.Count == 0 || count <= 0)
             return [];
 
-        return await context.BondEntries
-            .AsNoTracking()
-            .Where(e => accountIds.Contains(e.AccountId))
+        List<BondAccountEntry> results = [];
+        foreach (var accountIdChunk in accountIds.Distinct().Chunk(_maxAccountIdsPerQuery))
+        {
+            results.AddRange(await context.BondEntries
+                .AsNoTracking()
+                .Where(e => accountIdChunk.Contains(e.AccountId))
+                .OrderByDescending(e => e.PostingDate)
+                .ThenByDescending(e => e.EntryId)
+                // The dashboard only needs account, ordering, value-change, and bond id fields.
+                .Select(e => new BondAccountEntry(e.AccountId, e.EntryId, e.PostingDate, 0, e.ValueChange, e.BondDetailsId))
+                .Take(count)
+                .ToListAsync(cancellationToken));
+        }
+
+        return results
             .OrderByDescending(e => e.PostingDate)
             .ThenByDescending(e => e.EntryId)
             .Take(count)
-            .ToListAsync(cancellationToken);
+            .ToList();
     }
 
     public Task<IReadOnlyList<BondAccountEntry>> GetRecentUnlabelled(int count, CancellationToken cancellationToken = default) =>

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondEntryRepository.cs
@@ -468,6 +468,23 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<IReadOnlyList<BondAccountEntry>> GetMostRecentByAccounts(
+        IReadOnlyCollection<int> accountIds,
+        int count,
+        CancellationToken cancellationToken = default)
+    {
+        if (accountIds.Count == 0 || count <= 0)
+            return [];
+
+        return await context.BondEntries
+            .AsNoTracking()
+            .Where(e => accountIds.Contains(e.AccountId))
+            .OrderByDescending(e => e.PostingDate)
+            .ThenByDescending(e => e.EntryId)
+            .Take(count)
+            .ToListAsync(cancellationToken);
+    }
+
     public Task<IReadOnlyList<BondAccountEntry>> GetRecentUnlabelled(int count, CancellationToken cancellationToken = default) =>
         Task.FromResult<IReadOnlyList<BondAccountEntry>>([]);
 

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Repositories/CurrencyEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Repositories/CurrencyEntryRepository.cs
@@ -526,6 +526,23 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
             .ToListAsync(cancellationToken);
     }
 
+    public async Task<IReadOnlyList<CurrencyAccountEntry>> GetMostRecentByAccounts(
+        IReadOnlyCollection<int> accountIds,
+        int count,
+        CancellationToken cancellationToken = default)
+    {
+        if (accountIds.Count == 0 || count <= 0)
+            return [];
+
+        return await context.CurrencyEntries
+            .AsNoTracking()
+            .Where(e => accountIds.Contains(e.AccountId))
+            .OrderByDescending(e => e.PostingDate)
+            .ThenByDescending(e => e.EntryId)
+            .Take(count)
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<IReadOnlyList<CurrencyAccountEntry>> GetRecentUnlabelled(int count, CancellationToken cancellationToken = default)
     {
         if (count <= 0) return [];

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Repositories/CurrencyEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Repositories/CurrencyEntryRepository.cs
@@ -9,6 +9,10 @@ namespace FinanceManager.Infrastructure.Features.FinancialAccounts.Currencies.Re
 
 public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryRepository<CurrencyAccountEntry>
 {
+    // SQL Server permits at most 2,100 parameters per command. Keep room for the Take parameter and
+    // future predicates when a user has an unusually large number of accounts.
+    private const int _maxAccountIdsPerQuery = 2_000;
+
     private readonly CurrencyEntryValueCalculator _valueCalculator = new(context);
     public Task<bool> Add(CurrencyAccountEntry entry, bool recalculate) =>
         Add(entry, recalculate, CancellationToken.None);
@@ -534,13 +538,30 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
         if (accountIds.Count == 0 || count <= 0)
             return [];
 
-        return await context.CurrencyEntries
-            .AsNoTracking()
-            .Where(e => accountIds.Contains(e.AccountId))
+        List<CurrencyAccountEntry> results = [];
+        foreach (var accountIdChunk in accountIds.Distinct().Chunk(_maxAccountIdsPerQuery))
+        {
+            results.AddRange(await context.CurrencyEntries
+                .AsNoTracking()
+                .Where(e => accountIdChunk.Contains(e.AccountId))
+                .OrderByDescending(e => e.PostingDate)
+                .ThenByDescending(e => e.EntryId)
+                // The dashboard does not need Value or labels for this read. Materialise only the
+                // account, ordering, value-change, and description fields it projects into its DTO.
+                .Select(e => new CurrencyAccountEntry(e.AccountId, e.EntryId, e.PostingDate, 0, e.ValueChange)
+                {
+                    Description = e.Description,
+                    ContractorDetails = e.ContractorDetails,
+                })
+                .Take(count)
+                .ToListAsync(cancellationToken));
+        }
+
+        return results
             .OrderByDescending(e => e.PostingDate)
             .ThenByDescending(e => e.EntryId)
             .Take(count)
-            .ToListAsync(cancellationToken);
+            .ToList();
     }
 
     public async Task<IReadOnlyList<CurrencyAccountEntry>> GetRecentUnlabelled(int count, CancellationToken cancellationToken = default)

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Shared/Repositories/CachedAccountEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Shared/Repositories/CachedAccountEntryRepository.cs
@@ -195,6 +195,7 @@ public class CachedAccountEntryRepository<T>(
 
     public Task<T?> Get(int accountId, int entryId) => inner.Get(accountId, entryId);
     public Task<IReadOnlyList<T>> GetByIds(IReadOnlyCollection<int> entryIds, CancellationToken cancellationToken = default) => inner.GetByIds(entryIds, cancellationToken);
+    public Task<IReadOnlyList<T>> GetMostRecentByAccounts(IReadOnlyCollection<int> accountIds, int count, CancellationToken cancellationToken = default) => inner.GetMostRecentByAccounts(accountIds, count, cancellationToken);
     public Task<IReadOnlyList<T>> GetRecentUnlabelled(int count, CancellationToken cancellationToken = default) => inner.GetRecentUnlabelled(count, cancellationToken);
     public Task<T?> GetNextYounger(int accountId, int entryId) => inner.GetNextYounger(accountId, entryId);
     public Task<T?> GetNextYounger(int accountId, DateTime date) =>

--- a/code/FinanceManager.Tests.Integration/Repositories/SqliteRecentEntriesTests.cs
+++ b/code/FinanceManager.Tests.Integration/Repositories/SqliteRecentEntriesTests.cs
@@ -23,6 +23,7 @@ public sealed class SqliteRecentEntriesTests : IDisposable
     private readonly CommandCounter _commands = new();
     private readonly AppDbContext _context;
 
+    // Explicit setup keeps connection opening, context creation, and EnsureCreated in deterministic order.
     public SqliteRecentEntriesTests()
     {
         _connection = new SqliteConnection("DataSource=:memory:");
@@ -32,6 +33,44 @@ public sealed class SqliteRecentEntriesTests : IDisposable
             .AddInterceptors(_commands)
             .Options);
         _context.Database.EnsureCreated();
+    }
+
+    [Fact]
+    public async Task CurrencyRecentRead_FiltersAndOrdersAcrossAccounts()
+    {
+        _context.CurrencyEntries.AddRange(
+            new CurrencyAccountEntry(1, 10, new DateTime(2024, 3, 1), 100, 1),
+            new CurrencyAccountEntry(2, 11, new DateTime(2024, 3, 3), 100, 1),
+            new CurrencyAccountEntry(1, 12, new DateTime(2024, 3, 2), 100, 1),
+            new CurrencyAccountEntry(3, 13, new DateTime(2024, 3, 4), 100, 1));
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        _commands.Reset();
+
+        var result = await new CurrencyEntryRepository(_context)
+            .GetMostRecentByAccounts([1, 2], 2, TestContext.Current.CancellationToken);
+
+        Assert.Equal([11, 12], result.Select(entry => entry.EntryId));
+        Assert.All(result, entry => Assert.Equal(0, entry.Value));
+        Assert.Equal(1, _commands.Count);
+    }
+
+    [Fact]
+    public async Task BondRecentRead_FiltersAndOrdersAcrossAccounts()
+    {
+        _context.BondEntries.AddRange(
+            new BondAccountEntry(1, 10, new DateTime(2024, 3, 1), 100, 1, 7),
+            new BondAccountEntry(2, 11, new DateTime(2024, 3, 3), 100, 1, 7),
+            new BondAccountEntry(1, 12, new DateTime(2024, 3, 2), 100, 1, 7),
+            new BondAccountEntry(3, 13, new DateTime(2024, 3, 4), 100, 1, 7));
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        _commands.Reset();
+
+        var result = await new BondEntryRepository(_context)
+            .GetMostRecentByAccounts([1, 2], 2, TestContext.Current.CancellationToken);
+
+        Assert.Equal([11, 12], result.Select(entry => entry.EntryId));
+        Assert.All(result, entry => Assert.Equal(0, entry.Value));
+        Assert.Equal(1, _commands.Count);
     }
 
     [Theory]
@@ -60,10 +99,17 @@ public sealed class SqliteRecentEntriesTests : IDisposable
         await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
         _commands.Reset();
 
-        var result = await new CurrencyEntryRepository(_context)
+        var repository = new CurrencyEntryRepository(_context);
+        var result = await repository
+            .GetMostRecentByAccounts(accountIds, 3, TestContext.Current.CancellationToken);
+        var coldQueryCount = _commands.Count;
+        _commands.Reset();
+        var warmResult = await repository
             .GetMostRecentByAccounts(accountIds, 3, TestContext.Current.CancellationToken);
 
         Assert.Equal(Math.Min(3, accountCount * 2), result.Count);
+        Assert.Equal(result.Select(entry => entry.EntryId), warmResult.Select(entry => entry.EntryId));
+        Assert.Equal(1, coldQueryCount);
         Assert.Equal(1, _commands.Count);
     }
 
@@ -95,11 +141,43 @@ public sealed class SqliteRecentEntriesTests : IDisposable
         await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
         _commands.Reset();
 
-        var result = await new BondEntryRepository(_context)
+        var repository = new BondEntryRepository(_context);
+        var result = await repository
+            .GetMostRecentByAccounts(accountIds, 3, TestContext.Current.CancellationToken);
+        var coldQueryCount = _commands.Count;
+        _commands.Reset();
+        var warmResult = await repository
             .GetMostRecentByAccounts(accountIds, 3, TestContext.Current.CancellationToken);
 
         Assert.Equal(Math.Min(3, accountCount * 2), result.Count);
+        Assert.Equal(result.Select(entry => entry.EntryId), warmResult.Select(entry => entry.EntryId));
+        Assert.Equal(1, coldQueryCount);
         Assert.Equal(1, _commands.Count);
+    }
+
+    [Fact]
+    public async Task CurrencyRecentRead_ChunksAccountIdsBeyondSqlServerParameterLimit()
+    {
+        const int accountCount = 2_001;
+        var accountIds = Enumerable.Range(1, accountCount).ToArray();
+        foreach (var accountId in accountIds)
+        {
+            _context.CurrencyEntries.Add(new CurrencyAccountEntry(
+                accountId,
+                0,
+                new DateTime(2024, 2, 1, 0, 0, 0, DateTimeKind.Utc),
+                100,
+                accountId));
+        }
+
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        _commands.Reset();
+
+        var result = await new CurrencyEntryRepository(_context)
+            .GetMostRecentByAccounts(accountIds, 2, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(2, _commands.Count);
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Integration/Repositories/SqliteRecentEntriesTests.cs
+++ b/code/FinanceManager.Tests.Integration/Repositories/SqliteRecentEntriesTests.cs
@@ -1,0 +1,160 @@
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Infrastructure.Features.FinancialAccounts.Bond.Repositories;
+using FinanceManager.Infrastructure.Features.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Infrastructure.Persistence;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using System.Data.Common;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Repositories;
+
+/// <summary>
+/// Verifies that recent currency and bond reads stay at one bounded relational command as the number
+/// of accounts grows. The dashboard account stream supplies the ownership boundary before it invokes
+/// these repository methods; the repository query itself is deliberately limited to those ids.
+/// </summary>
+[Trait("Category", "Integration")]
+public sealed class SqliteRecentEntriesTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly CommandCounter _commands = new();
+    private readonly AppDbContext _context;
+
+    public SqliteRecentEntriesTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        _context = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(_connection)
+            .AddInterceptors(_commands)
+            .Options);
+        _context.Database.EnsureCreated();
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(100)]
+    public async Task CurrencyRecentRead_UsesOneBoundedQuery(int accountCount)
+    {
+        var accountIds = Enumerable.Range(1, accountCount).ToArray();
+        foreach (var accountId in accountIds)
+        {
+            _context.CurrencyEntries.Add(new CurrencyAccountEntry(
+                accountId,
+                0,
+                new DateTime(2024, 1, accountId % 28 + 1, 0, 0, 0, DateTimeKind.Utc),
+                100,
+                accountId));
+            _context.CurrencyEntries.Add(new CurrencyAccountEntry(
+                accountId,
+                0,
+                new DateTime(2024, 2, accountId % 28 + 1, 0, 0, 0, DateTimeKind.Utc),
+                100,
+                accountId));
+        }
+
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        _commands.Reset();
+
+        var result = await new CurrencyEntryRepository(_context)
+            .GetMostRecentByAccounts(accountIds, 3, TestContext.Current.CancellationToken);
+
+        Assert.Equal(Math.Min(3, accountCount * 2), result.Count);
+        Assert.Equal(1, _commands.Count);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(10)]
+    [InlineData(100)]
+    public async Task BondRecentRead_UsesOneBoundedQuery(int accountCount)
+    {
+        var accountIds = Enumerable.Range(1, accountCount).ToArray();
+        foreach (var accountId in accountIds)
+        {
+            _context.BondEntries.Add(new BondAccountEntry(
+                accountId,
+                0,
+                new DateTime(2024, 1, accountId % 28 + 1, 0, 0, 0, DateTimeKind.Utc),
+                100,
+                accountId,
+                1));
+            _context.BondEntries.Add(new BondAccountEntry(
+                accountId,
+                0,
+                new DateTime(2024, 2, accountId % 28 + 1, 0, 0, 0, DateTimeKind.Utc),
+                100,
+                accountId,
+                1));
+        }
+
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        _commands.Reset();
+
+        var result = await new BondEntryRepository(_context)
+            .GetMostRecentByAccounts(accountIds, 3, TestContext.Current.CancellationToken);
+
+        Assert.Equal(Math.Min(3, accountCount * 2), result.Count);
+        Assert.Equal(1, _commands.Count);
+    }
+
+    [Fact]
+    public async Task BondNameRead_UsesOneQueryAndOmitsMissingDetails()
+    {
+        var bond = new BondDetails(
+            "EDO0134",
+            "Treasury",
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2034, 12, 31),
+            [],
+            currency: DefaultCurrency.PLN);
+        _context.Bonds.Add(bond);
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        _commands.Reset();
+
+        var result = await new BondDetailsRepository(_context)
+            .GetNamesByIdsAsync([bond.Id, bond.Id + 1000], TestContext.Current.CancellationToken);
+
+        Assert.Equal("EDO0134", result[bond.Id]);
+        Assert.DoesNotContain(bond.Id + 1000, result.Keys);
+        Assert.Equal(1, _commands.Count);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    private sealed class CommandCounter : DbCommandInterceptor
+    {
+        private int _count;
+
+        public int Count => Volatile.Read(ref _count);
+
+        public void Reset() => Interlocked.Exchange(ref _count, 0);
+
+        public override InterceptionResult<DbDataReader> ReaderExecuting(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result)
+        {
+            Interlocked.Increment(ref _count);
+            return result;
+        }
+
+        public override ValueTask<InterceptionResult<DbDataReader>> ReaderExecutingAsync(
+            DbCommand command,
+            CommandEventData eventData,
+            InterceptionResult<DbDataReader> result,
+            CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref _count);
+            return ValueTask.FromResult(result);
+        }
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/TransactionLogServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/TransactionLogServiceTests.cs
@@ -54,8 +54,10 @@ public class TransactionLogServiceTests
         ]);
 
         SetupBondAccount(accountId: 20, "Bonds", [new BondAccountEntry(20, 3, new DateTime(2024, 3, 3), 10, 10, bondDetailsId: 7)]);
-        _bondDetailsRepository.Setup(r => r.GetByIdAsync(7, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BondDetails("EDO0134", "Treasury", new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31), []));
+        _bondDetailsRepository.Setup(r => r.GetNamesByIdsAsync(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(7)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, string> { [7] = "EDO0134" });
 
         SetupInvestmentAccount(accountId: 30, "Broker", [new InvestmentTransaction
         {
@@ -148,6 +150,60 @@ public class TransactionLogServiceTests
     }
 
     [Fact]
+    public async Task GetLastTransactions_BatchesBondNameResolution_AndFallsBackForMissingDetails()
+    {
+        SetupBondAccount(accountId: 20, "Bonds", [
+            new BondAccountEntry(20, 2, new DateTime(2024, 3, 2), 10, 10, bondDetailsId: 8),
+            new BondAccountEntry(20, 1, new DateTime(2024, 3, 1), 10, 10, bondDetailsId: 7),
+        ]);
+        _bondDetailsRepository.Setup(r => r.GetNamesByIdsAsync(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 2 && ids.Contains(7) && ids.Contains(8)),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, string> { [7] = "EDO0134" });
+
+        var result = await _service.GetLastTransactions(_userId, 10, TestContext.Current.CancellationToken);
+
+        Assert.Equal(["Bond", "EDO0134"], result.Select(entry => entry.Description));
+        _bondDetailsRepository.Verify(r => r.GetNamesByIdsAsync(
+            It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 2 && ids.Contains(7) && ids.Contains(8)),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _bondDetailsRepository.Verify(r => r.GetByIdAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetLastTransactions_PassesOnlyAvailableAccountIdsToBatchQueries()
+    {
+        _currencyAccountRepository.Setup(r => r.GetAvailableAccounts(_userId))
+            .Returns(ToAsyncEnumerable([
+                new AvailableAccount(10, "Bank"),
+                new AvailableAccount(11, "Savings"),
+            ]));
+        _bondAccountRepository.Setup(r => r.GetAvailableAccounts(_userId))
+            .Returns(ToAsyncEnumerable([new AvailableAccount(20, "Bonds")]));
+        _currencyEntryRepository.Setup(r => r.GetMostRecentByAccounts(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 2 && ids.Contains(10) && ids.Contains(11)),
+                3,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _bondEntryRepository.Setup(r => r.GetMostRecentByAccounts(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(20)),
+                3,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        await _service.GetLastTransactions(_userId, 3, TestContext.Current.CancellationToken);
+
+        _currencyEntryRepository.Verify(r => r.GetMostRecentByAccounts(
+            It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 2 && ids.Contains(10) && ids.Contains(11)),
+            3,
+            It.IsAny<CancellationToken>()), Times.Once);
+        _bondEntryRepository.Verify(r => r.GetMostRecentByAccounts(
+            It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(20)),
+            3,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task GetLastTransactions_DoesNotQueryEntries_WhileAccountStreamIsStillOpen()
     {
         // A scoped EF Core DbContext allows only one active query: issuing an entry
@@ -158,13 +214,19 @@ public class TransactionLogServiceTests
 
         _currencyAccountRepository.Setup(r => r.GetAvailableAccounts(_userId))
             .Returns(TrackedAsyncEnumerable([new AvailableAccount(10, "Bank")], currencyStreamOpen));
-        _currencyEntryRepository.Setup(r => r.Get(10, It.IsAny<DateTime>(), It.IsAny<int>(), true))
+        _currencyEntryRepository.Setup(r => r.GetMostRecentByAccounts(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(10)),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
             .Callback(() => Assert.False(currencyStreamOpen.Value, "Entry query issued while the currency accounts stream was still open."))
             .ReturnsAsync([]);
 
         _bondAccountRepository.Setup(r => r.GetAvailableAccounts(_userId))
             .Returns(TrackedAsyncEnumerable([new AvailableAccount(20, "Bonds")], bondStreamOpen));
-        _bondEntryRepository.Setup(r => r.Get(20, It.IsAny<DateTime>(), It.IsAny<int>(), true))
+        _bondEntryRepository.Setup(r => r.GetMostRecentByAccounts(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(20)),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
             .Callback(() => Assert.False(bondStreamOpen.Value, "Entry query issued while the bond accounts stream was still open."))
             .ReturnsAsync([]);
 
@@ -173,15 +235,24 @@ public class TransactionLogServiceTests
 
         // Assert
         Assert.Empty(result);
-        _currencyEntryRepository.Verify(r => r.Get(10, It.IsAny<DateTime>(), It.IsAny<int>(), true), Times.Once);
-        _bondEntryRepository.Verify(r => r.Get(20, It.IsAny<DateTime>(), It.IsAny<int>(), true), Times.Once);
+        _currencyEntryRepository.Verify(r => r.GetMostRecentByAccounts(
+            It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(10)),
+            10,
+            It.IsAny<CancellationToken>()), Times.Once);
+        _bondEntryRepository.Verify(r => r.GetMostRecentByAccounts(
+            It.Is<IReadOnlyCollection<int>>(ids => ids.Count == 1 && ids.Contains(20)),
+            10,
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     private void SetupCurrencyAccount(int accountId, string name, List<CurrencyAccountEntry> entries)
     {
         _currencyAccountRepository.Setup(r => r.GetAvailableAccounts(_userId))
             .Returns(ToAsyncEnumerable([new AvailableAccount(accountId, name)]));
-        _currencyEntryRepository.Setup(r => r.Get(accountId, It.IsAny<DateTime>(), It.IsAny<int>(), true))
+        _currencyEntryRepository.Setup(r => r.GetMostRecentByAccounts(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.Contains(accountId)),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(entries);
     }
 
@@ -189,7 +260,10 @@ public class TransactionLogServiceTests
     {
         _bondAccountRepository.Setup(r => r.GetAvailableAccounts(_userId))
             .Returns(ToAsyncEnumerable([new AvailableAccount(accountId, name)]));
-        _bondEntryRepository.Setup(r => r.Get(accountId, It.IsAny<DateTime>(), It.IsAny<int>(), true))
+        _bondEntryRepository.Setup(r => r.GetMostRecentByAccounts(
+                It.Is<IReadOnlyCollection<int>>(ids => ids.Contains(accountId)),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(entries);
     }
 

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Features/FinancialAccounts/Shared/Repositories/EntryRepositoryGetTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Features/FinancialAccounts/Shared/Repositories/EntryRepositoryGetTests.cs
@@ -42,40 +42,6 @@ public sealed class EntryRepositoryGetTests
         Assert.Equal("Interest", Assert.Single(Assert.IsType<BondAccountEntry>(result).Labels).Name);
     }
 
-    [Fact]
-    public async Task CurrencyGetMostRecentByAccounts_IsBoundedAndOrderedAcrossAccounts()
-    {
-        await using var context = CreateContext();
-        context.CurrencyEntries.AddRange(
-            new CurrencyAccountEntry(1, 10, new DateTime(2024, 3, 1), 100, 1),
-            new CurrencyAccountEntry(2, 11, new DateTime(2024, 3, 3), 100, 1),
-            new CurrencyAccountEntry(1, 12, new DateTime(2024, 3, 2), 100, 1),
-            new CurrencyAccountEntry(3, 13, new DateTime(2024, 3, 4), 100, 1));
-        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
-
-        var result = await new CurrencyEntryRepository(context)
-            .GetMostRecentByAccounts([1, 2], 2, TestContext.Current.CancellationToken);
-
-        Assert.Equal([11, 12], result.Select(entry => entry.EntryId));
-    }
-
-    [Fact]
-    public async Task BondGetMostRecentByAccounts_IsBoundedAndOrderedAcrossAccounts()
-    {
-        await using var context = CreateContext();
-        context.BondEntries.AddRange(
-            new BondAccountEntry(1, 10, new DateTime(2024, 3, 1), 100, 1, 7),
-            new BondAccountEntry(2, 11, new DateTime(2024, 3, 3), 100, 1, 7),
-            new BondAccountEntry(1, 12, new DateTime(2024, 3, 2), 100, 1, 7),
-            new BondAccountEntry(3, 13, new DateTime(2024, 3, 4), 100, 1, 7));
-        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
-
-        var result = await new BondEntryRepository(context)
-            .GetMostRecentByAccounts([1, 2], 2, TestContext.Current.CancellationToken);
-
-        Assert.Equal([11, 12], result.Select(entry => entry.EntryId));
-    }
-
     private static AppDbContext CreateContext() =>
         new(new DbContextOptionsBuilder<AppDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Features/FinancialAccounts/Shared/Repositories/EntryRepositoryGetTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Features/FinancialAccounts/Shared/Repositories/EntryRepositoryGetTests.cs
@@ -42,6 +42,40 @@ public sealed class EntryRepositoryGetTests
         Assert.Equal("Interest", Assert.Single(Assert.IsType<BondAccountEntry>(result).Labels).Name);
     }
 
+    [Fact]
+    public async Task CurrencyGetMostRecentByAccounts_IsBoundedAndOrderedAcrossAccounts()
+    {
+        await using var context = CreateContext();
+        context.CurrencyEntries.AddRange(
+            new CurrencyAccountEntry(1, 10, new DateTime(2024, 3, 1), 100, 1),
+            new CurrencyAccountEntry(2, 11, new DateTime(2024, 3, 3), 100, 1),
+            new CurrencyAccountEntry(1, 12, new DateTime(2024, 3, 2), 100, 1),
+            new CurrencyAccountEntry(3, 13, new DateTime(2024, 3, 4), 100, 1));
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await new CurrencyEntryRepository(context)
+            .GetMostRecentByAccounts([1, 2], 2, TestContext.Current.CancellationToken);
+
+        Assert.Equal([11, 12], result.Select(entry => entry.EntryId));
+    }
+
+    [Fact]
+    public async Task BondGetMostRecentByAccounts_IsBoundedAndOrderedAcrossAccounts()
+    {
+        await using var context = CreateContext();
+        context.BondEntries.AddRange(
+            new BondAccountEntry(1, 10, new DateTime(2024, 3, 1), 100, 1, 7),
+            new BondAccountEntry(2, 11, new DateTime(2024, 3, 3), 100, 1, 7),
+            new BondAccountEntry(1, 12, new DateTime(2024, 3, 2), 100, 1, 7),
+            new BondAccountEntry(3, 13, new DateTime(2024, 3, 4), 100, 1, 7));
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await new BondEntryRepository(context)
+            .GetMostRecentByAccounts([1, 2], 2, TestContext.Current.CancellationToken);
+
+        Assert.Equal([11, 12], result.Select(entry => entry.EntryId));
+    }
+
     private static AppDbContext CreateContext() =>
         new(new DbContextOptionsBuilder<AppDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())


### PR DESCRIPTION
## Summary

- Replace per-account currency and bond dashboard entry reads with bounded cross-account queries.
- Batch bond-name resolution while preserving the deleted-detail fallback and deterministic ordering.
- Add service/repository coverage plus relational SQLite query-count fixtures for 1, 10, and 100 accounts, including SQL Server-safe chunking for oversized account sets.

Closes #742

## Validation

- `dotnet format ./FinanceManager.slnx --no-restore --verify-no-changes`
- Focused TransactionLogService tests: 8 passed
- Focused entry repository tests: 2 passed
- SqliteRecentEntriesTests: 10 passed (including cold/warm query-count checks and a 2,001-account chunking fixture)
- Full integration suite: 326 passed
- `dotnet build ./FinanceManager.slnx --no-restore`: 0 warnings, 0 errors

The full unit suite reported 983 passed and 6 unrelated existing failures in locale/external-data-sensitive currency exchange and paycheck-cache tests.

## Risks

- The new recent-entry methods intentionally omit navigation includes because the dashboard needs only entry scalars and resolves bond names in one projected batch query.
- Account IDs are de-duplicated and chunked at 2,000 per provider query to stay below SQL Server's parameter limit while retaining a global top-count result.
- The issue remains in progress while this pull request awaits review.
