### PR TITLE
Skip price histories for closed investment positions

### DIFF
--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
@@ -132,13 +132,24 @@ internal class InvestmentValuationService(
         var relevant = transactions.Where(t => t.TradeDate <= endDateOnly).ToList();
         if (relevant.Count == 0) return result;
 
+        // Retain each (account, listing) pair when its opening holding before the range is non-zero
+        // OR it has trades in the range. Exclude positions fully closed before the window so they
+        // never trigger unneeded price-series fetches.
+        var retainedTransactions = relevant
+            .GroupBy(t => (t.AccountId, t.AssetListingId))
+            .Where(group => group.Where(t => t.TradeDate < startDateOnly).Sum(t => t.SignedQuantity) != 0m
+                || group.Any(t => t.TradeDate >= startDateOnly))
+            .SelectMany(group => group)
+            .ToList();
+        if (retainedTransactions.Count == 0) return result;
+
         // One price-series fetch per distinct listing across all accounts (target currency already
         // applied). Accounts holding the same instrument share this series instead of re-fetching it.
         var priceSeries = new Dictionary<long, IReadOnlyDictionary<DateTime, decimal>>();
-        foreach (var listingId in relevant.Select(t => t.AssetListingId).Distinct())
+        foreach (var listingId in retainedTransactions.Select(t => t.AssetListingId).Distinct())
             priceSeries[listingId] = await priceProvider.GetPricePerUnitSeriesAsync(listingId, targetCurrency, start, end, ct);
 
-        foreach (var accountGroup in relevant.GroupBy(t => t.AccountId))
+        foreach (var accountGroup in retainedTransactions.GroupBy(t => t.AccountId))
         {
             var series = BuildAccountSeries(accountGroup, startDate, endDate, startDateOnly, priceSeries);
             if (series.Count > 0) result[accountGroup.Key] = series;

--- a/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
@@ -268,6 +268,139 @@ public class InvestmentValuationServiceTests
     }
 
     [Fact]
+    public async Task GetAccountValueSeries_SkipsPriceHistory_ForPositionClosedBeforeValuationWindow()
+    {
+        var start = new DateTime(2024, 2, 1);
+        var end = new DateTime(2024, 2, 2);
+
+        // Position was bought and fully sold before the valuation window opened.
+        _transactionRepository
+            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10)),
+                Tx(10, InvestmentTransactionType.Sell, 5m, new DateOnly(2024, 1, 20))
+            });
+
+        var series = await CreateSut().GetAccountValueSeriesAsync(_accountId, _usd, start, end, TestContext.Current.CancellationToken);
+
+        Assert.Empty(series);
+        _priceProvider.Verify(
+            x => x.GetPricePerUnitSeriesAsync(10, It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAccountValueSeries_OnlyFetchesPriceHistoryForActiveListings_WhenAccountHasClosedPosition()
+    {
+        var start = new DateTime(2024, 2, 1);
+        var end = new DateTime(2024, 2, 2);
+
+        // Listing 10 was fully closed before the window; Listing 20 is still held.
+        _transactionRepository
+            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10)),
+                Tx(10, InvestmentTransactionType.Sell, 5m, new DateOnly(2024, 1, 20)),
+                Tx(20, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 15))
+            });
+
+        _priceProvider
+            .Setup(x => x.GetPricePerUnitSeriesAsync(20, _usd, start, end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, decimal>
+            {
+                [start] = 50m,
+                [end] = 55m
+            });
+
+        var series = await CreateSut().GetAccountValueSeriesAsync(_accountId, _usd, start, end, TestContext.Current.CancellationToken);
+
+        Assert.Equal(100m, series[start]); // 2 * 50
+        Assert.Equal(110m, series[end]);   // 2 * 55
+
+        _priceProvider.Verify(
+            x => x.GetPricePerUnitSeriesAsync(10, It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _priceProvider.Verify(
+            x => x.GetPricePerUnitSeriesAsync(20, _usd, start, end, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAccountValueSeries_PreservesInWindowOpenAndClose()
+    {
+        var start = new DateTime(2024, 2, 1);
+        var end = new DateTime(2024, 2, 3);
+
+        // Position opens on Day 2 and closes on Day 3 (both in-window). Opening holding is 0.
+        _transactionRepository
+            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                Tx(10, InvestmentTransactionType.Buy, 3m, new DateOnly(2024, 2, 2)),
+                Tx(10, InvestmentTransactionType.Sell, 3m, new DateOnly(2024, 2, 3))
+            });
+
+        _priceProvider
+            .Setup(x => x.GetPricePerUnitSeriesAsync(10, _usd, start, end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, decimal>
+            {
+                [start] = 10m,
+                [start.AddDays(1)] = 15m,
+                [end] = 20m
+            });
+
+        var series = await CreateSut().GetAccountValueSeriesAsync(_accountId, _usd, start, end, TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain(start, series.Keys);
+        Assert.Equal(45m, series[start.AddDays(1)]); // 3 * 15
+        Assert.DoesNotContain(end, series.Keys); // 0 holding after sell
+
+        _priceProvider.Verify(
+            x => x.GetPricePerUnitSeriesAsync(10, _usd, start, end, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAccountValueSeries_EvaluatesAccountsIndependently_WithoutCrossAccountSuppression()
+    {
+        var start = new DateTime(2024, 2, 1);
+        var end = new DateTime(2024, 2, 2);
+        int[] accountIds = [10, 20];
+
+        // Each account is evaluated independently: account 10 holds 5 units while account 20's
+        // -5-unit position offsets it globally. A global listing net would incorrectly skip both.
+        _transactionRepository
+            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(10) && a.Contains(20)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<InvestmentTransaction>
+            {
+                Tx(100, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10), accountId: 10),
+                Tx(100, InvestmentTransactionType.Sell, 5m, new DateOnly(2024, 1, 20), accountId: 20)
+            });
+
+        _priceProvider
+            .Setup(x => x.GetPricePerUnitSeriesAsync(100, _usd, start, end, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<DateTime, decimal>
+            {
+                [start] = 20m,
+                [end] = 25m
+            });
+
+        var byAccount = await CreateSut().GetAccountValueSeriesAsync(accountIds, _usd, start, end, TestContext.Current.CancellationToken);
+
+        Assert.True(byAccount.ContainsKey(10));
+        Assert.Equal(100m, byAccount[10][start]); // 5 * 20
+        Assert.Equal(125m, byAccount[10][end]);   // 5 * 25
+        Assert.Equal(-100m, byAccount[20][start]); // account 20's -5-unit position is independent
+        Assert.Equal(-125m, byAccount[20][end]);
+
+        _priceProvider.Verify(
+            x => x.GetPricePerUnitSeriesAsync(100, _usd, start, end, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task GetCapitalSeries_AccumulatesBuysAndSells_CarriesOpeningCapital_AndCombinesSameDayFlows()
     {
         var start = new DateTime(2024, 1, 2);


### PR DESCRIPTION
## Summary

- filter investment valuation history by each `(account, listing)` pair before requesting price series
- skip pairs fully closed before the valuation window while retaining any pair with a non-zero opening holding or in-window activity
- preserve in-window open/close positions, independent account evaluation, and one shared price fetch per retained listing
- add regression coverage for pre-window closure, active-listing selection, in-window open/close, and cross-account offsets

Closes #746

## Validation

- `dotnet build ./code/FinanceManager.slnx --no-restore -p:BuildProjectReferences=false -p:UseSharedCompilation=false` — passed (0 warnings, 0 errors)
- `dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --no-restore --no-build -- --filter-class FinanceManager.Tests.Unit.Application.Services.Investments.InvestmentValuationServiceTests` — passed (25)
- full unit suite — 983 passed, 6 known baseline failures in unrelated locale/external-currency and paycheck-cache tests
- `dotnet test --project ./FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj --no-restore --no-build` — passed (316)
- `dotnet test --project ./FinanceManager.Tests.Architecture/FinanceManager.Tests.Architecture.csproj --no-restore --no-build` — passed (9)
- `dotnet format ./code/FinanceManager.slnx --no-restore --verify-no-changes` — passed

## Risks

Filtering is limited to the requested valuation range and does not alter transaction semantics or price-provider behavior. The issue remains in progress pending review and required remote checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Investment account value history now excludes positions fully closed before the selected valuation period.
  * Price history is fetched only for listings active during the requested period.
  * Opening and closing transactions within the period are reflected correctly.
  * Multiple accounts are evaluated independently without incorrectly suppressing results.

* **Tests**
  * Added coverage for closed positions, active listings, in-period transitions, and multi-account valuations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->