### PR TITLE
Fix capital chart range and legend contrast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ rules agents must follow when updating this file.
 - Exchange rates are now stored in the application database: a conversion first checks the in-memory cache and the database (including inverse pairs), and only on a miss asks the external rate provider — whose answer is persisted so the same pair and date never leave the app twice. Unknown pairs additionally fall back to a cross-rate via USD.
 
 ### Fixed
+- Investment and bond account capital charts now carry the final value through the selected range end, and their legend labels follow the active theme for readable contrast. #753
 - The administration dashboard's new-visitors information control now has a grammatically correct screen-reader label. #730
 - Account transaction toolbar controls now share a consistent height, and the search button matches their outlined styling. #726
 - External provider retries are now bounded and degraded outcomes remain distinct from caller cancellation after transient failures. #719

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/BondAccountComponents/TransactionHistory/BondAccountDetailsPageContent.razor.cs
@@ -291,10 +291,10 @@ public partial class BondAccountDetailsPageContent : ComponentBase, IAsyncDispos
                         var capitalTask = MoneyFlowHttpClient.GetCapital(userId, currency, dateStart, dateEnd, [accountId]);
                         await Task.WhenAll(balanceTask, capitalTask);
 
-                        var series = (await balanceTask)
-                            .SkipWhile(x => x.Value == 0)
-                            .ToList();
-                        var capitalSeries = await capitalTask;
+                        var series = ChartHelper.EnsureSeriesEndsAt(
+                            (await balanceTask).SkipWhile(x => x.Value == 0),
+                            dateEnd);
+                        var capitalSeries = ChartHelper.EnsureSeriesEndsAt(await capitalTask, dateEnd);
                         var currentBalance = series.LastOrDefault()?.Value ?? 0;
                         var balanceChange = series.Count >= 2 ? series.Last().Value - series.First().Value : 0;
                         var startBalance = currentBalance - balanceChange;

--- a/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
+++ b/code/FinanceManager.Components/Features/FinancialAccounts/Components/InvestmentAccountComponents/InvestmentAccountDetailsPageContent.razor.cs
@@ -408,7 +408,11 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
             .ToList();
         // The benchmark tracks the account's own contributions, so it is asked for the whole range
         // and starts itself on the day the account first holds something — no base point to seed.
-        var benchmarkSeries = chartRequests.BenchmarkSeries;
+        var benchmarkSeries = chartRequests.BenchmarkSeries
+            .OrderBy(x => x.Key)
+            .Select(x => new TimeSeriesModel(x.Key, x.Value))
+            .ToList();
+        var capitalSeries = ChartHelper.EnsureSeriesEndsAt(chartRequests.CapitalSeries, dateEnd);
         var currentBalance = orderedSeries.LastOrDefault()?.Value ?? 0;
 
         // Capital value (remaining buy cost) and current valuation are the two source-of-truth
@@ -422,7 +426,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
             dateStart,
             dateEnd,
             [.. orderedSeries.SkipWhile(x => x.Value == 0)],
-            [.. benchmarkSeries.OrderBy(x => x.Key).Select(x => new TimeSeriesModel(x.Key, x.Value))],
+            benchmarkSeries,
             benchmarkName,
             currentBalance,
             capitalValue,
@@ -430,7 +434,7 @@ public partial class InvestmentAccountDetailsPageContent : ComponentBase, IAsync
             balanceChange,
             capitalValue == 0m ? null : balanceChange / capitalValue * 100m,
             BuildHoldings(transactions, holdings, dateEnd),
-            [.. chartRequests.CapitalSeries]);
+            capitalSeries);
     }
 
     // Only chart data is restored. The selected range and its dates stay owned by the user's

--- a/code/FinanceManager.Components/Shared/Helpers/ChartHelper.cs
+++ b/code/FinanceManager.Components/Shared/Helpers/ChartHelper.cs
@@ -1,7 +1,27 @@
+using FinanceManager.Domain.MoneyFlow.Entities;
+
 namespace FinanceManager.Components.Shared.Helpers;
 
 public static class ChartHelper
 {
+    /// <summary>
+    /// Carries the final known value through the requested chart end date when a bucketed
+    /// cumulative series ends at the first date of its final bucket. The source sequence is not
+    /// mutated, and an empty series or one that already reaches the end is returned unchanged.
+    /// </summary>
+    public static List<TimeSeriesModel> EnsureSeriesEndsAt(IEnumerable<TimeSeriesModel> series, DateTime endDate)
+    {
+        var ordered = series.OrderBy(point => point.DateTime).ToList();
+        if (ordered.Count == 0) return ordered;
+
+        var targetDate = endDate.Date;
+        var last = ordered[^1];
+        if (last.DateTime.Date >= targetDate) return ordered;
+
+        ordered.Add(new TimeSeriesModel(targetDate, last.Value, last.Name));
+        return ordered;
+    }
+
     /// <summary>
     /// Compact currency tick labels for a y-axis: 2.5k / 7.5k / 10k / 13k. Shared by the
     /// dashboard time-series cards and the account details hero chart so both label their

--- a/code/FinanceManager.Components/wwwroot/css/account-details-hero.css
+++ b/code/FinanceManager.Components/wwwroot/css/account-details-hero.css
@@ -15,6 +15,12 @@
     stroke-linejoin: round;
 }
 
+/* ApexCharts defaults legend labels to a fixed dark grey. Use the active MudBlazor palette so
+   the Balance, benchmark, and Capital labels remain readable when the app switches to dark mode. */
+.fm-hero-chart .apexcharts-legend-text {
+    color: var(--mud-palette-text-primary) !important;
+}
+
 /* ApexCharts overlays a full-plot <foreignObject> (it only carries an injected <style>
    block) with pointer-events:auto, which sits on top of the series and swallows mousemove.
    The element is purely decorative, so disabling its pointer events lets the crosshair

--- a/code/FinanceManager.Tests.Unit/Components/Shared/Helpers/ChartHelperTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Shared/Helpers/ChartHelperTests.cs
@@ -1,10 +1,53 @@
 using FinanceManager.Components.Shared.Helpers;
+using FinanceManager.Domain.MoneyFlow.Entities;
 
 namespace FinanceManager.Tests.Unit.Components.Shared.Helpers;
 
 [Trait("Category", "Unit")]
 public class ChartHelperTests
 {
+    [Fact]
+    public void EnsureSeriesEndsAt_CarriesCapitalThroughTheRequestedEndAfterFinalTransaction()
+    {
+        var series = new List<TimeSeriesModel>
+        {
+            new(new DateTime(2026, 1, 1), 100m, "Capital"),
+            new(new DateTime(2026, 2, 1), 125m, "Capital"),
+        };
+
+        var result = ChartHelper.EnsureSeriesEndsAt(series, new DateTime(2026, 3, 31));
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(new DateTime(2026, 3, 31), result[^1].DateTime);
+        Assert.Equal(125m, result[^1].Value);
+        Assert.Equal("Capital", result[^1].Name);
+        Assert.Equal(2, series.Count);
+        Assert.Equal(new DateTime(2026, 2, 1), series[^1].DateTime);
+        Assert.Equal(125m, series[^1].Value);
+    }
+
+    [Fact]
+    public void EnsureSeriesEndsAt_DoesNotAddDuplicateWhenEndAlreadyExists()
+    {
+        var series = new List<TimeSeriesModel>
+        {
+            new(new DateTime(2026, 3, 30), 100m),
+            new(new DateTime(2026, 3, 31), 125m),
+        };
+
+        var result = ChartHelper.EnsureSeriesEndsAt(series, new DateTime(2026, 3, 31, 23, 59, 59));
+
+        Assert.Equal(2, result.Count);
+        Assert.Same(series[0], result[0]);
+        Assert.Same(series[1], result[1]);
+    }
+
+    [Fact]
+    public void EnsureSeriesEndsAt_LeavesEmptySeriesEmpty()
+    {
+        Assert.Empty(ChartHelper.EnsureSeriesEndsAt([], new DateTime(2026, 3, 31)));
+    }
+
     [Fact]
     public void AddYRangePadding_AddsFivePercentBelowAndAboveDisplayedRange()
     {

--- a/code/FinanceManager.Tests.Unit/Components/Shared/Helpers/ChartHelperTests.cs
+++ b/code/FinanceManager.Tests.Unit/Components/Shared/Helpers/ChartHelperTests.cs
@@ -9,11 +9,11 @@ public class ChartHelperTests
     [Fact]
     public void EnsureSeriesEndsAt_CarriesCapitalThroughTheRequestedEndAfterFinalTransaction()
     {
-        var series = new List<TimeSeriesModel>
-        {
+        List<TimeSeriesModel> series =
+        [
             new(new DateTime(2026, 1, 1), 100m, "Capital"),
             new(new DateTime(2026, 2, 1), 125m, "Capital"),
-        };
+        ];
 
         var result = ChartHelper.EnsureSeriesEndsAt(series, new DateTime(2026, 3, 31));
 
@@ -29,11 +29,11 @@ public class ChartHelperTests
     [Fact]
     public void EnsureSeriesEndsAt_DoesNotAddDuplicateWhenEndAlreadyExists()
     {
-        var series = new List<TimeSeriesModel>
-        {
+        List<TimeSeriesModel> series =
+        [
             new(new DateTime(2026, 3, 30), 100m),
             new(new DateTime(2026, 3, 31), 125m),
-        };
+        ];
 
         var result = ChartHelper.EnsureSeriesEndsAt(series, new DateTime(2026, 3, 31, 23, 59, 59));
 


### PR DESCRIPTION
Closes #753

## Summary
- Carry cumulative capital through the selected end date for investment and bond account charts when bucketed data ends earlier.
- Extend the bond balance endpoint consistently so chart boundaries stay aligned without introducing a value change.
- Use the active MudBlazor text palette for ApexCharts legend labels in light and dark themes.
- Add regression coverage for a final capital transaction before the selected range end, including empty/no-op behavior.

## Validation
- `dotnet format ./code/FinanceManager.slnx --verify-no-changes --verbosity minimal`
- `dotnet build ./code/FinanceManager.slnx --no-restore`
- `cd code && dotnet test --project ./FinanceManager.Tests.Architecture/FinanceManager.Tests.Architecture.csproj --culture en-US` (9 passed)
- `cd code && dotnet test --project ./FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --culture en-US` (1,010 passed)
- `cd code && dotnet test --project ./FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj --culture en-US` (326 passed)
- Guest account chart rendering verified for Investment `/AccountDetails/3` and Bond `/AccountDetails/4`; dark-theme desktop captures show the range-ending Capital line and readable legend labels. The available in-app browser exposes a fixed desktop viewport, so a separate mobile viewport capture was not available in this environment.

## Risk
- The carry-forward is presentation-only and clones the final known value; it does not change valuation or capital calculations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Charts now extend the latest balance, capital, and benchmark values through the selected end date for more complete visualizations.
  - Improved chart legend readability in dark mode.
  - Prevented duplicate end-date points and preserved empty chart series.
  - Chart data remains correctly ordered and avoids modifying the original series.

- **Tests**
  - Added coverage for chart end-date handling, input preservation, duplicate prevention, and empty series.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->