### PR TITLE
Batch currency and bond import persistence

### DIFF
--- a/code/FinanceManager.Application/FinancialAccounts/Bond/Import/BondAccountImportService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Bond/Import/BondAccountImportService.cs
@@ -14,6 +14,10 @@ public class BondAccountImportService(
     ImportAccountValidator importAccountValidator,
     ILogger<BondAccountImportService> logger) : IBondAccountImportService
 {
+    // Keep each persistence operation bounded so a large import can make progress across
+    // independently committed batches and does not create an unbounded EF change tracker.
+    private const int _persistenceBatchSize = 500;
+
     public Task<BondImportResult> ImportEntries(
         int userId,
         int accountId,
@@ -48,21 +52,27 @@ public class BondAccountImportService(
         var errors = new List<string>();
         var conflicts = new List<BondImportConflict>();
 
-        var existingAll = cancellationToken.CanBeCanceled
+        var existingEntries = cancellationToken.CanBeCanceled
             ? await bondAccountEntryRepository
                 .Get(accountId, minDay.AddDays(-1), maxDay.AddDays(1), cancellationToken)
                 .ToListAsync(cancellationToken)
             : await bondAccountEntryRepository
                 .Get(accountId, minDay.AddDays(-1), maxDay.AddDays(1))
                 .ToListAsync();
+        var importsByDay = entryList
+            .GroupBy(x => x.PostingDate.Date)
+            .ToDictionary(g => g.Key, g => g.ToList());
+        var existingByDay = existingEntries
+            .GroupBy(e => e.PostingDate.Date)
+            .ToDictionary(g => g.Key, g => g.ToList());
+        BondAccountEntry? oldestInserted = null;
+
         for (var day = maxDay; day >= minDay; day = day.AddDays(-1))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var importsThisDay = entryList.Where(x => x.PostingDate.Date == day).ToList();
-            var existingThisDay = existingAll.Where(e => e.PostingDate.Date == day).ToList();
-
-            if (importsThisDay.Count == 0)
+            if (!importsByDay.TryGetValue(day, out var importsThisDay))
                 continue;
+            var existingThisDay = existingByDay.GetValueOrDefault(day) ?? [];
 
             var exactMatches = ImportConflictDetector.GetExactMatches(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
             var importsOnly = ImportConflictDetector.GetImportsMissingFromExisting(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
@@ -76,6 +86,7 @@ public class BondAccountImportService(
                 continue;
             }
 
+            var entriesToInsert = new List<BondAccountEntry>(importsThisDay.Count);
             foreach (var import in importsThisDay)
             {
                 try
@@ -84,19 +95,7 @@ public class BondAccountImportService(
                         throw new Exception($"Date kind of this entry posting date: {import.PostingDate}, value change: {import.ValueChange} is not UTC - {import.PostingDate.Kind}");
 
                     var newEntry = new BondAccountEntry(accountId, 0, ImportDateNormalizer.ToSecond(import.PostingDate), import.ValueChange, import.ValueChange, import.BondDetailsId);
-                    var added = cancellationToken.CanBeCanceled
-                        ? await bondAccountEntryRepository.Add(newEntry, recalculate: false, cancellationToken)
-                        : await bondAccountEntryRepository.Add(newEntry, recalculate: false);
-                    if (added)
-                    {
-                        imported++;
-                        existingAll.Add(newEntry);
-                    }
-                    else
-                    {
-                        failed++;
-                        errors.Add($"Failed to import entry with date {import.PostingDate}.");
-                    }
+                    entriesToInsert.Add(newEntry);
                 }
                 catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
                 {
@@ -115,13 +114,53 @@ public class BondAccountImportService(
                     errors.Add(ex.Message);
                 }
             }
+
+            foreach (var batch in entriesToInsert.Chunk(_persistenceBatchSize))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var batchList = batch.ToList();
+                try
+                {
+                    var added = cancellationToken.CanBeCanceled
+                        ? await bondAccountEntryRepository.Add(batchList, recalculate: false, cancellationToken)
+                        : await bondAccountEntryRepository.Add(batchList, recalculate: false);
+
+                    if (added)
+                    {
+                        imported += batchList.Count;
+                        if (oldestInserted is null || batchList[0].PostingDate < oldestInserted.PostingDate)
+                            oldestInserted = batchList[0];
+                    }
+                    else
+                    {
+                        failed += batchList.Count;
+                        errors.AddRange(batchList.Select(entry => $"Failed to import entry with date {entry.PostingDate}."));
+                    }
+                }
+                catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+                {
+                    logger.LogDebug(ex, "Bond account import cancelled.");
+                    throw;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    failed += batchList.Count;
+                    errors.AddRange(batchList.Select(entry => $"Cancellation while importing entry with date {entry.PostingDate}."));
+                    logger.LogDebug(ex, "Bond account import entries cancelled or timed out; marking them failed.");
+                }
+                catch (Exception ex)
+                {
+                    failed += batchList.Count;
+                    errors.AddRange(batchList.Select(_ => ex.Message));
+                }
+            }
         }
 
         if (imported > 0)
         {
             try
             {
-                await RecalculateBonds(accountId, minDay, maxDay, cancellationToken);
+                await RecalculateBonds(accountId, oldestInserted?.EntryId ?? 0, minDay, maxDay, cancellationToken);
             }
             catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
             {
@@ -183,8 +222,17 @@ public class BondAccountImportService(
         }
     }
 
-    private async Task RecalculateBonds(int accountId, DateTime minDay, DateTime maxDay, CancellationToken cancellationToken)
+    private async Task RecalculateBonds(int accountId, int anchorEntryId, DateTime minDay, DateTime maxDay, CancellationToken cancellationToken)
     {
+        if (anchorEntryId != 0)
+        {
+            if (cancellationToken.CanBeCanceled)
+                await bondAccountEntryRepository.RecalculateValues(accountId, anchorEntryId, cancellationToken);
+            else
+                await bondAccountEntryRepository.RecalculateValues(accountId, anchorEntryId);
+            return;
+        }
+
         var entriesToRecalc = cancellationToken.CanBeCanceled
             ? await bondAccountEntryRepository
                 .Get(accountId, minDay.AddDays(-1), maxDay.AddDays(1), cancellationToken)
@@ -193,17 +241,14 @@ public class BondAccountImportService(
                 .Get(accountId, minDay.AddDays(-1), maxDay.AddDays(1))
                 .ToListAsync();
 
-        foreach (var bondGroup in entriesToRecalc.GroupBy(e => e.BondDetailsId))
-        {
-            var earliest = bondGroup.OrderBy(e => e.PostingDate).ThenBy(e => e.EntryId).FirstOrDefault();
-            if (earliest is null)
-                continue;
+        var earliest = entriesToRecalc.OrderBy(e => e.PostingDate).ThenBy(e => e.EntryId).FirstOrDefault();
+        if (earliest is null)
+            return;
 
-            if (cancellationToken.CanBeCanceled)
-                await bondAccountEntryRepository.RecalculateValues(accountId, earliest.EntryId, cancellationToken);
-            else
-                await bondAccountEntryRepository.RecalculateValues(accountId, earliest.EntryId);
-        }
+        if (cancellationToken.CanBeCanceled)
+            await bondAccountEntryRepository.RecalculateValues(accountId, earliest.EntryId, cancellationToken);
+        else
+            await bondAccountEntryRepository.RecalculateValues(accountId, earliest.EntryId);
     }
 
     // Bond entries are compared on posting date (second precision), value change and bond details.

--- a/code/FinanceManager.Application/FinancialAccounts/Bond/Import/BondAccountImportService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Bond/Import/BondAccountImportService.cs
@@ -67,112 +67,123 @@ public class BondAccountImportService(
             .ToDictionary(g => g.Key, g => g.ToList());
         BondAccountEntry? oldestInserted = null;
 
-        for (var day = maxDay; day >= minDay; day = day.AddDays(-1))
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (!importsByDay.TryGetValue(day, out var importsThisDay))
-                continue;
-            var existingThisDay = existingByDay.GetValueOrDefault(day) ?? [];
-
-            var exactMatches = ImportConflictDetector.GetExactMatches(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
-            var importsOnly = ImportConflictDetector.GetImportsMissingFromExisting(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
-            var existingOnly = ImportConflictDetector.GetExistingMissingFromImports(existingThisDay, importsThisDay, ExistingKey, ImportKey).ToList();
-
-            if (exactMatches.Count != 0 || existingOnly.Count != 0)
-            {
-                conflicts.AddRange(exactMatches.Select(x => new BondImportConflict(accountId, x.Import, x.Existing, "Exact match")));
-                conflicts.AddRange(importsOnly.Select(x => new BondImportConflict(accountId, x, null, "Import not found in existing")));
-                conflicts.AddRange(existingOnly.Select(x => new BondImportConflict(accountId, null, x, "Existing not found in import")));
-                continue;
-            }
-
-            var entriesToInsert = new List<BondAccountEntry>(importsThisDay.Count);
-            foreach (var import in importsThisDay)
-            {
-                try
-                {
-                    if (import.PostingDate.Kind != DateTimeKind.Utc)
-                        throw new Exception($"Date kind of this entry posting date: {import.PostingDate}, value change: {import.ValueChange} is not UTC - {import.PostingDate.Kind}");
-
-                    var newEntry = new BondAccountEntry(accountId, 0, ImportDateNormalizer.ToSecond(import.PostingDate), import.ValueChange, import.ValueChange, import.BondDetailsId);
-                    entriesToInsert.Add(newEntry);
-                }
-                catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
-                {
-                    logger.LogDebug(ex, "Bond account import cancelled.");
-                    throw;
-                }
-                catch (OperationCanceledException ex)
-                {
-                    failed++;
-                    errors.Add($"Cancellation while importing entry with date {import.PostingDate}.");
-                    logger.LogDebug(ex, "Bond account import entry cancelled or timed out for {PostingDate}; marking it failed.", import.PostingDate);
-                }
-                catch (Exception ex)
-                {
-                    failed++;
-                    errors.Add(ex.Message);
-                }
-            }
-
-            foreach (var batch in entriesToInsert.Chunk(_persistenceBatchSize))
+            for (var day = maxDay; day >= minDay; day = day.AddDays(-1))
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                var batchList = batch.ToList();
-                try
-                {
-                    var added = cancellationToken.CanBeCanceled
-                        ? await bondAccountEntryRepository.Add(batchList, recalculate: false, cancellationToken)
-                        : await bondAccountEntryRepository.Add(batchList, recalculate: false);
+                if (!importsByDay.TryGetValue(day, out var importsThisDay))
+                    continue;
+                var existingThisDay = existingByDay.GetValueOrDefault(day) ?? [];
 
-                    if (added)
+                var exactMatches = ImportConflictDetector.GetExactMatches(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
+                var importsOnly = ImportConflictDetector.GetImportsMissingFromExisting(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
+                var existingOnly = ImportConflictDetector.GetExistingMissingFromImports(existingThisDay, importsThisDay, ExistingKey, ImportKey).ToList();
+
+                if (exactMatches.Count != 0 || existingOnly.Count != 0)
+                {
+                    conflicts.AddRange(exactMatches.Select(x => new BondImportConflict(accountId, x.Import, x.Existing, "Exact match")));
+                    conflicts.AddRange(importsOnly.Select(x => new BondImportConflict(accountId, x, null, "Import not found in existing")));
+                    conflicts.AddRange(existingOnly.Select(x => new BondImportConflict(accountId, null, x, "Existing not found in import")));
+                    continue;
+                }
+
+                var entriesToInsert = new List<BondAccountEntry>(importsThisDay.Count);
+                foreach (var import in importsThisDay)
+                {
+                    try
                     {
-                        imported += batchList.Count;
-                        if (oldestInserted is null || batchList[0].PostingDate < oldestInserted.PostingDate)
-                            oldestInserted = batchList[0];
+                        if (import.PostingDate.Kind != DateTimeKind.Utc)
+                            throw new Exception($"Date kind of this entry posting date: {import.PostingDate}, value change: {import.ValueChange} is not UTC - {import.PostingDate.Kind}");
+
+                        var newEntry = new BondAccountEntry(accountId, 0, ImportDateNormalizer.ToSecond(import.PostingDate), import.ValueChange, import.ValueChange, import.BondDetailsId);
+                        entriesToInsert.Add(newEntry);
                     }
-                    else
+                    catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+                    {
+                        logger.LogDebug(ex, "Bond account import cancelled.");
+                        throw;
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        failed++;
+                        errors.Add($"Cancellation while importing entry with date {import.PostingDate}.");
+                        logger.LogDebug(ex, "Bond account import entry cancelled or timed out for {PostingDate}; marking it failed.", import.PostingDate);
+                    }
+                    catch (Exception ex)
+                    {
+                        failed++;
+                        errors.Add(ex.Message);
+                    }
+                }
+
+                foreach (var batch in entriesToInsert.Chunk(_persistenceBatchSize))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var batchList = batch.ToList();
+                    try
+                    {
+                        var added = cancellationToken.CanBeCanceled
+                            ? await bondAccountEntryRepository.Add(batchList, recalculate: false, cancellationToken)
+                            : await bondAccountEntryRepository.Add(batchList, recalculate: false);
+
+                        if (added)
+                        {
+                            imported += batchList.Count;
+                            var batchOldest = batchList.MinBy(entry => (entry.PostingDate, entry.EntryId))!;
+                            if (oldestInserted is null || batchOldest.PostingDate < oldestInserted.PostingDate ||
+                                batchOldest.PostingDate == oldestInserted.PostingDate && batchOldest.EntryId < oldestInserted.EntryId)
+                                oldestInserted = batchOldest;
+                        }
+                        else
+                        {
+                            failed += batchList.Count;
+                            errors.AddRange(batchList.Select(entry => $"Failed to import entry with date {entry.PostingDate}."));
+                        }
+                    }
+                    catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+                    {
+                        logger.LogDebug(ex, "Bond account import cancelled.");
+                        throw;
+                    }
+                    catch (OperationCanceledException ex)
                     {
                         failed += batchList.Count;
-                        errors.AddRange(batchList.Select(entry => $"Failed to import entry with date {entry.PostingDate}."));
+                        errors.AddRange(batchList.Select(entry => $"Cancellation while importing entry with date {entry.PostingDate}."));
+                        logger.LogDebug(ex, "Bond account import entries cancelled or timed out; marking them failed.");
                     }
+                    catch (Exception ex)
+                    {
+                        failed += batchList.Count;
+                        errors.AddRange(batchList.Select(_ => ex.Message));
+                    }
+                }
+            }
+
+            if (imported > 0)
+            {
+                try
+                {
+                    await RecalculateBonds(accountId, oldestInserted?.EntryId ?? 0, minDay, maxDay, cancellationToken);
                 }
                 catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
                 {
-                    logger.LogDebug(ex, "Bond account import cancelled.");
+                    logger.LogDebug(ex, "Bond account import recalculation cancelled.");
                     throw;
                 }
                 catch (OperationCanceledException ex)
                 {
-                    failed += batchList.Count;
-                    errors.AddRange(batchList.Select(entry => $"Cancellation while importing entry with date {entry.PostingDate}."));
-                    logger.LogDebug(ex, "Bond account import entries cancelled or timed out; marking them failed.");
-                }
-                catch (Exception ex)
-                {
-                    failed += batchList.Count;
-                    errors.AddRange(batchList.Select(_ => ex.Message));
+                    await RecalculateCommittedEntries(accountId, oldestInserted);
+                    failed++;
+                    errors.Add("Recalculation cancelled or timed out.");
+                    logger.LogDebug(ex, "Bond account import recalculation cancelled or timed out; marking it failed.");
                 }
             }
         }
-
-        if (imported > 0)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            try
-            {
-                await RecalculateBonds(accountId, oldestInserted?.EntryId ?? 0, minDay, maxDay, cancellationToken);
-            }
-            catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
-            {
-                logger.LogDebug(ex, "Bond account import recalculation cancelled.");
-                throw;
-            }
-            catch (OperationCanceledException ex)
-            {
-                failed++;
-                errors.Add("Recalculation cancelled or timed out.");
-                logger.LogDebug(ex, "Bond account import recalculation cancelled or timed out; marking it failed.");
-            }
+            await RecalculateCommittedEntries(accountId, oldestInserted);
+            throw;
         }
 
         return new(accountId, imported, failed, errors, conflicts);
@@ -221,6 +232,11 @@ public class BondAccountImportService(
             }
         }
     }
+
+    private Task RecalculateCommittedEntries(int accountId, BondAccountEntry? oldestInserted) =>
+        oldestInserted is null
+            ? Task.CompletedTask
+            : bondAccountEntryRepository.RecalculateValues(accountId, oldestInserted.EntryId, CancellationToken.None);
 
     private async Task RecalculateBonds(int accountId, int anchorEntryId, DateTime minDay, DateTime maxDay, CancellationToken cancellationToken)
     {

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/Import/CurrencyAccountImportService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/Import/CurrencyAccountImportService.cs
@@ -70,138 +70,154 @@ public class CurrencyAccountImportService(ICurrencyAccountRepository<CurrencyAcc
             .GroupBy(e => e.PostingDate.Date)
             .ToDictionary(g => g.Key, g => g.ToList());
 
-        for (var day = maxDay; day >= minDay; day = day.AddDays(-1))
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (!importsByDay.TryGetValue(day, out var importsThisDay)) continue;
-            var existingThisDay = existingByDay.GetValueOrDefault(day) ?? [];
-
-            var exactMatches = ImportConflictDetector.GetExactMatches(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
-            var importsOnly = ImportConflictDetector.GetImportsMissingFromExisting(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
-            var existingOnly = ImportConflictDetector.GetExistingMissingFromImports(existingThisDay, importsThisDay, ExistingKey, ImportKey).ToList();
-
-            if (exactMatches.Count != 0 || existingOnly.Count != 0)
+            for (var day = maxDay; day >= minDay; day = day.AddDays(-1))
             {
-                var dailyConflicts = new List<ImportConflict>();
-                dailyConflicts.AddRange(exactMatches.Select(x => new ImportConflict(accountId, x.Import, x.Existing, "Exact match")));
-                dailyConflicts.AddRange(importsOnly.Select(x => new ImportConflict(accountId, x, null, "Import not found in existing")));
-                dailyConflicts.AddRange(existingOnly.Select(x => new ImportConflict(accountId, null, x, "Existing not found in import")));
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!importsByDay.TryGetValue(day, out var importsThisDay)) continue;
+                var existingThisDay = existingByDay.GetValueOrDefault(day) ?? [];
 
-                conflicts.AddRange(dailyConflicts);
+                var exactMatches = ImportConflictDetector.GetExactMatches(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
+                var importsOnly = ImportConflictDetector.GetImportsMissingFromExisting(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
+                var existingOnly = ImportConflictDetector.GetExistingMissingFromImports(existingThisDay, importsThisDay, ExistingKey, ImportKey).ToList();
 
-                if (onConflicts is not null)
-                    await onConflicts(dailyConflicts);
+                if (exactMatches.Count != 0 || existingOnly.Count != 0)
+                {
+                    var dailyConflicts = new List<ImportConflict>();
+                    dailyConflicts.AddRange(exactMatches.Select(x => new ImportConflict(accountId, x.Import, x.Existing, "Exact match")));
+                    dailyConflicts.AddRange(importsOnly.Select(x => new ImportConflict(accountId, x, null, "Import not found in existing")));
+                    dailyConflicts.AddRange(existingOnly.Select(x => new ImportConflict(accountId, null, x, "Existing not found in import")));
+
+                    conflicts.AddRange(dailyConflicts);
+
+                    if (onConflicts is not null)
+                        await onConflicts(dailyConflicts);
+
+                    processed += importsThisDay.Count;
+                    if (onProgress is not null)
+                        await onProgress(processed, imported, failed);
+
+                    continue;
+                }
+
+                var entriesToInsert = new List<CurrencyAccountEntry>(importsThisDay.Count);
+                foreach (var import in importsThisDay)
+                {
+                    try
+                    {
+                        if (import.PostingDate.Kind != DateTimeKind.Utc)
+                            throw new Exception($"Date kind of this entry posting date: {import.PostingDate}, value change: {import.ValueChange} is not UTC - {import.PostingDate.Kind}");
+
+                        CurrencyAccountEntry newEntry = new(accountId, 0, ImportDateNormalizer.ToSecond(import.PostingDate), import.ValueChange, import.ValueChange)
+                        {
+                            Description = import.Description ?? string.Empty,
+                            ContractorDetails = import.ContractorDetails,
+                            Labels = []
+                        };
+                        entriesToInsert.Add(newEntry);
+                    }
+                    catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+                    {
+                        logger.LogDebug(ex, "Currency account import cancelled.");
+                        throw;
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        failed++;
+                        errors.Add($"Cancellation while importing entry with date {import.PostingDate}.");
+                        logger.LogDebug(ex, "Currency account import entry cancelled or timed out for {PostingDate}; marking it failed.", import.PostingDate);
+                    }
+                    catch (Exception ex)
+                    {
+                        failed++;
+                        errors.Add(ex.Message);
+                    }
+
+                }
+
+                foreach (var batch in entriesToInsert.Chunk(_persistenceBatchSize))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var batchList = batch.ToList();
+                    try
+                    {
+                        var added = cancellationToken.CanBeCanceled
+                            ? await currencyAccountEntryRepository.Add(batchList, recalculate: false, cancellationToken)
+                            : await currencyAccountEntryRepository.Add(batchList, recalculate: false);
+                        if (added)
+                        {
+                            imported += batchList.Count;
+                            var batchOldest = batchList.MinBy(entry => (entry.PostingDate, entry.EntryId))!;
+                            if (oldestInserted is null || batchOldest.PostingDate < oldestInserted.PostingDate ||
+                                batchOldest.PostingDate == oldestInserted.PostingDate && batchOldest.EntryId < oldestInserted.EntryId)
+                                oldestInserted = batchOldest;
+                        }
+                        else
+                        {
+                            failed += batchList.Count;
+                            errors.AddRange(batchList.Select(entry => $"Failed to import entry with date {entry.PostingDate}."));
+                        }
+                    }
+                    catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+                    {
+                        logger.LogDebug(ex, "Currency account import batch cancelled.");
+                        throw;
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        failed += batchList.Count;
+                        errors.AddRange(batchList.Select(entry => $"Cancellation while importing entry with date {entry.PostingDate}."));
+                        logger.LogDebug(ex, "Currency account import batch cancelled or timed out.");
+                    }
+                    catch (Exception ex)
+                    {
+                        failed += batchList.Count;
+                        errors.AddRange(batchList.Select(_ => ex.Message));
+                    }
+                }
 
                 processed += importsThisDay.Count;
                 if (onProgress is not null)
                     await onProgress(processed, imported, failed);
-
-                continue;
             }
 
-            var entriesToInsert = new List<CurrencyAccountEntry>(importsThisDay.Count);
-            foreach (var import in importsThisDay)
+            if (oldestInserted is not null)
             {
                 try
                 {
-                    if (import.PostingDate.Kind != DateTimeKind.Utc)
-                        throw new Exception($"Date kind of this entry posting date: {import.PostingDate}, value change: {import.ValueChange} is not UTC - {import.PostingDate.Kind}");
-
-                    CurrencyAccountEntry newEntry = new(accountId, 0, ImportDateNormalizer.ToSecond(import.PostingDate), import.ValueChange, import.ValueChange)
-                    {
-                        Description = import.Description ?? string.Empty,
-                        ContractorDetails = import.ContractorDetails,
-                        Labels = []
-                    };
-                    entriesToInsert.Add(newEntry);
-                }
-                catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
-                {
-                    logger.LogDebug(ex, "Currency account import cancelled.");
-                    throw;
-                }
-                catch (OperationCanceledException ex)
-                {
-                    failed++;
-                    errors.Add($"Cancellation while importing entry with date {import.PostingDate}.");
-                    logger.LogDebug(ex, "Currency account import entry cancelled or timed out for {PostingDate}; marking it failed.", import.PostingDate);
-                }
-                catch (Exception ex)
-                {
-                    failed++;
-                    errors.Add(ex.Message);
-                }
-
-            }
-
-            foreach (var batch in entriesToInsert.Chunk(_persistenceBatchSize))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                var batchList = batch.ToList();
-                try
-                {
-                    var added = cancellationToken.CanBeCanceled
-                        ? await currencyAccountEntryRepository.Add(batchList, recalculate: false, cancellationToken)
-                        : await currencyAccountEntryRepository.Add(batchList, recalculate: false);
-                    if (added)
-                    {
-                        imported += batchList.Count;
-                        if (oldestInserted is null || batchList[0].PostingDate < oldestInserted.PostingDate)
-                            oldestInserted = batchList[0];
-                    }
+                    if (cancellationToken.CanBeCanceled)
+                        await currencyAccountEntryRepository.RecalculateValues(accountId, oldestInserted.EntryId, cancellationToken);
                     else
-                    {
-                        failed += batchList.Count;
-                        errors.AddRange(batchList.Select(entry => $"Failed to import entry with date {entry.PostingDate}."));
-                    }
+                        await currencyAccountEntryRepository.RecalculateValues(accountId, oldestInserted.EntryId);
                 }
                 catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
                 {
-                    logger.LogDebug(ex, "Currency account import batch cancelled.");
+                    logger.LogDebug(ex, "Currency account import recalculation cancelled.");
                     throw;
                 }
                 catch (OperationCanceledException ex)
                 {
-                    failed += batchList.Count;
-                    errors.AddRange(batchList.Select(entry => $"Cancellation while importing entry with date {entry.PostingDate}."));
-                    logger.LogDebug(ex, "Currency account import batch cancelled or timed out.");
-                }
-                catch (Exception ex)
-                {
-                    failed += batchList.Count;
-                    errors.AddRange(batchList.Select(_ => ex.Message));
+                    await RecalculateCommittedEntries(accountId, oldestInserted);
+                    failed++;
+                    errors.Add("Recalculation cancelled or timed out.");
+                    logger.LogDebug(ex, "Currency account import recalculation cancelled or timed out; marking it failed.");
                 }
             }
-
-            processed += importsThisDay.Count;
-            if (onProgress is not null)
-                await onProgress(processed, imported, failed);
         }
-
-        if (oldestInserted is not null)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            try
-            {
-                if (cancellationToken.CanBeCanceled)
-                    await currencyAccountEntryRepository.RecalculateValues(accountId, oldestInserted.EntryId, cancellationToken);
-                else
-                    await currencyAccountEntryRepository.RecalculateValues(accountId, oldestInserted.EntryId);
-            }
-            catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
-            {
-                logger.LogDebug(ex, "Currency account import recalculation cancelled.");
-                throw;
-            }
-            catch (OperationCanceledException ex)
-            {
-                failed++;
-                errors.Add("Recalculation cancelled or timed out.");
-                logger.LogDebug(ex, "Currency account import recalculation cancelled or timed out; marking it failed.");
-            }
+            await RecalculateCommittedEntries(accountId, oldestInserted);
+            throw;
         }
 
         return new(accountId, imported, failed, errors, conflicts);
     }
+
+    private Task RecalculateCommittedEntries(int accountId, CurrencyAccountEntry? oldestInserted) =>
+        oldestInserted is null
+            ? Task.CompletedTask
+            : currencyAccountEntryRepository.RecalculateValues(accountId, oldestInserted.EntryId, CancellationToken.None);
 
     public Task ApplyResolvedConflicts(IEnumerable<ResolvedImportConflict> resolvedConflicts) =>
         ApplyResolvedConflicts(resolvedConflicts, CancellationToken.None);

--- a/code/FinanceManager.Application/FinancialAccounts/Currencies/Import/CurrencyAccountImportService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Currencies/Import/CurrencyAccountImportService.cs
@@ -12,6 +12,10 @@ public class CurrencyAccountImportService(ICurrencyAccountRepository<CurrencyAcc
     IAccountEntryRepository<CurrencyAccountEntry> currencyAccountEntryRepository,
     ImportAccountValidator importAccountValidator, ILogger<CurrencyAccountImportService> logger) : ICurrencyAccountImportService
 {
+    // Keep each persistence operation bounded so large imports retain partial-failure semantics and
+    // do not create an unbounded EF change tracker or provider command batch.
+    private const int _persistenceBatchSize = 500;
+
     public Task<ImportResult> ImportEntries(
         int userId,
         int accountId,
@@ -52,20 +56,25 @@ public class CurrencyAccountImportService(ICurrencyAccountRepository<CurrencyAcc
         var conflicts = new List<ImportConflict>();
         CurrencyAccountEntry? oldestInserted = null;
 
-        var existingAll = cancellationToken.CanBeCanceled
+        var existingEntries = cancellationToken.CanBeCanceled
             ? await currencyAccountEntryRepository
                 .Get(accountId, minDay.AddDays(-1), maxDay.AddDays(1), cancellationToken)
                 .ToListAsync(cancellationToken)
             : await currencyAccountEntryRepository
                 .Get(accountId, minDay.AddDays(-1), maxDay.AddDays(1))
                 .ToListAsync();
+        var importsByDay = entryList
+            .GroupBy(x => x.PostingDate.Date)
+            .ToDictionary(g => g.Key, g => g.ToList());
+        var existingByDay = existingEntries
+            .GroupBy(e => e.PostingDate.Date)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
         for (var day = maxDay; day >= minDay; day = day.AddDays(-1))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var importsThisDay = entryList.Where(x => x.PostingDate.Date == day).ToList();
-            var existingThisDay = existingAll.Where(e => e.PostingDate.Date == day).ToList();
-
-            if (importsThisDay.Count == 0) continue;
+            if (!importsByDay.TryGetValue(day, out var importsThisDay)) continue;
+            var existingThisDay = existingByDay.GetValueOrDefault(day) ?? [];
 
             var exactMatches = ImportConflictDetector.GetExactMatches(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
             var importsOnly = ImportConflictDetector.GetImportsMissingFromExisting(importsThisDay, existingThisDay, ImportKey, ExistingKey).ToList();
@@ -90,6 +99,7 @@ public class CurrencyAccountImportService(ICurrencyAccountRepository<CurrencyAcc
                 continue;
             }
 
+            var entriesToInsert = new List<CurrencyAccountEntry>(importsThisDay.Count);
             foreach (var import in importsThisDay)
             {
                 try
@@ -103,22 +113,7 @@ public class CurrencyAccountImportService(ICurrencyAccountRepository<CurrencyAcc
                         ContractorDetails = import.ContractorDetails,
                         Labels = []
                     };
-
-                    var added = cancellationToken.CanBeCanceled
-                        ? await currencyAccountEntryRepository.Add(newEntry, recalculate: false, cancellationToken)
-                        : await currencyAccountEntryRepository.Add(newEntry, recalculate: false);
-                    if (added)
-                    {
-                        imported++;
-                        existingAll.Add(newEntry);
-                        if (oldestInserted is null || newEntry.PostingDate < oldestInserted.PostingDate)
-                            oldestInserted = newEntry;
-                    }
-                    else
-                    {
-                        failed++;
-                        errors.Add($"Failed to import entry with date {import.PostingDate}.");
-                    }
+                    entriesToInsert.Add(newEntry);
                 }
                 catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
                 {
@@ -137,6 +132,45 @@ public class CurrencyAccountImportService(ICurrencyAccountRepository<CurrencyAcc
                     errors.Add(ex.Message);
                 }
 
+            }
+
+            foreach (var batch in entriesToInsert.Chunk(_persistenceBatchSize))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var batchList = batch.ToList();
+                try
+                {
+                    var added = cancellationToken.CanBeCanceled
+                        ? await currencyAccountEntryRepository.Add(batchList, recalculate: false, cancellationToken)
+                        : await currencyAccountEntryRepository.Add(batchList, recalculate: false);
+                    if (added)
+                    {
+                        imported += batchList.Count;
+                        if (oldestInserted is null || batchList[0].PostingDate < oldestInserted.PostingDate)
+                            oldestInserted = batchList[0];
+                    }
+                    else
+                    {
+                        failed += batchList.Count;
+                        errors.AddRange(batchList.Select(entry => $"Failed to import entry with date {entry.PostingDate}."));
+                    }
+                }
+                catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+                {
+                    logger.LogDebug(ex, "Currency account import batch cancelled.");
+                    throw;
+                }
+                catch (OperationCanceledException ex)
+                {
+                    failed += batchList.Count;
+                    errors.AddRange(batchList.Select(entry => $"Cancellation while importing entry with date {entry.PostingDate}."));
+                    logger.LogDebug(ex, "Currency account import batch cancelled or timed out.");
+                }
+                catch (Exception ex)
+                {
+                    failed += batchList.Count;
+                    errors.AddRange(batchList.Select(_ => ex.Message));
+                }
             }
 
             processed += importsThisDay.Count;

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondEntryRepository.cs
@@ -37,10 +37,11 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
             await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
             context.BondEntries.Add(newEntry);
             await context.SaveChangesAsync(cancellationToken);
-            if (entry.EntryId == 0 && newEntry.EntryId != 0)
-                _entryIdProperty?.SetValue(entry, newEntry.EntryId);
             await RecalculateValues(newEntry.AccountId, newEntry.EntryId, cancellationToken);
             await transaction.CommitAsync(cancellationToken);
+            if (entry.EntryId == 0 && newEntry.EntryId != 0)
+                _entryIdProperty?.SetValue(entry, newEntry.EntryId);
+            context.ChangeTracker.Clear();
         }
         else
         {
@@ -62,6 +63,7 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
                     await RecalculateValues(newEntry.AccountId, newEntry.EntryId, CancellationToken.None);
                 }
             }
+            context.ChangeTracker.Clear();
         }
         return true;
     }
@@ -106,13 +108,14 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
             // Relational: transactional mutation + recalculation commit together atomically.
             await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
             await context.SaveChangesAsync(cancellationToken);
+            await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
             foreach (var (source, target) in pairs)
             {
                 if (source.EntryId == 0 && target.EntryId != 0)
                     _entryIdProperty?.SetValue(source, target.EntryId);
             }
-            await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, cancellationToken);
-            await transaction.CommitAsync(cancellationToken);
+            context.ChangeTracker.Clear();
         }
         else
         {
@@ -136,6 +139,7 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
                     await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, CancellationToken.None);
                 }
             }
+            context.ChangeTracker.Clear();
         }
 
         return true;

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondEntryRepository.cs
@@ -15,6 +15,9 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
     private const int _maxAccountIdsPerQuery = 2_000;
 
     private readonly BondEntryValueCalculator _valueCalculator = new(context);
+    private static readonly System.Reflection.PropertyInfo? _entryIdProperty =
+        typeof(FinancialEntryBase).GetProperty(nameof(FinancialEntryBase.EntryId));
+
     public Task<bool> Add(BondAccountEntry entry, bool recalculate) =>
         Add(entry, recalculate, CancellationToken.None);
 
@@ -25,14 +28,41 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
         var newEntry = new BondAccountEntry(entry.AccountId, 0, DateTime.SpecifyKind(entry.PostingDate, DateTimeKind.Utc),
          0, entry.ValueChange, entry.BondDetailsId)
         {
-            Labels = entry.Labels,
+            Labels = await ResolveTrackedLabels(entry.Labels, cancellationToken),
         };
 
-        context.BondEntries.Add(newEntry);
-        await context.SaveChangesAsync(cancellationToken);
-
-        if (recalculate)
+        if (context.Database.IsRelational() && recalculate)
+        {
+            // Relational: transactional mutation + recalculation commit together atomically.
+            await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+            context.BondEntries.Add(newEntry);
+            await context.SaveChangesAsync(cancellationToken);
+            if (entry.EntryId == 0 && newEntry.EntryId != 0)
+                _entryIdProperty?.SetValue(entry, newEntry.EntryId);
             await RecalculateValues(newEntry.AccountId, newEntry.EntryId, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        }
+        else
+        {
+            // Non-relational or no recalculation: persist entry first.
+            context.BondEntries.Add(newEntry);
+            await context.SaveChangesAsync(cancellationToken);
+            if (entry.EntryId == 0 && newEntry.EntryId != 0)
+                _entryIdProperty?.SetValue(entry, newEntry.EntryId);
+            if (recalculate)
+            {
+                // Post-commit repair: complete recalculation before propagating cancellation.
+                try
+                {
+                    await RecalculateValues(newEntry.AccountId, newEntry.EntryId, cancellationToken);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    // Provider timeout or internal cancellation: complete recalculation with no-token fallback.
+                    await RecalculateValues(newEntry.AccountId, newEntry.EntryId, CancellationToken.None);
+                }
+            }
+        }
         return true;
     }
     public Task<bool> Add(IEnumerable<BondAccountEntry> entries, bool recalculate = true) =>
@@ -43,27 +73,88 @@ public class BondEntryRepository(AppDbContext context) : IBondAccountEntryReposi
         bool recalculate,
         CancellationToken cancellationToken)
     {
-        BondAccountEntry? firstEntry = null;
+        var entryList = entries as IList<BondAccountEntry> ?? entries.ToList();
+        if (entryList.Count == 0) return true;
 
-        foreach (var entry in entries)
+        var existingLabelIds = entryList.SelectMany(e => e.Labels).Where(l => l.Id != 0).Select(l => l.Id).Distinct().ToList();
+        var trackedById = existingLabelIds.Count == 0
+            ? []
+            : await context.FinancialLabels.Where(l => existingLabelIds.Contains(l.Id)).ToDictionaryAsync(l => l.Id, cancellationToken);
+
+        List<(BondAccountEntry Source, BondAccountEntry Target)> pairs = new(entryList.Count);
+        BondAccountEntry? oldestEntry = null;
+
+        foreach (var entry in entryList)
         {
             // Don't use entry.Value as it may be a placeholder
             // The correct value will be calculated during recalculation
             var newEntry = new BondAccountEntry(entry.AccountId, 0, DateTime.SpecifyKind(entry.PostingDate, DateTimeKind.Utc),
              0, entry.ValueChange, entry.BondDetailsId)
             {
-                Labels = entry.Labels,
+                Labels = entry.Labels.Select(l => l.Id != 0 && trackedById.TryGetValue(l.Id, out var tracked) ? tracked : l).ToList(),
             };
 
-            if (firstEntry is null) firstEntry = newEntry;
+            pairs.Add((entry, newEntry));
+            if (oldestEntry is null || newEntry.PostingDate < oldestEntry.PostingDate)
+                oldestEntry = newEntry;
+
             context.BondEntries.Add(newEntry);
         }
 
-        await context.SaveChangesAsync(cancellationToken);
-        if (recalculate && firstEntry is not null)
-            await RecalculateValues(firstEntry.AccountId, firstEntry.EntryId, cancellationToken);
+        if (context.Database.IsRelational() && recalculate && oldestEntry is not null)
+        {
+            // Relational: transactional mutation + recalculation commit together atomically.
+            await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
+            await context.SaveChangesAsync(cancellationToken);
+            foreach (var (source, target) in pairs)
+            {
+                if (source.EntryId == 0 && target.EntryId != 0)
+                    _entryIdProperty?.SetValue(source, target.EntryId);
+            }
+            await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
+        }
+        else
+        {
+            // Non-relational or no recalculation: persist entries first.
+            await context.SaveChangesAsync(cancellationToken);
+            foreach (var (source, target) in pairs)
+            {
+                if (source.EntryId == 0 && target.EntryId != 0)
+                    _entryIdProperty?.SetValue(source, target.EntryId);
+            }
+            if (recalculate && oldestEntry is not null)
+            {
+                // Post-commit repair: complete recalculation before propagating cancellation.
+                try
+                {
+                    await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, cancellationToken);
+                }
+                catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+                {
+                    // Provider timeout or internal cancellation: complete recalculation with no-token fallback.
+                    await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, CancellationToken.None);
+                }
+            }
+        }
 
         return true;
+    }
+
+    private async Task<List<FinancialLabel>> ResolveTrackedLabels(
+        ICollection<FinancialLabel> labels,
+        CancellationToken cancellationToken)
+    {
+        if (labels.Count == 0) return [];
+
+        var existingIds = labels.Where(l => l.Id != 0).Select(l => l.Id).Distinct().ToList();
+        var trackedById = existingIds.Count == 0
+            ? []
+            : await context.FinancialLabels.Where(l => existingIds.Contains(l.Id)).ToDictionaryAsync(l => l.Id, cancellationToken);
+
+        return labels
+            .Select(l => l.Id != 0 && trackedById.TryGetValue(l.Id, out var tracked) ? tracked : l)
+            .ToList();
     }
 
     public Task<bool> Delete(int accountId, int entryId) =>

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Repositories/CurrencyEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Repositories/CurrencyEntryRepository.cs
@@ -14,6 +14,9 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
     private const int _maxAccountIdsPerQuery = 2_000;
 
     private readonly CurrencyEntryValueCalculator _valueCalculator = new(context);
+    private static readonly System.Reflection.PropertyInfo? _entryIdProperty =
+        typeof(FinancialEntryBase).GetProperty(nameof(FinancialEntryBase.EntryId));
+
     public Task<bool> Add(CurrencyAccountEntry entry, bool recalculate) =>
         Add(entry, recalculate, CancellationToken.None);
 
@@ -32,6 +35,8 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
             await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
             context.CurrencyEntries.Add(newAccountEntry);
             await context.SaveChangesAsync(cancellationToken);
+            if (entry.EntryId == 0 && newAccountEntry.EntryId != 0)
+                _entryIdProperty?.SetValue(entry, newAccountEntry.EntryId);
             await RecalculateValues(newAccountEntry.AccountId, newAccountEntry.EntryId, cancellationToken);
             await transaction.CommitAsync(cancellationToken);
         }
@@ -40,6 +45,8 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
             // Non-relational or no recalculation: persist entry first.
             context.CurrencyEntries.Add(newAccountEntry);
             await context.SaveChangesAsync(cancellationToken);
+            if (entry.EntryId == 0 && newAccountEntry.EntryId != 0)
+                _entryIdProperty?.SetValue(entry, newAccountEntry.EntryId);
             if (recalculate)
             {
                 // Post-commit repair: complete recalculation before propagating cancellation.
@@ -65,6 +72,7 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
         CancellationToken cancellationToken)
     {
         var entryList = entries as IList<CurrencyAccountEntry> ?? entries.ToList();
+        if (entryList.Count == 0) return true;
 
         // Re-resolve already-persisted labels to context-tracked instances in one query so EF reuses the
         // existing rows instead of trying to INSERT detached copies — the guest seeder reads labels via
@@ -74,7 +82,8 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
             ? []
             : await context.FinancialLabels.Where(l => existingLabelIds.Contains(l.Id)).ToDictionaryAsync(l => l.Id, cancellationToken);
 
-        CurrencyAccountEntry? firstEntry = null;
+        List<(CurrencyAccountEntry Source, CurrencyAccountEntry Target)> pairs = new(entryList.Count);
+        CurrencyAccountEntry? oldestEntry = null;
 
         foreach (var entry in entryList)
         {
@@ -85,34 +94,46 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
                 Labels = entry.Labels.Select(l => l.Id != 0 && trackedById.TryGetValue(l.Id, out var tracked) ? tracked : l).ToList(),
             };
 
-            if (firstEntry is null) firstEntry = newEntry;
+            pairs.Add((entry, newEntry));
+            if (oldestEntry is null || newEntry.PostingDate < oldestEntry.PostingDate)
+                oldestEntry = newEntry;
 
             context.CurrencyEntries.Add(newEntry);
         }
 
-        if (context.Database.IsRelational() && recalculate && firstEntry is not null)
+        if (context.Database.IsRelational() && recalculate && oldestEntry is not null)
         {
             // Relational: transactional mutation + recalculation commit together atomically.
             await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
             await context.SaveChangesAsync(cancellationToken);
-            await RecalculateValues(firstEntry.AccountId, firstEntry.EntryId, cancellationToken);
+            foreach (var (source, target) in pairs)
+            {
+                if (source.EntryId == 0 && target.EntryId != 0)
+                    _entryIdProperty?.SetValue(source, target.EntryId);
+            }
+            await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, cancellationToken);
             await transaction.CommitAsync(cancellationToken);
         }
         else
         {
             // Non-relational or no recalculation: persist entries first.
             await context.SaveChangesAsync(cancellationToken);
-            if (recalculate && firstEntry is not null)
+            foreach (var (source, target) in pairs)
+            {
+                if (source.EntryId == 0 && target.EntryId != 0)
+                    _entryIdProperty?.SetValue(source, target.EntryId);
+            }
+            if (recalculate && oldestEntry is not null)
             {
                 // Post-commit repair: complete recalculation before propagating cancellation.
                 try
                 {
-                    await RecalculateValues(firstEntry.AccountId, firstEntry.EntryId, cancellationToken);
+                    await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, cancellationToken);
                 }
                 catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
                 {
                     // Provider timeout or internal cancellation: complete recalculation with no-token fallback.
-                    await RecalculateValues(firstEntry.AccountId, firstEntry.EntryId, CancellationToken.None);
+                    await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, CancellationToken.None);
                 }
             }
         }

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Repositories/CurrencyEntryRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Currencies/Repositories/CurrencyEntryRepository.cs
@@ -35,10 +35,11 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
             await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
             context.CurrencyEntries.Add(newAccountEntry);
             await context.SaveChangesAsync(cancellationToken);
-            if (entry.EntryId == 0 && newAccountEntry.EntryId != 0)
-                _entryIdProperty?.SetValue(entry, newAccountEntry.EntryId);
             await RecalculateValues(newAccountEntry.AccountId, newAccountEntry.EntryId, cancellationToken);
             await transaction.CommitAsync(cancellationToken);
+            if (entry.EntryId == 0 && newAccountEntry.EntryId != 0)
+                _entryIdProperty?.SetValue(entry, newAccountEntry.EntryId);
+            context.ChangeTracker.Clear();
         }
         else
         {
@@ -60,6 +61,7 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
                     await RecalculateValues(newAccountEntry.AccountId, newAccountEntry.EntryId, CancellationToken.None);
                 }
             }
+            context.ChangeTracker.Clear();
         }
         return true;
     }
@@ -106,13 +108,14 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
             // Relational: transactional mutation + recalculation commit together atomically.
             await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
             await context.SaveChangesAsync(cancellationToken);
+            await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, cancellationToken);
+            await transaction.CommitAsync(cancellationToken);
             foreach (var (source, target) in pairs)
             {
                 if (source.EntryId == 0 && target.EntryId != 0)
                     _entryIdProperty?.SetValue(source, target.EntryId);
             }
-            await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, cancellationToken);
-            await transaction.CommitAsync(cancellationToken);
+            context.ChangeTracker.Clear();
         }
         else
         {
@@ -136,6 +139,7 @@ public class CurrencyEntryRepository(AppDbContext context) : IAccountEntryReposi
                     await RecalculateValues(oldestEntry.AccountId, oldestEntry.EntryId, CancellationToken.None);
                 }
             }
+            context.ChangeTracker.Clear();
         }
         return true;
     }

--- a/code/FinanceManager.Tests.Integration/Repositories/SqliteBondImportBatchTests.cs
+++ b/code/FinanceManager.Tests.Integration/Repositories/SqliteBondImportBatchTests.cs
@@ -1,0 +1,246 @@
+using FinanceManager.Application.FinancialAccounts.Bond.Import;
+using FinanceManager.Application.FinancialAccounts.Shared.Imports;
+using FinanceManager.Application.Identity.Users;
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Bond.Imports;
+using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Shared.ValueObjects;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Domain.Identity.Repositories;
+using FinanceManager.Infrastructure.Features.FinancialAccounts.Bond.Repositories;
+using FinanceManager.Infrastructure.Persistence;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Repositories;
+
+[Trait("Category", "Integration")]
+public sealed class SqliteBondImportBatchTests : IDisposable
+{
+    private const int _accountId = 7410;
+    private const int _userId = 42;
+
+    private readonly SqliteConnection _connection;
+    private readonly AppDbContext _context;
+    private readonly BondEntryRepository _repo;
+
+    public SqliteBondImportBatchTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _context = new AppDbContext(
+            new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(_connection)
+                .Options);
+
+        _context.Database.EnsureCreated();
+        _repo = new BondEntryRepository(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task AddBatch_PersistsAllEntries_AndPopulatesGeneratedIds()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan15 = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var entry1 = new BondAccountEntry(_accountId, 0, jan10, 0, 500m, bondDetailsId: 1);
+        var entry2 = new BondAccountEntry(_accountId, 0, jan15, 0, 300m, bondDetailsId: 1);
+        List<BondAccountEntry> batch = [entry1, entry2];
+
+        var added = await _repo.Add(batch, recalculate: false, cancellationToken: ct);
+
+        Assert.True(added);
+        Assert.True(entry1.EntryId > 0, "entry1.EntryId must be populated with database-generated ID");
+        Assert.True(entry2.EntryId > 0, "entry2.EntryId must be populated with database-generated ID");
+        Assert.NotEqual(entry1.EntryId, entry2.EntryId);
+
+        var dbEntries = await _context.BondEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == _accountId)
+            .OrderBy(e => e.PostingDate)
+            .ToListAsync(ct);
+
+        Assert.Equal(2, dbEntries.Count);
+        Assert.Equal(entry1.EntryId, dbEntries[0].EntryId);
+        Assert.Equal(entry2.EntryId, dbEntries[1].EntryId);
+    }
+
+    [Fact]
+    public async Task AddBatch_WithOutOfOrderDatesAndRecalculation_AnchorsToEarliestDate()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan15 = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var jan20 = new DateTime(2025, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        const int bondA = 1;
+        const int bondB = 2;
+
+        // Seed existing baseline
+        await _repo.Add(new BondAccountEntry(_accountId, 0, jan10, 0, 1000m, bondA), recalculate: true, cancellationToken: ct);
+        await _repo.Add(new BondAccountEntry(_accountId, 0, jan10, 0, 2000m, bondB), recalculate: true, cancellationToken: ct);
+
+        // Batch provided in reverse date order: jan20 first, then jan15
+        var entryJan20 = new BondAccountEntry(_accountId, 0, jan20, 0, 500m, bondA);
+        var entryJan15 = new BondAccountEntry(_accountId, 0, jan15, 0, 200m, bondA);
+        var entryJan15B = new BondAccountEntry(_accountId, 0, jan15, 0, 400m, bondB);
+
+        var added = await _repo.Add([entryJan20, entryJan15, entryJan15B], recalculate: true, cancellationToken: ct);
+
+        Assert.True(added);
+        Assert.True(entryJan20.EntryId > 0);
+        Assert.True(entryJan15.EntryId > 0);
+        Assert.True(entryJan15B.EntryId > 0);
+
+        var bondAEntries = await _context.BondEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == _accountId && e.BondDetailsId == bondA)
+            .OrderBy(e => e.PostingDate)
+            .ToListAsync(ct);
+
+        var bondBEntries = await _context.BondEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == _accountId && e.BondDetailsId == bondB)
+            .OrderBy(e => e.PostingDate)
+            .ToListAsync(ct);
+
+        // Bond A: Jan 10 (1000), Jan 15 (+200 -> 1200), Jan 20 (+500 -> 1700)
+        Assert.Equal(3, bondAEntries.Count);
+        Assert.Equal(1000m, bondAEntries[0].Value);
+        Assert.Equal(1200m, bondAEntries[1].Value);
+        Assert.Equal(1700m, bondAEntries[2].Value);
+
+        // Bond B: Jan 10 (2000), Jan 15 (+400 -> 2400)
+        Assert.Equal(2, bondBEntries.Count);
+        Assert.Equal(2000m, bondBEntries[0].Value);
+        Assert.Equal(2400m, bondBEntries[1].Value);
+    }
+
+    [Fact]
+    public async Task AddBatch_WithTrackedLabels_ReusesExistingLabelsWithoutDuplicateInserts()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var existingLabel = new FinancialLabel { Name = "FixedIncome" };
+        _context.FinancialLabels.Add(existingLabel);
+        await _context.SaveChangesAsync(ct);
+
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var entry = new BondAccountEntry(_accountId, 0, jan10, 0, 500m, bondDetailsId: 1)
+        {
+            Labels = [new FinancialLabel { Id = existingLabel.Id, Name = existingLabel.Name }]
+        };
+
+        var added = await _repo.Add([entry], recalculate: false, cancellationToken: ct);
+
+        Assert.True(added);
+        Assert.Equal(1, await _context.FinancialLabels.CountAsync(ct));
+
+        var loaded = await _context.BondEntries
+            .Include(e => e.Labels)
+            .FirstOrDefaultAsync(e => e.EntryId == entry.EntryId, ct);
+
+        Assert.NotNull(loaded);
+        Assert.Single(loaded.Labels);
+        Assert.Equal(existingLabel.Id, loaded.Labels.First().Id);
+    }
+
+    [Fact]
+    public async Task ServiceImport_WithRelationalPersistence_PreservesReverseDayConflictAndRecalculatesRunningBalances()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Setup service with real repository and mocks for plan/account ownership
+        var mockAccountRepo = new Mock<IAccountRepository<BondAccount>>();
+        var account = new BondAccount(_userId, _accountId, "TestBonds");
+        mockAccountRepo.Setup(x => x.Get(_accountId, It.IsAny<CancellationToken>())).ReturnsAsync(account);
+        mockAccountRepo.Setup(x => x.Get(_accountId)).ReturnsAsync(account);
+
+        var mockCurrencyAccountRepo = new Mock<ICurrencyAccountRepository<CurrencyAccount>>();
+        var mockCurrencyEntryRepo = new Mock<IAccountEntryRepository<CurrencyAccountEntry>>();
+        var mockInvestmentRepo = new Mock<IInvestmentTransactionRepository>();
+        var mockUserRepo = new Mock<IUserRepository>();
+
+        var user = new User { Login = "TestUser", UserId = _userId, PricingLevel = PricingLevel.Premium, CreationDate = DateTime.UtcNow };
+        mockUserRepo.Setup(x => x.GetUser(_userId)).ReturnsAsync(user);
+
+        mockCurrencyEntryRepo.Setup(x => x.GetEntriesCountPerUser(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, int>());
+        mockInvestmentRepo.Setup(x => x.GetByUser(It.IsAny<long>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var userPlanVerifier = new UserPlanVerifier(
+            mockCurrencyAccountRepo.Object,
+            mockCurrencyEntryRepo.Object,
+            mockInvestmentRepo.Object,
+            _repo,
+            mockUserRepo.Object);
+
+        var importAccountValidator = new ImportAccountValidator(userPlanVerifier);
+        var logger = new Mock<ILogger<BondAccountImportService>>();
+        var service = new BondAccountImportService(mockAccountRepo.Object, _repo, importAccountValidator, logger.Object);
+
+        // Seed existing baseline entries on Jan 10 and Jan 20
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan15 = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var jan20 = new DateTime(2025, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+        var jan25 = new DateTime(2025, 1, 25, 0, 0, 0, DateTimeKind.Utc);
+
+        const int bondA = 1;
+        await _repo.Add(new BondAccountEntry(_accountId, 0, jan10, 0, 1000m, bondA), recalculate: true, cancellationToken: ct);
+        await _repo.Add(new BondAccountEntry(_accountId, 0, jan20, 0, 500m, bondA), recalculate: true, cancellationToken: ct);
+
+        // Import dataset:
+        // - Jan 25: clean new day -> should be imported
+        // - Jan 20: exact match with existing entry -> conflict day, should be skipped
+        // - Jan 15: clean new day -> should be imported
+        List<BondEntryImport> importEntries =
+        [
+            new(jan15, 200m, bondA),
+            new(jan20, 500m, bondA),
+            new(jan25, 300m, bondA)
+        ];
+
+        var result = await service.ImportEntries(_userId, _accountId, importEntries, ct);
+
+        Assert.Equal(2, result.Imported);
+        Assert.Equal(0, result.Failed);
+        Assert.Single(result.Conflicts);
+        Assert.Equal("Exact match", result.Conflicts[0].Reason);
+
+        // Verify database state: 4 total entries in chronological order
+        var entries = await _context.BondEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == _accountId)
+            .OrderBy(e => e.PostingDate)
+            .ToListAsync(ct);
+
+        Assert.Equal(4, entries.Count);
+        Assert.Equal(jan10, entries[0].PostingDate);
+        Assert.Equal(1000m, entries[0].Value);
+
+        Assert.Equal(jan15, entries[1].PostingDate);
+        Assert.Equal(1200m, entries[1].Value); // 1000 + 200
+
+        Assert.Equal(jan20, entries[2].PostingDate);
+        Assert.Equal(1700m, entries[2].Value); // 1200 + 500
+
+        Assert.Equal(jan25, entries[3].PostingDate);
+        Assert.Equal(2000m, entries[3].Value); // 1700 + 300
+    }
+}

--- a/code/FinanceManager.Tests.Integration/Repositories/SqliteBondImportBatchTests.cs
+++ b/code/FinanceManager.Tests.Integration/Repositories/SqliteBondImportBatchTests.cs
@@ -79,6 +79,7 @@ public sealed class SqliteBondImportBatchTests : IDisposable
         Assert.Equal(2, dbEntries.Count);
         Assert.Equal(entry1.EntryId, dbEntries[0].EntryId);
         Assert.Equal(entry2.EntryId, dbEntries[1].EntryId);
+        Assert.Empty(_context.ChangeTracker.Entries());
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Integration/Repositories/SqliteCurrencyImportBatchTests.cs
+++ b/code/FinanceManager.Tests.Integration/Repositories/SqliteCurrencyImportBatchTests.cs
@@ -17,6 +17,7 @@ public sealed class SqliteCurrencyImportBatchTests : IDisposable
     private readonly AppDbContext _context;
     private readonly CurrencyEntryRepository _repo;
 
+    // Ordered SQLite setup requires explicit constructor statements and cannot be expressed with a primary constructor.
     public SqliteCurrencyImportBatchTests()
     {
         _connection = new SqliteConnection("DataSource=:memory:");
@@ -63,6 +64,7 @@ public sealed class SqliteCurrencyImportBatchTests : IDisposable
         Assert.Equal(2, dbEntries.Count);
         Assert.Equal(entry1.EntryId, dbEntries[0].EntryId);
         Assert.Equal(entry2.EntryId, dbEntries[1].EntryId);
+        Assert.Empty(_context.ChangeTracker.Entries());
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Integration/Repositories/SqliteCurrencyImportBatchTests.cs
+++ b/code/FinanceManager.Tests.Integration/Repositories/SqliteCurrencyImportBatchTests.cs
@@ -1,0 +1,128 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+using FinanceManager.Infrastructure.Features.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Infrastructure.Persistence;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Repositories;
+
+[Trait("Category", "Integration")]
+public sealed class SqliteCurrencyImportBatchTests : IDisposable
+{
+    private const int _accountId = 7411;
+
+    private readonly SqliteConnection _connection;
+    private readonly AppDbContext _context;
+    private readonly CurrencyEntryRepository _repo;
+
+    public SqliteCurrencyImportBatchTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _context = new AppDbContext(
+            new DbContextOptionsBuilder<AppDbContext>()
+                .UseSqlite(_connection)
+                .Options);
+
+        _context.Database.EnsureCreated();
+        _repo = new CurrencyEntryRepository(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
+
+    [Fact]
+    public async Task AddBatch_PersistsAllEntries_AndPopulatesGeneratedIds()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan15 = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var entry1 = new CurrencyAccountEntry(_accountId, 0, jan10, 0, 500m);
+        var entry2 = new CurrencyAccountEntry(_accountId, 0, jan15, 0, 300m);
+
+        var added = await _repo.Add([entry2, entry1], recalculate: false, cancellationToken: ct);
+
+        Assert.True(added);
+        Assert.True(entry1.EntryId > 0);
+        Assert.True(entry2.EntryId > 0);
+        Assert.NotEqual(entry1.EntryId, entry2.EntryId);
+
+        var dbEntries = await _context.CurrencyEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == _accountId)
+            .OrderBy(e => e.PostingDate)
+            .ToListAsync(ct);
+
+        Assert.Equal(2, dbEntries.Count);
+        Assert.Equal(entry1.EntryId, dbEntries[0].EntryId);
+        Assert.Equal(entry2.EntryId, dbEntries[1].EntryId);
+    }
+
+    [Fact]
+    public async Task AddBatch_WithOutOfOrderDates_AnchorsRecalculationAtEarliestEntry()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan15 = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+        var jan20 = new DateTime(2025, 1, 20, 0, 0, 0, DateTimeKind.Utc);
+        var jan25 = new DateTime(2025, 1, 25, 0, 0, 0, DateTimeKind.Utc);
+
+        await _repo.Add(new CurrencyAccountEntry(_accountId, 0, jan10, 0, 1_000m), recalculate: true, cancellationToken: ct);
+        await _repo.Add(new CurrencyAccountEntry(_accountId, 0, jan20, 0, 500m), recalculate: true, cancellationToken: ct);
+
+        var entryJan25 = new CurrencyAccountEntry(_accountId, 0, jan25, 0, 300m);
+        var entryJan15 = new CurrencyAccountEntry(_accountId, 0, jan15, 0, 200m);
+
+        var added = await _repo.Add([entryJan25, entryJan15], recalculate: true, cancellationToken: ct);
+
+        Assert.True(added);
+        Assert.True(entryJan25.EntryId > 0);
+        Assert.True(entryJan15.EntryId > 0);
+
+        var entries = await _context.CurrencyEntries
+            .AsNoTracking()
+            .Where(e => e.AccountId == _accountId)
+            .OrderBy(e => e.PostingDate)
+            .ToListAsync(ct);
+
+        Assert.Equal(4, entries.Count);
+        Assert.Equal(1_000m, entries[0].Value);
+        Assert.Equal(1_200m, entries[1].Value);
+        Assert.Equal(1_700m, entries[2].Value);
+        Assert.Equal(2_000m, entries[3].Value);
+    }
+
+    [Fact]
+    public async Task AddBatch_WithTrackedLabels_ReusesExistingLabelsWithoutDuplicateInserts()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var existingLabel = new FinancialLabel { Name = "Imported" };
+        _context.FinancialLabels.Add(existingLabel);
+        await _context.SaveChangesAsync(ct);
+
+        var postingDate = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var entry = new CurrencyAccountEntry(_accountId, 0, postingDate, 0, 500m)
+        {
+            Labels = [new FinancialLabel { Id = existingLabel.Id, Name = existingLabel.Name }]
+        };
+
+        var added = await _repo.Add([entry], recalculate: false, cancellationToken: ct);
+
+        Assert.True(added);
+        Assert.Equal(1, await _context.FinancialLabels.CountAsync(ct));
+
+        var loaded = await _context.CurrencyEntries
+            .Include(e => e.Labels)
+            .SingleAsync(e => e.EntryId == entry.EntryId, ct);
+
+        Assert.Single(loaded.Labels);
+        Assert.Equal(existingLabel.Id, loaded.Labels.First().Id);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/BondAccountImportServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/BondAccountImportServiceTests.cs
@@ -106,6 +106,42 @@ public class BondAccountImportServiceTests
     }
 
     [Fact]
+    public async Task ImportEntries_WhenCallerCancelsAfterCommit_RecalculatesCommittedEntriesBeforePropagating()
+    {
+        const int userId = 1;
+        const int accountId = 10;
+        var account = new BondAccount(userId, accountId, "TestBonds");
+        _mockAccountRepository.Setup(x => x.Get(accountId, It.IsAny<CancellationToken>())).ReturnsAsync(account);
+        _mockAccountRepository.Setup(x => x.Get(accountId)).ReturnsAsync(account);
+
+        using var cancellation = new CancellationTokenSource();
+        var date = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        List<BondEntryImport> entries = [new(date, 100m, 1)];
+
+        _mockBondEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<BondAccountEntry>>(), false, It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<BondAccountEntry>, bool, CancellationToken>((batch, _, _) =>
+            {
+                foreach (var entry in batch)
+                    typeof(FinancialEntryBase).GetProperty(nameof(FinancialEntryBase.EntryId))?.SetValue(entry, 100);
+                cancellation.Cancel();
+            })
+            .ReturnsAsync(true);
+        _mockBondEntryRepository.Setup(x => x.RecalculateValues(accountId, 100, It.Is<CancellationToken>(token => token == cancellation.Token)))
+            .ThrowsAsync(new OperationCanceledException(cancellation.Token));
+        _mockBondEntryRepository.Setup(x => x.RecalculateValues(accountId, 100, CancellationToken.None))
+            .Returns(Task.CompletedTask);
+
+#pragma warning disable xUnit1051
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _service.ImportEntries(userId, accountId, entries, cancellation.Token));
+#pragma warning restore xUnit1051
+
+        _mockBondEntryRepository.Verify(
+            x => x.RecalculateValues(accountId, 100, CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task ImportEntries_AccountNotFound_ThrowsInvalidOperationException()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -359,10 +395,10 @@ public class BondAccountImportServiceTests
             .ReturnsAsync(true);
 
         // Internal OperationCanceledException (not from caller token)
-        _mockBondEntryRepository.Setup(x => x.RecalculateValues(accountId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new OperationCanceledException());
         _mockBondEntryRepository.Setup(x => x.RecalculateValues(accountId, It.IsAny<int>()))
             .ThrowsAsync(new OperationCanceledException());
+        _mockBondEntryRepository.Setup(x => x.RecalculateValues(accountId, It.IsAny<int>(), CancellationToken.None))
+            .Returns(Task.CompletedTask);
 
 #pragma warning disable xUnit1051
         var result = await _service.ImportEntries(userId, accountId, domainEntries, CancellationToken.None);
@@ -372,6 +408,9 @@ public class BondAccountImportServiceTests
         Assert.Equal(1, result.Failed);
         Assert.Single(result.Errors);
         Assert.Contains("Recalculation cancelled or timed out", result.Errors[0]);
+        _mockBondEntryRepository.Verify(
+            x => x.RecalculateValues(accountId, 77, CancellationToken.None),
+            Times.Once);
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Unit/Application/Services/BondAccountImportServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/BondAccountImportServiceTests.cs
@@ -1,0 +1,398 @@
+using FinanceManager.Application.FinancialAccounts.Bond.Import;
+using FinanceManager.Application.FinancialAccounts.Shared.Imports;
+using FinanceManager.Application.Identity.Users;
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Bond.Imports;
+using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Imports;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Shared.ValueObjects;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Domain.Identity.Repositories;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace FinanceManager.Tests.Unit.Application.Services;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class BondAccountImportServiceTests
+{
+    private readonly Mock<IAccountRepository<BondAccount>> _mockAccountRepository;
+    private readonly Mock<IBondAccountEntryRepository<BondAccountEntry>> _mockBondEntryRepository;
+    private readonly Mock<ICurrencyAccountRepository<CurrencyAccount>> _mockCurrencyAccountRepository;
+    private readonly Mock<IAccountEntryRepository<CurrencyAccountEntry>> _mockCurrencyEntryRepository;
+    private readonly Mock<IInvestmentTransactionRepository> _mockInvestmentTransactionRepository;
+    private readonly Mock<IUserRepository> _mockUserRepository;
+    private readonly UserPlanVerifier _userPlanVerifier;
+    private readonly BondAccountImportService _service;
+
+    public BondAccountImportServiceTests()
+    {
+        _mockAccountRepository = new Mock<IAccountRepository<BondAccount>>();
+        _mockBondEntryRepository = new Mock<IBondAccountEntryRepository<BondAccountEntry>>();
+        _mockCurrencyAccountRepository = new Mock<ICurrencyAccountRepository<CurrencyAccount>>();
+        _mockCurrencyEntryRepository = new Mock<IAccountEntryRepository<CurrencyAccountEntry>>();
+        _mockInvestmentTransactionRepository = new Mock<IInvestmentTransactionRepository>();
+        _mockUserRepository = new Mock<IUserRepository>();
+
+        var user = new User { Login = "TestUser", UserId = 1, PricingLevel = PricingLevel.Premium, CreationDate = DateTime.UtcNow };
+        _mockUserRepository.Setup(x => x.GetUser(It.IsAny<int>())).ReturnsAsync(user);
+
+        _userPlanVerifier = new UserPlanVerifier(
+            _mockCurrencyAccountRepository.Object,
+            _mockCurrencyEntryRepository.Object,
+            _mockInvestmentTransactionRepository.Object,
+            _mockBondEntryRepository.Object,
+            _mockUserRepository.Object);
+
+        _mockCurrencyEntryRepository.Setup(x => x.GetEntriesCountPerUser(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, int>());
+        _mockBondEntryRepository.Setup(x => x.GetEntriesCountPerUser(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<int, int>());
+        _mockInvestmentTransactionRepository.Setup(x => x.GetByUser(It.IsAny<long>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        // Default: return empty list for Get queries with or without cancellation token
+        _mockBondEntryRepository.Setup(x => x.Get(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(new List<BondAccountEntry>().ToAsyncEnumerable());
+        _mockBondEntryRepository.Setup(x => x.Get(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new List<BondAccountEntry>().ToAsyncEnumerable());
+
+        var mockLogger = new Mock<ILogger<BondAccountImportService>>();
+        var importAccountValidator = new ImportAccountValidator(_userPlanVerifier);
+        _service = new BondAccountImportService(
+            _mockAccountRepository.Object,
+            _mockBondEntryRepository.Object,
+            importAccountValidator,
+            mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task ImportEntries_EmptyList_ReturnsZeroImported()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var result = await _service.ImportEntries(1, 1, [], ct);
+
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(0, result.Failed);
+        Assert.Empty(result.Errors);
+        Assert.Empty(result.Conflicts);
+        _mockBondEntryRepository.Verify(x => x.Add(It.IsAny<IEnumerable<BondAccountEntry>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ImportEntries_NullEntries_ThrowsArgumentNullException()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _service.ImportEntries(1, 1, null!, ct));
+    }
+
+    [Fact]
+    public async Task ImportEntries_WhenCallerCancels_PropagatesCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+#pragma warning disable xUnit1051
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _service.ImportEntries(1, 1, [], cancellationToken: cancellation.Token));
+#pragma warning restore xUnit1051
+    }
+
+    [Fact]
+    public async Task ImportEntries_AccountNotFound_ThrowsInvalidOperationException()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        _mockAccountRepository.Setup(x => x.Get(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BondAccount?)null);
+        _mockAccountRepository.Setup(x => x.Get(1))
+            .ReturnsAsync((BondAccount?)null);
+
+        var entries = new List<BondEntryImport>
+        {
+            new(DateTime.UtcNow.Date, 100m, 1)
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _service.ImportEntries(1, 1, entries, ct));
+    }
+
+    [Fact]
+    public async Task ImportEntries_UserNotOwner_ThrowsInvalidOperationException()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var account = new BondAccount(2, 1, "OtherUserAccount");
+        _mockAccountRepository.Setup(x => x.Get(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(account);
+        _mockAccountRepository.Setup(x => x.Get(1))
+            .ReturnsAsync(account);
+
+        var entries = new List<BondEntryImport>
+        {
+            new(DateTime.UtcNow.Date, 100m, 1)
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _service.ImportEntries(1, 1, entries, ct));
+    }
+
+    [Fact]
+    public async Task ImportEntries_SuccessfulBatch_PersistsInSingleBatchAndRecalculatesOnce()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        const int userId = 1;
+        const int accountId = 10;
+        var account = new BondAccount(userId, accountId, "TestBonds");
+        _mockAccountRepository.Setup(x => x.Get(accountId, It.IsAny<CancellationToken>())).ReturnsAsync(account);
+        _mockAccountRepository.Setup(x => x.Get(accountId)).ReturnsAsync(account);
+
+        var day1 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var day2 = new DateTime(2025, 1, 10, 1, 0, 0, DateTimeKind.Utc);
+        List<BondEntryImport> domainEntries =
+        [
+            new(day1, 100m, 1),
+            new(day2, 200m, 2)
+        ];
+
+        _mockBondEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<BondAccountEntry>>(), false, It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<BondAccountEntry>, bool, CancellationToken>((entries, _, _) =>
+            {
+                int id = 100;
+                foreach (var e in entries)
+                    typeof(FinancialEntryBase).GetProperty(nameof(FinancialEntryBase.EntryId))?.SetValue(e, id++);
+            })
+            .ReturnsAsync(true);
+        _mockBondEntryRepository.Setup(x => x.RecalculateValues(accountId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.ImportEntries(userId, accountId, domainEntries, ct);
+
+        Assert.Equal(accountId, result.AccountId);
+        Assert.Equal(2, result.Imported);
+        Assert.Equal(0, result.Failed);
+        Assert.Empty(result.Errors);
+        Assert.Empty(result.Conflicts);
+
+        // Exactly one batch Add call
+        _mockBondEntryRepository.Verify(
+            x => x.Add(It.Is<IEnumerable<BondAccountEntry>>(e => e.Count() == 2), false, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Exactly one recalculation call using the generated ID anchor (100)
+        _mockBondEntryRepository.Verify(
+            x => x.RecalculateValues(accountId, 100, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportEntries_UsesBoundedPersistenceBatches()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        const int userId = 1;
+        const int accountId = 10;
+        var account = new BondAccount(userId, accountId, "TestBonds");
+        _mockAccountRepository.Setup(x => x.Get(accountId, It.IsAny<CancellationToken>())).ReturnsAsync(account);
+        _mockAccountRepository.Setup(x => x.Get(accountId)).ReturnsAsync(account);
+
+        var date = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var domainEntries = Enumerable.Range(0, 1_001)
+            .Select(i => new BondEntryImport(date.AddMinutes(i), i + 1m, 1))
+            .ToArray();
+        var batchSizes = new List<int>();
+        _mockBondEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<BondAccountEntry>>(), false, It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<BondAccountEntry>, bool, CancellationToken>((batch, _, _) => batchSizes.Add(batch.Count()))
+            .ReturnsAsync(true);
+
+        var result = await _service.ImportEntries(userId, accountId, domainEntries, ct);
+
+        Assert.Equal(1_001, result.Imported);
+        Assert.Equal(0, result.Failed);
+        Assert.Equal([500, 500, 1], batchSizes);
+    }
+
+    [Fact]
+    public async Task ImportEntries_WhenRepositoryAddFails_MarksAllEntriesFailed()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        const int userId = 1;
+        const int accountId = 10;
+        var account = new BondAccount(userId, accountId, "TestBonds");
+        _mockAccountRepository.Setup(x => x.Get(accountId, It.IsAny<CancellationToken>())).ReturnsAsync(account);
+        _mockAccountRepository.Setup(x => x.Get(accountId)).ReturnsAsync(account);
+
+        var day1 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        List<BondEntryImport> domainEntries =
+        [
+            new(day1, 100m, 1),
+            new(day1.AddHours(1), 200m, 1)
+        ];
+
+        _mockBondEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<BondAccountEntry>>(), false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _service.ImportEntries(userId, accountId, domainEntries, ct);
+
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(2, result.Failed);
+        Assert.Equal(2, result.Errors.Count);
+        _mockBondEntryRepository.Verify(x => x.RecalculateValues(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ImportEntries_InvalidPostingDateKind_FailsIndividuallyAndBatchesValidEntries()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        const int userId = 1;
+        const int accountId = 10;
+        var account = new BondAccount(userId, accountId, "TestBonds");
+        _mockAccountRepository.Setup(x => x.Get(accountId, It.IsAny<CancellationToken>())).ReturnsAsync(account);
+        _mockAccountRepository.Setup(x => x.Get(accountId)).ReturnsAsync(account);
+
+        var validDate = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var invalidDate = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Unspecified);
+        List<BondEntryImport> domainEntries =
+        [
+            new(validDate, 100m, 1),
+            new(invalidDate, 200m, 1)
+        ];
+
+        _mockBondEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<BondAccountEntry>>(), false, It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<BondAccountEntry>, bool, CancellationToken>((entries, _, _) =>
+            {
+                foreach (var e in entries)
+                    typeof(FinancialEntryBase).GetProperty(nameof(FinancialEntryBase.EntryId))?.SetValue(e, 50);
+            })
+            .ReturnsAsync(true);
+        _mockBondEntryRepository.Setup(x => x.RecalculateValues(accountId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.ImportEntries(userId, accountId, domainEntries, ct);
+
+        Assert.Equal(1, result.Imported);
+        Assert.Equal(1, result.Failed);
+        Assert.Single(result.Errors);
+        Assert.Contains("is not UTC", result.Errors[0]);
+
+        _mockBondEntryRepository.Verify(
+            x => x.Add(It.Is<IEnumerable<BondAccountEntry>>(e => e.Count() == 1), false, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportEntries_ReverseDayConflictHandling_SkipsConflictDayAndBatchesCleanDay()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        const int userId = 1;
+        const int accountId = 10;
+        var account = new BondAccount(userId, accountId, "TestBonds");
+        _mockAccountRepository.Setup(x => x.Get(accountId, It.IsAny<CancellationToken>())).ReturnsAsync(account);
+        _mockAccountRepository.Setup(x => x.Get(accountId)).ReturnsAsync(account);
+
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        var jan15 = new DateTime(2025, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        // Existing entry matches jan15 exactly
+        var existingEntry = new BondAccountEntry(accountId, 101, jan15, 500m, 500m, 1);
+        _mockBondEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(new List<BondAccountEntry> { existingEntry }.ToAsyncEnumerable());
+        _mockBondEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(new List<BondAccountEntry> { existingEntry }.ToAsyncEnumerable());
+
+        List<BondEntryImport> domainEntries =
+        [
+            new(jan10, 100m, 1), // Clean day
+            new(jan15, 500m, 1)  // Conflict day (exact match)
+        ];
+
+        _mockBondEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<BondAccountEntry>>(), false, It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<BondAccountEntry>, bool, CancellationToken>((entries, _, _) =>
+            {
+                foreach (var e in entries)
+                    typeof(FinancialEntryBase).GetProperty(nameof(FinancialEntryBase.EntryId))?.SetValue(e, 42);
+            })
+            .ReturnsAsync(true);
+        _mockBondEntryRepository.Setup(x => x.RecalculateValues(accountId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _service.ImportEntries(userId, accountId, domainEntries, ct);
+
+        Assert.Equal(1, result.Imported);
+        Assert.Equal(0, result.Failed);
+        Assert.Single(result.Conflicts);
+        Assert.Equal("Exact match", result.Conflicts[0].Reason);
+
+        // Jan 10 was batched and persisted
+        _mockBondEntryRepository.Verify(
+            x => x.Add(It.Is<IEnumerable<BondAccountEntry>>(e => e.Count() == 1 && e.First().PostingDate == jan10), false, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportEntries_RecalculationTimeout_MarksFailedWithoutThrowing()
+    {
+        const int userId = 1;
+        const int accountId = 10;
+        var account = new BondAccount(userId, accountId, "TestBonds");
+        _mockAccountRepository.Setup(x => x.Get(accountId, It.IsAny<CancellationToken>())).ReturnsAsync(account);
+        _mockAccountRepository.Setup(x => x.Get(accountId)).ReturnsAsync(account);
+
+        var jan10 = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        List<BondEntryImport> domainEntries = [new(jan10, 100m, 1)];
+
+        _mockBondEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<BondAccountEntry>>(), false, It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<BondAccountEntry>, bool, CancellationToken>((entries, _, _) =>
+            {
+                foreach (var e in entries)
+                    typeof(FinancialEntryBase).GetProperty(nameof(FinancialEntryBase.EntryId))?.SetValue(e, 77);
+            })
+            .ReturnsAsync(true);
+        _mockBondEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<BondAccountEntry>>(), false))
+            .Callback<IEnumerable<BondAccountEntry>, bool>((entries, _) =>
+            {
+                foreach (var e in entries)
+                    typeof(FinancialEntryBase).GetProperty(nameof(FinancialEntryBase.EntryId))?.SetValue(e, 77);
+            })
+            .ReturnsAsync(true);
+
+        // Internal OperationCanceledException (not from caller token)
+        _mockBondEntryRepository.Setup(x => x.RecalculateValues(accountId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+        _mockBondEntryRepository.Setup(x => x.RecalculateValues(accountId, It.IsAny<int>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+#pragma warning disable xUnit1051
+        var result = await _service.ImportEntries(userId, accountId, domainEntries, CancellationToken.None);
+#pragma warning restore xUnit1051
+
+        Assert.Equal(1, result.Imported);
+        Assert.Equal(1, result.Failed);
+        Assert.Single(result.Errors);
+        Assert.Contains("Recalculation cancelled or timed out", result.Errors[0]);
+    }
+
+    [Fact]
+    public async Task ApplyResolvedConflicts_DeletesExistingAndAddsImported()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var conflict = new ResolvedBondImportConflict
+        {
+            AccountId = 10,
+            ExistingId = 55,
+            LeaveExisting = false,
+            AddImported = true,
+            ImportData = new BondEntryImport(new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc), 150m, 2)
+        };
+
+        _mockBondEntryRepository.Setup(x => x.Delete(10, 55, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _mockBondEntryRepository.Setup(x => x.Add(It.IsAny<BondAccountEntry>(), true, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        await _service.ApplyResolvedConflicts([conflict], ct);
+
+        _mockBondEntryRepository.Verify(x => x.Delete(10, 55, It.IsAny<CancellationToken>()), Times.Once);
+        _mockBondEntryRepository.Verify(x => x.Add(It.Is<BondAccountEntry>(e => e.AccountId == 10 && e.BondDetailsId == 2), true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/CurrencyAccountImportServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/CurrencyAccountImportServiceTests.cs
@@ -8,6 +8,7 @@ using FinanceManager.Domain.FinancialAccounts.Currencies.Imports;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
 using FinanceManager.Domain.FinancialAccounts.Shared.Imports;
 using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Shared.ValueObjects;
@@ -134,6 +135,80 @@ public class CurrencyAccountImportServiceTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
             _service.ImportEntries(1, 1, [], cancellationToken: cancellation.Token));
 #pragma warning restore xUnit1051
+    }
+
+    [Fact]
+    public async Task ImportEntries_WhenCallerCancelsAfterCommit_RecalculatesCommittedEntriesBeforePropagating()
+    {
+        const int userId = 1;
+        const int accountId = 10;
+        var account = new CurrencyAccount(userId, accountId, "Test");
+        _mockAccountRepository.Setup(x => x.Get(accountId, It.IsAny<CancellationToken>())).ReturnsAsync(account);
+        _mockAccountRepository.Setup(x => x.Get(accountId)).ReturnsAsync(account);
+        _mockAccountEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Returns(Array.Empty<CurrencyAccountEntry>().ToAsyncEnumerable());
+
+        using var cancellation = new CancellationTokenSource();
+        var date = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        List<CurrencyEntryImport> entries = [new(date, 100m)];
+
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), false, It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<CurrencyAccountEntry>, bool, CancellationToken>((batch, _, _) =>
+            {
+                foreach (var entry in batch)
+                    typeof(FinancialEntryBase).GetProperty(nameof(FinancialEntryBase.EntryId))?.SetValue(entry, 100);
+                cancellation.Cancel();
+            })
+            .ReturnsAsync(true);
+        _mockAccountEntryRepository.Setup(x => x.RecalculateValues(accountId, 100, It.Is<CancellationToken>(token => token == cancellation.Token)))
+            .ThrowsAsync(new OperationCanceledException(cancellation.Token));
+        _mockAccountEntryRepository.Setup(x => x.RecalculateValues(accountId, 100, CancellationToken.None))
+            .Returns(Task.CompletedTask);
+
+#pragma warning disable xUnit1051
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _service.ImportEntries(userId, accountId, entries, cancellation.Token));
+#pragma warning restore xUnit1051
+
+        _mockAccountEntryRepository.Verify(
+            x => x.RecalculateValues(accountId, 100, CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportEntries_RecalculationTimeout_RepairsCommittedEntriesBeforeReturning()
+    {
+        const int userId = 1;
+        const int accountId = 10;
+        var account = new CurrencyAccount(userId, accountId, "Test");
+        _mockAccountRepository.Setup(x => x.Get(accountId)).ReturnsAsync(account);
+        _mockAccountEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(Array.Empty<CurrencyAccountEntry>().ToAsyncEnumerable());
+
+        var date = new DateTime(2025, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+        List<CurrencyEntryImport> entries = [new(date, 100m)];
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), false))
+            .Callback<IEnumerable<CurrencyAccountEntry>, bool>((batch, _) =>
+            {
+                foreach (var entry in batch)
+                    typeof(FinancialEntryBase).GetProperty(nameof(FinancialEntryBase.EntryId))?.SetValue(entry, 77);
+            })
+            .ReturnsAsync(true);
+        _mockAccountEntryRepository.Setup(x => x.RecalculateValues(accountId, 77))
+            .ThrowsAsync(new OperationCanceledException());
+        _mockAccountEntryRepository.Setup(x => x.RecalculateValues(accountId, 77, CancellationToken.None))
+            .Returns(Task.CompletedTask);
+
+#pragma warning disable xUnit1051
+        var result = await _service.ImportEntries(userId, accountId, entries, CancellationToken.None);
+#pragma warning restore xUnit1051
+
+        Assert.Equal(1, result.Imported);
+        Assert.Equal(1, result.Failed);
+        Assert.Contains("Recalculation cancelled or timed out", Assert.Single(result.Errors));
+        _mockAccountEntryRepository.Verify(
+            x => x.RecalculateValues(accountId, 77, CancellationToken.None),
+            Times.Once);
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Unit/Application/Services/CurrencyAccountImportServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/CurrencyAccountImportServiceTests.cs
@@ -53,6 +53,11 @@ public class CurrencyAccountImportServiceTests
         _mockBondEntryRepository.Setup(x => x.GetEntriesCountPerUser(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<int, int>());
 
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), It.IsAny<bool>()))
+            .ReturnsAsync(true);
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
         var mockLogger = new Mock<ILogger<CurrencyAccountImportService>>();
         var importAccountValidator = new ImportAccountValidator(_userPlanVerifier);
         _service = new CurrencyAccountImportService(_mockAccountRepository.Object, _mockAccountEntryRepository.Object, importAccountValidator, mockLogger.Object);
@@ -77,7 +82,7 @@ public class CurrencyAccountImportServiceTests
         ];
 
         _mockAccountEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(new List<CurrencyAccountEntry>().ToAsyncEnumerable());
-        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<CurrencyAccountEntry>(), It.IsAny<bool>())).ReturnsAsync(true);
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), It.IsAny<bool>())).ReturnsAsync(true);
 
         // Act
         var result = await _service.ImportEntries(userId, accountId, domainEntries);
@@ -217,8 +222,8 @@ public class CurrencyAccountImportServiceTests
             .Returns(Array.Empty<CurrencyAccountEntry>().ToAsyncEnumerable());
 
         var addedEntries = new List<CurrencyAccountEntry>();
-        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<CurrencyAccountEntry>(), It.IsAny<bool>()))
-            .Callback<CurrencyAccountEntry, bool>((entry, _) => addedEntries.Add(entry))
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), It.IsAny<bool>()))
+            .Callback<IEnumerable<CurrencyAccountEntry>, bool>((entries, _) => addedEntries.AddRange(entries))
             .ReturnsAsync(true);
 
         // Act
@@ -361,7 +366,7 @@ public class CurrencyAccountImportServiceTests
         _mockAccountEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(Array.Empty<CurrencyAccountEntry>().ToAsyncEnumerable());
 
-        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<CurrencyAccountEntry>(), It.IsAny<bool>()))
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), It.IsAny<bool>()))
             .ReturnsAsync(false);
 
         // Act
@@ -391,7 +396,7 @@ public class CurrencyAccountImportServiceTests
         _mockAccountEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(Array.Empty<CurrencyAccountEntry>().ToAsyncEnumerable());
 
-        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<CurrencyAccountEntry>(), It.IsAny<bool>()))
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), It.IsAny<bool>()))
             .ReturnsAsync(true);
 
         // Act
@@ -401,6 +406,34 @@ public class CurrencyAccountImportServiceTests
         Assert.Equal(500, result.Imported);
         Assert.Equal(0, result.Failed);
         Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public async Task ImportEntries_UsesBoundedPersistenceBatches()
+    {
+        var userId = 1;
+        var accountId = 1;
+        var date = DateTime.UtcNow.Date;
+        var entries = Enumerable.Range(0, 1_001)
+            .Select(i => new CurrencyEntryImport(date.AddMinutes(i), i + 1m))
+            .ToArray();
+
+        var account = new CurrencyAccount(userId, accountId, "Test");
+        _mockAccountRepository.Setup(x => x.Get(accountId)).ReturnsAsync(account);
+        _mockAccountRepository.Setup(x => x.GetAvailableAccounts(userId)).Returns(Array.Empty<AvailableAccount>().ToAsyncEnumerable());
+        _mockAccountEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            .Returns(Array.Empty<CurrencyAccountEntry>().ToAsyncEnumerable());
+
+        var batchSizes = new List<int>();
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), It.IsAny<bool>()))
+            .Callback<IEnumerable<CurrencyAccountEntry>, bool>((batch, _) => batchSizes.Add(batch.Count()))
+            .ReturnsAsync(true);
+
+        var result = await _service.ImportEntries(userId, accountId, entries);
+
+        Assert.Equal(1_001, result.Imported);
+        Assert.Equal(0, result.Failed);
+        Assert.Equal([500, 500, 1], batchSizes);
     }
 
     [Fact]
@@ -424,7 +457,7 @@ public class CurrencyAccountImportServiceTests
         _mockAccountEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(Array.Empty<CurrencyAccountEntry>().ToAsyncEnumerable());
 
-        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<CurrencyAccountEntry>(), It.IsAny<bool>()))
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), It.IsAny<bool>()))
             .ReturnsAsync(true);
 
         // Act
@@ -454,7 +487,7 @@ public class CurrencyAccountImportServiceTests
         _mockAccountRepository.Setup(x => x.GetAvailableAccounts(userId)).Returns(Array.Empty<AvailableAccount>().ToAsyncEnumerable());
         _mockAccountEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(Array.Empty<CurrencyAccountEntry>().ToAsyncEnumerable());
-        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<CurrencyAccountEntry>(), It.IsAny<bool>()))
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), It.IsAny<bool>()))
             .ReturnsAsync(true);
 
         var progressUpdates = new List<(int Processed, int Imported, int Failed)>();
@@ -498,7 +531,7 @@ public class CurrencyAccountImportServiceTests
         var existingEntry = new CurrencyAccountEntry(accountId, 10, conflictDay, 200m, 200m);
         _mockAccountEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(new[] { existingEntry }.ToAsyncEnumerable());
-        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<CurrencyAccountEntry>(), It.IsAny<bool>()))
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), It.IsAny<bool>()))
             .ReturnsAsync(true);
 
         var conflictBatches = new List<IReadOnlyList<ImportConflict>>();
@@ -518,7 +551,7 @@ public class CurrencyAccountImportServiceTests
         Assert.Equal(1, result.Imported);
         Assert.Single(result.Conflicts);
         Assert.Single(conflictBatches);
-        _mockAccountEntryRepository.Verify(x => x.Add(It.Is<CurrencyAccountEntry>(e => e.PostingDate.Date == date), It.IsAny<bool>()), Times.Once);
+        _mockAccountEntryRepository.Verify(x => x.Add(It.Is<IEnumerable<CurrencyAccountEntry>>(entries => entries.Single().PostingDate.Date == date), It.IsAny<bool>()), Times.Once);
     }
 
     [Fact]
@@ -542,17 +575,15 @@ public class CurrencyAccountImportServiceTests
         _mockAccountEntryRepository.Setup(x => x.Get(accountId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(Array.Empty<CurrencyAccountEntry>().ToAsyncEnumerable());
 
-        _mockAccountEntryRepository.Setup(x => x.Add(It.Is<CurrencyAccountEntry>(e => e.ValueChange == 200m), It.IsAny<bool>()))
+        _mockAccountEntryRepository.Setup(x => x.Add(It.IsAny<IEnumerable<CurrencyAccountEntry>>(), It.IsAny<bool>()))
             .ReturnsAsync(false);
-        _mockAccountEntryRepository.Setup(x => x.Add(It.Is<CurrencyAccountEntry>(e => e.ValueChange != 200m), It.IsAny<bool>()))
-            .ReturnsAsync(true);
 
         // Act
         var result = await _service.ImportEntries(userId, accountId, entries);
 
         // Assert
-        Assert.Equal(2, result.Imported);
-        Assert.Equal(1, result.Failed);
+        Assert.Equal(0, result.Imported);
+        Assert.Equal(3, result.Failed);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #741

## Summary
- batch currency and bond import persistence into bounded 500-row operations grouped by import day, retaining duplicate/conflict detection, reverse-day ordering, progress, cancellation, and partial-failure reporting
- add batch repository persistence with tracked-label reuse, generated entry-id propagation, and one earliest-entry recalculation anchor per import
- add unit and SQLite integration coverage for batching, generated IDs, recalculation, conflicts, and labels

## Orchestration evidence
- baseline: `develop` at `ef573bb10f1fb21c5554635c858eab041e7ac29c`
- Antigravity/Agy: bond service/repository/tests, isolated scope, completed with exactly four authorized files; no commit or push
- LM Studio/Qwen: currency scope launched in its isolated worktree and remains live after extended prompt processing, but produced no diff or final evidence; coordinator completed the disjoint currency scope from the same baseline and records Qwen as pending rather than claiming completion
- coordinator: reconciled the scoped results on `codex/issue-741-batch-currency-and-bond-import-persistence`

## Validation
- focused currency unit: 24 passed
- focused bond unit: 12 passed
- full integration: 333 passed
- architecture: 9 passed
- solution build: passed with 0 warnings and 0 errors
- scoped `dotnet format --verify-no-changes`: passed
- LF line-ending and `git diff --check`: passed
- full unit: 1,017 passed, 6 pre-existing failures in unrelated investment-paycheck culture-key and currency-exchange tests

## Risk
- repository batch APIs report success/failure per batch, so a provider failure marks the entire attempted batch failed while prior committed batches remain intact
- resolved conflict application remains per-entry because it can span independent account mutations; import persistence itself uses one recalculation anchor after successful batches
- no user-visible behavior changed, so no changelog entry was added

Please review the repository transaction/cache semantics and the partial-failure behavior around provider errors and cancellation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Financial account imports now save entries in bounded batches, improving efficiency for large imports.
  - Running balances are recalculated from the earliest affected entry to maintain accurate results.

- **Reliability**
  - Imported entries receive their database-generated identifiers after saving.
  - Existing financial labels are reused to avoid duplicate records.
  - Import conflicts, cancellations, and partial failures are handled more consistently.
  - Cancelled or interrupted imports repair committed entries before completing cancellation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->