### PR TITLE
Project and aggregate investment history at the database boundary

### DIFF
--- a/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Investments/Valuation/InvestmentValuationService.cs
@@ -62,23 +62,21 @@ internal class InvestmentValuationService(
         var result = new Dictionary<int, decimal>();
         if (accountIds.Count == 0) return result;
 
-        var transactions = await transactionRepository.GetByAccounts(accountIds, ct);
-        if (transactions.Count == 0) return result;
-
         var asOfDate = DateOnly.FromDateTime(asOf);
+        var rawHoldingsByAccount = await transactionRepository.GetHoldingsByAccountAsOf(accountIds, asOfDate, ct);
+        if (rawHoldingsByAccount.Count == 0) return result;
 
         // Net holding per (account, listing) as of the date, dropping zero net positions so fully
         // closed holdings never trigger a (wasted, potentially failing) price fetch.
         var holdingsByAccount = new Dictionary<int, Dictionary<long, decimal>>();
-        foreach (var group in transactions.Where(t => t.TradeDate <= asOfDate).GroupBy(t => t.AccountId))
+        foreach (var (accountId, holdings) in rawHoldingsByAccount)
         {
-            var perListing = group
-                .GroupBy(t => t.AssetListingId)
-                .Select(g => (ListingId: g.Key, Holding: g.Sum(t => t.SignedQuantity)))
-                .Where(x => x.Holding != 0m)
-                .ToDictionary(x => x.ListingId, x => x.Holding);
-            if (perListing.Count > 0) holdingsByAccount[group.Key] = perListing;
+            var nonZero = holdings.Where(kvp => kvp.Value != 0m).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            if (nonZero.Count > 0)
+                holdingsByAccount[accountId] = nonZero;
         }
+
+        if (holdingsByAccount.Count == 0) return result;
 
         // Price each distinct listing across all accounts once, not once per owning account.
         var prices = new Dictionary<long, decimal>();
@@ -121,37 +119,47 @@ internal class InvestmentValuationService(
         var result = new Dictionary<int, IReadOnlyDictionary<DateTime, decimal>>();
         if (accountIds.Count == 0 || start == default || end == default || end < start) return result;
 
-        var transactions = await transactionRepository.GetByAccounts(accountIds, ct);
-        if (transactions.Count == 0) return result;
-
         var startDate = start.Date;
         var endDate = end.Date;
         var startDateOnly = DateOnly.FromDateTime(startDate);
         var endDateOnly = DateOnly.FromDateTime(endDate);
 
-        var relevant = transactions.Where(t => t.TradeDate <= endDateOnly).ToList();
-        if (relevant.Count == 0) return result;
+        var inputs = await transactionRepository.GetValuationInputs(accountIds, startDateOnly, endDateOnly, ct);
+        if (inputs.OpeningPositions.Count == 0 && inputs.InWindowTrades.Count == 0) return result;
+
+        var openingByAccountListing = inputs.OpeningPositions
+            .ToDictionary(p => (p.AccountId, p.AssetListingId), p => p.Quantity);
+
+        var tradesByAccountListing = inputs.InWindowTrades
+            .GroupBy(t => (t.AccountId, t.AssetListingId))
+            .ToDictionary(g => g.Key, g => g.ToList());
 
         // Retain each (account, listing) pair when its opening holding before the range is non-zero
         // OR it has trades in the range. Exclude positions fully closed before the window so they
         // never trigger unneeded price-series fetches.
-        var retainedTransactions = relevant
-            .GroupBy(t => (t.AccountId, t.AssetListingId))
-            .Where(group => group.Where(t => t.TradeDate < startDateOnly).Sum(t => t.SignedQuantity) != 0m
-                || group.Any(t => t.TradeDate >= startDateOnly))
-            .SelectMany(group => group)
+        var allKeys = openingByAccountListing.Keys.Union(tradesByAccountListing.Keys).ToList();
+        var retainedKeys = allKeys
+            .Where(k => (openingByAccountListing.TryGetValue(k, out var openQty) && openQty != 0m)
+                || tradesByAccountListing.ContainsKey(k))
             .ToList();
-        if (retainedTransactions.Count == 0) return result;
+        if (retainedKeys.Count == 0) return result;
 
         // One price-series fetch per distinct listing across all accounts (target currency already
         // applied). Accounts holding the same instrument share this series instead of re-fetching it.
         var priceSeries = new Dictionary<long, IReadOnlyDictionary<DateTime, decimal>>();
-        foreach (var listingId in retainedTransactions.Select(t => t.AssetListingId).Distinct())
+        foreach (var listingId in retainedKeys.Select(k => k.AssetListingId).Distinct())
             priceSeries[listingId] = await priceProvider.GetPricePerUnitSeriesAsync(listingId, targetCurrency, start, end, ct);
 
-        foreach (var accountGroup in retainedTransactions.GroupBy(t => t.AccountId))
+        foreach (var accountGroup in retainedKeys.GroupBy(k => k.AccountId))
         {
-            var series = BuildAccountSeries(accountGroup, startDate, endDate, startDateOnly, priceSeries);
+            var series = BuildAccountSeries(
+                accountGroup.Key,
+                accountGroup.Select(k => k.AssetListingId),
+                openingByAccountListing,
+                tradesByAccountListing,
+                startDate,
+                endDate,
+                priceSeries);
             if (series.Count > 0) result[accountGroup.Key] = series;
         }
 
@@ -169,10 +177,11 @@ internal class InvestmentValuationService(
         if (accountIds.Count == 0 || start == default || end == default || end < start)
             return result;
 
-        var transactions = await transactionRepository.GetByAccounts(accountIds, ct);
         var endDate = end.Date;
-        var capitalFlows = transactions
-            .Where(transaction => transaction.TradeDate.ToDateTime(TimeOnly.MinValue) <= endDate)
+        var endDateOnly = DateOnly.FromDateTime(endDate);
+
+        var capitalFlowInputs = await transactionRepository.GetCapitalFlowInputs(accountIds, endDateOnly, ct);
+        var capitalFlows = capitalFlowInputs
             .Select(ToCapitalFlow)
             .Where(flow => flow.Amount != 0m)
             .ToList();
@@ -192,35 +201,40 @@ internal class InvestmentValuationService(
     // Fold one account's transactions against the shared per-listing price series: carry each
     // listing's holding forward across days without a trade and value it at that day's price.
     private static Dictionary<DateTime, decimal> BuildAccountSeries(
-        IEnumerable<InvestmentTransaction> accountTransactions,
+        int accountId,
+        IEnumerable<long> listingIds,
+        IReadOnlyDictionary<(int AccountId, long AssetListingId), decimal> openingByAccountListing,
+        IReadOnlyDictionary<(int AccountId, long AssetListingId), List<IInvestmentTransactionRepository.ValuationTradeInput>> tradesByAccountListing,
         DateTime startDate,
         DateTime endDate,
-        DateOnly startDateOnly,
         IReadOnlyDictionary<long, IReadOnlyDictionary<DateTime, decimal>> priceSeries)
     {
         var result = new Dictionary<DateTime, decimal>();
-
-        var byListing = accountTransactions.GroupBy(t => t.AssetListingId).ToList();
+        var listings = listingIds.ToList();
 
         var holdings = new Dictionary<long, decimal>();
         var dailyDeltas = new Dictionary<long, Dictionary<DateTime, decimal>>();
 
-        foreach (var group in byListing)
+        foreach (var listingId in listings)
         {
-            var listingId = group.Key;
-            holdings[listingId] = group.Where(t => t.TradeDate < startDateOnly).Sum(t => t.SignedQuantity);
-            dailyDeltas[listingId] = group
-                .Where(t => t.TradeDate >= startDateOnly)
-                .GroupBy(t => t.TradeDate.ToDateTime(TimeOnly.MinValue))
-                .ToDictionary(g => g.Key, g => g.Sum(t => t.SignedQuantity));
+            holdings[listingId] = openingByAccountListing.GetValueOrDefault((accountId, listingId), 0m);
+            if (tradesByAccountListing.TryGetValue((accountId, listingId), out var trades))
+            {
+                dailyDeltas[listingId] = trades
+                    .GroupBy(t => t.TradeDate.ToDateTime(TimeOnly.MinValue))
+                    .ToDictionary(g => g.Key, g => g.Sum(t => t.SignedQuantity));
+            }
+            else
+            {
+                dailyDeltas[listingId] = [];
+            }
         }
 
         for (var date = startDate; date <= endDate; date = date.AddDays(1))
         {
             decimal dayValue = 0m;
-            foreach (var group in byListing)
+            foreach (var listingId in listings)
             {
-                var listingId = group.Key;
                 if (dailyDeltas[listingId].TryGetValue(date, out var delta))
                     holdings[listingId] += delta;
 
@@ -305,11 +319,11 @@ internal class InvestmentValuationService(
                 : null;
     }
 
-    private static InvestmentCapitalFlow ToCapitalFlow(InvestmentTransaction transaction)
+    private static InvestmentCapitalFlow ToCapitalFlow(IInvestmentTransactionRepository.CapitalFlowInput flow)
     {
-        var gross = transaction.Quantity * transaction.UnitPrice;
-        var fee = transaction.Fee ?? 0m;
-        var amount = transaction.Type switch
+        var gross = flow.Quantity * flow.UnitPrice;
+        var fee = flow.Fee ?? 0m;
+        var amount = flow.Type switch
         {
             // The new investment model has no separate deposit/transfer rows. Buy/Sell are the
             // persisted cash-impact records, while an unknown future type must not add capital.
@@ -318,13 +332,13 @@ internal class InvestmentValuationService(
             _ => 0m
         };
 
-        var currency = transaction.Currency.Trim();
+        var currency = flow.Currency.Trim();
         var isMinorQuote = DefaultCurrency.MinorQuoteUnits.TryGetValue(currency, out var majorCurrency);
-        var multiplier = isMinorQuote ? transaction.AssetListing?.PriceMultiplier ?? 0.01m : 1m;
+        var multiplier = isMinorQuote ? flow.ListingPriceMultiplier ?? 0.01m : 1m;
 
         return new InvestmentCapitalFlow(
-            transaction.AccountId,
-            transaction.TradeDate.ToDateTime(TimeOnly.MinValue).Date,
+            flow.AccountId,
+            flow.TradeDate.ToDateTime(TimeOnly.MinValue).Date,
             amount * multiplier,
             isMinorQuote ? majorCurrency! : currency);
     }
@@ -347,10 +361,9 @@ internal class InvestmentValuationService(
         var startDateOnly = DateOnly.FromDateTime(startDate);
         var endDateOnly = DateOnly.FromDateTime(endDate);
 
-        var transactions = (await transactionRepository.GetByAccounts([accountId], ct))
-            .Where(t => t.TradeDate <= endDateOnly)
-            .ToList();
-        if (transactions.Count == 0) return new Dictionary<DateTime, decimal>();
+        var inputs = await transactionRepository.GetValuationInputs([accountId], startDateOnly, endDateOnly, ct);
+        if (inputs.OpeningPositions.Count == 0 && inputs.InWindowTrades.Count == 0)
+            return new Dictionary<DateTime, decimal>();
 
         var raw = assetListingId is long listingId
             ? await priceProvider.GetPricePerUnitSeriesAsync(listingId, targetCurrency, start, end, ct)
@@ -358,10 +371,16 @@ internal class InvestmentValuationService(
         var index = ToDailySeries(raw, startDate, endDate);
         if (index.Count == 0) return new Dictionary<DateTime, decimal>();
 
+        var relevantListingIds = inputs.OpeningPositions
+            .Select(p => p.AssetListingId)
+            .Union(inputs.InWindowTrades.Select(t => t.AssetListingId))
+            .Distinct()
+            .ToList();
+
         // Contributions are measured at the same market prices the account's own value series uses,
         // so a day's contribution equals the value that trade added to the account that day.
         var priceSeries = new Dictionary<long, Dictionary<DateTime, decimal>>();
-        foreach (var id in transactions.Select(t => t.AssetListingId).Distinct())
+        foreach (var id in relevantListingIds)
         {
             // Benchmarking against an instrument the account also holds would otherwise fetch that
             // listing's prices twice over the same range — the benchmark's own series is identical.
@@ -373,7 +392,7 @@ internal class InvestmentValuationService(
                     endDate);
         }
 
-        return BuildContributionMatchedSeries(transactions, index, priceSeries, startDate, endDate, startDateOnly);
+        return BuildContributionMatchedSeries(inputs, index, priceSeries, startDate, endDate);
     }
 
     // Both the benchmark index and instrument prices are published on their own calendars — monthly
@@ -408,15 +427,13 @@ internal class InvestmentValuationService(
     // Fold the account's cash flows into benchmark units: seed with whatever the account already held
     // when the range opened, then buy or sell units as trades move money in and out.
     private static Dictionary<DateTime, decimal> BuildContributionMatchedSeries(
-        IEnumerable<InvestmentTransaction> transactions,
+        IInvestmentTransactionRepository.AccountValuationInputs inputs,
         IReadOnlyDictionary<DateTime, decimal> index,
         IReadOnlyDictionary<long, Dictionary<DateTime, decimal>> priceSeries,
         DateTime startDate,
-        DateTime endDate,
-        DateOnly startDateOnly)
+        DateTime endDate)
     {
-        var byDate = transactions
-            .Where(t => t.TradeDate >= startDateOnly)
+        var byDate = inputs.InWindowTrades
             .GroupBy(t => t.TradeDate.ToDateTime(TimeOnly.MinValue))
             .ToDictionary(
                 g => g.Key,
@@ -424,10 +441,8 @@ internal class InvestmentValuationService(
                     .Select(l => (ListingId: l.Key, Quantity: l.Sum(t => t.SignedQuantity)))
                     .ToList());
 
-        var openingValue = transactions
-            .Where(t => t.TradeDate < startDateOnly)
-            .GroupBy(t => t.AssetListingId)
-            .Sum(g => g.Sum(t => t.SignedQuantity) * PriceOn(priceSeries, g.Key, startDate));
+        var openingValue = inputs.OpeningPositions
+            .Sum(p => p.Quantity * PriceOn(priceSeries, p.AssetListingId, startDate));
 
         var result = new Dictionary<DateTime, decimal>();
         decimal units = 0m;

--- a/code/FinanceManager.Domain/FinancialAccounts/Investments/Repositories/IInvestmentTransactionRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Investments/Repositories/IInvestmentTransactionRepository.cs
@@ -44,9 +44,53 @@ public interface IInvestmentTransactionRepository
     Task<IReadOnlyDictionary<long, decimal>> GetHoldingsAsOf(IReadOnlyCollection<int> accountIds, DateOnly asOf, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Signed-quantity holdings per account and <see cref="AssetListing"/> as of a date for the given accounts,
+    /// projected and aggregated at the database level.
+    /// </summary>
+    Task<IReadOnlyDictionary<int, IReadOnlyDictionary<long, decimal>>> GetHoldingsByAccountAsOf(IReadOnlyCollection<int> accountIds, DateOnly asOf, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Aggregated opening holdings before <paramref name="startDate"/> and daily signed-quantity deltas within
+    /// [<paramref name="startDate"/>, <paramref name="endDate"/>] for the given accounts, projected and aggregated
+    /// at the database boundary without loading out-of-range rows or full entity graphs.
+    /// </summary>
+    Task<AccountValuationInputs> GetValuationInputs(IReadOnlyCollection<int> accountIds, DateOnly startDate, DateOnly endDate, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Bounded historical capital flow projection inputs for transactions on or before <paramref name="toDate"/>
+    /// across the given accounts, selecting only fields needed for cash flow calculations.
+    /// </summary>
+    Task<IReadOnlyList<CapitalFlowInput>> GetCapitalFlowInputs(IReadOnlyCollection<int> accountIds, DateOnly toDate, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// The distinct <see cref="AssetListing"/> ids referenced by any investment transaction across all
     /// users, resolved in a single grouped query. Feeds maintenance jobs (e.g. the weekly price
     /// backfill) that must cover every instrument anyone holds without materialising transactions.
     /// </summary>
     Task<IReadOnlyList<long>> GetDistinctAssetListingIds(CancellationToken cancellationToken = default);
+
+    public sealed record ValuationTradeInput(
+        int AccountId,
+        long AssetListingId,
+        DateOnly TradeDate,
+        decimal SignedQuantity);
+
+    public sealed record ValuationOpeningPosition(
+        int AccountId,
+        long AssetListingId,
+        decimal Quantity);
+
+    public sealed record AccountValuationInputs(
+        IReadOnlyList<ValuationOpeningPosition> OpeningPositions,
+        IReadOnlyList<ValuationTradeInput> InWindowTrades);
+
+    public sealed record CapitalFlowInput(
+        int AccountId,
+        DateOnly TradeDate,
+        InvestmentTransactionType Type,
+        decimal Quantity,
+        decimal UnitPrice,
+        decimal? Fee,
+        string Currency,
+        decimal? ListingPriceMultiplier);
 }

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Investments/Repositories/InvestmentTransactionRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Investments/Repositories/InvestmentTransactionRepository.cs
@@ -96,14 +96,107 @@ public class InvestmentTransactionRepository(AppDbContext context) : IInvestment
 
         var rows = await context.InvestmentTransactions.AsNoTracking()
             .Where(x => accountIds.Contains(x.AccountId) && x.TradeDate <= asOf)
-            .Select(x => new { x.AssetListingId, x.Type, x.Quantity })
+            .GroupBy(x => x.AssetListingId)
+            .Select(g => new
+            {
+                ListingId = g.Key,
+                Holding = g.Sum(t => t.Type == InvestmentTransactionType.Sell ? -t.Quantity : t.Quantity)
+            })
+            .ToListAsync(cancellationToken);
+
+        return rows.ToDictionary(x => x.ListingId, x => x.Holding);
+    }
+
+    public async Task<IReadOnlyDictionary<int, IReadOnlyDictionary<long, decimal>>> GetHoldingsByAccountAsOf(
+        IReadOnlyCollection<int> accountIds,
+        DateOnly asOf,
+        CancellationToken cancellationToken = default)
+    {
+        if (accountIds.Count == 0) return new Dictionary<int, IReadOnlyDictionary<long, decimal>>();
+
+        var rows = await context.InvestmentTransactions.AsNoTracking()
+            .Where(x => accountIds.Contains(x.AccountId) && x.TradeDate <= asOf)
+            .GroupBy(x => new { x.AccountId, x.AssetListingId })
+            .Select(g => new
+            {
+                g.Key.AccountId,
+                g.Key.AssetListingId,
+                Holding = g.Sum(t => t.Type == InvestmentTransactionType.Sell ? -t.Quantity : t.Quantity)
+            })
             .ToListAsync(cancellationToken);
 
         return rows
-            .GroupBy(x => x.AssetListingId)
+            .GroupBy(x => x.AccountId)
             .ToDictionary(
                 g => g.Key,
-                g => g.Sum(t => t.Type == InvestmentTransactionType.Sell ? -t.Quantity : t.Quantity));
+                g => (IReadOnlyDictionary<long, decimal>)g.ToDictionary(x => x.AssetListingId, x => x.Holding));
+    }
+
+    public async Task<IInvestmentTransactionRepository.AccountValuationInputs> GetValuationInputs(
+        IReadOnlyCollection<int> accountIds,
+        DateOnly startDate,
+        DateOnly endDate,
+        CancellationToken cancellationToken = default)
+    {
+        if (accountIds.Count == 0 || startDate > endDate)
+            return new IInvestmentTransactionRepository.AccountValuationInputs([], []);
+
+        var openingRows = await context.InvestmentTransactions.AsNoTracking()
+            .Where(x => accountIds.Contains(x.AccountId) && x.TradeDate < startDate)
+            .GroupBy(x => new { x.AccountId, x.AssetListingId })
+            .Select(g => new
+            {
+                g.Key.AccountId,
+                g.Key.AssetListingId,
+                Quantity = g.Sum(t => t.Type == InvestmentTransactionType.Sell ? -t.Quantity : t.Quantity)
+            })
+            .Where(x => x.Quantity != 0m)
+            .ToListAsync(cancellationToken);
+
+        var tradeRows = await context.InvestmentTransactions.AsNoTracking()
+            .Where(x => accountIds.Contains(x.AccountId) && x.TradeDate >= startDate && x.TradeDate <= endDate)
+            .GroupBy(x => new { x.AccountId, x.AssetListingId, x.TradeDate })
+            .Select(g => new
+            {
+                g.Key.AccountId,
+                g.Key.AssetListingId,
+                g.Key.TradeDate,
+                SignedQuantity = g.Sum(t => t.Type == InvestmentTransactionType.Sell ? -t.Quantity : t.Quantity)
+            })
+            .Where(x => x.SignedQuantity != 0m)
+            .ToListAsync(cancellationToken);
+
+        var openingPositions = openingRows
+            .Select(x => new IInvestmentTransactionRepository.ValuationOpeningPosition(x.AccountId, x.AssetListingId, x.Quantity))
+            .ToList();
+
+        var trades = tradeRows
+            .Select(x => new IInvestmentTransactionRepository.ValuationTradeInput(x.AccountId, x.AssetListingId, x.TradeDate, x.SignedQuantity))
+            .ToList();
+
+        return new IInvestmentTransactionRepository.AccountValuationInputs(openingPositions, trades);
+    }
+
+    public async Task<IReadOnlyList<IInvestmentTransactionRepository.CapitalFlowInput>> GetCapitalFlowInputs(
+        IReadOnlyCollection<int> accountIds,
+        DateOnly toDate,
+        CancellationToken cancellationToken = default)
+    {
+        if (accountIds.Count == 0) return [];
+
+        return await context.InvestmentTransactions.AsNoTracking()
+            .Where(x => accountIds.Contains(x.AccountId) && x.TradeDate <= toDate)
+            .OrderBy(x => x.TradeDate).ThenBy(x => x.Id)
+            .Select(x => new IInvestmentTransactionRepository.CapitalFlowInput(
+                x.AccountId,
+                x.TradeDate,
+                x.Type,
+                x.Quantity,
+                x.UnitPrice,
+                x.Fee,
+                x.Currency,
+                (decimal?)x.AssetListing.PriceMultiplier))
+            .ToListAsync(cancellationToken);
     }
 
     public async Task<IReadOnlyList<long>> GetDistinctAssetListingIds(CancellationToken cancellationToken = default) =>

--- a/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/Investments/InvestmentValuationServiceTests.cs
@@ -123,14 +123,10 @@ public class InvestmentValuationServiceTests
         int[] accountIds = [10, 20];
 
         // Both accounts hold the same listing (10); account 20 also holds listing 30.
-        _transactionRepository
-            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(10) && a.Contains(20)), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                Tx(10, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 6, 1), accountId: 10),
-                Tx(10, InvestmentTransactionType.Buy, 3m, new DateOnly(2024, 6, 1), accountId: 20),
-                Tx(30, InvestmentTransactionType.Buy, 1m, new DateOnly(2024, 6, 1), accountId: 20)
-            });
+        SetupTransactions(
+            Tx(10, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 6, 1), accountId: 10),
+            Tx(10, InvestmentTransactionType.Buy, 3m, new DateOnly(2024, 6, 1), accountId: 20),
+            Tx(30, InvestmentTransactionType.Buy, 1m, new DateOnly(2024, 6, 1), accountId: 20));
         _priceProvider.Setup(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(100m);
         _priceProvider.Setup(x => x.GetPricePerUnitAsync(30, _usd, asOf, It.IsAny<CancellationToken>())).ReturnsAsync(40m);
 
@@ -141,6 +137,7 @@ public class InvestmentValuationServiceTests
 
         // The shared listing is priced once for the whole set, not once per owning account.
         _priceProvider.Verify(x => x.GetPricePerUnitAsync(10, _usd, asOf, It.IsAny<CancellationToken>()), Times.Once);
+        _transactionRepository.Verify(x => x.GetHoldingsByAccountAsOf(accountIds, DateOnly.FromDateTime(asOf), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -165,13 +162,9 @@ public class InvestmentValuationServiceTests
         var end = new DateTime(2024, 1, 4);
 
         // Buy 2 on Jan 1, buy 1 more on Jan 3 → holding is 2 on Jan 1-2, then 3 on Jan 3-4.
-        _transactionRepository
-            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                Tx(10, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 1)),
-                Tx(10, InvestmentTransactionType.Buy, 1m, new DateOnly(2024, 1, 3))
-            });
+        SetupTransactions(
+            Tx(10, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 1)),
+            Tx(10, InvestmentTransactionType.Buy, 1m, new DateOnly(2024, 1, 3)));
 
         // Flat price of 10 every day in the window.
         _priceProvider
@@ -199,12 +192,8 @@ public class InvestmentValuationServiceTests
         var end = new DateTime(2024, 2, 2);
 
         // The only purchase happened before the window; the holding must be carried into it.
-        _transactionRepository
-            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 15))
-            });
+        SetupTransactions(
+            Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 15)));
         _priceProvider
             .Setup(x => x.GetPricePerUnitSeriesAsync(10, _usd, start, end, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<DateTime, decimal>
@@ -222,9 +211,7 @@ public class InvestmentValuationServiceTests
     [Fact]
     public async Task GetAccountValueSeries_ReturnsEmpty_WhenNoTransactions()
     {
-        _transactionRepository
-            .Setup(x => x.GetByAccounts(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>());
+        SetupTransactions();
 
         var series = await CreateSut().GetAccountValueSeriesAsync(
             _accountId, _usd, new DateTime(2024, 1, 1), new DateTime(2024, 1, 31), TestContext.Current.CancellationToken);
@@ -240,14 +227,10 @@ public class InvestmentValuationServiceTests
         int[] accountIds = [10, 20];
 
         // Both accounts hold listing 10; account 20 also holds listing 30.
-        _transactionRepository
-            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(10) && a.Contains(20)), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                Tx(10, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 1), accountId: 10),
-                Tx(10, InvestmentTransactionType.Buy, 3m, new DateOnly(2024, 1, 1), accountId: 20),
-                Tx(30, InvestmentTransactionType.Buy, 1m, new DateOnly(2024, 1, 1), accountId: 20)
-            });
+        SetupTransactions(
+            Tx(10, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 1), accountId: 10),
+            Tx(10, InvestmentTransactionType.Buy, 3m, new DateOnly(2024, 1, 1), accountId: 20),
+            Tx(30, InvestmentTransactionType.Buy, 1m, new DateOnly(2024, 1, 1), accountId: 20));
 
         _priceProvider
             .Setup(x => x.GetPricePerUnitSeriesAsync(10, _usd, start, end, It.IsAny<CancellationToken>()))
@@ -274,13 +257,9 @@ public class InvestmentValuationServiceTests
         var end = new DateTime(2024, 2, 2);
 
         // Position was bought and fully sold before the valuation window opened.
-        _transactionRepository
-            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10)),
-                Tx(10, InvestmentTransactionType.Sell, 5m, new DateOnly(2024, 1, 20))
-            });
+        SetupTransactions(
+            Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10)),
+            Tx(10, InvestmentTransactionType.Sell, 5m, new DateOnly(2024, 1, 20)));
 
         var series = await CreateSut().GetAccountValueSeriesAsync(_accountId, _usd, start, end, TestContext.Current.CancellationToken);
 
@@ -297,14 +276,10 @@ public class InvestmentValuationServiceTests
         var end = new DateTime(2024, 2, 2);
 
         // Listing 10 was fully closed before the window; Listing 20 is still held.
-        _transactionRepository
-            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10)),
-                Tx(10, InvestmentTransactionType.Sell, 5m, new DateOnly(2024, 1, 20)),
-                Tx(20, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 15))
-            });
+        SetupTransactions(
+            Tx(10, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10)),
+            Tx(10, InvestmentTransactionType.Sell, 5m, new DateOnly(2024, 1, 20)),
+            Tx(20, InvestmentTransactionType.Buy, 2m, new DateOnly(2024, 1, 15)));
 
         _priceProvider
             .Setup(x => x.GetPricePerUnitSeriesAsync(20, _usd, start, end, It.IsAny<CancellationToken>()))
@@ -334,13 +309,9 @@ public class InvestmentValuationServiceTests
         var end = new DateTime(2024, 2, 3);
 
         // Position opens on Day 2 and closes on Day 3 (both in-window). Opening holding is 0.
-        _transactionRepository
-            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(_accountId)), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                Tx(10, InvestmentTransactionType.Buy, 3m, new DateOnly(2024, 2, 2)),
-                Tx(10, InvestmentTransactionType.Sell, 3m, new DateOnly(2024, 2, 3))
-            });
+        SetupTransactions(
+            Tx(10, InvestmentTransactionType.Buy, 3m, new DateOnly(2024, 2, 2)),
+            Tx(10, InvestmentTransactionType.Sell, 3m, new DateOnly(2024, 2, 3)));
 
         _priceProvider
             .Setup(x => x.GetPricePerUnitSeriesAsync(10, _usd, start, end, It.IsAny<CancellationToken>()))
@@ -371,13 +342,9 @@ public class InvestmentValuationServiceTests
 
         // Each account is evaluated independently: account 10 holds 5 units while account 20's
         // -5-unit position offsets it globally. A global listing net would incorrectly skip both.
-        _transactionRepository
-            .Setup(x => x.GetByAccounts(It.Is<IReadOnlyCollection<int>>(a => a.Contains(10) && a.Contains(20)), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<InvestmentTransaction>
-            {
-                Tx(100, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10), accountId: 10),
-                Tx(100, InvestmentTransactionType.Sell, 5m, new DateOnly(2024, 1, 20), accountId: 20)
-            });
+        SetupTransactions(
+            Tx(100, InvestmentTransactionType.Buy, 5m, new DateOnly(2024, 1, 10), accountId: 10),
+            Tx(100, InvestmentTransactionType.Sell, 5m, new DateOnly(2024, 1, 20), accountId: 20));
 
         _priceProvider
             .Setup(x => x.GetPricePerUnitSeriesAsync(100, _usd, start, end, It.IsAny<CancellationToken>()))
@@ -619,10 +586,67 @@ public class InvestmentValuationServiceTests
         Assert.Empty(series);
     }
 
-    private void SetupTransactions(params InvestmentTransaction[] transactions) =>
+    private void SetupTransactions(params InvestmentTransaction[] transactions)
+    {
         _transactionRepository
             .Setup(x => x.GetByAccounts(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(transactions);
+
+        _transactionRepository
+            .Setup(x => x.GetHoldingsByAccountAsOf(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<int> accounts, DateOnly asOf, CancellationToken _) =>
+            {
+                var dict = new Dictionary<int, IReadOnlyDictionary<long, decimal>>();
+                foreach (var group in transactions.Where(t => accounts.Contains(t.AccountId) && t.TradeDate <= asOf).GroupBy(t => t.AccountId))
+                {
+                    var perListing = group
+                        .GroupBy(t => t.AssetListingId)
+                        .ToDictionary(g => g.Key, g => g.Sum(t => t.SignedQuantity));
+                    dict[group.Key] = perListing;
+                }
+                return dict;
+            });
+
+        _transactionRepository
+            .Setup(x => x.GetValuationInputs(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<int> accounts, DateOnly startDate, DateOnly endDate, CancellationToken _) =>
+            {
+                var opening = transactions
+                    .Where(t => accounts.Contains(t.AccountId) && t.TradeDate < startDate)
+                    .GroupBy(t => (t.AccountId, t.AssetListingId))
+                    .Select(g => new IInvestmentTransactionRepository.ValuationOpeningPosition(g.Key.AccountId, g.Key.AssetListingId, g.Sum(t => t.SignedQuantity)))
+                    .Where(p => p.Quantity != 0m)
+                    .ToList();
+
+                var trades = transactions
+                    .Where(t => accounts.Contains(t.AccountId) && t.TradeDate >= startDate && t.TradeDate <= endDate)
+                    .GroupBy(t => (t.AccountId, t.AssetListingId, t.TradeDate))
+                    .Select(g => new IInvestmentTransactionRepository.ValuationTradeInput(g.Key.AccountId, g.Key.AssetListingId, g.Key.TradeDate, g.Sum(t => t.SignedQuantity)))
+                    .Where(t => t.SignedQuantity != 0m)
+                    .ToList();
+
+                return new IInvestmentTransactionRepository.AccountValuationInputs(opening, trades);
+            });
+
+        _transactionRepository
+            .Setup(x => x.GetCapitalFlowInputs(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<DateOnly>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<int> accounts, DateOnly toDate, CancellationToken _) =>
+            {
+                return transactions
+                    .Where(t => accounts.Contains(t.AccountId) && t.TradeDate <= toDate)
+                    .OrderBy(t => t.TradeDate).ThenBy(t => t.Id)
+                    .Select(t => new IInvestmentTransactionRepository.CapitalFlowInput(
+                        t.AccountId,
+                        t.TradeDate,
+                        t.Type,
+                        t.Quantity,
+                        t.UnitPrice,
+                        t.Fee,
+                        t.Currency,
+                        t.AssetListing?.PriceMultiplier))
+                    .ToList();
+            });
+    }
 
     private void SetupPrices(long listingId, Dictionary<DateTime, decimal> prices) =>
         _priceProvider

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Features/FinancialAccounts/Investments/Repositories/InvestmentModelRepositoryTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Features/FinancialAccounts/Investments/Repositories/InvestmentModelRepositoryTests.cs
@@ -429,4 +429,298 @@ public class InvestmentModelRepositoryTests
         Assert.Single(range);
         Assert.Equal(505m, range[0].Price);
     }
+
+    [Fact]
+    public async Task GetHoldingsByAccountAsOf_GroupsByAccountAndListing_AndNetsSignedQuantities()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var ctx = CreateContext();
+        var assetRepo = new AssetRepository(ctx);
+        var listingRepo = new AssetListingRepository(ctx);
+        var txRepo = new InvestmentTransactionRepository(ctx);
+
+        var asset = await assetRepo.Add(MakeISharesAsset(), ct);
+        var listing1 = await listingRepo.Add(new AssetListing
+        {
+            AssetId = asset.Id,
+            Ticker = "CSPX",
+            ExchangeMic = "XLON",
+            ExchangeName = "London Stock Exchange",
+            TradingCurrency = "USD"
+        }, ct);
+        var listing2 = await listingRepo.Add(new AssetListing
+        {
+            AssetId = asset.Id,
+            Ticker = "SXR8",
+            ExchangeMic = "XETR",
+            ExchangeName = "Xetra",
+            TradingCurrency = "EUR"
+        }, ct);
+
+        // Account 10: Buy 5 CSPX on Jan 10, Sell 2 CSPX on Jan 15, Buy 10 SXR8 on Jan 12
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = 10,
+            AssetListingId = listing1.Id,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = 5.5m,
+            UnitPrice = 500m,
+            Currency = "USD",
+            TradeDate = new DateOnly(2026, 1, 10)
+        }, ct);
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = 10,
+            AssetListingId = listing1.Id,
+            Type = InvestmentTransactionType.Sell,
+            Quantity = 2.25m,
+            UnitPrice = 510m,
+            Currency = "USD",
+            TradeDate = new DateOnly(2026, 1, 15)
+        }, ct);
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = 10,
+            AssetListingId = listing2.Id,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = 10m,
+            UnitPrice = 450m,
+            Currency = "EUR",
+            TradeDate = new DateOnly(2026, 1, 12)
+        }, ct);
+
+        // Account 20: Buy 1 CSPX on Jan 10, Buy 2 CSPX on Jan 25 (after as-of)
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = 20,
+            AssetListingId = listing1.Id,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = 1m,
+            UnitPrice = 500m,
+            Currency = "USD",
+            TradeDate = new DateOnly(2026, 1, 10)
+        }, ct);
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = 20,
+            AssetListingId = listing1.Id,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = 2m,
+            UnitPrice = 500m,
+            Currency = "USD",
+            TradeDate = new DateOnly(2026, 1, 25)
+        }, ct);
+
+        // Account 30 (not requested): Buy 100 CSPX
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = 30,
+            AssetListingId = listing1.Id,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = 100m,
+            UnitPrice = 500m,
+            Currency = "USD",
+            TradeDate = new DateOnly(2026, 1, 10)
+        }, ct);
+
+        var asOf = new DateOnly(2026, 1, 20);
+        var holdings = await txRepo.GetHoldingsByAccountAsOf([10, 20], asOf, ct);
+
+        Assert.Equal(2, holdings.Count);
+        Assert.True(holdings.ContainsKey(10));
+        Assert.True(holdings.ContainsKey(20));
+        Assert.False(holdings.ContainsKey(30));
+
+        Assert.Equal(3.25m, holdings[10][listing1.Id]); // 5.5 - 2.25
+        Assert.Equal(10m, holdings[10][listing2.Id]);
+        Assert.Equal(1m, holdings[20][listing1.Id]); // Jan 25 trade excluded
+    }
+
+    [Fact]
+    public async Task GetValuationInputs_SplitsOpeningAndInWindow_AndExcludesOutOfRange()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var ctx = CreateContext();
+        var assetRepo = new AssetRepository(ctx);
+        var listingRepo = new AssetListingRepository(ctx);
+        var txRepo = new InvestmentTransactionRepository(ctx);
+
+        var asset = await assetRepo.Add(MakeISharesAsset(), ct);
+        var listing = await listingRepo.Add(new AssetListing
+        {
+            AssetId = asset.Id,
+            Ticker = "CSPX",
+            ExchangeMic = "XLON",
+            ExchangeName = "London Stock Exchange",
+            TradingCurrency = "USD"
+        }, ct);
+
+        const int accountId = 10;
+        // Opening before window (window: Jan 10 to Jan 20)
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = accountId,
+            AssetListingId = listing.Id,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = 5m,
+            UnitPrice = 100m,
+            Currency = "USD",
+            TradeDate = new DateOnly(2026, 1, 1)
+        }, ct);
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = accountId,
+            AssetListingId = listing.Id,
+            Type = InvestmentTransactionType.Sell,
+            Quantity = 1m,
+            UnitPrice = 105m,
+            Currency = "USD",
+            TradeDate = new DateOnly(2026, 1, 5)
+        }, ct);
+
+        // In-window trades (Jan 10, Jan 15)
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = accountId,
+            AssetListingId = listing.Id,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = 2m,
+            UnitPrice = 110m,
+            Currency = "USD",
+            TradeDate = new DateOnly(2026, 1, 10)
+        }, ct);
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = accountId,
+            AssetListingId = listing.Id,
+            Type = InvestmentTransactionType.Sell,
+            Quantity = 0.5m,
+            UnitPrice = 115m,
+            Currency = "USD",
+            TradeDate = new DateOnly(2026, 1, 15)
+        }, ct);
+
+        // After window (Jan 25)
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = accountId,
+            AssetListingId = listing.Id,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = 20m,
+            UnitPrice = 120m,
+            Currency = "USD",
+            TradeDate = new DateOnly(2026, 1, 25)
+        }, ct);
+
+        var inputs = await txRepo.GetValuationInputs(
+            [accountId],
+            new DateOnly(2026, 1, 10),
+            new DateOnly(2026, 1, 20),
+            ct);
+
+        Assert.Single(inputs.OpeningPositions);
+        Assert.Equal(accountId, inputs.OpeningPositions[0].AccountId);
+        Assert.Equal(listing.Id, inputs.OpeningPositions[0].AssetListingId);
+        Assert.Equal(4m, inputs.OpeningPositions[0].Quantity); // 5 - 1
+
+        Assert.Equal(2, inputs.InWindowTrades.Count);
+        var trade1 = inputs.InWindowTrades.Single(t => t.TradeDate == new DateOnly(2026, 1, 10));
+        Assert.Equal(2m, trade1.SignedQuantity);
+        var trade2 = inputs.InWindowTrades.Single(t => t.TradeDate == new DateOnly(2026, 1, 15));
+        Assert.Equal(-0.5m, trade2.SignedQuantity);
+    }
+
+    [Fact]
+    public async Task GetCapitalFlowInputs_ProjectsBoundedFields_AndIncludesPriceMultiplier()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var ctx = CreateContext();
+        var assetRepo = new AssetRepository(ctx);
+        var listingRepo = new AssetListingRepository(ctx);
+        var txRepo = new InvestmentTransactionRepository(ctx);
+
+        var asset = await assetRepo.Add(MakeISharesAsset(), ct);
+        var gbxListing = await listingRepo.Add(new AssetListing
+        {
+            AssetId = asset.Id,
+            Ticker = "CSP1",
+            ExchangeMic = "XLON",
+            ExchangeName = "London Stock Exchange",
+            TradingCurrency = "GBX",
+            PriceMultiplier = 0.01m
+        }, ct);
+
+        const int accountId = 10;
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = accountId,
+            AssetListingId = gbxListing.Id,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = 10m,
+            UnitPrice = 40000m,
+            Fee = 500m,
+            Currency = "GBX",
+            TradeDate = new DateOnly(2026, 1, 10)
+        }, ct);
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = accountId,
+            AssetListingId = gbxListing.Id,
+            Type = InvestmentTransactionType.Sell,
+            Quantity = 5m,
+            UnitPrice = 42000m,
+            Fee = 250m,
+            Currency = "GBX",
+            TradeDate = new DateOnly(2026, 1, 15)
+        }, ct);
+        // After toDate
+        await txRepo.Add(new InvestmentTransaction
+        {
+            UserId = 1,
+            AccountId = accountId,
+            AssetListingId = gbxListing.Id,
+            Type = InvestmentTransactionType.Buy,
+            Quantity = 1m,
+            UnitPrice = 43000m,
+            Currency = "GBX",
+            TradeDate = new DateOnly(2026, 1, 25)
+        }, ct);
+
+        var flows = await txRepo.GetCapitalFlowInputs([accountId], new DateOnly(2026, 1, 20), ct);
+
+        Assert.Equal(2, flows.Count);
+
+        var buyFlow = flows[0];
+        Assert.Equal(accountId, buyFlow.AccountId);
+        Assert.Equal(new DateOnly(2026, 1, 10), buyFlow.TradeDate);
+        Assert.Equal(InvestmentTransactionType.Buy, buyFlow.Type);
+        Assert.Equal(10m, buyFlow.Quantity);
+        Assert.Equal(40000m, buyFlow.UnitPrice);
+        Assert.Equal(500m, buyFlow.Fee);
+        Assert.Equal("GBX", buyFlow.Currency);
+        Assert.Equal(0.01m, buyFlow.ListingPriceMultiplier);
+
+        var sellFlow = flows[1];
+        Assert.Equal(accountId, sellFlow.AccountId);
+        Assert.Equal(new DateOnly(2026, 1, 15), sellFlow.TradeDate);
+        Assert.Equal(InvestmentTransactionType.Sell, sellFlow.Type);
+        Assert.Equal(5m, sellFlow.Quantity);
+        Assert.Equal(42000m, sellFlow.UnitPrice);
+        Assert.Equal(250m, sellFlow.Fee);
+        Assert.Equal("GBX", sellFlow.Currency);
+        Assert.Equal(0.01m, sellFlow.ListingPriceMultiplier);
+    }
 }


### PR DESCRIPTION
## Summary

- Add relational projections for per-account holdings, opening/in-window valuation inputs, and bounded capital-flow inputs.
- Move investment valuation and benchmark filtering/aggregation to those projections while preserving signed trades, fees, fractional quantities, quote-unit multipliers, boundaries, conversion, and carry-forward behavior.
- Add relational repository coverage and valuation regression coverage for equivalent results and excluded future/closed rows.

Closes #745

## Validation

- `dotnet test FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --no-restore --filter-class FinanceManager.Tests.Unit.Application.Services.Investments.InvestmentValuationServiceTests` — 25/25 passed.
- `dotnet test FinanceManager.Tests.Unit/FinanceManager.Tests.Unit.csproj --no-restore --filter-class FinanceManager.Tests.Unit.Infrastructure.Features.FinancialAccounts.Investments.Repositories.InvestmentModelRepositoryTests` — 14/14 passed.
- `dotnet test FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj --no-restore --filter-class FinanceManager.Tests.Integration.Features.FinancialAccounts.Investments.Controllers.InvestmentValuationControllerTests` — 10/10 passed.
- `dotnet test FinanceManager.Tests.Integration/FinanceManager.Tests.Integration.csproj --no-restore` — 326/326 passed.
- `dotnet test FinanceManager.Tests.Architecture/FinanceManager.Tests.Architecture.csproj --no-restore` — 9/9 passed.
- `dotnet build FinanceManager.slnx --no-restore --nologo -v:minimal` — passed, 0 warnings/errors.
- Scoped `dotnet format --verify-no-changes`, LF checks, and `git diff --check` — passed.

The full unit suite had 1,007 passed and six unrelated baseline failures (four provider-null currency tests and two locale-sensitive investment paycheck cache-key tests). Relational validation used the existing SQLite integration harness; SQL Server/PostgreSQL execution-plan inspection is not available in this local run.

## Risk

The new repository contracts return only fields needed by each valuation scenario; existing full-entity transaction methods remain for other callers. Query aggregation preserves the prior signed-quantity and date-boundary semantics.
