### PR TITLE
Reuse bond definitions and derived dashboard values #747

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ rules agents must follow when updating this file.
 - Users can now pick a preferred currency in **Settings → Preferences**. All dashboards, charts, and asset valuations are recalculated to that currency; when a rate to the preferred currency is unavailable, values fall back to USD instead of disappearing.
 
 ### Changed
+- Dashboard bond valuation now loads only referenced bond definitions once per request and reuses matching daily prices across net-worth and balance aggregates. #747
 - Currency conversions and overlapping chart date ranges now reuse resolved daily exchange rates while continuing to refresh missing values. #743
 - Historical exchange-rate range lookups now use bounded provider range requests, avoiding concurrent per-date NBP request bursts while preserving provider fallback and missing-day behavior. #728
 - Card explanations now open from card header labels with polished, viewport-aware tooltip surfaces and no standalone info icons. #730

--- a/code/FinanceManager.Application/FinancialAccounts/Bond/Balance/BondBalanceService.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Bond/Balance/BondBalanceService.cs
@@ -1,7 +1,7 @@
+using FinanceManager.Application.FinancialAccounts.Bond.Valuation;
 using FinanceManager.Application.FinancialAccounts.Shared;
 using FinanceManager.Application.Shared;
 using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
-using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Services;
 using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
@@ -14,7 +14,7 @@ namespace FinanceManager.Application.FinancialAccounts.Bond.Balance;
 
 internal class BondBalanceService(
     IFinancialAccountRepository financialAccountRepository,
-    IBondDetailsRepository bondDetailsRepository,
+    BondDashboardContext bondDashboardContext,
     ICurrencyExchangeService currencyExchangeService) : IBalanceServiceTyped
 {
     public Task<List<TimeSeriesModel>> GetInflow(int userId, Currency currency, DateTime start, DateTime end) =>
@@ -44,14 +44,21 @@ internal class BondBalanceService(
         if (start == default || end == default || end.Date < start.Date) return [];
 
         var accountIdFilter = accountIds.Count > 0 ? accountIds.ToHashSet() : [];
-        var bondDetails = await bondDetailsRepository.GetAllAsync().ToDictionaryAsync(x => x.Id);
-        List<BondCapitalFlow> flows = [];
-
+        List<BondAccount> bondAccounts = [];
         await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, start, end))
         {
             if (account is null) continue;
             if (accountIdFilter.Count > 0 && !accountIdFilter.Contains(account.AccountId)) continue;
+            bondAccounts.Add(account);
+        }
 
+        // Only the definitions the accounts actually reference are loaded (detached, no-tracking),
+        // shared with the other dashboard bond paths through the request-scoped context.
+        var bondDetails = await bondDashboardContext.LoadReferencedDetailsAsync(bondAccounts);
+        List<BondCapitalFlow> flows = [];
+
+        foreach (var account in bondAccounts)
+        {
             // GetAccounts carries only the latest pre-range row per bond. Its running Value is the
             // number of units already held, which seeds the visible range without treating accrued
             // interest as user-paid capital.
@@ -118,8 +125,8 @@ internal class BondBalanceService(
         }
 
         return TimeBucketService.Get(cumulative.Select(x => (x.Key, x.Value)))
-                                .Select(bucket => new TimeSeriesModel(bucket.Date, bucket.Objects.Last()))
-                                .ToList();
+                                 .Select(bucket => new TimeSeriesModel(bucket.Date, bucket.Objects.Last()))
+                                 .ToList();
     }
 
     public Task<List<TimeSeriesModel>> GetClosingBalance(int userId, Currency currency, DateTime start, DateTime end) =>
@@ -129,16 +136,27 @@ internal class BondBalanceService(
     {
         if (end > DateTime.UtcNow) end = DateTime.UtcNow;
 
-        Dictionary<DateTime, decimal> prices = [];
         var accountIdFilter = accountIds.Count > 0 ? accountIds.ToHashSet() : [];
-        var bondDetails = await bondDetailsRepository.GetAllAsync().ToListAsync();
-
+        List<BondAccount> bondAccounts = [];
         await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, start, end))
         {
             if (account is null) continue;
             if (accountIdFilter.Count > 0 && !accountIdFilter.Contains(account.AccountId)) continue;
+            bondAccounts.Add(account);
+        }
 
-            foreach (var price in account.GetDailyPrice(DateOnly.FromDateTime(start), DateOnly.FromDateTime(end), bondDetails))
+        var bondDetails = (await bondDashboardContext.LoadReferencedDetailsAsync(bondAccounts)).Values.ToList();
+
+        Dictionary<DateTime, decimal> prices = [];
+        foreach (var account in bondAccounts)
+        {
+            // Per-date prices resolve through the request-scoped context, which memoizes each
+            // account/bond/date so the dashboard's net-worth path never recomputes the same price.
+            foreach (var price in account.GetDailyPrice(
+                         DateOnly.FromDateTime(start),
+                         DateOnly.FromDateTime(end),
+                         bondDetails,
+                         (entry, _, date) => bondDashboardContext.GetOrComputePrice(account.AccountId, entry, date)))
             {
                 var date = price.Key.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
                 if (!prices.ContainsKey(date))
@@ -149,23 +167,28 @@ internal class BondBalanceService(
         }
 
         return TimeBucketService.Get(prices.OrderBy(x => x.Key).Select(x => (x.Key, x.Value)))
-                                .Select(bucket => new TimeSeriesModel(bucket.Date, bucket.Objects.Last()))
-                                .ToList();
+                                 .Select(bucket => new TimeSeriesModel(bucket.Date, bucket.Objects.Last()))
+                                 .ToList();
     }
 
     private async Task<List<TimeSeriesModel>> AggregateByDay(int userId, DateTime start, DateTime end, Func<BondAccountEntry, bool> predicate, IReadOnlyCollection<int> accountIds)
     {
         if (end > DateTime.UtcNow) end = DateTime.UtcNow;
 
-        Dictionary<DateTime, decimal> result = [];
         var accountIdFilter = accountIds.Count > 0 ? accountIds.ToHashSet() : [];
-        var bondDetails = await bondDetailsRepository.GetAllAsync().ToDictionaryAsync(x => x.Id);
-
+        List<BondAccount> bondAccounts = [];
         await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, start, end))
         {
             if (account?.Entries is null) continue;
             if (accountIdFilter.Count > 0 && !accountIdFilter.Contains(account.AccountId)) continue;
+            bondAccounts.Add(account);
+        }
 
+        var bondDetails = await bondDashboardContext.LoadReferencedDetailsAsync(bondAccounts);
+
+        Dictionary<DateTime, decimal> result = [];
+        foreach (var account in bondAccounts)
+        {
             foreach (var entry in account.Entries)
             {
                 if (entry.PostingDate.Date < start.Date || entry.PostingDate.Date > end.Date) continue;
@@ -181,8 +204,8 @@ internal class BondBalanceService(
         }
 
         return TimeBucketService.Get(result.OrderBy(x => x.Key).Select(x => (x.Key, x.Value)))
-                                .Select(bucket => new TimeSeriesModel(bucket.Date, bucket.Objects.Sum()))
-                                .ToList();
+                                 .Select(bucket => new TimeSeriesModel(bucket.Date, bucket.Objects.Sum()))
+                                 .ToList();
     }
 
     private sealed record BondCapitalFlow(DateTime Date, decimal Amount, Currency Currency);

--- a/code/FinanceManager.Application/FinancialAccounts/Bond/Valuation/BondDashboardContext.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Bond/Valuation/BondDashboardContext.cs
@@ -1,0 +1,74 @@
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
+
+namespace FinanceManager.Application.FinancialAccounts.Bond.Valuation;
+
+/// <summary>
+/// Request-scoped context shared by the bond dashboard paths (net worth, closing balance, ...).
+/// It loads only the bond definitions actually referenced by the given accounts through a single
+/// no-tracking query, stores detached snapshots, and memoizes the deterministic per-account,
+/// per-bond, per-date prices so every price is computed at most once per request.
+/// </summary>
+public class BondDashboardContext(IBondDetailsRepository bondDetailsRepository)
+{
+    private readonly Dictionary<int, BondDetails> _details = [];
+    private readonly HashSet<int> _requestedIds = [];
+    private readonly Dictionary<(int AccountId, int EntryId, int BondDetailsId, DateOnly PostingDate, decimal Value, DateOnly Date), decimal> _prices = [];
+
+    /// <summary>
+    /// Loads the bond definitions referenced by the accounts (in-range entries plus next-older boundary
+    /// entries). Repeated calls within one request only query ids not requested yet, so the union of
+    /// references across the dashboard's services costs a single repository round-trip. Missing
+    /// definitions are omitted; <see cref="GetDetails"/> keeps the existing throw for them.
+    /// </summary>
+    public async Task<IReadOnlyDictionary<int, BondDetails>> LoadReferencedDetailsAsync(
+        IEnumerable<BondAccount> accounts,
+        CancellationToken cancellationToken = default)
+    {
+        var missing = accounts
+            .SelectMany(x => x.GetStoredBondsIds())
+            .Where(id => !_requestedIds.Contains(id))
+            .Distinct()
+            .ToList();
+
+        if (missing.Count > 0)
+        {
+            var loaded = await bondDetailsRepository.GetByIdsAsync(missing, cancellationToken);
+            _requestedIds.UnionWith(missing);
+            foreach (var details in loaded)
+                _details[details.Id] = details;
+        }
+
+        return _details;
+    }
+
+    /// <summary>
+    /// Returns the stored definition, throwing for a deleted bond exactly like the previous dashboard
+    /// paths did when their details dictionary had no entry for the id.
+    /// </summary>
+    public BondDetails GetDetails(int bondDetailsId)
+    {
+        if (!_details.TryGetValue(bondDetailsId, out var details))
+            throw new InvalidOperationException($"Bond valuation requires details for bond id {bondDetailsId}.");
+
+        return details;
+    }
+
+    /// <summary>
+    /// Returns the memoized price of the entry at the date, computing it only on the first request for
+    /// that account/entry/date. Bond pricing is a pure function of the entry and the definition, so two
+    /// dashboard paths that materialize the same account within one request share a single computation
+    /// without allowing a changed entry snapshot to reuse a stale value.
+    /// </summary>
+    public decimal GetOrComputePrice(int accountId, BondAccountEntry entry, DateOnly date)
+    {
+        var key = (accountId, entry.EntryId, entry.BondDetailsId, DateOnly.FromDateTime(entry.PostingDate), entry.Value, date);
+        if (_prices.TryGetValue(key, out var price))
+            return price;
+
+        price = entry.GetPriceAt(date, GetDetails(entry.BondDetailsId));
+        _prices[key] = price;
+
+        return price;
+    }
+}

--- a/code/FinanceManager.Application/FinancialAccounts/Registration.cs
+++ b/code/FinanceManager.Application/FinancialAccounts/Registration.cs
@@ -8,6 +8,7 @@ using FinanceManager.Application.FinancialAccounts.Bond.Details;
 using FinanceManager.Application.FinancialAccounts.Bond.Export;
 using FinanceManager.Application.FinancialAccounts.Bond.Import;
 using FinanceManager.Application.FinancialAccounts.Bond.Seeders;
+using FinanceManager.Application.FinancialAccounts.Bond.Valuation;
 using FinanceManager.Application.FinancialAccounts.Currencies;
 using FinanceManager.Application.FinancialAccounts.Currencies.Assets;
 using FinanceManager.Application.FinancialAccounts.Currencies.Balance;
@@ -42,7 +43,8 @@ internal static class Registration
 {
     public static IServiceCollection AddFinancialAccountsApplication(this IServiceCollection services)
     {
-        services.AddScoped<IBalanceServiceTyped, CurrencyBalanceService>()
+        services.AddScoped<BondDashboardContext>()
+                .AddScoped<IBalanceServiceTyped, CurrencyBalanceService>()
                 .AddScoped<IBalanceServiceTyped, BondBalanceService>()
                 .AddScoped<IBalanceServiceTyped, InvestmentBalanceService>()
                 .AddScoped<IBalanceService, BalanceService>()

--- a/code/FinanceManager.Application/MoneyFlow/NetWorth/NetWorthService.cs
+++ b/code/FinanceManager.Application/MoneyFlow/NetWorth/NetWorthService.cs
@@ -1,5 +1,5 @@
+using FinanceManager.Application.FinancialAccounts.Bond.Valuation;
 using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
-using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Entities;
 using FinanceManager.Domain.FinancialAccounts.Investments.Services;
@@ -12,14 +12,15 @@ using FinanceManager.Domain.MoneyFlow.Services;
 
 namespace FinanceManager.Application.MoneyFlow.NetWorth;
 
-public class NetWorthService(IFinancialAccountRepository financialAccountRepository,
-IBondDetailsRepository bondDetailsRepository, IInvestmentValuationService investmentValuationService) : INetWorthService
+public class NetWorthService(
+    IFinancialAccountRepository financialAccountRepository,
+    BondDashboardContext bondDashboardContext,
+    IInvestmentValuationService investmentValuationService) : INetWorthService
 {
     public async Task<decimal?> GetNetWorth(int userId, Currency currency, DateTime date)
     {
         if (date > DateTime.UtcNow) date = DateTime.UtcNow;
         decimal result = 0;
-        var bondDetails = await bondDetailsRepository.GetAllAsync().ToDictionaryAsync(x => x.Id);
 
         await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, date.Date, date))
         {
@@ -29,16 +30,22 @@ IBondDetailsRepository bondDetailsRepository, IInvestmentValuationService invest
             result += newestEntry.Value;
         }
 
+        List<BondAccount> bondAccounts = [];
         await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, date.Date, date))
+            bondAccounts.Add(account);
+
+        // Only the definitions the accounts actually reference are loaded (detached, no-tracking),
+        // and prices memoize in the request-scoped context so the dashboard's other bond paths reuse them.
+        await bondDashboardContext.LoadReferencedDetailsAsync(bondAccounts);
+
+        foreach (var account in bondAccounts)
         {
             foreach (var detailsId in account.GetStoredBondsIds())
             {
                 var newestEntry = account.GetThisOrNextOlder(date, detailsId);
                 if (newestEntry is null) continue;
-                if (!bondDetails.TryGetValue(detailsId, out var details))
-                    throw new InvalidOperationException($"Bond valuation requires details for bond id {detailsId}.");
 
-                result += newestEntry.GetPriceAt(DateOnly.FromDateTime(date), details);
+                result += bondDashboardContext.GetOrComputePrice(account.AccountId, newestEntry, DateOnly.FromDateTime(date));
             }
         }
 
@@ -54,8 +61,6 @@ IBondDetailsRepository bondDetailsRepository, IInvestmentValuationService invest
 
         Dictionary<DateTime, decimal> result = [];
 
-        var bondDetails = await bondDetailsRepository.GetAllAsync().ToDictionaryAsync(x => x.Id);
-
         List<CurrencyAccount> currencyAccounts = [];
         await foreach (var account in financialAccountRepository.GetAccounts<CurrencyAccount>(userId, start, end))
             currencyAccounts.Add(account);
@@ -63,6 +68,8 @@ IBondDetailsRepository bondDetailsRepository, IInvestmentValuationService invest
         List<BondAccount> bondAccounts = [];
         await foreach (var account in financialAccountRepository.GetAccounts<BondAccount>(userId, start, end))
             bondAccounts.Add(account);
+
+        await bondDashboardContext.LoadReferencedDetailsAsync(bondAccounts);
 
         List<InvestmentAccount> investmentAccounts = [];
         await foreach (var account in financialAccountRepository.GetAccounts<InvestmentAccount>(userId, start, end))
@@ -92,10 +99,7 @@ IBondDetailsRepository bondDetailsRepository, IInvestmentValuationService invest
                 {
                     var entry = account.GetThisOrNextOlder(date, detailsId);
                     if (entry is null) continue;
-                    if (!bondDetails.TryGetValue(detailsId, out var details))
-                        throw new InvalidOperationException($"Bond valuation requires details for bond id {detailsId}.");
-
-                    dailyTotal += entry.GetPriceAt(DateOnly.FromDateTime(date), details);
+                    dailyTotal += bondDashboardContext.GetOrComputePrice(account.AccountId, entry, DateOnly.FromDateTime(date));
                 }
             }
 

--- a/code/FinanceManager.Domain/FinancialAccounts/Bond/Entities/BondAccount.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Bond/Entities/BondAccount.cs
@@ -145,7 +145,16 @@ public class BondAccount : FinancialAccountBase<BondAccountEntry>
         }
     }
 
-    public Dictionary<DateOnly, decimal> GetDailyPrice(DateOnly start, DateOnly end, List<BondDetails> bondDetails)
+    /// <summary>
+    /// Prices the account per day. An optional <paramref name="priceAt"/> callback replaces the
+    /// default per-entry pricing (<see cref="BondAccountEntry.GetPriceAt(DateOnly, BondDetails)"/>) so
+    /// callers can reuse cached prices; the existing missing-details behaviour is unchanged.
+    /// </summary>
+    public Dictionary<DateOnly, decimal> GetDailyPrice(
+        DateOnly start,
+        DateOnly end,
+        List<BondDetails> bondDetails,
+        Func<BondAccountEntry, BondDetails, DateOnly, decimal>? priceAt = null)
     {
         var result = new Dictionary<DateOnly, decimal>();
         if (Entries is null || start > end) return result;
@@ -160,6 +169,8 @@ public class BondAccount : FinancialAccountBase<BondAccountEntry>
         if (missingDetailIds.Count != 0)
             throw new InvalidOperationException($"Bond valuation requires details for bond ids: {string.Join(", ", missingDetailIds)}.");
 
+        var resolvePrice = priceAt ?? ((entry, details, date) => entry.GetPriceAt(date, details));
+
         for (var date = start; date <= end; date = date.AddDays(1))
         {
             decimal total = 0;
@@ -168,7 +179,7 @@ public class BondAccount : FinancialAccountBase<BondAccountEntry>
                 var currentEntry = GetThisOrNextOlder(date.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc), detailId);
                 if (currentEntry is null) continue;
 
-                total += currentEntry.GetPriceAt(date, detailsById[detailId]);
+                total += resolvePrice(currentEntry, detailsById[detailId], date);
             }
 
             if (total != 0)

--- a/code/FinanceManager.Domain/FinancialAccounts/Bond/Repositories/IBondDetailsRepository.cs
+++ b/code/FinanceManager.Domain/FinancialAccounts/Bond/Repositories/IBondDetailsRepository.cs
@@ -10,6 +10,11 @@ public interface IBondDetailsRepository
     /// the dashboard's existing fallback description for deleted bond details.
     /// </summary>
     Task<IReadOnlyDictionary<int, string>> GetNamesByIdsAsync(IReadOnlyCollection<int> ids, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Resolves full, detached (no-tracking) bond definitions for a set of ids in one query. Missing ids are
+    /// omitted so callers can retain their existing fallback for deleted bond details.
+    /// </summary>
+    Task<IReadOnlyList<BondDetails>> GetByIdsAsync(IReadOnlyCollection<int> ids, CancellationToken cancellationToken = default);
     IAsyncEnumerable<BondDetails> GetAllAsync(CancellationToken cancellationToken = default);
     Task<IReadOnlyList<BondDetails>> GetByIssuerAsync(string issuer, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<string>> GetIssuersAsync(CancellationToken cancellationToken = default);

--- a/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondDetailsRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondDetailsRepository.cs
@@ -32,6 +32,21 @@ internal class BondDetailsRepository(AppDbContext context) : IBondDetailsReposit
     public async Task<BondDetails?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
         => await context.Bonds.Include(b => b.CalculationMethods).FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
 
+    public async Task<IReadOnlyList<BondDetails>> GetByIdsAsync(
+        IReadOnlyCollection<int> ids,
+        CancellationToken cancellationToken = default)
+    {
+        if (ids.Count == 0)
+            return [];
+
+        return await context.Bonds
+            .AsNoTracking()
+            .Include(b => b.CalculationMethods)
+            .Include(b => b.Currency)
+            .Where(b => ids.Contains(b.Id))
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<IReadOnlyDictionary<int, string>> GetNamesByIdsAsync(
         IReadOnlyCollection<int> ids,
         CancellationToken cancellationToken = default)

--- a/code/FinanceManager.Tests.Unit/Application/FinancialAccounts/Bond/Valuation/BondDashboardContextTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/FinancialAccounts/Bond/Valuation/BondDashboardContextTests.cs
@@ -1,0 +1,178 @@
+using FinanceManager.Application.FinancialAccounts.Bond.Valuation;
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Domain.Shared;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.FinancialAccounts.Bond.Valuation;
+
+[Collection("Application")]
+[Trait("Category", "Unit")]
+public class BondDashboardContextTests
+{
+    [Fact]
+    public async Task LoadReferencedDetailsAsync_BatchesDistinctIds_AndReusesTheRequestSnapshot()
+    {
+        var details = new[]
+        {
+            CreateDetails(1),
+            CreateDetails(2),
+        };
+        var requestedIds = new List<int[]>();
+        var repository = new Mock<IBondDetailsRepository>();
+        repository
+            .Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .Callback((IReadOnlyCollection<int> ids, CancellationToken _) => requestedIds.Add(ids.ToArray()))
+            .ReturnsAsync((IReadOnlyList<BondDetails>)details);
+
+        var context = new BondDashboardContext(repository.Object);
+        var account = new BondAccount(
+            1,
+            10,
+            "Bonds",
+            [
+                new BondAccountEntry(10, 1, new DateTime(2024, 1, 1), 10m, 10m, 1),
+                new BondAccountEntry(10, 2, new DateTime(2024, 1, 2), 20m, 10m, 1),
+            ],
+            AccountLabel.Other,
+            new Dictionary<int, BondAccountEntry>
+            {
+                [2] = new BondAccountEntry(10, 3, new DateTime(2023, 12, 1), 5m, 5m, 2),
+            });
+
+        var first = await context.LoadReferencedDetailsAsync([account], TestContext.Current.CancellationToken);
+        var second = await context.LoadReferencedDetailsAsync([account], TestContext.Current.CancellationToken);
+
+        Assert.Single(requestedIds);
+        Assert.Equal(new[] { 1, 2 }, requestedIds[0].OrderBy(x => x));
+        Assert.Same(details[0], first[1]);
+        Assert.Same(details[0], second[1]);
+        Assert.Same(details[1], second[2]);
+    }
+
+    [Fact]
+    public async Task LoadReferencedDetailsAsync_RemembersMissingIds_AndPreservesMissingDefinitionError()
+    {
+        var requestedIds = new List<int[]>();
+        var repository = new Mock<IBondDetailsRepository>();
+        repository
+            .Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .Callback((IReadOnlyCollection<int> ids, CancellationToken _) => requestedIds.Add(ids.ToArray()))
+            .ReturnsAsync((IReadOnlyList<BondDetails>)[]);
+
+        var context = new BondDashboardContext(repository.Object);
+        var account = new BondAccount(
+            1,
+            10,
+            "Bonds",
+            [new BondAccountEntry(10, 1, new DateTime(2024, 1, 1), 10m, 10m, 99)],
+            AccountLabel.Other);
+
+        await context.LoadReferencedDetailsAsync([account], TestContext.Current.CancellationToken);
+        await context.LoadReferencedDetailsAsync([account], TestContext.Current.CancellationToken);
+
+        Assert.Single(requestedIds);
+        var exception = Assert.Throws<InvalidOperationException>(() => context.GetDetails(99));
+        Assert.Equal("Bond valuation requires details for bond id 99.", exception.Message);
+    }
+
+    [Fact]
+    public async Task GetOrComputePrice_ReusesMatchingPriceWithinTheRequest()
+    {
+        var details = CreateDetails(1, unitValue: 100m);
+        var repository = new Mock<IBondDetailsRepository>();
+        repository
+            .Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<BondDetails>)[details]);
+
+        var context = new BondDashboardContext(repository.Object);
+        var account = new BondAccount(
+            1,
+            10,
+            "Bonds",
+            [new BondAccountEntry(10, 1, new DateTime(2024, 1, 1), 10m, 10m, 1)],
+            AccountLabel.Other);
+        await context.LoadReferencedDetailsAsync([account], TestContext.Current.CancellationToken);
+
+        var entry = account.Entries[0];
+        var first = context.GetOrComputePrice(account.AccountId, entry, new DateOnly(2024, 1, 2));
+        var second = context.GetOrComputePrice(account.AccountId, entry, new DateOnly(2024, 1, 2));
+
+        Assert.Equal(1_000m, first);
+        Assert.Equal(first, second);
+
+        entry.Value = 12m;
+        Assert.Equal(1_200m, context.GetOrComputePrice(account.AccountId, entry, new DateOnly(2024, 1, 2)));
+    }
+
+    [Fact]
+    public async Task GetOrComputePrice_UsesFreshDefinitionsAfterAnEditInANewRequest()
+    {
+        var originalDetails = CreateDetails(1, unitValue: 100m);
+        var updatedDetails = CreateDetails(1, unitValue: 125m);
+        var entry = new BondAccountEntry(10, 1, new DateTime(2024, 1, 1), 10m, 10m, 1);
+        var account = new BondAccount(1, 10, "Bonds", [entry], AccountLabel.Other);
+
+        var originalRepository = new Mock<IBondDetailsRepository>();
+        originalRepository
+            .Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<BondDetails>)[originalDetails]);
+        var originalContext = new BondDashboardContext(originalRepository.Object);
+        await originalContext.LoadReferencedDetailsAsync([account], TestContext.Current.CancellationToken);
+
+        var updatedRepository = new Mock<IBondDetailsRepository>();
+        updatedRepository
+            .Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<BondDetails>)[updatedDetails]);
+        var updatedContext = new BondDashboardContext(updatedRepository.Object);
+        await updatedContext.LoadReferencedDetailsAsync([account], TestContext.Current.CancellationToken);
+
+        var date = new DateOnly(2024, 1, 2);
+        Assert.Equal(1_000m, originalContext.GetOrComputePrice(10, entry, date));
+        Assert.Equal(1_250m, updatedContext.GetOrComputePrice(10, entry, date));
+    }
+
+    [Fact]
+    public async Task GetOrComputePrice_ThrowsForMissingDefinition()
+    {
+        var repository = new Mock<IBondDetailsRepository>();
+        repository
+            .Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<BondDetails>)[]);
+        var context = new BondDashboardContext(repository.Object);
+        var account = new BondAccount(
+            1,
+            10,
+            "Bonds",
+            [new BondAccountEntry(10, 1, new DateTime(2024, 1, 1), 10m, 10m, 42)],
+            AccountLabel.Other);
+        await context.LoadReferencedDetailsAsync([account], TestContext.Current.CancellationToken);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            context.GetOrComputePrice(10, account.Entries[0], new DateOnly(2024, 1, 2)));
+
+        Assert.Equal("Bond valuation requires details for bond id 42.", exception.Message);
+    }
+
+    private static BondDetails CreateDetails(int id, decimal unitValue = 100m) =>
+        new(
+            "Bond",
+            "Issuer",
+            new DateOnly(2023, 1, 1),
+            new DateOnly(2025, 1, 1),
+            [new BondCalculationMethod
+            {
+                DateOperator = DateOperator.UntilDate,
+                DateValue = "2025-01-01",
+                Rate = 0m,
+            }],
+            DefaultCurrency.PLN,
+            BondType.InflationBond,
+            unitValue)
+        {
+            Id = id,
+        };
+}

--- a/code/FinanceManager.Tests.Unit/Application/Services/BondBalanceServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/BondBalanceServiceTests.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Application.FinancialAccounts.Bond.Balance;
+using FinanceManager.Application.FinancialAccounts.Bond.Valuation;
 using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
 using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
@@ -25,7 +26,7 @@ public class BondBalanceServiceTests
     {
         _service = new BondBalanceService(
             _financialAccountRepositoryMock.Object,
-            _bondDetailsRepositoryMock.Object,
+            new BondDashboardContext(_bondDetailsRepositoryMock.Object),
             _currencyExchangeServiceMock.Object);
     }
 
@@ -55,7 +56,7 @@ public class BondBalanceServiceTests
 
         _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                                        .Returns(new[] { account }.ToAsyncEnumerable());
-        _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).Returns(new[] { details }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock.Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new[] { details });
 
         var result = await _service.GetClosingBalance(userId, DefaultCurrency.PLN, startDate, endDate);
 
@@ -90,7 +91,7 @@ public class BondBalanceServiceTests
 
         _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                                        .Returns(new[] { account }.ToAsyncEnumerable());
-        _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).Returns(new[] { details }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock.Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new[] { details });
 
         var result = await _service.GetNetCashFlow(userId, DefaultCurrency.PLN, startDate, endDate);
 
@@ -116,7 +117,7 @@ public class BondBalanceServiceTests
         var details = CreateDetails(startDate, endDate, DefaultCurrency.PLN);
         _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                                        .Returns(new[] { account }.ToAsyncEnumerable());
-        _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).Returns(new[] { details }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock.Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new[] { details });
 
         var result = await _service.GetCapital(userId, DefaultCurrency.PLN, startDate, endDate);
 
@@ -140,7 +141,7 @@ public class BondBalanceServiceTests
 
         _financialAccountRepositoryMock.Setup(repo => repo.GetAccounts<BondAccount>(userId, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                                        .Returns(new[] { account }.ToAsyncEnumerable());
-        _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).Returns(new[] { details }.ToAsyncEnumerable());
+        _bondDetailsRepositoryMock.Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new[] { details });
         _currencyExchangeServiceMock
             .Setup(x => x.GetExchangeRateAsync(DefaultCurrency.USD, DefaultCurrency.PLN, startDate, endDate))
             .ReturnsAsync([

--- a/code/FinanceManager.Tests.Unit/Application/Services/NetWorthServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Services/NetWorthServiceTests.cs
@@ -1,3 +1,4 @@
+using FinanceManager.Application.FinancialAccounts.Bond.Valuation;
 using FinanceManager.Application.MoneyFlow.NetWorth;
 using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
 using FinanceManager.Domain.FinancialAccounts.Bond.Repositories;
@@ -22,7 +23,7 @@ public class NetWorthServiceTests
 
     public NetWorthServiceTests()
     {
-        _bondDetailsRepositoryMock.Setup(x => x.GetAllAsync(It.IsAny<CancellationToken>())).Returns(AsyncEnumerable.Empty<BondDetails>());
+        _bondDetailsRepositoryMock.Setup(x => x.GetByIdsAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<CancellationToken>())).ReturnsAsync(Array.Empty<BondDetails>());
 
         _financialAccountRepositoryMock.Setup(r => r.GetAccounts<CurrencyAccount>(It.IsAny<int>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
             .Returns(AsyncEnumerable.Empty<CurrencyAccount>());
@@ -41,7 +42,10 @@ public class NetWorthServiceTests
             .Setup(x => x.GetAccountValueSeriesAsync(It.IsAny<IReadOnlyCollection<int>>(), It.IsAny<Currency>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<int, IReadOnlyDictionary<DateTime, decimal>>());
 
-        _netWorthService = new NetWorthService(_financialAccountRepositoryMock.Object, _bondDetailsRepositoryMock.Object, _investmentValuationServiceMock.Object);
+        _netWorthService = new NetWorthService(
+            _financialAccountRepositoryMock.Object,
+            new BondDashboardContext(_bondDetailsRepositoryMock.Object),
+            _investmentValuationServiceMock.Object);
     }
 
     [Fact]

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondDetailsRepositoryTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Features/FinancialAccounts/Bond/Repositories/BondDetailsRepositoryTests.cs
@@ -1,0 +1,70 @@
+using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.Shared;
+using FinanceManager.Infrastructure.Features.FinancialAccounts.Bond.Repositories;
+using FinanceManager.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Tests.Unit.Infrastructure.Features.FinancialAccounts.Bond.Repositories;
+
+[Collection("Infrastructure")]
+[Trait("Category", "Unit")]
+public class BondDetailsRepositoryTests
+{
+    [Fact]
+    public async Task GetByIdsAsync_ReturnsRequestedDetachedDefinitionsWithRelatedData()
+    {
+        await using var context = CreateContext();
+        var currency = new Currency(1, "PLN", "zł");
+        var first = CreateBond("First", currency);
+        var second = CreateBond("Second", currency);
+        context.Currencies.Add(currency);
+        context.Bonds.AddRange(first, second);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        context.ChangeTracker.Clear();
+
+        var repository = new BondDetailsRepository(context);
+        var result = await repository.GetByIdsAsync([first.Id, 999], TestContext.Current.CancellationToken);
+
+        var returned = Assert.Single(result);
+        Assert.Equal(first.Id, returned.Id);
+        Assert.Equal("First", returned.Name);
+        Assert.Equal(currency.Id, returned.Currency.Id);
+        Assert.Single(returned.CalculationMethods);
+        Assert.Same(returned, returned.CalculationMethods[0].BondDetails);
+        Assert.Empty(context.ChangeTracker.Entries());
+    }
+
+    [Fact]
+    public async Task GetByIdsAsync_WithNoIds_ReturnsEmptyWithoutMaterializingDefinitions()
+    {
+        await using var context = CreateContext();
+        var repository = new BondDetailsRepository(context);
+
+        var result = await repository.GetByIdsAsync([], TestContext.Current.CancellationToken);
+
+        Assert.Empty(result);
+        Assert.Empty(context.ChangeTracker.Entries());
+    }
+
+    private static AppDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static BondDetails CreateBond(string name, Currency currency) =>
+        new(
+            name,
+            "Issuer",
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2025, 1, 1),
+            [new BondCalculationMethod
+            {
+                DateOperator = DateOperator.UntilDate,
+                DateValue = "2025-01-01",
+                Rate = 0.01m,
+            }],
+            currency,
+            BondType.InflationBond,
+            100m);
+}


### PR DESCRIPTION
Closes #747

## Summary

- Added a request-scoped `BondDashboardContext` that batches only referenced bond-definition IDs and keeps detached snapshots shared across dashboard bond paths.
- Reused matching per-account, per-entry, per-date bond prices between net-worth and balance calculations without cross-request mutable state.
- Added a bounded no-tracking repository query, preserved missing-definition errors, and kept currency/calculation-method data available for capital valuation.
- Added focused context, repository, service, and edit-sensitivity coverage plus an Unreleased changelog entry.

## Validation

- `dotnet format code/FinanceManager.slnx --verify-no-changes --no-restore`: passed
- `dotnet build code/FinanceManager.slnx --no-restore -p:TreatWarningsAsErrors=true`: passed (0 warnings, 0 errors)
- Bond balance unit tests: 4 passed
- Net-worth unit tests: 5 passed
- Bond dashboard context tests: 5 passed
- Bond details repository tests: 2 passed
- Bond account tests: 10 passed
- Full integration suite: 326 passed
- Architecture suite: 9 passed
- Full unit suite: 1,011 passed, 6 unrelated existing failures in investment-paycheck cache/currency-exchange tests (locale/provider baseline)
- `git diff --check`: passed

## Risks

The scoped cache is intentionally request-lifetime only. The six full-unit failures predate this change and are outside the touched paths; CI should remain the source of truth for the complete baseline.
