### PR TITLE
Add configurable financial alerts and watchlists #735

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ rules agents must follow when updating this file.
 ## [Unreleased]
 
 ### Added
+- Configurable in-app financial alerts and watchlists now monitor balances, category and merchant spending, large transactions, and subscription price changes with dashboard status and duplicate-trigger suppression. #735
 - Investment and bond account charts now show cumulative user-paid capital alongside account value and the selected benchmark, including range-start carry-over, withdrawals, same-day events, and historical currency conversion. #729
 - Every card on the dashboard, account, admin, and welcome pages now carries an information icon that shows a short tooltip explaining what the card is about, on hover or keyboard focus. #730
 - Authorized maintenance workers can now query bounded, read-only application log history with time, level, and text filters. #722

--- a/code/FinanceManager.Api/Features/Alerts/Controllers/FinancialAlertsController.cs
+++ b/code/FinanceManager.Api/Features/Alerts/Controllers/FinancialAlertsController.cs
@@ -1,0 +1,148 @@
+using FinanceManager.Api.Shared.Helpers;
+using FinanceManager.Application.Alerts.Models;
+using FinanceManager.Application.Alerts.Services;
+using FinanceManager.Domain.Alerts.Commands;
+using FinanceManager.Domain.Alerts.Dtos;
+using FinanceManager.Domain.Alerts.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FinanceManager.Api.Features.Alerts.Controllers;
+
+[Authorize]
+[ApiController]
+[Route("api/[controller]")]
+[Tags("Financial Alerts")]
+public sealed class FinancialAlertsController(IFinancialAlertService alertService) : ControllerBase
+{
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IReadOnlyList<FinancialAlertDto>))]
+    public async Task<IActionResult> Get(CancellationToken cancellationToken = default)
+    {
+        var userId = ApiAuthenticationHelper.GetUserId(User);
+        var alerts = await alertService.GetAlertsAsync(userId, cancellationToken);
+        return Ok(alerts.Select(FinancialAlertDto.FromEntity).ToList());
+    }
+
+    [HttpGet("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FinancialAlertDto))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Get(Guid id, CancellationToken cancellationToken = default)
+    {
+        var userId = ApiAuthenticationHelper.GetUserId(User);
+        var alert = await alertService.GetAlertByIdAsync(userId, id, cancellationToken);
+        return alert is null ? NotFound() : Ok(FinancialAlertDto.FromEntity(alert));
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(FinancialAlertDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateFinancialAlert command,
+        CancellationToken cancellationToken = default)
+    {
+        var validationError = Validate(command);
+        if (validationError is not null)
+            return BadRequest(validationError);
+
+        var userId = ApiAuthenticationHelper.GetUserId(User);
+        var alert = await alertService.CreateAlertAsync(userId, command, cancellationToken);
+        var dto = FinancialAlertDto.FromEntity(alert);
+        return CreatedAtAction(nameof(Get), new { id = alert.Id }, dto);
+    }
+
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FinancialAlertDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Update(
+        Guid id,
+        [FromBody] UpdateFinancialAlert command,
+        CancellationToken cancellationToken = default)
+    {
+        var validationError = Validate(command);
+        if (validationError is not null)
+            return BadRequest(validationError);
+
+        var userId = ApiAuthenticationHelper.GetUserId(User);
+        var alert = await alertService.UpdateAlertAsync(userId, id, command, cancellationToken);
+        return alert is null ? NotFound() : Ok(FinancialAlertDto.FromEntity(alert));
+    }
+
+    [HttpPatch("{id:guid}/enabled")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> SetEnabled(
+        Guid id,
+        [FromBody] bool enabled,
+        CancellationToken cancellationToken = default)
+    {
+        var userId = ApiAuthenticationHelper.GetUserId(User);
+        return await alertService.SetEnabledAsync(userId, id, enabled, cancellationToken)
+            ? NoContent()
+            : NotFound();
+    }
+
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken = default)
+    {
+        var userId = ApiAuthenticationHelper.GetUserId(User);
+        return await alertService.DeleteAlertAsync(userId, id, cancellationToken)
+            ? NoContent()
+            : NotFound();
+    }
+
+    [HttpPost("evaluate")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IReadOnlyList<AlertEvaluationOutcome>))]
+    public async Task<IActionResult> Evaluate(CancellationToken cancellationToken = default)
+    {
+        var userId = ApiAuthenticationHelper.GetUserId(User);
+        return Ok(await alertService.EvaluateAlertsAsync(userId, cancellationToken));
+    }
+
+    [HttpPost("{id:guid}/evaluate")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(AlertEvaluationOutcome))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Evaluate(Guid id, CancellationToken cancellationToken = default)
+    {
+        var userId = ApiAuthenticationHelper.GetUserId(User);
+        var outcome = await alertService.EvaluateAlertAsync(userId, id, cancellationToken);
+        return outcome is null ? NotFound() : Ok(outcome);
+    }
+
+    private static string? Validate(CreateFinancialAlert command)
+    {
+        if (command is null)
+            return "Alert payload is required.";
+
+        if (string.IsNullOrWhiteSpace(command.Title) || command.Title.Trim().Length > 200)
+            return "Title is required and must be at most 200 characters.";
+
+        if (command.MerchantName?.Length > 200 || command.LabelName?.Length > 200)
+            return "Scope names must be at most 200 characters.";
+
+        if (command.CooldownPeriod is { } cooldown && cooldown < TimeSpan.Zero)
+            return "Cooldown period cannot be negative.";
+
+        return null;
+    }
+
+    private static string? Validate(UpdateFinancialAlert command)
+    {
+        if (command is null)
+            return "Alert payload is required.";
+
+        if (string.IsNullOrWhiteSpace(command.Title) || command.Title.Trim().Length > 200)
+            return "Title is required and must be at most 200 characters.";
+
+        if (command.MerchantName?.Length > 200 || command.LabelName?.Length > 200)
+            return "Scope names must be at most 200 characters.";
+
+        if (command.CooldownPeriod is { } cooldown && cooldown < TimeSpan.Zero)
+            return "Cooldown period cannot be negative.";
+
+        return null;
+    }
+}

--- a/code/FinanceManager.Api/Migrations/20260911134011_AddFinancialAlerts.Designer.cs
+++ b/code/FinanceManager.Api/Migrations/20260911134011_AddFinancialAlerts.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceManager.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceManager.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260911134011_AddFinancialAlerts")]
+    partial class AddFinancialAlerts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/code/FinanceManager.Api/Migrations/20260911134011_AddFinancialAlerts.cs
+++ b/code/FinanceManager.Api/Migrations/20260911134011_AddFinancialAlerts.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+
+#nullable disable
+
+namespace FinanceManager.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFinancialAlerts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FinancialAlerts",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    AlertType = table.Column<int>(type: "integer", nullable: false),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    ComparisonOperator = table.Column<int>(type: "integer", nullable: false),
+                    Threshold = table.Column<decimal>(type: "numeric(18,2)", precision: 18, scale: 2, nullable: false),
+                    EvaluationPeriod = table.Column<int>(type: "integer", nullable: false),
+                    AccountId = table.Column<int>(type: "integer", nullable: true),
+                    LabelId = table.Column<int>(type: "integer", nullable: true),
+                    LabelName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    MerchantName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    SubscriptionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    LastStatus = table.Column<int>(type: "integer", nullable: false),
+                    LastTriggeredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastTriggeredValue = table.Column<decimal>(type: "numeric", nullable: true),
+                    LastTriggeredConditionFingerprint = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    CooldownPeriod = table.Column<TimeSpan>(type: "interval", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FinancialAlerts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_FinancialAlerts_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FinancialAlerts_UserId_AlertType",
+                table: "FinancialAlerts",
+                columns: new[] { "UserId", "AlertType" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FinancialAlerts_UserId_IsEnabled",
+                table: "FinancialAlerts",
+                columns: new[] { "UserId", "IsEnabled" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FinancialAlerts");
+        }
+    }
+}

--- a/code/FinanceManager.Application/Alerts/Models/AlertEvaluationOutcome.cs
+++ b/code/FinanceManager.Application/Alerts/Models/AlertEvaluationOutcome.cs
@@ -1,0 +1,21 @@
+using FinanceManager.Domain.Alerts.Enums;
+
+namespace FinanceManager.Application.Alerts.Models;
+
+public record AlertEvaluationOutcome(
+    Guid AlertId,
+    string AlertTitle,
+    AlertType AlertType,
+    AlertTriggerStatus Status,
+    bool IsTriggered,
+    bool IsNewlyTriggered,
+    bool IsSuppressed,
+    DeDuplicationReason DeDuplicationReason,
+    decimal CurrentValue,
+    decimal Threshold,
+    AlertComparisonOperator ComparisonOperator,
+    string ConditionFingerprint,
+    string Message,
+    DateTime EvaluatedAt,
+    IReadOnlyDictionary<string, string> Context,
+    string? ErrorMessage = null);

--- a/code/FinanceManager.Application/Alerts/Models/AlertEvaluationSnapshot.cs
+++ b/code/FinanceManager.Application/Alerts/Models/AlertEvaluationSnapshot.cs
@@ -1,0 +1,50 @@
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.Labels.Entities;
+
+namespace FinanceManager.Application.Alerts.Models;
+
+public class AlertEvaluationSnapshot
+{
+    public IReadOnlyList<CurrencyAccount> Accounts { get; init; } = [];
+    public IReadOnlyList<CurrencyAccountEntry> RecentEntries { get; init; } = [];
+    public IReadOnlyList<RecurringTransactionResult> Subscriptions { get; init; } = [];
+    public DateTime EvaluationDate { get; init; } = DateTime.UtcNow;
+
+    public AlertEvaluationSnapshot()
+    {
+    }
+
+    public AlertEvaluationSnapshot(
+        IReadOnlyList<CurrencyAccount> accounts,
+        IReadOnlyList<RecurringTransactionResult> subscriptions,
+        DateTime? evaluationDate = null)
+    {
+        Accounts = accounts;
+        Subscriptions = subscriptions;
+        EvaluationDate = evaluationDate ?? DateTime.UtcNow;
+    }
+
+    public AlertEvaluationSnapshot(
+        IReadOnlyList<CurrencyAccount> accounts,
+        IReadOnlyList<CurrencyAccountEntry> recentEntries,
+        IReadOnlyList<RecurringTransactionResult> subscriptions,
+        DateTime? evaluationDate = null)
+    {
+        Accounts = accounts;
+        RecentEntries = recentEntries;
+        Subscriptions = subscriptions;
+        EvaluationDate = evaluationDate ?? DateTime.UtcNow;
+    }
+
+    public IReadOnlyList<CurrencyAccountEntry> GetAllEntries()
+    {
+        var entriesByAccount = Accounts
+            .Where(a => a.Entries is not null)
+            .SelectMany(a => a.Entries);
+
+        return entriesByAccount
+            .Concat(RecentEntries)
+            .DistinctBy(e => (e.AccountId, e.EntryId))
+            .ToList();
+    }
+}

--- a/code/FinanceManager.Application/Alerts/Models/DeDuplicationReason.cs
+++ b/code/FinanceManager.Application/Alerts/Models/DeDuplicationReason.cs
@@ -1,0 +1,9 @@
+namespace FinanceManager.Application.Alerts.Models;
+
+public enum DeDuplicationReason
+{
+    None = 0,
+    UnchangedCondition = 1,
+    CooldownActive = 2,
+    AlertDisabled = 3
+}

--- a/code/FinanceManager.Application/Alerts/Services/FinancialAlertEvaluator.cs
+++ b/code/FinanceManager.Application/Alerts/Services/FinancialAlertEvaluator.cs
@@ -1,0 +1,485 @@
+using FinanceManager.Application.Alerts.Models;
+using FinanceManager.Domain.Alerts.Entities;
+using FinanceManager.Domain.Alerts.Enums;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.Labels.Entities;
+using System.Globalization;
+
+namespace FinanceManager.Application.Alerts.Services;
+
+public class FinancialAlertEvaluator : IFinancialAlertEvaluator
+{
+    public AlertEvaluationOutcome Evaluate(FinancialAlert alert, AlertEvaluationSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(alert);
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var evaluationTime = snapshot.EvaluationDate;
+
+        if (!alert.IsEnabled)
+        {
+            return new AlertEvaluationOutcome(
+                alert.Id,
+                alert.Title,
+                alert.AlertType,
+                AlertTriggerStatus.Disabled,
+                IsTriggered: false,
+                IsNewlyTriggered: false,
+                IsSuppressed: true,
+                DeDuplicationReason.AlertDisabled,
+                CurrentValue: 0m,
+                alert.Threshold,
+                alert.ComparisonOperator,
+                ConditionFingerprint: string.Empty,
+                Message: $"Alert '{alert.Title}' is disabled.",
+                EvaluatedAt: evaluationTime,
+                Context: new Dictionary<string, string>());
+        }
+
+        try
+        {
+            var rawOutcome = alert.AlertType switch
+            {
+                AlertType.AccountBalance => EvaluateAccountBalance(alert, snapshot),
+                AlertType.CategorySpending => EvaluateCategorySpending(alert, snapshot),
+                AlertType.MerchantSpending => EvaluateMerchantSpending(alert, snapshot),
+                AlertType.LargeTransaction => EvaluateLargeTransaction(alert, snapshot),
+                AlertType.SubscriptionPriceChange => EvaluateSubscriptionPriceChange(alert, snapshot),
+                _ => throw new NotSupportedException($"Alert type '{alert.AlertType}' is not supported.")
+            };
+
+            if (!rawOutcome.ConditionMet)
+            {
+                return new AlertEvaluationOutcome(
+                    alert.Id,
+                    alert.Title,
+                    alert.AlertType,
+                    AlertTriggerStatus.Healthy,
+                    IsTriggered: false,
+                    IsNewlyTriggered: false,
+                    IsSuppressed: false,
+                    DeDuplicationReason.None,
+                    rawOutcome.ObservedValue,
+                    alert.Threshold,
+                    alert.ComparisonOperator,
+                    rawOutcome.Fingerprint,
+                    rawOutcome.Message,
+                    evaluationTime,
+                    rawOutcome.Context);
+            }
+
+            // Condition is met. Check de-duplication: unchanged condition vs cooldown vs new trigger.
+            if (alert.IsUnchangedTrigger(rawOutcome.Fingerprint))
+            {
+                return new AlertEvaluationOutcome(
+                    alert.Id,
+                    alert.Title,
+                    alert.AlertType,
+                    AlertTriggerStatus.Triggered,
+                    IsTriggered: true,
+                    IsNewlyTriggered: false,
+                    IsSuppressed: true,
+                    DeDuplicationReason.UnchangedCondition,
+                    rawOutcome.ObservedValue,
+                    alert.Threshold,
+                    alert.ComparisonOperator,
+                    rawOutcome.Fingerprint,
+                    rawOutcome.Message,
+                    evaluationTime,
+                    rawOutcome.Context);
+            }
+
+            if (alert.IsSuppressedByCooldown(evaluationTime))
+            {
+                return new AlertEvaluationOutcome(
+                    alert.Id,
+                    alert.Title,
+                    alert.AlertType,
+                    AlertTriggerStatus.Triggered,
+                    IsTriggered: true,
+                    IsNewlyTriggered: false,
+                    IsSuppressed: true,
+                    DeDuplicationReason.CooldownActive,
+                    rawOutcome.ObservedValue,
+                    alert.Threshold,
+                    alert.ComparisonOperator,
+                    rawOutcome.Fingerprint,
+                    rawOutcome.Message,
+                    evaluationTime,
+                    rawOutcome.Context);
+            }
+
+            // Newly triggered
+            return new AlertEvaluationOutcome(
+                alert.Id,
+                alert.Title,
+                alert.AlertType,
+                AlertTriggerStatus.Triggered,
+                IsTriggered: true,
+                IsNewlyTriggered: true,
+                IsSuppressed: false,
+                DeDuplicationReason.None,
+                rawOutcome.ObservedValue,
+                alert.Threshold,
+                alert.ComparisonOperator,
+                rawOutcome.Fingerprint,
+                rawOutcome.Message,
+                evaluationTime,
+                rawOutcome.Context);
+        }
+        catch (Exception ex)
+        {
+            return new AlertEvaluationOutcome(
+                alert.Id,
+                alert.Title,
+                alert.AlertType,
+                AlertTriggerStatus.Healthy,
+                IsTriggered: false,
+                IsNewlyTriggered: false,
+                IsSuppressed: false,
+                DeDuplicationReason.None,
+                CurrentValue: 0m,
+                alert.Threshold,
+                alert.ComparisonOperator,
+                ConditionFingerprint: string.Empty,
+                Message: $"Evaluation failed: {ex.Message}",
+                EvaluatedAt: evaluationTime,
+                Context: new Dictionary<string, string>(),
+                ErrorMessage: ex.ToString());
+        }
+    }
+
+    public IReadOnlyList<AlertEvaluationOutcome> EvaluateAll(
+        IEnumerable<FinancialAlert> alerts,
+        AlertEvaluationSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(alerts);
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var outcomes = new List<AlertEvaluationOutcome>();
+        foreach (var alert in alerts)
+        {
+            outcomes.Add(Evaluate(alert, snapshot));
+        }
+
+        return outcomes;
+    }
+
+    private static RawConditionResult EvaluateAccountBalance(FinancialAlert alert, AlertEvaluationSnapshot snapshot)
+    {
+        var context = new Dictionary<string, string>();
+        var inv = CultureInfo.InvariantCulture;
+
+        if (alert.AccountId is int targetAccountId)
+        {
+            var account = snapshot.Accounts.FirstOrDefault(a => a.AccountId == targetAccountId);
+            var balance = GetAccountBalance(account);
+            var accountName = account?.Name ?? $"Account #{targetAccountId}";
+
+            context["AccountId"] = targetAccountId.ToString(inv);
+            context["AccountName"] = accountName;
+            context["Balance"] = balance.ToString("F2", inv);
+
+            var conditionMet = MatchesComparison(balance, alert.ComparisonOperator, alert.Threshold);
+            var fingerprint = $"AccountBalance:AccountId={targetAccountId}:Balance={balance.ToString("F2", inv)}:Op={alert.ComparisonOperator}:Threshold={alert.Threshold.ToString("F2", inv)}";
+            var message = $"Account '{accountName}' balance is {balance.ToString("N2", inv)} (threshold: {alert.ComparisonOperator} {alert.Threshold.ToString("N2", inv)})";
+
+            return new RawConditionResult(conditionMet, balance, fingerprint, message, context);
+        }
+
+        // AccountId is null: evaluate each available account
+        CurrencyAccount? triggeredAccount = null;
+        decimal? triggeredBalance = null;
+
+        foreach (var account in snapshot.Accounts)
+        {
+            var balance = GetAccountBalance(account);
+            if (MatchesComparison(balance, alert.ComparisonOperator, alert.Threshold))
+            {
+                if (triggeredBalance is null)
+                {
+                    triggeredAccount = account;
+                    triggeredBalance = balance;
+                }
+                else
+                {
+                    var isMoreExtreme = alert.ComparisonOperator is AlertComparisonOperator.LessThan or AlertComparisonOperator.LessThanOrEqual
+                        ? balance < triggeredBalance.Value
+                        : balance > triggeredBalance.Value;
+
+                    if (isMoreExtreme)
+                    {
+                        triggeredAccount = account;
+                        triggeredBalance = balance;
+                    }
+                }
+            }
+        }
+
+        if (triggeredAccount is not null && triggeredBalance is decimal chosenBalance)
+        {
+            context["AccountId"] = triggeredAccount.AccountId.ToString(inv);
+            context["AccountName"] = triggeredAccount.Name;
+            context["Balance"] = chosenBalance.ToString("F2", inv);
+
+            var fingerprint = $"AccountBalance:AccountId={triggeredAccount.AccountId}:Balance={chosenBalance.ToString("F2", inv)}:Op={alert.ComparisonOperator}:Threshold={alert.Threshold.ToString("F2", inv)}";
+            var message = $"Account '{triggeredAccount.Name}' balance is {chosenBalance.ToString("N2", inv)} (threshold: {alert.ComparisonOperator} {alert.Threshold.ToString("N2", inv)})";
+
+            return new RawConditionResult(true, chosenBalance, fingerprint, message, context);
+        }
+
+        var defaultBalance = snapshot.Accounts.Count > 0 ? GetAccountBalance(snapshot.Accounts[0]) : 0m;
+        var defaultFingerprint = $"AccountBalance:NoMatch:Op={alert.ComparisonOperator}:Threshold={alert.Threshold.ToString("F2", inv)}";
+        var defaultMessage = $"No account violated balance threshold {alert.ComparisonOperator} {alert.Threshold.ToString("N2", inv)}";
+
+        return new RawConditionResult(false, defaultBalance, defaultFingerprint, defaultMessage, context);
+    }
+
+    private static RawConditionResult EvaluateCategorySpending(FinancialAlert alert, AlertEvaluationSnapshot snapshot)
+    {
+        var inv = CultureInfo.InvariantCulture;
+        var (startDate, endDate) = GetPeriodRange(alert.EvaluationPeriod, snapshot.EvaluationDate);
+        var periodKey = FormatPeriodKey(alert.EvaluationPeriod, startDate, endDate);
+        var allEntries = snapshot.GetAllEntries();
+
+        var qualifyingEntries = allEntries
+            .Where(e => e.PostingDate >= startDate && e.PostingDate <= endDate)
+            .Where(e => alert.AccountId is not int accId || e.AccountId == accId)
+            .Where(e => e.ValueChange < 0)
+            .Where(e =>
+            {
+                if (e.Labels is null || e.Labels.Count == 0) return false;
+                if (alert.LabelId is int targetId)
+                    return e.Labels.Any(l => l.Id == targetId);
+                if (!string.IsNullOrWhiteSpace(alert.LabelName))
+                    return e.Labels.Any(l => string.Equals(l.Name, alert.LabelName, StringComparison.OrdinalIgnoreCase));
+                return true;
+            })
+            .ToList();
+
+        var totalSpend = qualifyingEntries.Sum(e => Math.Abs(e.ValueChange));
+        var labelKey = alert.LabelId?.ToString(inv) ?? alert.LabelName ?? "All";
+        var conditionMet = MatchesComparison(totalSpend, alert.ComparisonOperator, alert.Threshold);
+
+        var fingerprint = $"CategorySpending:Label={labelKey}:Period={periodKey}:Spend={totalSpend.ToString("F2", inv)}:Op={alert.ComparisonOperator}:Threshold={alert.Threshold.ToString("F2", inv)}";
+        var message = $"Spending for category '{labelKey}' in {alert.EvaluationPeriod} is {totalSpend.ToString("N2", inv)} (threshold: {alert.ComparisonOperator} {alert.Threshold.ToString("N2", inv)})";
+
+        var context = new Dictionary<string, string>
+        {
+            ["Label"] = labelKey,
+            ["Period"] = periodKey,
+            ["TotalSpend"] = totalSpend.ToString("F2", inv),
+            ["TransactionCount"] = qualifyingEntries.Count.ToString(inv)
+        };
+
+        return new RawConditionResult(conditionMet, totalSpend, fingerprint, message, context);
+    }
+
+    private static RawConditionResult EvaluateMerchantSpending(FinancialAlert alert, AlertEvaluationSnapshot snapshot)
+    {
+        var inv = CultureInfo.InvariantCulture;
+        var (startDate, endDate) = GetPeriodRange(alert.EvaluationPeriod, snapshot.EvaluationDate);
+        var periodKey = FormatPeriodKey(alert.EvaluationPeriod, startDate, endDate);
+        var allEntries = snapshot.GetAllEntries();
+        var merchantTarget = (alert.MerchantName ?? string.Empty).Trim();
+
+        var qualifyingEntries = allEntries
+            .Where(e => e.PostingDate >= startDate && e.PostingDate <= endDate)
+            .Where(e => alert.AccountId is not int accId || e.AccountId == accId)
+            .Where(e => e.ValueChange < 0)
+            .Where(e =>
+            {
+                if (string.IsNullOrWhiteSpace(merchantTarget)) return true;
+                var contractor = e.ContractorDetails ?? string.Empty;
+                var desc = e.Description ?? string.Empty;
+                return contractor.Contains(merchantTarget, StringComparison.OrdinalIgnoreCase)
+                    || desc.Contains(merchantTarget, StringComparison.OrdinalIgnoreCase);
+            })
+            .ToList();
+
+        var totalSpend = qualifyingEntries.Sum(e => Math.Abs(e.ValueChange));
+        var conditionMet = MatchesComparison(totalSpend, alert.ComparisonOperator, alert.Threshold);
+
+        var fingerprint = $"MerchantSpending:Merchant={merchantTarget.ToLowerInvariant()}:Period={periodKey}:Spend={totalSpend.ToString("F2", inv)}:Op={alert.ComparisonOperator}:Threshold={alert.Threshold.ToString("F2", inv)}";
+        var message = $"Spending for merchant '{merchantTarget}' in {alert.EvaluationPeriod} is {totalSpend.ToString("N2", inv)} (threshold: {alert.ComparisonOperator} {alert.Threshold.ToString("N2", inv)})";
+
+        var context = new Dictionary<string, string>
+        {
+            ["Merchant"] = merchantTarget,
+            ["Period"] = periodKey,
+            ["TotalSpend"] = totalSpend.ToString("F2", inv),
+            ["TransactionCount"] = qualifyingEntries.Count.ToString(inv)
+        };
+
+        return new RawConditionResult(conditionMet, totalSpend, fingerprint, message, context);
+    }
+
+    private static RawConditionResult EvaluateLargeTransaction(FinancialAlert alert, AlertEvaluationSnapshot snapshot)
+    {
+        var inv = CultureInfo.InvariantCulture;
+        var (startDate, endDate) = GetPeriodRange(alert.EvaluationPeriod, snapshot.EvaluationDate);
+        var allEntries = snapshot.GetAllEntries();
+
+        // Historical import protection: for AllTime alerts, do not fire on transactions posted before alert creation
+        var effectiveStart = startDate;
+        if (alert.EvaluationPeriod == AlertEvaluationPeriod.AllTime && alert.CreatedAt != default)
+        {
+            effectiveStart = alert.CreatedAt.Date;
+        }
+
+        var qualifyingEntries = allEntries
+            .Where(e => e.PostingDate >= effectiveStart && e.PostingDate <= endDate)
+            .Where(e => alert.AccountId is not int accId || e.AccountId == accId)
+            .Where(e => e.ValueChange < 0)
+            .Where(e => MatchesComparison(Math.Abs(e.ValueChange), alert.ComparisonOperator, alert.Threshold))
+            .OrderByDescending(e => Math.Abs(e.ValueChange))
+            .ThenByDescending(e => e.PostingDate)
+            .ToList();
+
+        if (qualifyingEntries.Count > 0)
+        {
+            var largest = qualifyingEntries[0];
+            var largestAmount = Math.Abs(largest.ValueChange);
+            var entryIds = string.Join(",", qualifyingEntries.Select(e => $"{e.AccountId}:{e.EntryId}").Order());
+
+            var fingerprint = $"LargeTransaction:Entries={entryIds}:Max={largestAmount.ToString("F2", inv)}:Op={alert.ComparisonOperator}:Threshold={alert.Threshold.ToString("F2", inv)}";
+            var message = $"Large transaction of {largestAmount.ToString("N2", inv)} detected on {largest.PostingDate:yyyy-MM-dd} (threshold: {alert.ComparisonOperator} {alert.Threshold.ToString("N2", inv)})";
+
+            var context = new Dictionary<string, string>
+            {
+                ["TriggeringAccountId"] = largest.AccountId.ToString(inv),
+                ["TriggeringEntryId"] = largest.EntryId.ToString(inv),
+                ["Amount"] = largestAmount.ToString("F2", inv),
+                ["PostingDate"] = largest.PostingDate.ToString("yyyy-MM-dd"),
+                ["ContractorDetails"] = largest.ContractorDetails ?? string.Empty,
+                ["Description"] = largest.Description
+            };
+
+            return new RawConditionResult(true, largestAmount, fingerprint, message, context);
+        }
+
+        var defaultFingerprint = $"LargeTransaction:NoMatch:Op={alert.ComparisonOperator}:Threshold={alert.Threshold.ToString("F2", inv)}";
+        var defaultMessage = $"No transaction violated threshold {alert.ComparisonOperator} {alert.Threshold.ToString("N2", inv)}";
+
+        return new RawConditionResult(false, 0m, defaultFingerprint, defaultMessage, new Dictionary<string, string>());
+    }
+
+    private static RawConditionResult EvaluateSubscriptionPriceChange(FinancialAlert alert, AlertEvaluationSnapshot snapshot)
+    {
+        var inv = CultureInfo.InvariantCulture;
+        var targetSubs = snapshot.Subscriptions.AsEnumerable();
+        if (alert.SubscriptionId is Guid subId)
+        {
+            targetSubs = targetSubs.Where(s => s.PatternId == subId);
+        }
+
+        var qualifyingSubs = new List<(RecurringTransactionResult Sub, decimal PriceDelta)>();
+
+        foreach (var sub in targetSubs)
+        {
+            if (sub.PreviousAmount <= 0m || sub.LastAmount == sub.PreviousAmount)
+                continue;
+
+            var delta = sub.PriceDelta;
+
+            var matches = alert.Threshold switch
+            {
+                0m when alert.ComparisonOperator == AlertComparisonOperator.GreaterThan => delta > 0m,
+                0m when alert.ComparisonOperator == AlertComparisonOperator.NotEqual => delta != 0m,
+                _ => MatchesComparison(delta, alert.ComparisonOperator, alert.Threshold)
+            };
+
+            if (matches)
+            {
+                qualifyingSubs.Add((sub, delta));
+            }
+        }
+
+        if (qualifyingSubs.Count > 0)
+        {
+            var (topSub, delta) = qualifyingSubs
+                .OrderByDescending(x => Math.Abs(x.PriceDelta))
+                .First();
+
+            var subKeys = string.Join(",", qualifyingSubs.Select(s => $"{s.Sub.PatternId}:{s.Sub.PreviousAmount.ToString("F2", inv)}->{s.Sub.LastAmount.ToString("F2", inv)}:{s.Sub.LastChargeDate:yyyyMMdd}").Order());
+            var fingerprint = $"SubscriptionPriceChange:Subs={subKeys}";
+            var message = $"Subscription '{topSub.Name}' price changed by {delta.ToString("+0.00;-0.00", inv)} (from {topSub.PreviousAmount.ToString("N2", inv)} to {topSub.LastAmount.ToString("N2", inv)})";
+
+            var context = new Dictionary<string, string>
+            {
+                ["PatternId"] = topSub.PatternId.ToString(),
+                ["SubscriptionName"] = topSub.Name,
+                ["PreviousAmount"] = topSub.PreviousAmount.ToString("F2", inv),
+                ["LastAmount"] = topSub.LastAmount.ToString("F2", inv),
+                ["PriceDelta"] = delta.ToString("F2", inv),
+                ["LastChargeDate"] = topSub.LastChargeDate.ToString("yyyy-MM-dd")
+            };
+
+            return new RawConditionResult(true, delta, fingerprint, message, context);
+        }
+
+        var defaultFingerprint = $"SubscriptionPriceChange:NoMatch:Op={alert.ComparisonOperator}:Threshold={alert.Threshold.ToString("F2", inv)}";
+        var defaultMessage = $"No subscription price change matched threshold {alert.ComparisonOperator} {alert.Threshold.ToString("N2", inv)}";
+
+        return new RawConditionResult(false, 0m, defaultFingerprint, defaultMessage, new Dictionary<string, string>());
+    }
+
+    private static decimal GetAccountBalance(CurrencyAccount? account)
+    {
+        if (account is null || account.Entries is null || account.Entries.Count == 0)
+            return 0m;
+
+        var latestEntry = account.Entries
+            .OrderByDescending(e => e.PostingDate)
+            .ThenByDescending(e => e.EntryId)
+            .FirstOrDefault();
+
+        return latestEntry?.Value ?? account.Entries[0].Value;
+    }
+
+    private static bool MatchesComparison(decimal actual, AlertComparisonOperator op, decimal threshold) => op switch
+    {
+        AlertComparisonOperator.GreaterThan => actual > threshold,
+        AlertComparisonOperator.GreaterThanOrEqual => actual >= threshold,
+        AlertComparisonOperator.LessThan => actual < threshold,
+        AlertComparisonOperator.LessThanOrEqual => actual <= threshold,
+        AlertComparisonOperator.Equal => actual == threshold,
+        AlertComparisonOperator.NotEqual => actual != threshold,
+        _ => false
+    };
+
+    private static (DateTime Start, DateTime End) GetPeriodRange(AlertEvaluationPeriod period, DateTime evaluationDate)
+    {
+        return period switch
+        {
+            AlertEvaluationPeriod.CurrentMonth => (
+                new DateTime(evaluationDate.Year, evaluationDate.Month, 1, 0, 0, 0, DateTimeKind.Utc),
+                evaluationDate),
+            AlertEvaluationPeriod.Last30Days => (
+                evaluationDate.Date.AddDays(-30),
+                evaluationDate),
+            AlertEvaluationPeriod.Last7Days => (
+                evaluationDate.Date.AddDays(-7),
+                evaluationDate),
+            AlertEvaluationPeriod.AllTime => (
+                DateTime.MinValue,
+                evaluationDate),
+            _ => (DateTime.MinValue, evaluationDate)
+        };
+    }
+
+    private static string FormatPeriodKey(AlertEvaluationPeriod period, DateTime start, DateTime end) => period switch
+    {
+        AlertEvaluationPeriod.CurrentMonth => $"{start:yyyy-MM}",
+        AlertEvaluationPeriod.Last30Days => $"30d-{end:yyyyMMdd}",
+        AlertEvaluationPeriod.Last7Days => $"7d-{end:yyyyMMdd}",
+        _ => "AllTime"
+    };
+
+    private sealed record RawConditionResult(
+        bool ConditionMet,
+        decimal ObservedValue,
+        string Fingerprint,
+        string Message,
+        IReadOnlyDictionary<string, string> Context);
+}

--- a/code/FinanceManager.Application/Alerts/Services/FinancialAlertService.cs
+++ b/code/FinanceManager.Application/Alerts/Services/FinancialAlertService.cs
@@ -1,0 +1,200 @@
+using FinanceManager.Application.Alerts.Models;
+using FinanceManager.Domain.Alerts.Commands;
+using FinanceManager.Domain.Alerts.Entities;
+using FinanceManager.Domain.Alerts.Enums;
+using FinanceManager.Domain.Alerts.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using FinanceManager.Domain.Labels.Services;
+using FinanceManager.Domain.Shared.Services;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Application.Alerts.Services;
+
+public class FinancialAlertService(
+    IFinancialAlertRepository alertRepository,
+    IFinancialAccountRepository accountRepository,
+    IRecurringTransactionDetectorService recurringTransactionDetectorService,
+    IFinancialAlertEvaluator evaluator,
+    IDateTimeProvider dateTimeProvider,
+    ILogger<FinancialAlertService> logger) : IFinancialAlertService
+{
+    public async Task<IReadOnlyList<FinancialAlert>> GetAlertsAsync(int userId, CancellationToken cancellationToken = default)
+    {
+        return await alertRepository.GetAlertsByUserId(userId, cancellationToken);
+    }
+
+    public async Task<FinancialAlert?> GetAlertByIdAsync(int userId, Guid alertId, CancellationToken cancellationToken = default)
+    {
+        return await alertRepository.GetById(userId, alertId, cancellationToken);
+    }
+
+    public async Task<FinancialAlert> CreateAlertAsync(
+        int userId,
+        CreateFinancialAlert command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var alert = new FinancialAlert(
+            userId,
+            command.Title,
+            command.AlertType,
+            command.ComparisonOperator,
+            command.Threshold,
+            command.EvaluationPeriod,
+            command.AccountId,
+            command.LabelId,
+            command.LabelName,
+            command.MerchantName,
+            command.SubscriptionId,
+            command.CooldownPeriod);
+
+        return await alertRepository.Add(alert, cancellationToken);
+    }
+
+    public async Task<FinancialAlert?> UpdateAlertAsync(
+        int userId,
+        Guid alertId,
+        UpdateFinancialAlert command,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var alert = await alertRepository.GetById(userId, alertId, cancellationToken);
+        if (alert is null)
+        {
+            return null;
+        }
+
+        alert.UpdateFrom(command);
+        await alertRepository.Update(alert, cancellationToken);
+
+        return alert;
+    }
+
+    public async Task<bool> DeleteAlertAsync(int userId, Guid alertId, CancellationToken cancellationToken = default)
+    {
+        return await alertRepository.Delete(userId, alertId, cancellationToken);
+    }
+
+    public async Task<bool> SetEnabledAsync(
+        int userId,
+        Guid alertId,
+        bool isEnabled,
+        CancellationToken cancellationToken = default)
+    {
+        var alert = await alertRepository.GetById(userId, alertId, cancellationToken);
+        if (alert is null)
+        {
+            return false;
+        }
+
+        alert.IsEnabled = isEnabled;
+        alert.UpdatedAt = dateTimeProvider.UtcNow;
+        await alertRepository.Update(alert, cancellationToken);
+
+        return true;
+    }
+
+    public async Task<IReadOnlyList<AlertEvaluationOutcome>> EvaluateAlertsAsync(
+        int userId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var alerts = await alertRepository.GetAlertsByUserId(userId, cancellationToken);
+            if (alerts.Count == 0)
+            {
+                return [];
+            }
+
+            var snapshot = await BuildSnapshotAsync(userId, alerts, cancellationToken);
+            var outcomes = evaluator.EvaluateAll(alerts, snapshot);
+
+            foreach (var outcome in outcomes)
+            {
+                var alert = alerts.FirstOrDefault(a => a.Id == outcome.AlertId);
+                if (alert is null) continue;
+
+                if (outcome.IsNewlyTriggered)
+                {
+                    alert.RecordTrigger(outcome.CurrentValue, outcome.ConditionFingerprint, outcome.EvaluatedAt);
+                    await alertRepository.Update(alert, cancellationToken);
+                }
+                else if (!outcome.IsTriggered && alert.LastStatus == AlertTriggerStatus.Triggered)
+                {
+                    alert.RecordResolved(outcome.EvaluatedAt);
+                    await alertRepository.Update(alert, cancellationToken);
+                }
+            }
+
+            return outcomes;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to evaluate financial alerts for user {UserId}", userId);
+            return [];
+        }
+    }
+
+    public async Task<AlertEvaluationOutcome?> EvaluateAlertAsync(
+        int userId,
+        Guid alertId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var alert = await alertRepository.GetById(userId, alertId, cancellationToken);
+            if (alert is null)
+            {
+                return null;
+            }
+
+            var snapshot = await BuildSnapshotAsync(userId, [alert], cancellationToken);
+            var outcome = evaluator.Evaluate(alert, snapshot);
+
+            if (outcome.IsNewlyTriggered)
+            {
+                alert.RecordTrigger(outcome.CurrentValue, outcome.ConditionFingerprint, outcome.EvaluatedAt);
+                await alertRepository.Update(alert, cancellationToken);
+            }
+            else if (!outcome.IsTriggered && alert.LastStatus == AlertTriggerStatus.Triggered)
+            {
+                alert.RecordResolved(outcome.EvaluatedAt);
+                await alertRepository.Update(alert, cancellationToken);
+            }
+
+            return outcome;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to evaluate financial alert {AlertId} for user {UserId}", alertId, userId);
+            return null;
+        }
+    }
+
+    private async Task<AlertEvaluationSnapshot> BuildSnapshotAsync(
+        int userId,
+        IReadOnlyList<FinancialAlert> alerts,
+        CancellationToken cancellationToken)
+    {
+        var now = dateTimeProvider.UtcNow;
+        // Keep the normal evaluation bounded, but load the complete history whenever an all-time
+        // rule is present so imports and old transactions are evaluated deterministically.
+        var start = alerts.Any(alert => alert.EvaluationPeriod == AlertEvaluationPeriod.AllTime)
+            ? DateTime.MinValue
+            : now.Date.AddMonths(-12);
+        var end = now.Date.AddDays(1);
+
+        var accounts = new List<CurrencyAccount>();
+        await foreach (var account in accountRepository.GetAccounts<CurrencyAccount>(userId, start, end).WithCancellation(cancellationToken))
+        {
+            accounts.Add(account);
+        }
+
+        var subscriptions = await recurringTransactionDetectorService.GetRecurringTransactions(userId, cancellationToken);
+
+        return new AlertEvaluationSnapshot(accounts, subscriptions, now);
+    }
+}

--- a/code/FinanceManager.Application/Alerts/Services/IFinancialAlertEvaluator.cs
+++ b/code/FinanceManager.Application/Alerts/Services/IFinancialAlertEvaluator.cs
@@ -1,0 +1,10 @@
+using FinanceManager.Application.Alerts.Models;
+using FinanceManager.Domain.Alerts.Entities;
+
+namespace FinanceManager.Application.Alerts.Services;
+
+public interface IFinancialAlertEvaluator
+{
+    AlertEvaluationOutcome Evaluate(FinancialAlert alert, AlertEvaluationSnapshot snapshot);
+    IReadOnlyList<AlertEvaluationOutcome> EvaluateAll(IEnumerable<FinancialAlert> alerts, AlertEvaluationSnapshot snapshot);
+}

--- a/code/FinanceManager.Application/Alerts/Services/IFinancialAlertService.cs
+++ b/code/FinanceManager.Application/Alerts/Services/IFinancialAlertService.cs
@@ -1,0 +1,17 @@
+using FinanceManager.Application.Alerts.Models;
+using FinanceManager.Domain.Alerts.Commands;
+using FinanceManager.Domain.Alerts.Entities;
+
+namespace FinanceManager.Application.Alerts.Services;
+
+public interface IFinancialAlertService
+{
+    Task<IReadOnlyList<FinancialAlert>> GetAlertsAsync(int userId, CancellationToken cancellationToken = default);
+    Task<FinancialAlert?> GetAlertByIdAsync(int userId, Guid alertId, CancellationToken cancellationToken = default);
+    Task<FinancialAlert> CreateAlertAsync(int userId, CreateFinancialAlert command, CancellationToken cancellationToken = default);
+    Task<FinancialAlert?> UpdateAlertAsync(int userId, Guid alertId, UpdateFinancialAlert command, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAlertAsync(int userId, Guid alertId, CancellationToken cancellationToken = default);
+    Task<bool> SetEnabledAsync(int userId, Guid alertId, bool isEnabled, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<AlertEvaluationOutcome>> EvaluateAlertsAsync(int userId, CancellationToken cancellationToken = default);
+    Task<AlertEvaluationOutcome?> EvaluateAlertAsync(int userId, Guid alertId, CancellationToken cancellationToken = default);
+}

--- a/code/FinanceManager.Application/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Application/ServiceCollectionExtension.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Application.Administration;
+using FinanceManager.Application.Alerts.Services;
 using FinanceManager.Application.Dashboard;
 using FinanceManager.Application.FinancialAccounts;
 using FinanceManager.Application.Identity;
@@ -39,6 +40,8 @@ public static class ServiceCollectionExtension
             .AddIdentityApplication()
             .AddFinancialAccountsApplication()
             .AddLabelsApplication()
+            .AddScoped<IFinancialAlertEvaluator, FinancialAlertEvaluator>()
+            .AddScoped<IFinancialAlertService, FinancialAlertService>()
             .AddInsightsApplication()
             .AddMoneyFlowApplication()
             .AddDashboardApplication()

--- a/code/FinanceManager.Components/Features/Alerts/Components/AlertsPage.razor
+++ b/code/FinanceManager.Components/Features/Alerts/Components/AlertsPage.razor
@@ -1,0 +1,180 @@
+@page "/Alerts"
+@using FinanceManager.Application.Alerts.Models
+@using FinanceManager.Domain.Alerts.Dtos
+@using FinanceManager.Domain.Alerts.Enums
+
+<PageTitle>Alerts and watchlists</PageTitle>
+
+<SectionContent SectionName="page-title">
+    <MudText Typo="Typo.h6">Alerts and watchlists</MudText>
+</SectionContent>
+
+<MudContainer MaxWidth="MaxWidth.Large" Class="py-6">
+    <div class="d-flex flex-wrap justify-space-between align-center gap-3 mb-5">
+        <div>
+            <MudText Typo="Typo.h4" HtmlTag="h1">Alerts and watchlists</MudText>
+            <MudText Typo="Typo.body1" Color="Color.Secondary">
+                Define deterministic checks for balances, spending, transactions, and subscription changes.
+            </MudText>
+        </div>
+        <MudButton Variant="Variant.Outlined" Color="Color.Primary" StartIcon="@Icons.Material.Filled.Refresh"
+                   Disabled="@_isLoading" OnClick="RefreshAsync">Evaluate now</MudButton>
+    </div>
+
+    @if (_errors.Count > 0)
+    {
+        <MudAlert Severity="Severity.Error" Class="mb-4">
+            @foreach (var error in _errors)
+            {
+                <div>@error</div>
+            }
+        </MudAlert>
+    }
+
+    <MudPaper Outlined Class="pa-4 mb-5">
+        <div class="d-flex justify-space-between align-center mb-3">
+            <MudText Typo="Typo.h6">@(_editingId is null ? "Create an alert" : "Edit alert")</MudText>
+            @if (_editingId is not null)
+            {
+                <MudButton Variant="Variant.Text" OnClick="CancelEdit">Cancel</MudButton>
+            }
+        </div>
+
+        <MudGrid Spacing="2">
+            <MudItem xs="12" md="6">
+                <MudTextField T="string" @bind-Value="_form.Title" Label="Alert name" Required="true"
+                              Variant="Variant.Outlined" Margin="Margin.Dense" MaxLength="200" />
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudSelect T="AlertType" @bind-Value="_form.AlertType" Label="Condition"
+                           Variant="Variant.Outlined" Margin="Margin.Dense">
+                    @foreach (var type in Enum.GetValues<AlertType>())
+                    {
+                        <MudSelectItem T="AlertType" Value="@type">@TypeLabel(type)</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+            <MudItem xs="6" md="3">
+                <MudSelect T="AlertComparisonOperator" @bind-Value="_form.ComparisonOperator" Label="Comparison"
+                           Variant="Variant.Outlined" Margin="Margin.Dense">
+                    @foreach (var comparison in Enum.GetValues<AlertComparisonOperator>())
+                    {
+                        <MudSelectItem T="AlertComparisonOperator" Value="@comparison">@ComparisonLabel(comparison)</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+            <MudItem xs="6" md="3">
+                <MudNumericField T="decimal" @bind-Value="_form.Threshold" Label="Threshold"
+                                 Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End"
+                                 AdornmentText="value" />
+            </MudItem>
+            <MudItem xs="12" md="3">
+                <MudSelect T="AlertEvaluationPeriod" @bind-Value="_form.EvaluationPeriod" Label="Evaluation period"
+                           Variant="Variant.Outlined" Margin="Margin.Dense">
+                    @foreach (var period in Enum.GetValues<AlertEvaluationPeriod>())
+                    {
+                        <MudSelectItem T="AlertEvaluationPeriod" Value="@period">@PeriodLabel(period)</MudSelectItem>
+                    }
+                </MudSelect>
+            </MudItem>
+            <MudItem xs="12" md="3">
+                <MudNumericField T="double" @bind-Value="_form.CooldownHours" Label="Cooldown (hours)"
+                                 Variant="Variant.Outlined" Margin="Margin.Dense" Min="0" />
+            </MudItem>
+
+            @if (_form.AlertType == AlertType.AccountBalance)
+            {
+                <MudItem xs="12" md="6">
+                    <MudTextField T="string" @bind-Value="_form.AccountIdText" Label="Account id (optional)"
+                                  HelperText="Leave empty to check every currency account." Variant="Variant.Outlined" Margin="Margin.Dense" />
+                </MudItem>
+            }
+            @if (_form.AlertType == AlertType.CategorySpending)
+            {
+                <MudItem xs="12" md="6">
+                    <MudTextField T="string" @bind-Value="_form.LabelName" Label="Label/category (optional)"
+                                  HelperText="Leave empty to include all labelled expenses." Variant="Variant.Outlined" Margin="Margin.Dense" />
+                </MudItem>
+            }
+            @if (_form.AlertType == AlertType.MerchantSpending)
+            {
+                <MudItem xs="12" md="6">
+                    <MudTextField T="string" @bind-Value="_form.MerchantName" Label="Merchant (optional)"
+                                  HelperText="Matches contractor or description text." Variant="Variant.Outlined" Margin="Margin.Dense" />
+                </MudItem>
+            }
+        </MudGrid>
+
+        <div class="d-flex justify-end mt-4">
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@_isSaving" OnClick="SaveAsync">
+                @(_editingId is null ? "Create alert" : "Save changes")
+            </MudButton>
+        </div>
+    </MudPaper>
+
+    @if (_isLoading && _alerts.Count == 0)
+    {
+        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Height="180px" />
+    }
+    else if (_alerts.Count == 0)
+    {
+        <MudPaper Outlined Class="pa-8 text-center">
+            <MudIcon Icon="@Icons.Material.Filled.NotificationsNone" Size="Size.Large" Color="Color.Secondary" />
+            <MudText Typo="Typo.h6" Class="mt-2">No alerts yet</MudText>
+            <MudText Typo="Typo.body2" Color="Color.Secondary">Create a watchlist condition above to start monitoring your finances.</MudText>
+        </MudPaper>
+    }
+    else
+    {
+        <MudTable Items="_alerts" Dense="true" Hover="true" Outlined="true" Elevation="0">
+            <HeaderContent>
+                <MudTh>Alert</MudTh>
+                <MudTh>Condition</MudTh>
+                <MudTh>Status</MudTh>
+                <MudTh>Observed</MudTh>
+                <MudTh Style="text-align:right">Actions</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Alert">
+                    <MudText Typo="Typo.body1" Class="font-weight-600">@context.Title</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">@PeriodLabel(context.EvaluationPeriod)</MudText>
+                </MudTd>
+                <MudTd DataLabel="Condition">
+                    <MudText Typo="Typo.body2">@TypeLabel(context.AlertType)</MudText>
+                    <MudText Typo="Typo.caption">@GetConditionLabel(context)</MudText>
+                </MudTd>
+                <MudTd DataLabel="Status">
+                    <MudChip T="string" Size="Size.Small" Color="@StatusColor(context)" Variant="Variant.Outlined">
+                        @(context.IsEnabled ? StatusLabel(context) : "Disabled")
+                    </MudChip>
+                </MudTd>
+                <MudTd DataLabel="Observed">
+                    @if (_outcomes.TryGetValue(context.Id, out var outcome))
+                    {
+                        <MudText Typo="Typo.body2">@outcome.CurrentValue.ToString("N2")</MudText>
+                        @if (outcome.IsTriggered)
+                        {
+                            <MudText Typo="Typo.caption" Color="Color.Warning">@outcome.Message</MudText>
+                        }
+                    }
+                    else if (context.LastTriggeredValue is decimal value)
+                    {
+                        <MudText Typo="Typo.body2">@value.ToString("N2")</MudText>
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">Not evaluated</MudText>
+                    }
+                </MudTd>
+                <MudTd DataLabel="Actions" Style="text-align:right; white-space:nowrap">
+                    <MudSwitch T="bool" Value="@context.IsEnabled" ValueChanged="@(value => ToggleEnabledAsync(context, value))"
+                               Color="Color.Primary" Size="Size.Small" aria-label="@(string.Concat("Enable ", context.Title))" />
+                    <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="@(() => BeginEdit(context))"
+                                   aria-label="@(string.Concat("Edit ", context.Title))" />
+                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Size="Size.Small" Color="Color.Error"
+                                   OnClick="@(() => DeleteAsync(context))" aria-label="@(string.Concat("Delete ", context.Title))" />
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    }
+</MudContainer>

--- a/code/FinanceManager.Components/Features/Alerts/Components/AlertsPage.razor.cs
+++ b/code/FinanceManager.Components/Features/Alerts/Components/AlertsPage.razor.cs
@@ -1,0 +1,261 @@
+using FinanceManager.Application.Alerts.Models;
+using FinanceManager.Components.Features.Alerts.HttpClients;
+using FinanceManager.Domain.Alerts.Commands;
+using FinanceManager.Domain.Alerts.Dtos;
+using FinanceManager.Domain.Alerts.Enums;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+using MudBlazor;
+
+namespace FinanceManager.Components.Features.Alerts.Components;
+
+public partial class AlertsPage : ComponentBase
+{
+    private readonly List<string> _errors = [];
+    private readonly Dictionary<Guid, AlertEvaluationOutcome> _outcomes = [];
+    private List<FinancialAlertDto> _alerts = [];
+    private AlertFormModel _form = new();
+    private Guid? _editingId;
+    private bool _isLoading = true;
+    private bool _isSaving;
+
+    [Inject] public required FinancialAlertsHttpClient HttpClient { get; set; }
+    [Inject] public required ILogger<AlertsPage> Logger { get; set; }
+    [Inject] public required ISnackbar Snackbar { get; set; }
+
+    protected override Task OnInitializedAsync() => RefreshAsync();
+
+    private async Task RefreshAsync()
+    {
+        _isLoading = true;
+        _errors.Clear();
+
+        try
+        {
+            var outcomes = await HttpClient.EvaluateAsync();
+            _outcomes.Clear();
+            foreach (var outcome in outcomes)
+                _outcomes[outcome.AlertId] = outcome;
+
+            _alerts = await HttpClient.GetAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unable to load financial alerts");
+            _errors.Add("Unable to load alerts. Please try again.");
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        _errors.Clear();
+        if (string.IsNullOrWhiteSpace(_form.Title))
+        {
+            _errors.Add("Alert name is required.");
+            return;
+        }
+
+        int? accountId = null;
+        if (!string.IsNullOrWhiteSpace(_form.AccountIdText))
+        {
+            if (!int.TryParse(_form.AccountIdText, out var parsedAccountId) || parsedAccountId <= 0)
+            {
+                _errors.Add("Account id must be a positive number.");
+                return;
+            }
+
+            accountId = parsedAccountId;
+        }
+
+        _isSaving = true;
+        try
+        {
+            TimeSpan? cooldown = _form.CooldownHours <= 0 ? null : TimeSpan.FromHours(_form.CooldownHours);
+            if (_editingId is Guid id)
+            {
+                var updated = await HttpClient.UpdateAsync(
+                    id,
+                    new UpdateFinancialAlert(
+                        _form.Title.Trim(),
+                        _form.IsEnabled,
+                        _form.ComparisonOperator,
+                        _form.Threshold,
+                        _form.EvaluationPeriod,
+                        accountId,
+                        null,
+                        NullIfWhiteSpace(_form.LabelName),
+                        NullIfWhiteSpace(_form.MerchantName),
+                        null,
+                        cooldown,
+                        _form.AlertType));
+                if (updated is null)
+                {
+                    _errors.Add("Unable to update this alert.");
+                    return;
+                }
+            }
+            else
+            {
+                var created = await HttpClient.CreateAsync(
+                    new CreateFinancialAlert(
+                        _form.Title.Trim(),
+                        _form.AlertType,
+                        _form.ComparisonOperator,
+                        _form.Threshold,
+                        _form.EvaluationPeriod,
+                        accountId,
+                        null,
+                        NullIfWhiteSpace(_form.LabelName),
+                        NullIfWhiteSpace(_form.MerchantName),
+                        null,
+                        cooldown));
+                if (created is null)
+                {
+                    _errors.Add("Unable to create this alert.");
+                    return;
+                }
+            }
+
+            Snackbar.Add(_editingId is null ? "Alert created." : "Alert updated.", Severity.Success);
+            CancelEdit();
+            await RefreshAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unable to save financial alert");
+            _errors.Add("Unable to save this alert. Please try again.");
+        }
+        finally
+        {
+            _isSaving = false;
+        }
+    }
+
+    private async Task ToggleEnabledAsync(FinancialAlertDto alert, bool enabled)
+    {
+        try
+        {
+            if (!await HttpClient.SetEnabledAsync(alert.Id, enabled))
+            {
+                Snackbar.Add("Unable to update this alert.", Severity.Error);
+                return;
+            }
+
+            await RefreshAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unable to toggle financial alert {AlertId}", alert.Id);
+            Snackbar.Add("Unable to update this alert.", Severity.Error);
+        }
+    }
+
+    private async Task DeleteAsync(FinancialAlertDto alert)
+    {
+        try
+        {
+            if (!await HttpClient.DeleteAsync(alert.Id))
+            {
+                Snackbar.Add("Unable to delete this alert.", Severity.Error);
+                return;
+            }
+
+            if (_editingId == alert.Id)
+                CancelEdit();
+            Snackbar.Add("Alert deleted.", Severity.Success);
+            await RefreshAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unable to delete financial alert {AlertId}", alert.Id);
+            Snackbar.Add("Unable to delete this alert.", Severity.Error);
+        }
+    }
+
+    private void BeginEdit(FinancialAlertDto alert)
+    {
+        _editingId = alert.Id;
+        _form = new AlertFormModel
+        {
+            Title = alert.Title,
+            AlertType = alert.AlertType,
+            IsEnabled = alert.IsEnabled,
+            ComparisonOperator = alert.ComparisonOperator,
+            Threshold = alert.Threshold,
+            EvaluationPeriod = alert.EvaluationPeriod,
+            AccountIdText = alert.AccountId?.ToString() ?? string.Empty,
+            LabelName = alert.LabelName ?? string.Empty,
+            MerchantName = alert.MerchantName ?? string.Empty,
+            CooldownHours = alert.CooldownPeriod?.TotalHours ?? 0,
+        };
+    }
+
+    private void CancelEdit()
+    {
+        _editingId = null;
+        _form = new AlertFormModel();
+        _errors.Clear();
+    }
+
+    private static string? NullIfWhiteSpace(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string TypeLabel(AlertType type) => type switch
+    {
+        AlertType.AccountBalance => "Account balance",
+        AlertType.CategorySpending => "Category spending",
+        AlertType.MerchantSpending => "Merchant spending",
+        AlertType.LargeTransaction => "Large transaction",
+        AlertType.SubscriptionPriceChange => "Subscription price change",
+        _ => type.ToString()
+    };
+
+    private static string ComparisonLabel(AlertComparisonOperator comparison) => comparison switch
+    {
+        AlertComparisonOperator.GreaterThan => ">",
+        AlertComparisonOperator.GreaterThanOrEqual => "≥",
+        AlertComparisonOperator.LessThan => "<",
+        AlertComparisonOperator.LessThanOrEqual => "≤",
+        AlertComparisonOperator.Equal => "=",
+        AlertComparisonOperator.NotEqual => "≠",
+        _ => comparison.ToString()
+    };
+
+    private static string PeriodLabel(AlertEvaluationPeriod period) => period switch
+    {
+        AlertEvaluationPeriod.CurrentMonth => "Current month",
+        AlertEvaluationPeriod.Last30Days => "Last 30 days",
+        AlertEvaluationPeriod.Last7Days => "Last 7 days",
+        AlertEvaluationPeriod.AllTime => "All time",
+        _ => period.ToString()
+    };
+
+    private static string GetConditionLabel(FinancialAlertDto alert) =>
+        $"{ComparisonLabel(alert.ComparisonOperator)} {alert.Threshold:N2}";
+
+    private string StatusLabel(FinancialAlertDto alert) =>
+        _outcomes.TryGetValue(alert.Id, out var outcome)
+            ? outcome.Status == AlertTriggerStatus.Triggered ? "Triggered" : "Healthy"
+            : alert.LastStatus == AlertTriggerStatus.Triggered ? "Triggered" : "Healthy";
+
+    private Color StatusColor(FinancialAlertDto alert) =>
+        StatusLabel(alert) == "Triggered" ? Color.Warning : Color.Success;
+
+    private sealed class AlertFormModel
+    {
+        public string Title { get; set; } = string.Empty;
+        public AlertType AlertType { get; set; } = AlertType.AccountBalance;
+        public bool IsEnabled { get; set; } = true;
+        public AlertComparisonOperator ComparisonOperator { get; set; } = AlertComparisonOperator.GreaterThan;
+        public decimal Threshold { get; set; }
+        public AlertEvaluationPeriod EvaluationPeriod { get; set; } = AlertEvaluationPeriod.CurrentMonth;
+        public string AccountIdText { get; set; } = string.Empty;
+        public string LabelName { get; set; } = string.Empty;
+        public string MerchantName { get; set; } = string.Empty;
+        public double CooldownHours { get; set; }
+    }
+}

--- a/code/FinanceManager.Components/Features/Alerts/HttpClients/FinancialAlertsHttpClient.cs
+++ b/code/FinanceManager.Components/Features/Alerts/HttpClients/FinancialAlertsHttpClient.cs
@@ -1,0 +1,66 @@
+using FinanceManager.Application.Alerts.Models;
+using FinanceManager.Domain.Alerts.Commands;
+using FinanceManager.Domain.Alerts.Dtos;
+using System.Net.Http.Json;
+
+namespace FinanceManager.Components.Features.Alerts.HttpClients;
+
+public sealed class FinancialAlertsHttpClient(HttpClient httpClient)
+{
+    private const string _endpoint = "api/FinancialAlerts";
+
+    public async Task<List<FinancialAlertDto>> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.GetFromJsonAsync<List<FinancialAlertDto>>(_endpoint, cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<FinancialAlertDto?> GetAsync(Guid id, CancellationToken cancellationToken = default) =>
+        await httpClient.GetFromJsonAsync<FinancialAlertDto>($"{_endpoint}/{id}", cancellationToken);
+
+    public async Task<FinancialAlertDto?> CreateAsync(
+        CreateFinancialAlert command,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.PostAsJsonAsync(_endpoint, command, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        return await response.Content.ReadFromJsonAsync<FinancialAlertDto>(cancellationToken: cancellationToken);
+    }
+
+    public async Task<FinancialAlertDto?> UpdateAsync(
+        Guid id,
+        UpdateFinancialAlert command,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.PutAsJsonAsync($"{_endpoint}/{id}", command, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+            return null;
+
+        return await response.Content.ReadFromJsonAsync<FinancialAlertDto>(cancellationToken: cancellationToken);
+    }
+
+    public async Task<bool> SetEnabledAsync(
+        Guid id,
+        bool enabled,
+        CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.PatchAsJsonAsync($"{_endpoint}/{id}/enabled", enabled, cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
+
+    public async Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.DeleteAsync($"{_endpoint}/{id}", cancellationToken);
+        return response.IsSuccessStatusCode;
+    }
+
+    public async Task<List<AlertEvaluationOutcome>> EvaluateAsync(CancellationToken cancellationToken = default)
+    {
+        using var response = await httpClient.PostAsync($"{_endpoint}/evaluate", content: null, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<List<AlertEvaluationOutcome>>(cancellationToken: cancellationToken);
+        return result ?? [];
+    }
+}

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Cards/FinancialAlertsCard.razor
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Cards/FinancialAlertsCard.razor
@@ -1,0 +1,68 @@
+<MudCard Outlined Class="d-flex flex-nowrap" Style="@($"height:{Height};")" data-testid="financial-alerts-card">
+    <MudPaper Class="d-flex align-center flex-grow-0 px-4 pt-3 pb-1 fm-card-info-header" Elevation="0">
+        <div class="flex-grow-1" style="min-width:0;">
+            <div class="d-flex align-center gap-1">
+                <CardInfoTooltip Text="Configured financial conditions that are currently triggered."
+                                 AriaLabel="About financial alerts card">
+                    <MudText Typo="Typo.h5">Alerts</MudText>
+                </CardInfoTooltip>
+            </div>
+            @if (_isLoading)
+            {
+                <MudText Typo="Typo.subtitle1" Class="text-muted"><StringSpinner CharactersCount="4" /></MudText>
+            }
+            else
+            {
+                <MudText Typo="Typo.subtitle1" Class="text-muted">
+                    @_triggered.Count triggered of @_alerts.Count configured
+                </MudText>
+            }
+        </div>
+    </MudPaper>
+
+    <MudPaper Class="flex-grow-1 overflow-auto" Elevation="0">
+        @if (_isLoading)
+        {
+            <div class="d-flex flex-grow-1 justify-center align-content-center flex-wrap">
+                <ChartSpinner MaxHeight="@Height" />
+            </div>
+        }
+        else if (_hasError)
+        {
+            <div class="d-flex flex-grow-1 justify-center align-content-center flex-wrap pa-4">
+                <MudText Typo="Typo.body2" Color="Color.Error">Unable to load alerts.</MudText>
+            </div>
+        }
+        else if (_triggered.Count == 0)
+        {
+            <div class="d-flex flex-grow-1 justify-center align-content-center flex-wrap pa-4">
+                <MudText Typo="Typo.body2" Color="Color.Success">All configured alerts are healthy.</MudText>
+            </div>
+        }
+        else
+        {
+            <MudList T="string" Dense="true" Class="px-2 py-0">
+                @foreach (var outcome in _triggered.Take(4))
+                {
+                    <MudListItem Class="py-1 px-2">
+                        <div class="d-flex align-items-center gap-2 w-100">
+                            <MudIcon Icon="@Icons.Material.Filled.WarningAmber" Color="Color.Warning" Size="Size.Small" />
+                            <div class="flex-grow-1" style="min-width:0;">
+                                <MudText Typo="Typo.body2" Class="font-weight-500" Style="white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">
+                                    @outcome.AlertTitle
+                                </MudText>
+                                <MudText Typo="Typo.caption" Color="Color.Secondary">@outcome.Message</MudText>
+                            </div>
+                        </div>
+                    </MudListItem>
+                }
+            </MudList>
+        }
+
+        <div class="d-flex justify-end px-3 pb-2">
+            <MudButton Href="Alerts" Variant="Variant.Text" Color="Color.Primary" EndIcon="@Icons.Material.Filled.ArrowForward">
+                Manage alerts
+            </MudButton>
+        </div>
+    </MudPaper>
+</MudCard>

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Cards/FinancialAlertsCard.razor.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Cards/FinancialAlertsCard.razor.cs
@@ -1,0 +1,39 @@
+using FinanceManager.Application.Alerts.Models;
+using FinanceManager.Components.Features.Alerts.HttpClients;
+using FinanceManager.Domain.Alerts.Dtos;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+
+namespace FinanceManager.Components.Features.Dashboard.Components.Cards;
+
+public partial class FinancialAlertsCard
+{
+    private bool _isLoading = true;
+    private bool _hasError;
+    private List<FinancialAlertDto> _alerts = [];
+    private List<AlertEvaluationOutcome> _triggered = [];
+
+    [Parameter] public string Height { get; set; } = "300px";
+
+    [Inject] public required FinancialAlertsHttpClient FinancialAlertsHttpClient { get; set; }
+    [Inject] public required ILogger<FinancialAlertsCard> Logger { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            var outcomes = await FinancialAlertsHttpClient.EvaluateAsync();
+            _triggered = outcomes.Where(x => x.IsTriggered).OrderByDescending(x => x.IsNewlyTriggered).ThenBy(x => x.AlertTitle).ToList();
+            _alerts = await FinancialAlertsHttpClient.GetAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Unable to load dashboard financial alerts");
+            _hasError = true;
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+}

--- a/code/FinanceManager.Components/Features/Dashboard/Components/Dashboard.razor
+++ b/code/FinanceManager.Components/Features/Dashboard/Components/Dashboard.razor
@@ -133,6 +133,13 @@
                 </MudItem>
             }
 
+            @if (IsCardVisible(DashboardCards.FinancialAlerts))
+            {
+                <MudItem xs="12" md="6" lg="4">
+                    <FinancialAlertsCard Height="@($"{_unitHeight * 3}px")" />
+                </MudItem>
+            }
+
             @if (IsCardVisible(DashboardCards.RecurringTransactions))
             {
                 <MudItem xs="12" md="6" lg="4">

--- a/code/FinanceManager.Components/Features/Dashboard/Models/DashboardCards.cs
+++ b/code/FinanceManager.Components/Features/Dashboard/Models/DashboardCards.cs
@@ -18,6 +18,7 @@ public static class DashboardCards
     public const string Assets = "assets";
     public const string Expenses = "expenses";
     public const string Insights = "insights";
+    public const string FinancialAlerts = "financial-alerts";
     public const string RecurringTransactions = "recurring-transactions";
     public const string TransactionLog = "transaction-log";
 
@@ -32,6 +33,7 @@ public static class DashboardCards
         new(Assets, "Assets"),
         new(Expenses, "Expenses"),
         new(Insights, "Financial insights"),
+        new(FinancialAlerts, "Alerts"),
         new(RecurringTransactions, "Recurring transactions"),
         new(TransactionLog, "Transaction log"),
     ];

--- a/code/FinanceManager.Components/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Components/ServiceCollectionExtension.cs
@@ -1,4 +1,5 @@
 using FinanceManager.Components.Features.Administration.HttpClients;
+using FinanceManager.Components.Features.Alerts.HttpClients;
 using FinanceManager.Components.Features.Dashboard.HttpClients;
 using FinanceManager.Components.Features.Dashboard.Services;
 using FinanceManager.Components.Features.FinancialAccounts.HttpClients;
@@ -62,6 +63,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<AdminMaintenanceKeyHttpClient>()
                 .AddScoped<AdminLogsHttpClient>()
                 .AddScoped<NewVisitorsHttpClient>()
+                .AddScoped<FinancialAlertsHttpClient>()
                 .AddScoped<CsvHeaderMappingHttpClient>()
                 .AddScoped<AccountDataSynchronizationService>()
                 .AddScoped<NavMenuStateCacheService>()

--- a/code/FinanceManager.Components/Shared/Layout/NavMenu.razor
+++ b/code/FinanceManager.Components/Shared/Layout/NavMenu.razor
@@ -24,6 +24,7 @@
     }
 
     <MudNavLink Icon="@Icons.Material.Filled.Subscriptions" Href="Subscriptions" data-testid="nav-subscriptions">Subscriptions</MudNavLink>
+    <MudNavLink Icon="@Icons.Material.Filled.Notifications" Href="Alerts" data-testid="nav-alerts">Alerts</MudNavLink>
     <MudDivider Class="my-2" />
 
     <MudText Typo="Typo.h6" Class="px-5" Color="Color.Primary">

--- a/code/FinanceManager.Components/_Imports.razor
+++ b/code/FinanceManager.Components/_Imports.razor
@@ -9,6 +9,8 @@
 
 @using FinanceManager.Components
 @using FinanceManager.Components.Features.Administration.HttpClients
+@using FinanceManager.Components.Features.Alerts.HttpClients
+@using FinanceManager.Components.Features.Alerts.Components
 @using FinanceManager.Components.Features.App.Components
 @using FinanceManager.Components.Features.Dashboard.Components
 @using FinanceManager.Components.Features.Dashboard.Components.Cards

--- a/code/FinanceManager.Domain/Alerts/Commands/CreateFinancialAlert.cs
+++ b/code/FinanceManager.Domain/Alerts/Commands/CreateFinancialAlert.cs
@@ -1,0 +1,16 @@
+using FinanceManager.Domain.Alerts.Enums;
+
+namespace FinanceManager.Domain.Alerts.Commands;
+
+public record CreateFinancialAlert(
+    string Title,
+    AlertType AlertType,
+    AlertComparisonOperator ComparisonOperator,
+    decimal Threshold,
+    AlertEvaluationPeriod EvaluationPeriod = AlertEvaluationPeriod.CurrentMonth,
+    int? AccountId = null,
+    int? LabelId = null,
+    string? LabelName = null,
+    string? MerchantName = null,
+    Guid? SubscriptionId = null,
+    TimeSpan? CooldownPeriod = null);

--- a/code/FinanceManager.Domain/Alerts/Commands/UpdateFinancialAlert.cs
+++ b/code/FinanceManager.Domain/Alerts/Commands/UpdateFinancialAlert.cs
@@ -1,0 +1,17 @@
+using FinanceManager.Domain.Alerts.Enums;
+
+namespace FinanceManager.Domain.Alerts.Commands;
+
+public record UpdateFinancialAlert(
+    string Title,
+    bool IsEnabled,
+    AlertComparisonOperator ComparisonOperator,
+    decimal Threshold,
+    AlertEvaluationPeriod EvaluationPeriod = AlertEvaluationPeriod.CurrentMonth,
+    int? AccountId = null,
+    int? LabelId = null,
+    string? LabelName = null,
+    string? MerchantName = null,
+    Guid? SubscriptionId = null,
+    TimeSpan? CooldownPeriod = null,
+    AlertType? AlertType = null);

--- a/code/FinanceManager.Domain/Alerts/Dtos/FinancialAlertDto.cs
+++ b/code/FinanceManager.Domain/Alerts/Dtos/FinancialAlertDto.cs
@@ -1,0 +1,47 @@
+using FinanceManager.Domain.Alerts.Entities;
+using FinanceManager.Domain.Alerts.Enums;
+
+namespace FinanceManager.Domain.Alerts.Dtos;
+
+public record FinancialAlertDto(
+    Guid Id,
+    int UserId,
+    string Title,
+    AlertType AlertType,
+    bool IsEnabled,
+    AlertComparisonOperator ComparisonOperator,
+    decimal Threshold,
+    AlertEvaluationPeriod EvaluationPeriod,
+    int? AccountId,
+    int? LabelId,
+    string? LabelName,
+    string? MerchantName,
+    Guid? SubscriptionId,
+    AlertTriggerStatus LastStatus,
+    DateTime? LastTriggeredAt,
+    decimal? LastTriggeredValue,
+    TimeSpan? CooldownPeriod,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt)
+{
+    public static FinancialAlertDto FromEntity(FinancialAlert entity) => new(
+        entity.Id,
+        entity.UserId,
+        entity.Title,
+        entity.AlertType,
+        entity.IsEnabled,
+        entity.ComparisonOperator,
+        entity.Threshold,
+        entity.EvaluationPeriod,
+        entity.AccountId,
+        entity.LabelId,
+        entity.LabelName,
+        entity.MerchantName,
+        entity.SubscriptionId,
+        entity.LastStatus,
+        entity.LastTriggeredAt,
+        entity.LastTriggeredValue,
+        entity.CooldownPeriod,
+        entity.CreatedAt,
+        entity.UpdatedAt);
+}

--- a/code/FinanceManager.Domain/Alerts/Entities/FinancialAlert.cs
+++ b/code/FinanceManager.Domain/Alerts/Entities/FinancialAlert.cs
@@ -1,0 +1,114 @@
+using FinanceManager.Domain.Alerts.Commands;
+using FinanceManager.Domain.Alerts.Enums;
+
+namespace FinanceManager.Domain.Alerts.Entities;
+
+public class FinancialAlert
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public int UserId { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public AlertType AlertType { get; set; }
+    public bool IsEnabled { get; set; } = true;
+    public AlertComparisonOperator ComparisonOperator { get; set; } = AlertComparisonOperator.GreaterThan;
+    public decimal Threshold { get; set; }
+    public AlertEvaluationPeriod EvaluationPeriod { get; set; } = AlertEvaluationPeriod.CurrentMonth;
+
+    public int? AccountId { get; set; }
+    public int? LabelId { get; set; }
+    public string? LabelName { get; set; }
+    public string? MerchantName { get; set; }
+    public Guid? SubscriptionId { get; set; }
+
+    public AlertTriggerStatus LastStatus { get; set; } = AlertTriggerStatus.Healthy;
+    public DateTime? LastTriggeredAt { get; set; }
+    public decimal? LastTriggeredValue { get; set; }
+    public string? LastTriggeredConditionFingerprint { get; set; }
+    public TimeSpan? CooldownPeriod { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? UpdatedAt { get; set; }
+
+    // Parameterless constructor for persistence and serialization frameworks.
+    public FinancialAlert()
+    {
+    }
+
+    public FinancialAlert(
+        int userId,
+        string title,
+        AlertType alertType,
+        AlertComparisonOperator comparisonOperator,
+        decimal threshold,
+        AlertEvaluationPeriod evaluationPeriod = AlertEvaluationPeriod.CurrentMonth,
+        int? accountId = null,
+        int? labelId = null,
+        string? labelName = null,
+        string? merchantName = null,
+        Guid? subscriptionId = null,
+        TimeSpan? cooldownPeriod = null)
+    {
+        UserId = userId;
+        Title = title;
+        AlertType = alertType;
+        ComparisonOperator = comparisonOperator;
+        Threshold = threshold;
+        EvaluationPeriod = evaluationPeriod;
+        AccountId = accountId;
+        LabelId = labelId;
+        LabelName = labelName;
+        MerchantName = merchantName;
+        SubscriptionId = subscriptionId;
+        CooldownPeriod = cooldownPeriod;
+    }
+
+    public void UpdateFrom(UpdateFinancialAlert command)
+    {
+        Title = command.Title;
+        IsEnabled = command.IsEnabled;
+        ComparisonOperator = command.ComparisonOperator;
+        Threshold = command.Threshold;
+        EvaluationPeriod = command.EvaluationPeriod;
+        AccountId = command.AccountId;
+        LabelId = command.LabelId;
+        LabelName = command.LabelName;
+        MerchantName = command.MerchantName;
+        SubscriptionId = command.SubscriptionId;
+        CooldownPeriod = command.CooldownPeriod;
+        if (command.AlertType is { } alertType)
+            AlertType = alertType;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public void RecordTrigger(decimal observedValue, string conditionFingerprint, DateTime triggeredAt)
+    {
+        LastStatus = AlertTriggerStatus.Triggered;
+        LastTriggeredValue = observedValue;
+        LastTriggeredConditionFingerprint = conditionFingerprint;
+        LastTriggeredAt = triggeredAt;
+        UpdatedAt = triggeredAt;
+    }
+
+    public void RecordResolved(DateTime evaluatedAt)
+    {
+        LastStatus = AlertTriggerStatus.Healthy;
+        LastTriggeredConditionFingerprint = null;
+        UpdatedAt = evaluatedAt;
+    }
+
+    public bool IsSuppressedByCooldown(DateTime currentTime)
+    {
+        if (CooldownPeriod is TimeSpan cooldown && LastTriggeredAt is DateTime lastTriggered)
+        {
+            return (currentTime - lastTriggered) < cooldown;
+        }
+
+        return false;
+    }
+
+    public bool IsUnchangedTrigger(string conditionFingerprint)
+    {
+        return LastStatus == AlertTriggerStatus.Triggered
+            && string.Equals(LastTriggeredConditionFingerprint, conditionFingerprint, StringComparison.Ordinal);
+    }
+}

--- a/code/FinanceManager.Domain/Alerts/Enums/AlertComparisonOperator.cs
+++ b/code/FinanceManager.Domain/Alerts/Enums/AlertComparisonOperator.cs
@@ -1,0 +1,11 @@
+namespace FinanceManager.Domain.Alerts.Enums;
+
+public enum AlertComparisonOperator
+{
+    GreaterThan = 1,
+    GreaterThanOrEqual = 2,
+    LessThan = 3,
+    LessThanOrEqual = 4,
+    Equal = 5,
+    NotEqual = 6
+}

--- a/code/FinanceManager.Domain/Alerts/Enums/AlertEvaluationPeriod.cs
+++ b/code/FinanceManager.Domain/Alerts/Enums/AlertEvaluationPeriod.cs
@@ -1,0 +1,9 @@
+namespace FinanceManager.Domain.Alerts.Enums;
+
+public enum AlertEvaluationPeriod
+{
+    CurrentMonth = 1,
+    Last30Days = 2,
+    Last7Days = 3,
+    AllTime = 4
+}

--- a/code/FinanceManager.Domain/Alerts/Enums/AlertTriggerStatus.cs
+++ b/code/FinanceManager.Domain/Alerts/Enums/AlertTriggerStatus.cs
@@ -1,0 +1,8 @@
+namespace FinanceManager.Domain.Alerts.Enums;
+
+public enum AlertTriggerStatus
+{
+    Healthy = 1,
+    Triggered = 2,
+    Disabled = 3
+}

--- a/code/FinanceManager.Domain/Alerts/Enums/AlertType.cs
+++ b/code/FinanceManager.Domain/Alerts/Enums/AlertType.cs
@@ -1,0 +1,10 @@
+namespace FinanceManager.Domain.Alerts.Enums;
+
+public enum AlertType
+{
+    AccountBalance = 1,
+    CategorySpending = 2,
+    MerchantSpending = 3,
+    LargeTransaction = 4,
+    SubscriptionPriceChange = 5
+}

--- a/code/FinanceManager.Domain/Alerts/Repositories/IFinancialAlertRepository.cs
+++ b/code/FinanceManager.Domain/Alerts/Repositories/IFinancialAlertRepository.cs
@@ -1,0 +1,12 @@
+using FinanceManager.Domain.Alerts.Entities;
+
+namespace FinanceManager.Domain.Alerts.Repositories;
+
+public interface IFinancialAlertRepository
+{
+    Task<IReadOnlyList<FinancialAlert>> GetAlertsByUserId(int userId, CancellationToken cancellationToken = default);
+    Task<FinancialAlert?> GetById(int userId, Guid alertId, CancellationToken cancellationToken = default);
+    Task<FinancialAlert> Add(FinancialAlert alert, CancellationToken cancellationToken = default);
+    Task Update(FinancialAlert alert, CancellationToken cancellationToken = default);
+    Task<bool> Delete(int userId, Guid alertId, CancellationToken cancellationToken = default);
+}

--- a/code/FinanceManager.Infrastructure/Features/Alerts/Repositories/FinancialAlertRepository.cs
+++ b/code/FinanceManager.Infrastructure/Features/Alerts/Repositories/FinancialAlertRepository.cs
@@ -1,0 +1,58 @@
+using FinanceManager.Domain.Alerts.Entities;
+using FinanceManager.Domain.Alerts.Repositories;
+using FinanceManager.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace FinanceManager.Infrastructure.Features.Alerts.Repositories;
+
+internal sealed class FinancialAlertRepository(AppDbContext context) : IFinancialAlertRepository
+{
+    public async Task<IReadOnlyList<FinancialAlert>> GetAlertsByUserId(
+        int userId,
+        CancellationToken cancellationToken = default) =>
+        await context.FinancialAlerts
+            .AsNoTracking()
+            .Where(x => x.UserId == userId)
+            .OrderBy(x => x.CreatedAt)
+            .ThenBy(x => x.Id)
+            .ToListAsync(cancellationToken);
+
+    public Task<FinancialAlert?> GetById(
+        int userId,
+        Guid alertId,
+        CancellationToken cancellationToken = default) =>
+        context.FinancialAlerts
+            .SingleOrDefaultAsync(x => x.UserId == userId && x.Id == alertId, cancellationToken);
+
+    public async Task<FinancialAlert> Add(
+        FinancialAlert alert,
+        CancellationToken cancellationToken = default)
+    {
+        context.FinancialAlerts.Add(alert);
+        await context.SaveChangesAsync(cancellationToken);
+        return alert;
+    }
+
+    public async Task Update(
+        FinancialAlert alert,
+        CancellationToken cancellationToken = default)
+    {
+        context.FinancialAlerts.Update(alert);
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<bool> Delete(
+        int userId,
+        Guid alertId,
+        CancellationToken cancellationToken = default)
+    {
+        var alert = await context.FinancialAlerts
+            .SingleOrDefaultAsync(x => x.UserId == userId && x.Id == alertId, cancellationToken);
+        if (alert is null)
+            return false;
+
+        context.FinancialAlerts.Remove(alert);
+        await context.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+}

--- a/code/FinanceManager.Infrastructure/Persistence/AppDbContext.cs
+++ b/code/FinanceManager.Infrastructure/Persistence/AppDbContext.cs
@@ -1,5 +1,6 @@
 using FinanceManager.Domain.Administration.Logging;
 using FinanceManager.Domain.Administration.Monitoring;
+using FinanceManager.Domain.Alerts.Entities;
 using FinanceManager.Domain.Assets.Entities;
 using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
 using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
@@ -41,6 +42,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<FinancialLabel> FinancialLabels { get; set; } = default!;
     public DbSet<FinancialLabelClassification> FinancialLabelClassifications { get; set; } = default!;
     public DbSet<RecurringSubscription> RecurringSubscriptions { get; set; } = default!;
+    public DbSet<FinancialAlert> FinancialAlerts { get; set; } = default!;
     public DbSet<BondDetails> Bonds { get; set; } = default!;
     public DbSet<CsvHeaderMapping> CsvHeaderMappings { get; set; } = default!;
     public DbSet<AiProviderConfiguration> AiProviderConfigurations { get; set; } = default!;
@@ -75,6 +77,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.ApplyConfiguration(new FinancialLabelConfiguration());
         modelBuilder.ApplyConfiguration(new FinancialLabelClassificationConfiguration());
         modelBuilder.ApplyConfiguration(new RecurringSubscriptionConfiguration());
+        modelBuilder.ApplyConfiguration(new FinancialAlertConfiguration());
         modelBuilder.ApplyConfiguration(new AiProviderConfigurationConfiguration());
         modelBuilder.ApplyConfiguration(new AiFallbackEntryConfiguration());
         modelBuilder.ApplyConfiguration(new AiProviderModelConfiguration());

--- a/code/FinanceManager.Infrastructure/Persistence/Configurations/FinancialAlertConfiguration.cs
+++ b/code/FinanceManager.Infrastructure/Persistence/Configurations/FinancialAlertConfiguration.cs
@@ -1,0 +1,40 @@
+using FinanceManager.Domain.Alerts.Entities;
+using FinanceManager.Domain.Identity.Dtos;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace FinanceManager.Infrastructure.Persistence.Configurations;
+
+internal sealed class FinancialAlertConfiguration : IEntityTypeConfiguration<FinancialAlert>
+{
+    public void Configure(EntityTypeBuilder<FinancialAlert> builder)
+    {
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Title)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(x => x.LabelName)
+            .HasMaxLength(200);
+
+        builder.Property(x => x.MerchantName)
+            .HasMaxLength(200);
+
+        builder.Property(x => x.LastTriggeredConditionFingerprint)
+            .HasMaxLength(1000);
+
+        builder.Property(x => x.Threshold)
+            .HasPrecision(18, 2);
+
+        // TimeSpan is intentionally kept as the provider-native duration/time value. Both configured
+        // relational providers and the in-memory test provider support nullable TimeSpan properties.
+        builder.HasOne<UserDto>()
+            .WithMany()
+            .HasForeignKey(x => x.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(x => new { x.UserId, x.IsEnabled });
+        builder.HasIndex(x => new { x.UserId, x.AlertType });
+    }
+}

--- a/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
+++ b/code/FinanceManager.Infrastructure/ServiceCollectionExtension.cs
@@ -9,6 +9,7 @@ using FinanceManager.Application.Shared.Options;
 using FinanceManager.Application.Shared.Persistence;
 using FinanceManager.Domain.Administration.Logging;
 using FinanceManager.Domain.Administration.Monitoring;
+using FinanceManager.Domain.Alerts.Repositories;
 using FinanceManager.Domain.Assets.Repositories;
 using FinanceManager.Domain.Dashboard.Services;
 using FinanceManager.Domain.FinancialAccounts.Bond.Entities;
@@ -31,6 +32,7 @@ using FinanceManager.Domain.Shared.ExternalServices.Repositories;
 using FinanceManager.Domain.Shared.Maintenance.Repositories;
 using FinanceManager.Infrastructure.Features.Administration.Repositories;
 using FinanceManager.Infrastructure.Features.Administration.Services;
+using FinanceManager.Infrastructure.Features.Alerts.Repositories;
 using FinanceManager.Infrastructure.Features.Assets.Providers;
 using FinanceManager.Infrastructure.Features.Assets.Repositories;
 using FinanceManager.Infrastructure.Features.FinancialAccounts.Bond.Repositories;
@@ -116,6 +118,7 @@ public static class ServiceCollectionExtension
                 .AddScoped<IFinancialInsightsRepository, FinancialInsightsRepository>()
                 .AddScoped<IFinancialLabelsRepository, FinancialLabelsRepository>()
                 .AddScoped<IRecurringSubscriptionRepository, RecurringSubscriptionRepository>()
+                .AddScoped<IFinancialAlertRepository, FinancialAlertRepository>()
                 .AddScoped<ICurrencyRepository, CurrencyRepository>()
                 .AddScoped<IExchangeRateRepository, ExchangeRateRepository>()
                 .AddScoped<IBondDetailsRepository, BondDetailsRepository>()

--- a/code/FinanceManager.Tests.Integration/Features/Alerts/Controllers/FinancialAlertsControllerTests.cs
+++ b/code/FinanceManager.Tests.Integration/Features/Alerts/Controllers/FinancialAlertsControllerTests.cs
@@ -1,0 +1,191 @@
+using FinanceManager.Application.Alerts.Models;
+using FinanceManager.Application.Alerts.Services;
+using FinanceManager.Domain.Alerts.Commands;
+using FinanceManager.Domain.Alerts.Dtos;
+using FinanceManager.Domain.Alerts.Entities;
+using FinanceManager.Domain.Alerts.Enums;
+using FinanceManager.Domain.Identity.Entities;
+using FinanceManager.Tests.Integration.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Net;
+using System.Net.Http.Json;
+using Xunit;
+
+namespace FinanceManager.Tests.Integration.Features.Alerts.Controllers;
+
+[Collection("api")]
+[Trait("Category", "Integration")]
+public sealed class FinancialAlertsControllerTests(OptionsProvider optionsProvider) : ControllerTests(optionsProvider)
+{
+    private const int _testUserId = 735;
+    private static readonly Mock<IFinancialAlertService> _serviceMock = new();
+
+    protected override void ConfigureServices(IServiceCollection services)
+    {
+        _serviceMock.Reset();
+        services.AddSingleton(_serviceMock.Object);
+    }
+
+    [Fact]
+    public async Task Get_ForAuthenticatedUser_ReturnsOnlyTheirAlerts()
+    {
+        var alert = CreateAlert(_testUserId, "Low cash");
+        _serviceMock
+            .Setup(x => x.GetAlertsAsync(_testUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([alert]);
+        Authorize("user", _testUserId, UserRole.User);
+
+        var response = await Client.GetAsync("api/FinancialAlerts", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<List<FinancialAlertDto>>(TestContext.Current.CancellationToken);
+        var returned = Assert.Single(result!);
+        Assert.Equal(alert.Id, returned.Id);
+        Assert.Equal("Low cash", returned.Title);
+        _serviceMock.Verify(x => x.GetAlertsAsync(_testUserId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Get_WithoutAuthentication_ReturnsUnauthorized()
+    {
+        var response = await Client.GetAsync("api/FinancialAlerts", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        _serviceMock.Verify(x => x.GetAlertsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Create_ForAuthenticatedUser_ReturnsCreatedAlert()
+    {
+        Authorize("user", _testUserId, UserRole.User);
+        var command = new CreateFinancialAlert(
+            "Restaurant spend",
+            AlertType.CategorySpending,
+            AlertComparisonOperator.GreaterThan,
+            1000m,
+            AlertEvaluationPeriod.CurrentMonth,
+            LabelName: "Restaurants",
+            CooldownPeriod: TimeSpan.FromHours(6));
+        var created = CreateAlert(_testUserId, command.Title, command.AlertType);
+        _serviceMock
+            .Setup(x => x.CreateAlertAsync(_testUserId, It.IsAny<CreateFinancialAlert>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(created);
+
+        var response = await Client.PostAsJsonAsync("api/FinancialAlerts", command, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<FinancialAlertDto>(TestContext.Current.CancellationToken);
+        Assert.Equal(created.Id, result!.Id);
+        _serviceMock.Verify(x => x.CreateAlertAsync(
+            _testUserId,
+            It.Is<CreateFinancialAlert>(x => x.Title == command.Title && x.AlertType == command.AlertType),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Create_WithInvalidTitle_ReturnsBadRequestWithoutCallingService()
+    {
+        Authorize("user", _testUserId, UserRole.User);
+        var command = new CreateFinancialAlert(
+            " ",
+            AlertType.AccountBalance,
+            AlertComparisonOperator.LessThan,
+            3000m);
+
+        var response = await Client.PostAsJsonAsync("api/FinancialAlerts", command, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        _serviceMock.Verify(x => x.CreateAlertAsync(It.IsAny<int>(), It.IsAny<CreateFinancialAlert>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Update_ForAuthenticatedUser_ReturnsUpdatedAlert()
+    {
+        Authorize("user", _testUserId, UserRole.User);
+        var alertId = Guid.NewGuid();
+        var command = new UpdateFinancialAlert(
+            "Updated alert",
+            true,
+            AlertComparisonOperator.GreaterThanOrEqual,
+            1250m,
+            AlertEvaluationPeriod.Last30Days,
+            MerchantName: "Market",
+            AlertType: AlertType.MerchantSpending);
+        var updated = CreateAlert(_testUserId, command.Title, AlertType.MerchantSpending);
+        updated.Id = alertId;
+        _serviceMock
+            .Setup(x => x.UpdateAlertAsync(_testUserId, alertId, It.IsAny<UpdateFinancialAlert>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updated);
+
+        var response = await Client.PutAsJsonAsync($"api/FinancialAlerts/{alertId}", command, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<FinancialAlertDto>(TestContext.Current.CancellationToken);
+        Assert.Equal(alertId, result!.Id);
+        _serviceMock.Verify(x => x.UpdateAlertAsync(
+            _testUserId,
+            alertId,
+            It.Is<UpdateFinancialAlert>(x => x.Title == command.Title && x.AlertType == AlertType.MerchantSpending),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SetEnabled_AndDelete_UseAuthenticatedUser()
+    {
+        Authorize("user", _testUserId, UserRole.User);
+        var alertId = Guid.NewGuid();
+        _serviceMock
+            .Setup(x => x.SetEnabledAsync(_testUserId, alertId, false, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _serviceMock
+            .Setup(x => x.DeleteAlertAsync(_testUserId, alertId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var patch = await Client.PatchAsJsonAsync($"api/FinancialAlerts/{alertId}/enabled", false, TestContext.Current.CancellationToken);
+        var delete = await Client.DeleteAsync($"api/FinancialAlerts/{alertId}", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NoContent, patch.StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent, delete.StatusCode);
+        _serviceMock.Verify(x => x.SetEnabledAsync(_testUserId, alertId, false, It.IsAny<CancellationToken>()), Times.Once);
+        _serviceMock.Verify(x => x.DeleteAlertAsync(_testUserId, alertId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Evaluate_ReturnsDeterministicOutcome()
+    {
+        Authorize("user", _testUserId, UserRole.User);
+        var alert = CreateAlert(_testUserId, "Large purchase", AlertType.LargeTransaction);
+        var outcome = new AlertEvaluationOutcome(
+            alert.Id,
+            alert.Title,
+            alert.AlertType,
+            AlertTriggerStatus.Triggered,
+            IsTriggered: true,
+            IsNewlyTriggered: true,
+            IsSuppressed: false,
+            DeDuplicationReason.None,
+            CurrentValue: 2500m,
+            Threshold: 2000m,
+            ComparisonOperator: AlertComparisonOperator.GreaterThan,
+            ConditionFingerprint: "large-1",
+            Message: "Large transaction",
+            EvaluatedAt: DateTime.UtcNow,
+            Context: new Dictionary<string, string>());
+        _serviceMock
+            .Setup(x => x.EvaluateAlertsAsync(_testUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([outcome]);
+
+        var response = await Client.PostAsync("api/FinancialAlerts/evaluate", content: null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<List<AlertEvaluationOutcome>>(TestContext.Current.CancellationToken);
+        var returned = Assert.Single(result!);
+        Assert.True(returned.IsTriggered);
+        Assert.Equal(2500m, returned.CurrentValue);
+        _serviceMock.Verify(x => x.EvaluateAlertsAsync(_testUserId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static FinancialAlert CreateAlert(int userId, string title, AlertType type = AlertType.AccountBalance) =>
+        new(userId, title, type, AlertComparisonOperator.GreaterThan, 100m);
+}

--- a/code/FinanceManager.Tests.Unit/Application/Alerts/FinancialAlertEvaluatorTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Alerts/FinancialAlertEvaluatorTests.cs
@@ -1,0 +1,380 @@
+using FinanceManager.Application.Alerts.Models;
+using FinanceManager.Application.Alerts.Services;
+using FinanceManager.Domain.Alerts.Entities;
+using FinanceManager.Domain.Alerts.Enums;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+using FinanceManager.Domain.Labels.Entities;
+
+namespace FinanceManager.Tests.Unit.Application.Alerts;
+
+[Trait("Category", "Unit")]
+public class FinancialAlertEvaluatorTests
+{
+    private readonly FinancialAlertEvaluator _evaluator = new();
+    private readonly DateTime _evaluationDate = new(2026, 9, 11, 14, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Evaluate_DisabledAlert_ReturnsSuppressedWithDisabledStatus()
+    {
+        var alert = new FinancialAlert(1, "Disabled Alert", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m)
+        {
+            IsEnabled = false
+        };
+
+        var snapshot = new AlertEvaluationSnapshot([], [], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.False(outcome.IsTriggered);
+        Assert.False(outcome.IsNewlyTriggered);
+        Assert.True(outcome.IsSuppressed);
+        Assert.Equal(DeDuplicationReason.AlertDisabled, outcome.DeDuplicationReason);
+        Assert.Equal(AlertTriggerStatus.Disabled, outcome.Status);
+    }
+
+    [Fact]
+    public void Evaluate_AccountBalance_TriggersWhenBalanceViolatesThreshold()
+    {
+        var alert = new FinancialAlert(1, "Low Cash", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 3000m, accountId: 10);
+
+        var account = new CurrencyAccount(1, 10, "Checking Account", AccountLabel.Cash);
+        account.Add(new CurrencyAccountEntry(10, 1, _evaluationDate.AddDays(-2), 2500m, 2500m));
+
+        var snapshot = new AlertEvaluationSnapshot([account], [], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.True(outcome.IsTriggered);
+        Assert.True(outcome.IsNewlyTriggered);
+        Assert.False(outcome.IsSuppressed);
+        Assert.Equal(AlertTriggerStatus.Triggered, outcome.Status);
+        Assert.Equal(2500m, outcome.CurrentValue);
+        Assert.Contains("2,500.00", outcome.Message);
+    }
+
+    [Fact]
+    public void Evaluate_AccountBalance_RemainsHealthyWhenBalanceSatisfiesThreshold()
+    {
+        var alert = new FinancialAlert(1, "Low Cash", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 3000m, accountId: 10);
+
+        var account = new CurrencyAccount(1, 10, "Checking Account", AccountLabel.Cash);
+        account.Add(new CurrencyAccountEntry(10, 1, _evaluationDate.AddDays(-2), 4500m, 4500m));
+
+        var snapshot = new AlertEvaluationSnapshot([account], [], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.False(outcome.IsTriggered);
+        Assert.False(outcome.IsNewlyTriggered);
+        Assert.False(outcome.IsSuppressed);
+        Assert.Equal(AlertTriggerStatus.Healthy, outcome.Status);
+        Assert.Equal(4500m, outcome.CurrentValue);
+    }
+
+    [Fact]
+    public void Evaluate_AccountBalance_WithoutAccountId_EvaluatesAcrossAllAccounts()
+    {
+        var alert = new FinancialAlert(1, "Any Low Account", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m);
+
+        var safeAccount = new CurrencyAccount(1, 1, "Safe Account", AccountLabel.Cash);
+        safeAccount.Add(new CurrencyAccountEntry(1, 1, _evaluationDate.AddDays(-2), 5000m, 5000m));
+
+        var lowAccount = new CurrencyAccount(1, 2, "Low Account", AccountLabel.Cash);
+        lowAccount.Add(new CurrencyAccountEntry(2, 1, _evaluationDate.AddDays(-2), 400m, 400m));
+
+        var snapshot = new AlertEvaluationSnapshot([safeAccount, lowAccount], [], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.True(outcome.IsTriggered);
+        Assert.Equal(400m, outcome.CurrentValue);
+        Assert.Equal("2", outcome.Context["AccountId"]);
+    }
+
+    [Fact]
+    public void Evaluate_CategorySpending_TriggersWhenSpendingExceedsThresholdInPeriod()
+    {
+        var diningLabel = new FinancialLabel { Id = 5, Name = "Restaurants" };
+        var alert = new FinancialAlert(1, "Restaurants Limit", AlertType.CategorySpending, AlertComparisonOperator.GreaterThan, 1000m,
+            evaluationPeriod: AlertEvaluationPeriod.CurrentMonth,
+            labelId: 5);
+
+        var account = new CurrencyAccount(1, 1, "Main", AccountLabel.Cash);
+        // Transaction inside current month (September 2026): expense of 600
+        account.Add(new CurrencyAccountEntry(1, 1, new DateTime(2026, 9, 3, 10, 0, 0, DateTimeKind.Utc), 1400m, -600m)
+        {
+            Labels = [diningLabel]
+        });
+        // Transaction inside current month: expense of 547
+        account.Add(new CurrencyAccountEntry(1, 2, new DateTime(2026, 9, 8, 12, 0, 0, DateTimeKind.Utc), 853m, -547m)
+        {
+            Labels = [diningLabel]
+        });
+        // Transaction outside current month (August 2026): expense of 800 (should be excluded)
+        account.Add(new CurrencyAccountEntry(1, 3, new DateTime(2026, 8, 20, 12, 0, 0, DateTimeKind.Utc), 2000m, -800m)
+        {
+            Labels = [diningLabel]
+        });
+
+        var snapshot = new AlertEvaluationSnapshot([account], [], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.True(outcome.IsTriggered);
+        Assert.True(outcome.IsNewlyTriggered);
+        Assert.Equal(1147m, outcome.CurrentValue);
+        Assert.Equal("2", outcome.Context["TransactionCount"]);
+    }
+
+    [Fact]
+    public void Evaluate_CategorySpending_MatchesByLabelName_IgnoresIncomeTransactions()
+    {
+        var groceriesLabel = new FinancialLabel { Id = 99, Name = "Groceries" };
+        var alert = new FinancialAlert(1, "Groceries Limit", AlertType.CategorySpending, AlertComparisonOperator.GreaterThan, 300m,
+            labelName: "groceries");
+
+        var account = new CurrencyAccount(1, 1, "Main", AccountLabel.Cash);
+        // Expense of 250
+        account.Add(new CurrencyAccountEntry(1, 1, _evaluationDate.AddDays(-2), 750m, -250m)
+        {
+            Labels = [groceriesLabel]
+        });
+        // Positive return / refund of 100 (should not count as spending)
+        account.Add(new CurrencyAccountEntry(1, 2, _evaluationDate.AddDays(-1), 850m, 100m)
+        {
+            Labels = [groceriesLabel]
+        });
+
+        var snapshot = new AlertEvaluationSnapshot([account], [], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.False(outcome.IsTriggered);
+        Assert.Equal(250m, outcome.CurrentValue);
+    }
+
+    [Fact]
+    public void Evaluate_MerchantSpending_MatchesContractorOrDescriptionAndTriggers()
+    {
+        var alert = new FinancialAlert(1, "Uber Spend", AlertType.MerchantSpending, AlertComparisonOperator.GreaterThan, 150m,
+            merchantName: "Uber");
+
+        var account = new CurrencyAccount(1, 1, "Main", AccountLabel.Cash);
+        // Matched via ContractorDetails
+        account.Add(new CurrencyAccountEntry(1, 1, _evaluationDate.AddDays(-3), 900m, -95m)
+        {
+            ContractorDetails = "Uber B.V. Amsterdam"
+        });
+        // Matched via Description
+        account.Add(new CurrencyAccountEntry(1, 2, _evaluationDate.AddDays(-1), 820m, -80m)
+        {
+            Description = "UBER TRIP HELP.UBER.COM"
+        });
+        // Different merchant
+        account.Add(new CurrencyAccountEntry(1, 3, _evaluationDate.AddDays(-1), 720m, -100m)
+        {
+            ContractorDetails = "Starbucks"
+        });
+
+        var snapshot = new AlertEvaluationSnapshot([account], [], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.True(outcome.IsTriggered);
+        Assert.Equal(175m, outcome.CurrentValue);
+        Assert.Equal("2", outcome.Context["TransactionCount"]);
+    }
+
+    [Fact]
+    public void Evaluate_LargeTransaction_TriggersOnSingleExpenseExceedingThreshold()
+    {
+        var alert = new FinancialAlert(1, "Large Spend", AlertType.LargeTransaction, AlertComparisonOperator.GreaterThanOrEqual, 2000m);
+
+        var account = new CurrencyAccount(1, 1, "Main", AccountLabel.Cash);
+        account.Add(new CurrencyAccountEntry(1, 1, _evaluationDate.AddDays(-2), 5000m, -2500m)
+        {
+            ContractorDetails = "Apple Store"
+        });
+        account.Add(new CurrencyAccountEntry(1, 2, _evaluationDate.AddDays(-1), 4700m, -300m));
+
+        var snapshot = new AlertEvaluationSnapshot([account], [], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.True(outcome.IsTriggered);
+        Assert.True(outcome.IsNewlyTriggered);
+        Assert.Equal(2500m, outcome.CurrentValue);
+        Assert.Equal("1", outcome.Context["TriggeringAccountId"]);
+        Assert.Equal("1", outcome.Context["TriggeringEntryId"]);
+    }
+
+    [Fact]
+    public void Evaluate_LargeTransaction_HistoricalImportProtection_DoesNotTriggerOnOldTransactions()
+    {
+        // Alert was created today with AllTime period
+        var alert = new FinancialAlert(1, "Large Spend", AlertType.LargeTransaction, AlertComparisonOperator.GreaterThanOrEqual, 2000m,
+            evaluationPeriod: AlertEvaluationPeriod.AllTime)
+        {
+            CreatedAt = _evaluationDate
+        };
+
+        var account = new CurrencyAccount(1, 1, "Main", AccountLabel.Cash);
+        // Old transaction from 6 months ago (historical import before alert was created)
+        account.Add(new CurrencyAccountEntry(1, 1, _evaluationDate.AddMonths(-6), 10000m, -4000m));
+
+        var snapshot = new AlertEvaluationSnapshot([account], [], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.False(outcome.IsTriggered);
+        Assert.Equal(0m, outcome.CurrentValue);
+    }
+
+    [Fact]
+    public void Evaluate_SubscriptionPriceChange_TriggersWhenSubscriptionIncreases()
+    {
+        var alert = new FinancialAlert(1, "Sub Price Hike", AlertType.SubscriptionPriceChange, AlertComparisonOperator.GreaterThan, 0m);
+
+        var subscriptionId = Guid.NewGuid();
+        var subscription = new RecurringTransactionResult("Netflix", 65m)
+        {
+            PatternId = subscriptionId,
+            LastAmount = 65m,
+            PreviousAmount = 49m,
+            LastChargeDate = _evaluationDate.AddDays(-5)
+        };
+
+        var snapshot = new AlertEvaluationSnapshot([], [subscription], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.True(outcome.IsTriggered);
+        Assert.True(outcome.IsNewlyTriggered);
+        Assert.Equal(16m, outcome.CurrentValue);
+        Assert.Equal("Netflix", outcome.Context["SubscriptionName"]);
+        Assert.Contains("49.00", outcome.Message);
+        Assert.Contains("65.00", outcome.Message);
+    }
+
+    [Fact]
+    public void Evaluate_SubscriptionPriceChange_DoesNotTriggerWhenPriceIsUnchanged()
+    {
+        var alert = new FinancialAlert(1, "Sub Price Hike", AlertType.SubscriptionPriceChange, AlertComparisonOperator.GreaterThan, 0m);
+
+        var subscription = new RecurringTransactionResult("Spotify", 30m)
+        {
+            PatternId = Guid.NewGuid(),
+            LastAmount = 30m,
+            PreviousAmount = 30m,
+            LastChargeDate = _evaluationDate.AddDays(-2)
+        };
+
+        var snapshot = new AlertEvaluationSnapshot([], [subscription], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.False(outcome.IsTriggered);
+        Assert.Equal(0m, outcome.CurrentValue);
+    }
+
+    [Fact]
+    public void Evaluate_SubscriptionPriceChange_IgnoresInitialDetectionWithoutPriorCharge()
+    {
+        var alert = new FinancialAlert(1, "Sub Price Hike", AlertType.SubscriptionPriceChange, AlertComparisonOperator.GreaterThan, 0m);
+
+        var newSubscription = new RecurringTransactionResult("New Service", 50m)
+        {
+            PatternId = Guid.NewGuid(),
+            LastAmount = 50m,
+            PreviousAmount = 0m,
+            LastChargeDate = _evaluationDate.AddDays(-1)
+        };
+
+        var snapshot = new AlertEvaluationSnapshot([], [newSubscription], _evaluationDate);
+        var outcome = _evaluator.Evaluate(alert, snapshot);
+
+        Assert.False(outcome.IsTriggered);
+    }
+
+    [Fact]
+    public void Evaluate_DeDuplication_SuppressesUnchangedConditionOnSubsequentRuns()
+    {
+        var alert = new FinancialAlert(1, "Low Balance", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m, accountId: 1);
+        var account = new CurrencyAccount(1, 1, "Main", AccountLabel.Cash);
+        account.Add(new CurrencyAccountEntry(1, 1, _evaluationDate.AddDays(-1), 600m, 600m));
+
+        var snapshot = new AlertEvaluationSnapshot([account], [], _evaluationDate);
+
+        // First evaluation: newly triggered
+        var firstOutcome = _evaluator.Evaluate(alert, snapshot);
+        Assert.True(firstOutcome.IsTriggered);
+        Assert.True(firstOutcome.IsNewlyTriggered);
+        Assert.False(firstOutcome.IsSuppressed);
+        Assert.Equal(DeDuplicationReason.None, firstOutcome.DeDuplicationReason);
+
+        // Simulate state recording in persistence/entity
+        alert.RecordTrigger(firstOutcome.CurrentValue, firstOutcome.ConditionFingerprint, firstOutcome.EvaluatedAt);
+
+        // Second evaluation (condition unchanged): suppressed duplicate!
+        var secondOutcome = _evaluator.Evaluate(alert, snapshot);
+        Assert.True(secondOutcome.IsTriggered);
+        Assert.False(secondOutcome.IsNewlyTriggered);
+        Assert.True(secondOutcome.IsSuppressed);
+        Assert.Equal(DeDuplicationReason.UnchangedCondition, secondOutcome.DeDuplicationReason);
+    }
+
+    [Fact]
+    public void Evaluate_DeDuplication_TriggersNewlyWhenConditionChanges()
+    {
+        var alert = new FinancialAlert(1, "Low Balance", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m, accountId: 1);
+        var account = new CurrencyAccount(1, 1, "Main", AccountLabel.Cash);
+        account.Add(new CurrencyAccountEntry(1, 1, _evaluationDate.AddDays(-2), 600m, 600m));
+
+        var snapshot1 = new AlertEvaluationSnapshot([account], [], _evaluationDate.AddDays(-1));
+        var outcome1 = _evaluator.Evaluate(alert, snapshot1);
+        alert.RecordTrigger(outcome1.CurrentValue, outcome1.ConditionFingerprint, outcome1.EvaluatedAt);
+
+        // Balance drops further to 400
+        account.Add(new CurrencyAccountEntry(1, 2, _evaluationDate, 400m, -200m));
+        var snapshot2 = new AlertEvaluationSnapshot([account], [], _evaluationDate);
+        var outcome2 = _evaluator.Evaluate(alert, snapshot2);
+
+        Assert.True(outcome2.IsTriggered);
+        Assert.True(outcome2.IsNewlyTriggered);
+        Assert.False(outcome2.IsSuppressed);
+        Assert.Equal(400m, outcome2.CurrentValue);
+    }
+
+    [Fact]
+    public void Evaluate_Cooldown_SuppressesDuplicateWhenWithinCooldownWindow()
+    {
+        var alert = new FinancialAlert(1, "Low Balance", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m, accountId: 1)
+        {
+            CooldownPeriod = TimeSpan.FromHours(24)
+        };
+
+        var account = new CurrencyAccount(1, 1, "Main", AccountLabel.Cash);
+        account.Add(new CurrencyAccountEntry(1, 1, _evaluationDate.AddHours(-2), 600m, 600m));
+
+        var snapshot1 = new AlertEvaluationSnapshot([account], [], _evaluationDate.AddHours(-2));
+        var outcome1 = _evaluator.Evaluate(alert, snapshot1);
+        alert.RecordTrigger(outcome1.CurrentValue, outcome1.ConditionFingerprint, outcome1.EvaluatedAt);
+
+        // Balance changed slightly to 550, but evaluated only 1 hour later (within 24h cooldown)
+        account.Add(new CurrencyAccountEntry(1, 2, _evaluationDate.AddHours(-1), 550m, -50m));
+        var snapshot2 = new AlertEvaluationSnapshot([account], [], _evaluationDate.AddHours(-1));
+        var outcome2 = _evaluator.Evaluate(alert, snapshot2);
+
+        Assert.True(outcome2.IsTriggered);
+        Assert.False(outcome2.IsNewlyTriggered);
+        Assert.True(outcome2.IsSuppressed);
+        Assert.Equal(DeDuplicationReason.CooldownActive, outcome2.DeDuplicationReason);
+    }
+
+    [Fact]
+    public void EvaluateAll_HandlesMultipleAlertsDeterministically()
+    {
+        var alert1 = new FinancialAlert(1, "Low Balance", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m, accountId: 1);
+        var alert2 = new FinancialAlert(1, "Large Spend", AlertType.LargeTransaction, AlertComparisonOperator.GreaterThan, 500m);
+
+        var account = new CurrencyAccount(1, 1, "Main", AccountLabel.Cash);
+        account.Add(new CurrencyAccountEntry(1, 1, _evaluationDate.AddDays(-1), 800m, -700m));
+
+        var snapshot = new AlertEvaluationSnapshot([account], [], _evaluationDate);
+        var outcomes = _evaluator.EvaluateAll([alert1, alert2], snapshot);
+
+        Assert.Equal(2, outcomes.Count);
+        Assert.True(outcomes[0].IsTriggered); // Balance 800 < 1000
+        Assert.True(outcomes[1].IsTriggered); // Spend 700 > 500
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Application/Alerts/FinancialAlertServiceTests.cs
+++ b/code/FinanceManager.Tests.Unit/Application/Alerts/FinancialAlertServiceTests.cs
@@ -1,0 +1,241 @@
+using FinanceManager.Application.Alerts.Models;
+using FinanceManager.Application.Alerts.Services;
+using FinanceManager.Domain.Alerts.Commands;
+using FinanceManager.Domain.Alerts.Entities;
+using FinanceManager.Domain.Alerts.Enums;
+using FinanceManager.Domain.Alerts.Repositories;
+using FinanceManager.Domain.FinancialAccounts.Currencies.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Entities;
+using FinanceManager.Domain.FinancialAccounts.Shared.Repositories;
+using FinanceManager.Domain.Labels.Entities;
+using FinanceManager.Domain.Labels.Services;
+using FinanceManager.Domain.Shared.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace FinanceManager.Tests.Unit.Application.Alerts;
+
+[Trait("Category", "Unit")]
+public class FinancialAlertServiceTests
+{
+    private readonly Mock<IFinancialAlertRepository> _alertRepositoryMock = new();
+    private readonly Mock<IFinancialAccountRepository> _accountRepositoryMock = new();
+    private readonly Mock<IRecurringTransactionDetectorService> _recurringServiceMock = new();
+    private readonly Mock<IFinancialAlertEvaluator> _evaluatorMock = new();
+    private readonly Mock<IDateTimeProvider> _dateTimeProviderMock = new();
+    private readonly Mock<ILogger<FinancialAlertService>> _loggerMock = new();
+
+    private readonly FinancialAlertService _service;
+    private readonly DateTime _now = new(2026, 9, 11, 15, 0, 0, DateTimeKind.Utc);
+
+    public FinancialAlertServiceTests()
+    {
+        _dateTimeProviderMock.Setup(d => d.UtcNow).Returns(_now);
+        _service = new FinancialAlertService(
+            _alertRepositoryMock.Object,
+            _accountRepositoryMock.Object,
+            _recurringServiceMock.Object,
+            _evaluatorMock.Object,
+            _dateTimeProviderMock.Object,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task GetAlertsAsync_ReturnsAlertsFromRepository()
+    {
+        var alerts = new List<FinancialAlert>
+        {
+            new(1, "Alert 1", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m)
+        };
+        _alertRepositoryMock.Setup(r => r.GetAlertsByUserId(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(alerts);
+
+        var result = await _service.GetAlertsAsync(1, TestContext.Current.CancellationToken);
+
+        Assert.Single(result);
+        Assert.Equal("Alert 1", result[0].Title);
+    }
+
+    [Fact]
+    public async Task CreateAlertAsync_AddsAlertToRepository()
+    {
+        var command = new CreateFinancialAlert(
+            Title: "New Alert",
+            AlertType: AlertType.CategorySpending,
+            ComparisonOperator: AlertComparisonOperator.GreaterThan,
+            Threshold: 500m);
+
+        _alertRepositoryMock.Setup(r => r.Add(It.IsAny<FinancialAlert>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((FinancialAlert a, CancellationToken _) => a);
+
+        var result = await _service.CreateAlertAsync(1, command, TestContext.Current.CancellationToken);
+
+        Assert.Equal("New Alert", result.Title);
+        Assert.Equal(500m, result.Threshold);
+        _alertRepositoryMock.Verify(r => r.Add(It.IsAny<FinancialAlert>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateAlertAsync_UpdatesExistingAlertInRepository()
+    {
+        var alertId = Guid.NewGuid();
+        var existing = new FinancialAlert(1, "Old Title", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m)
+        {
+            Id = alertId
+        };
+
+        _alertRepositoryMock.Setup(r => r.GetById(1, alertId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var command = new UpdateFinancialAlert(
+            Title: "Updated Title",
+            IsEnabled: true,
+            ComparisonOperator: AlertComparisonOperator.LessThanOrEqual,
+            Threshold: 1200m);
+
+        var result = await _service.UpdateAlertAsync(1, alertId, command, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal("Updated Title", result.Title);
+        Assert.Equal(1200m, result.Threshold);
+        _alertRepositoryMock.Verify(r => r.Update(existing, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SetEnabledAsync_TogglesEnabledAndPersists()
+    {
+        var alertId = Guid.NewGuid();
+        var existing = new FinancialAlert(1, "Alert", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m)
+        {
+            Id = alertId,
+            IsEnabled = true
+        };
+
+        _alertRepositoryMock.Setup(r => r.GetById(1, alertId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        var result = await _service.SetEnabledAsync(1, alertId, false, TestContext.Current.CancellationToken);
+
+        Assert.True(result);
+        Assert.False(existing.IsEnabled);
+        _alertRepositoryMock.Verify(r => r.Update(existing, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAlertAsync_CallsRepositoryDelete()
+    {
+        var alertId = Guid.NewGuid();
+        _alertRepositoryMock.Setup(r => r.Delete(1, alertId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var result = await _service.DeleteAlertAsync(1, alertId, TestContext.Current.CancellationToken);
+
+        Assert.True(result);
+        _alertRepositoryMock.Verify(r => r.Delete(1, alertId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAlertsAsync_CoordinatesEvaluationAndPersistsTriggeredState()
+    {
+        var alert = new FinancialAlert(1, "Low Cash", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m);
+        _alertRepositoryMock.Setup(r => r.GetAlertsByUserId(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([alert]);
+
+        var account = new CurrencyAccount(1, 1, "Cash", AccountLabel.Cash);
+        _accountRepositoryMock.Setup(r => r.GetAccounts<CurrencyAccount>(1, It.IsAny<DateTime>(), It.IsAny<DateTime>(), true))
+            .Returns(new[] { account }.ToAsyncEnumerable());
+
+        _recurringServiceMock.Setup(r => r.GetRecurringTransactions(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var outcome = new AlertEvaluationOutcome(
+            alert.Id,
+            alert.Title,
+            alert.AlertType,
+            AlertTriggerStatus.Triggered,
+            IsTriggered: true,
+            IsNewlyTriggered: true,
+            IsSuppressed: false,
+            DeDuplicationReason.None,
+            CurrentValue: 500m,
+            Threshold: 1000m,
+            ComparisonOperator: AlertComparisonOperator.LessThan,
+            ConditionFingerprint: "fp-1",
+            Message: "Triggered",
+            EvaluatedAt: _now,
+            Context: new Dictionary<string, string>());
+
+        _evaluatorMock.Setup(e => e.EvaluateAll(It.IsAny<IEnumerable<FinancialAlert>>(), It.IsAny<AlertEvaluationSnapshot>()))
+            .Returns([outcome]);
+
+        var results = await _service.EvaluateAlertsAsync(1, TestContext.Current.CancellationToken);
+
+        Assert.Single(results);
+        Assert.True(results[0].IsNewlyTriggered);
+        Assert.Equal(AlertTriggerStatus.Triggered, alert.LastStatus);
+        Assert.Equal(500m, alert.LastTriggeredValue);
+        Assert.Equal("fp-1", alert.LastTriggeredConditionFingerprint);
+
+        _alertRepositoryMock.Verify(r => r.Update(alert, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAlertsAsync_FailureIsolation_CatchesExceptionAndReturnsEmptyWithoutCrashing()
+    {
+        _alertRepositoryMock.Setup(r => r.GetAlertsByUserId(1, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB connection error"));
+
+        var results = await _service.EvaluateAlertsAsync(1, TestContext.Current.CancellationToken);
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task EvaluateAlertsAsync_AllTimeAlertLoadsCompleteAccountHistory()
+    {
+        var alert = new FinancialAlert(
+            1,
+            "All history",
+            AlertType.LargeTransaction,
+            AlertComparisonOperator.GreaterThan,
+            1000m,
+            evaluationPeriod: AlertEvaluationPeriod.AllTime);
+        _alertRepositoryMock.Setup(r => r.GetAlertsByUserId(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([alert]);
+        _accountRepositoryMock
+            .Setup(r => r.GetAccounts<CurrencyAccount>(
+                1,
+                DateTime.MinValue,
+                It.IsAny<DateTime>(),
+                true))
+            .Returns(new[] { new CurrencyAccount(1, 1, "Cash", AccountLabel.Cash) }.ToAsyncEnumerable());
+        _recurringServiceMock.Setup(r => r.GetRecurringTransactions(1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        _evaluatorMock.Setup(e => e.EvaluateAll(It.IsAny<IEnumerable<FinancialAlert>>(), It.IsAny<AlertEvaluationSnapshot>()))
+            .Returns([new AlertEvaluationOutcome(
+                alert.Id,
+                alert.Title,
+                alert.AlertType,
+                AlertTriggerStatus.Healthy,
+                IsTriggered: false,
+                IsNewlyTriggered: false,
+                IsSuppressed: false,
+                DeDuplicationReason.None,
+                CurrentValue: 0m,
+                Threshold: alert.Threshold,
+                ComparisonOperator: alert.ComparisonOperator,
+                ConditionFingerprint: "none",
+                Message: "Healthy",
+                EvaluatedAt: _now,
+                Context: new Dictionary<string, string>())]);
+
+        var results = await _service.EvaluateAlertsAsync(1, TestContext.Current.CancellationToken);
+
+        Assert.Single(results);
+        _accountRepositoryMock.Verify(r => r.GetAccounts<CurrencyAccount>(
+            1,
+            DateTime.MinValue,
+            It.IsAny<DateTime>(),
+            true), Times.Once);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Domain/Alerts/FinancialAlertTests.cs
+++ b/code/FinanceManager.Tests.Unit/Domain/Alerts/FinancialAlertTests.cs
@@ -1,0 +1,179 @@
+using FinanceManager.Domain.Alerts.Commands;
+using FinanceManager.Domain.Alerts.Dtos;
+using FinanceManager.Domain.Alerts.Entities;
+using FinanceManager.Domain.Alerts.Enums;
+
+namespace FinanceManager.Tests.Unit.Domain.Alerts;
+
+[Trait("Category", "Unit")]
+public class FinancialAlertTests
+{
+    [Fact]
+    public void Constructor_InitializesDefaultValues()
+    {
+        var alert = new FinancialAlert();
+
+        Assert.NotEqual(Guid.Empty, alert.Id);
+        Assert.True(alert.IsEnabled);
+        Assert.Equal(AlertComparisonOperator.GreaterThan, alert.ComparisonOperator);
+        Assert.Equal(AlertEvaluationPeriod.CurrentMonth, alert.EvaluationPeriod);
+        Assert.Equal(AlertTriggerStatus.Healthy, alert.LastStatus);
+        Assert.Null(alert.LastTriggeredAt);
+        Assert.Null(alert.LastTriggeredValue);
+        Assert.Null(alert.LastTriggeredConditionFingerprint);
+        Assert.Null(alert.CooldownPeriod);
+    }
+
+    [Fact]
+    public void ParameterizedConstructor_SetsAllConfiguredProperties()
+    {
+        var id = Guid.NewGuid();
+        var alert = new FinancialAlert(
+            userId: 42,
+            title: "Dining Alert",
+            alertType: AlertType.CategorySpending,
+            comparisonOperator: AlertComparisonOperator.GreaterThanOrEqual,
+            threshold: 500m,
+            evaluationPeriod: AlertEvaluationPeriod.CurrentMonth,
+            accountId: 2,
+            labelId: 10,
+            labelName: "Dining",
+            merchantName: null,
+            subscriptionId: null,
+            cooldownPeriod: TimeSpan.FromHours(12));
+
+        Assert.Equal(42, alert.UserId);
+        Assert.Equal("Dining Alert", alert.Title);
+        Assert.Equal(AlertType.CategorySpending, alert.AlertType);
+        Assert.Equal(AlertComparisonOperator.GreaterThanOrEqual, alert.ComparisonOperator);
+        Assert.Equal(500m, alert.Threshold);
+        Assert.Equal(AlertEvaluationPeriod.CurrentMonth, alert.EvaluationPeriod);
+        Assert.Equal(2, alert.AccountId);
+        Assert.Equal(10, alert.LabelId);
+        Assert.Equal("Dining", alert.LabelName);
+        Assert.Equal(TimeSpan.FromHours(12), alert.CooldownPeriod);
+        Assert.True(alert.IsEnabled);
+    }
+
+    [Fact]
+    public void UpdateFrom_UpdatesPropertiesAndSetsUpdatedAt()
+    {
+        var alert = new FinancialAlert(
+            userId: 1,
+            title: "Old Title",
+            alertType: AlertType.AccountBalance,
+            comparisonOperator: AlertComparisonOperator.LessThan,
+            threshold: 1000m);
+
+        var updateCommand = new UpdateFinancialAlert(
+            Title: "New Title",
+            IsEnabled: false,
+            ComparisonOperator: AlertComparisonOperator.LessThanOrEqual,
+            Threshold: 1500m,
+            EvaluationPeriod: AlertEvaluationPeriod.Last30Days,
+            AccountId: 5,
+            LabelId: null,
+            LabelName: null,
+            MerchantName: "Amazon",
+            SubscriptionId: null,
+            CooldownPeriod: TimeSpan.FromDays(1),
+            AlertType: AlertType.MerchantSpending);
+
+        alert.UpdateFrom(updateCommand);
+
+        Assert.Equal("New Title", alert.Title);
+        Assert.False(alert.IsEnabled);
+        Assert.Equal(AlertComparisonOperator.LessThanOrEqual, alert.ComparisonOperator);
+        Assert.Equal(1500m, alert.Threshold);
+        Assert.Equal(AlertType.MerchantSpending, alert.AlertType);
+        Assert.Equal(AlertEvaluationPeriod.Last30Days, alert.EvaluationPeriod);
+        Assert.Equal(5, alert.AccountId);
+        Assert.Equal("Amazon", alert.MerchantName);
+        Assert.Equal(TimeSpan.FromDays(1), alert.CooldownPeriod);
+        Assert.NotNull(alert.UpdatedAt);
+    }
+
+    [Fact]
+    public void RecordTrigger_SetsTriggeredStateAndFingerprint()
+    {
+        var alert = new FinancialAlert(1, "Balance", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m);
+        var triggeredTime = new DateTime(2026, 9, 11, 12, 0, 0, DateTimeKind.Utc);
+        var fingerprint = "AccountBalance:AccountId=1:Balance=500.00";
+
+        alert.RecordTrigger(500m, fingerprint, triggeredTime);
+
+        Assert.Equal(AlertTriggerStatus.Triggered, alert.LastStatus);
+        Assert.Equal(500m, alert.LastTriggeredValue);
+        Assert.Equal(fingerprint, alert.LastTriggeredConditionFingerprint);
+        Assert.Equal(triggeredTime, alert.LastTriggeredAt);
+        Assert.Equal(triggeredTime, alert.UpdatedAt);
+    }
+
+    [Fact]
+    public void RecordResolved_SetsHealthyStateAndClearsFingerprint()
+    {
+        var alert = new FinancialAlert(1, "Balance", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m);
+        alert.RecordTrigger(500m, "fp", DateTime.UtcNow);
+
+        var resolvedTime = DateTime.UtcNow.AddMinutes(5);
+        alert.RecordResolved(resolvedTime);
+
+        Assert.Equal(AlertTriggerStatus.Healthy, alert.LastStatus);
+        Assert.Null(alert.LastTriggeredConditionFingerprint);
+        Assert.Equal(resolvedTime, alert.UpdatedAt);
+    }
+
+    [Fact]
+    public void IsUnchangedTrigger_IdentifiesIdenticalFingerprintWhenTriggered()
+    {
+        var alert = new FinancialAlert(1, "Balance", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m);
+        alert.RecordTrigger(500m, "exact-fingerprint", DateTime.UtcNow);
+
+        Assert.True(alert.IsUnchangedTrigger("exact-fingerprint"));
+        Assert.False(alert.IsUnchangedTrigger("different-fingerprint"));
+
+        alert.RecordResolved(DateTime.UtcNow);
+        Assert.False(alert.IsUnchangedTrigger("exact-fingerprint"));
+    }
+
+    [Fact]
+    public void IsSuppressedByCooldown_ReturnsTrueWithinWindowAndFalseOutside()
+    {
+        var alert = new FinancialAlert(1, "Balance", AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m)
+        {
+            CooldownPeriod = TimeSpan.FromHours(1)
+        };
+
+        var triggerTime = new DateTime(2026, 9, 11, 10, 0, 0, DateTimeKind.Utc);
+        alert.RecordTrigger(500m, "fp", triggerTime);
+
+        Assert.True(alert.IsSuppressedByCooldown(triggerTime.AddMinutes(30)));
+        Assert.False(alert.IsSuppressedByCooldown(triggerTime.AddMinutes(61)));
+    }
+
+    [Fact]
+    public void FinancialAlertDto_FromEntity_MapsAllFieldsCorrectly()
+    {
+        var alert = new FinancialAlert(
+            userId: 7,
+            title: "Test Alert",
+            alertType: AlertType.LargeTransaction,
+            comparisonOperator: AlertComparisonOperator.GreaterThan,
+            threshold: 2000m,
+            evaluationPeriod: AlertEvaluationPeriod.Last7Days,
+            accountId: 3,
+            cooldownPeriod: TimeSpan.FromHours(2));
+
+        var dto = FinancialAlertDto.FromEntity(alert);
+
+        Assert.Equal(alert.Id, dto.Id);
+        Assert.Equal(7, dto.UserId);
+        Assert.Equal("Test Alert", dto.Title);
+        Assert.Equal(AlertType.LargeTransaction, dto.AlertType);
+        Assert.Equal(AlertComparisonOperator.GreaterThan, dto.ComparisonOperator);
+        Assert.Equal(2000m, dto.Threshold);
+        Assert.Equal(AlertEvaluationPeriod.Last7Days, dto.EvaluationPeriod);
+        Assert.Equal(3, dto.AccountId);
+        Assert.Equal(TimeSpan.FromHours(2), dto.CooldownPeriod);
+    }
+}

--- a/code/FinanceManager.Tests.Unit/Infrastructure/Features/Alerts/Repositories/FinancialAlertRepositoryTests.cs
+++ b/code/FinanceManager.Tests.Unit/Infrastructure/Features/Alerts/Repositories/FinancialAlertRepositoryTests.cs
@@ -1,0 +1,76 @@
+using FinanceManager.Domain.Alerts.Entities;
+using FinanceManager.Domain.Alerts.Enums;
+using FinanceManager.Infrastructure.Features.Alerts.Repositories;
+using FinanceManager.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace FinanceManager.Tests.Unit.Infrastructure.Features.Alerts.Repositories;
+
+[Collection("Infrastructure")]
+[Trait("Category", "Unit")]
+public sealed class FinancialAlertRepositoryTests
+{
+    [Fact]
+    public async Task GetAlertsByUserId_FiltersByOwnerAndOrdersByCreation()
+    {
+        await using var context = CreateContext();
+        var older = CreateAlert(1, "Older");
+        older.CreatedAt = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+        var newer = CreateAlert(1, "Newer");
+        newer.CreatedAt = older.CreatedAt.AddMinutes(1);
+        context.FinancialAlerts.AddRange(
+            newer,
+            older,
+            CreateAlert(2, "Another user"));
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var result = await new FinancialAlertRepository(context)
+            .GetAlertsByUserId(1, TestContext.Current.CancellationToken);
+
+        Assert.Equal([older.Id, newer.Id], result.Select(x => x.Id));
+    }
+
+    [Fact]
+    public async Task GetById_AndDelete_EnforceOwner()
+    {
+        await using var context = CreateContext();
+        var alert = CreateAlert(1, "Owned");
+        context.FinancialAlerts.Add(alert);
+        await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+        var repository = new FinancialAlertRepository(context);
+
+        Assert.Null(await repository.GetById(2, alert.Id, TestContext.Current.CancellationToken));
+        Assert.False(await repository.Delete(2, alert.Id, TestContext.Current.CancellationToken));
+        Assert.NotNull(await repository.GetById(1, alert.Id, TestContext.Current.CancellationToken));
+
+        Assert.True(await repository.Delete(1, alert.Id, TestContext.Current.CancellationToken));
+        Assert.Null(await repository.GetById(1, alert.Id, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task AddAndUpdate_PersistsAlertState()
+    {
+        await using var context = CreateContext();
+        var repository = new FinancialAlertRepository(context);
+        var alert = await repository.Add(CreateAlert(1, "Before"), TestContext.Current.CancellationToken);
+
+        alert.Title = "After";
+        alert.LastStatus = AlertTriggerStatus.Triggered;
+        alert.LastTriggeredValue = 2500m;
+        await repository.Update(alert, TestContext.Current.CancellationToken);
+
+        var persisted = await repository.GetById(1, alert.Id, TestContext.Current.CancellationToken);
+        Assert.Equal("After", persisted!.Title);
+        Assert.Equal(AlertTriggerStatus.Triggered, persisted.LastStatus);
+        Assert.Equal(2500m, persisted.LastTriggeredValue);
+    }
+
+    private static FinancialAlert CreateAlert(int userId, string title) =>
+        new(userId, title, AlertType.AccountBalance, AlertComparisonOperator.LessThan, 1000m);
+
+    private static AppDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+}


### PR DESCRIPTION
Closes #735

## Summary

- add a typed, user-owned financial alert/watchlist model with deterministic comparisons, evaluation periods, cooldowns, and unchanged-condition de-duplication
- support account-balance, label/category-spending, merchant-spending, large-transaction, and subscription-price-change conditions
- persist alerts with ownership filtering and migration, expose authorized CRUD/evaluation endpoints, and add a typed component client
- add an Alerts page plus a compact dashboard status card showing triggered counts, observed values, and management links
- isolate evaluation failures from transaction persistence and document the feature in the changelog

## Orchestration

- baseline: `origin/develop` @ `ef573bb10f1fb21c5554635c858eab041e7ac29c`
- Antigravity/Agy: isolated domain/application alert contracts and deterministic evaluator tests; exit 0, no commit/push
- LM Studio/Qwen: a retained prior process had no usable diff, test, or exit evidence, so it was not claimed as complete
- coordinator: persistence, migration, API, components, dashboard, registration, integration tests, and final reconciliation in disjoint paths

## Validation

- `dotnet build code/FinanceManager.slnx --no-restore -p:TreatWarningsAsErrors=true -m:1 /nodeReuse:false` — passed, 0 warnings/errors (exit 0)
- alert-focused unit tests — 35/35 passed (exit 0)
- alert controller integration tests — 7/7 passed (exit 0)
- full integration suite — 333/333 passed (exit 0)
- architecture suite — 9/9 passed (exit 0)
- `dotnet format ./code/FinanceManager.slnx --no-restore --verify-no-changes --verbosity minimal` — passed (exit 0)
- `dotnet ef migrations has-pending-model-changes --no-build` — no pending model changes (exit 0)
- `git diff --check` — passed (exit 0)
- UI smoke verification via `/DevelopLogin/guest/Alerts` at mobile and desktop sizes, plus dashboard alert-card DOM/screenshot checks — passed

The full unit suite was also run: 1,039/1,045 passed, with six pre-existing failures outside this change (two locale-sensitive investment-paycheck cache-key assertions and four nullable `Assert.NotNull` currency-exchange assertions). Those failures were not modified.

## Risks / follow-up

- v1 is intentionally in-app only; external notification delivery remains a later capability.
- dashboard/page evaluation performs an evaluation request on load; failures are surfaced as an empty/error state without blocking transaction persistence.
- the issue remains `in progress` until this PR is merged.

<!-- gh-implementation-plan -->
